### PR TITLE
Fix for binary_to_term with invalid term encoding

### DIFF
--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -310,7 +310,12 @@ static void const* *module_build_literals_table(const void *literalsBuf)
 
 term module_load_literal(Module *mod, int index, Context *ctx)
 {
-    return externalterm_to_term(mod->literals_table[index], ctx, 1);
+    term t = externalterm_to_term(mod->literals_table[index], ctx, 1);
+    if (term_is_invalid_term(t)) {
+        fprintf(stderr, "Invalid term reading literals_table[%i] from module\n", index);
+        abort();
+    }
+    return t;
 }
 
 const struct ExportedFunction *module_resolve_function(Module *mod, int import_table_index)

--- a/tests/erlang_tests/test_binary_to_term.erl
+++ b/tests/erlang_tests/test_binary_to_term.erl
@@ -52,6 +52,7 @@ start() ->
 
     {32768, 6} = erlang:binary_to_term(<<131,98,0,0,128,0, 127>>, [used]),
     test_catentate_and_split([foo, bar, 128, {foo, bar}, [a,b,c, {d}]]),
+    ok = test_invalid_term_encoding(),
     0.
 
 test_reverse(T, Interop) ->
@@ -82,3 +83,21 @@ split(Bin, Accum) ->
 reverse([], Accum) -> Accum;
 reverse([H|T], Accum) ->
     reverse(T, [H|Accum]).
+
+
+test_invalid_term_encoding() ->
+    ok = expect_badarg(
+        fun() ->
+            binary_to_term(<<"garbage">>)
+        end
+    ),
+    ok.
+
+expect_badarg(Fun) ->
+    try
+        Fun(),
+        fail
+    catch
+        _:badarg ->
+            ok
+    end.


### PR DESCRIPTION
This change removes explicit aborts when passing invalid encoded term.  Without this fix, binary_to_term when passed a binary that is not a valid encoded term will abort the process/VM.  

The abort handling is moved out to the module interface, where external term literals are loaded, so the behavior is unchanged in that case.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
