### PR TITLE
docs: fix simple typo, unitialized -> uninitialized

### DIFF
--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -765,7 +765,7 @@ static inline term term_from_const_binary(const void *data, uint32_t size, Conte
 * @brief Create an unititialized binary.
 *
 * @details Allocates a binary on the heap, and returns a term pointing to it.
-* Note that the data in teh binary is unitialized and could contain any garbage.
+* Note that the data in teh binary is uninitialized and could contain any garbage.
 * Make sure to initialize before use, if needed (e.g., via memset).
 * @param size size of binary data buffer.
 * @param ctx the context that owns the memory that will be allocated.
@@ -964,7 +964,7 @@ static inline uint64_t term_to_ref_ticks(term rt)
 /**
  * @brief Allocates a tuple on the heap
  *
- * @details Allocates an unitialized tuple on the heap with given arity.
+ * @details Allocates an uninitialized tuple on the heap with given arity.
  * @param size tuple arity (count of tuple elements).
  * @param ctx the context that owns the memory that will be allocated.
  * @return a term pointing on an empty tuple allocated on the heap.
@@ -1105,7 +1105,7 @@ static inline term term_get_list_tail(term t)
 }
 
 /**
- * @brief Allocate unitialized memory for a list item
+ * @brief Allocate uninitialized memory for a list item
  *
  * @details Allocates a memory area that will be used to store a list item.
  * @param ctx the context that owns the memory that will be allocated.


### PR DESCRIPTION
There is a small typo in src/libAtomVM/term.h.

Should read `uninitialized` rather than `unitialized`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md