### PR TITLE
Fixed memory leak in OP_TEST_HEAP, whereby the heap would g…

### DIFF
--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -64,7 +64,7 @@ enum MemoryGCResult memory_ensure_free(Context *c, uint32_t size)
         size_t memory_size = context_memory_size(c);
         if (UNLIKELY(memory_gc(c, memory_size + size + MIN_FREE_SPACE_SIZE) != MEMORY_GC_OK)) {
             //TODO: handle this more gracefully
-            TRACE("Unable to allocate memory for GC\n");
+            TRACE("Unable to allocate memory for GC.  memory_size=%zu size=%u\n", memory_size, size);
             return MEMORY_GC_ERROR_FAILED_ALLOCATION;
         }
         size_t new_free_space = context_avail_free_memory(c);
@@ -72,7 +72,7 @@ enum MemoryGCResult memory_ensure_free(Context *c, uint32_t size)
         if (new_free_space > new_minimum_free_space) {
             size_t new_memory_size = context_memory_size(c);
             if (UNLIKELY(memory_gc(c, (new_memory_size - new_free_space) + new_minimum_free_space) != MEMORY_GC_OK)) {
-                TRACE("Unable to allocate memory for GC shrink\n");
+                TRACE("Unable to allocate memory for GC shrink.  new_memory_size=%zu new_free_space=%zu new_minimum_free_space=%zu size=%u\n", new_memory_size, new_free_space, new_minimum_free_space, size);
                 return MEMORY_GC_ERROR_FAILED_ALLOCATION;
             }
         }


### PR DESCRIPTION
This change fixes the logic in the OP_TEST_HEAP operation, to shrink the heap if more space is being used than needed.  Without this fix, the heap will actually grow, instead of shrinking (because `heap_size` is added to the requested space).  This change removes the used size from the calculation.

Also added printf's to stderr to diagnose the file location of out of memory errors.  Could be helpful for debugging, and we may want to remove in the future, if it becomes an annoyance.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
