### PR TITLE
Fix memory corruption when taking the tail of a binary.

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -3536,7 +3536,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     VERIFY_IS_MATCH_STATE(src, "bs_get_tail");
 
                     avm_int_t bs_offset = term_get_match_state_offset(src);
-                    avm_int_t bs_bin = term_get_match_state_binary(src);
+                    term bs_bin = term_get_match_state_binary(src);
 
                     TRACE("bs_get_tail/3 src=0x%lx dreg=%c%i live=0x%lx \n", src, T_DEST_REG(dreg_type, dreg), live);
                     if (bs_offset == 0) {
@@ -3558,6 +3558,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                             }
                             DECODE_COMPACT_TERM(src, code, i, src_off, src_off);
+                            bs_bin = term_get_match_state_binary(src);
                             term t = term_maybe_create_sub_binary(bs_bin, start_pos, new_bin_size, ctx);
                             WRITE_REGISTER(dreg_type, dreg, t);
 

--- a/tests/erlang_tests/test_bs.erl
+++ b/tests/erlang_tests/test_bs.erl
@@ -82,6 +82,8 @@ start() ->
 
     test_match_case_type(),
 
+    ok = test_iterate_binary(),
+
     0.
 
 test_pack_small_ints({A, B, C}, Expect) ->
@@ -293,5 +295,17 @@ match_case_type(Term) ->
         _ ->
             something_else_entirely
     end.
+
+-define(TEST_BINARY_DATA, <<241,131,104,2,100,0,4,99,97,108,108,104,2,104,3,100,0,3,106,111,101,100,0,6,114,111,98,101,114,116,97,0,104,2,100,0,5,104,101,108,108,111,97,1>>).
+-define(TEST_LIST_DATA,    [241,131,104,2,100,0,4,99,97,108,108,104,2,104,3,100,0,3,106,111,101,100,0,6,114,111,98,101,114,116,97,0,104,2,100,0,5,104,101,108,108,111,97,1]).
+
+test_iterate_binary() ->
+    ?TEST_LIST_DATA = traverse(id(?TEST_BINARY_DATA), []),
+    ok.
+
+traverse(<<"">>, Accum) -> Accum;
+traverse(<<H:8, T/binary>>, Accum) ->
+    traverse(T, Accum ++ [H]).
+
 
 id(X) -> X.


### PR DESCRIPTION
The change resets the reference to the bs_bin match_state binary, after a potential GC.  Without this change, the reference to the match state binary passed into the sub-binary constructor may be invalid.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
