### PR TITLE
Adds support for `catch` and `catch_end` BEAM opcodes.

### DIFF
--- a/src/libAtomVM/opcodes.h
+++ b/src/libAtomVM/opcodes.h
@@ -69,6 +69,8 @@
 #define OP_SELECT_VAL 59
 #define OP_SELECT_TUPLE_ARITY 60
 #define OP_JUMP 61
+#define OP_CATCH 62
+#define OP_CATCH_END 63
 #define OP_MOVE 64
 #define OP_GET_LIST 65
 #define OP_GET_TUPLE_ELEMENT 66

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -310,6 +310,7 @@ compile_erlang(test_match)
 compile_erlang(test_ordering_0)
 compile_erlang(test_ordering_1)
 compile_erlang(test_bs)
+compile_erlang(test_catch)
 compile_erlang(test_gc)
 compile_erlang(test_raise)
 compile_erlang(test_map)
@@ -704,6 +705,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_ordering_0.beam
     test_ordering_1.beam
     test_bs.beam
+    test_catch.beam
     test_gc.beam
     test_raise.beam
     test_map.beam

--- a/tests/erlang_tests/test_catch.erl
+++ b/tests/erlang_tests/test_catch.erl
@@ -1,0 +1,45 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_catch).
+
+-export([start/0]).
+
+start() ->
+    ok = test_catch(),
+    0.
+
+test_catch() ->
+    ok = (catch maybe_crash(ok)),
+    throwme = (catch maybe_crash(throwme)),
+    {'EXIT', {{badmatch, bar}, _}} = (catch maybe_crash(crash_badmatch)),
+    {'EXIT', just_because} = (catch maybe_crash(crash_exit_just_because)),
+    ok.
+
+maybe_crash(ok) ->
+    ok;
+maybe_crash(crash_badmatch) ->
+    foo = id(bar);
+maybe_crash(crash_exit_just_because) ->
+    erlang:exit(just_because);
+maybe_crash(throwme) ->
+    throw(throwme).
+
+id(X) -> X.

--- a/tests/test.c
+++ b/tests/test.c
@@ -330,6 +330,7 @@ struct Test tests[] =
     {"test_binary_to_term.beam", 0},
     {"test_selective_receive.beam", 0},
     {"test_bs.beam", 0},
+    {"test_catch.beam", 0},
     {"test_gc.beam", 0 },
     {"test_raise.beam", 7},
     {"test_map.beam", 0},


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
