### PR TITLE
Add a 1 tick delay in sys_consume_pending_events on ESP32 platform.

### DIFF
--- a/src/platforms/esp32/main/sys.c
+++ b/src/platforms/esp32/main/sys.c
@@ -90,6 +90,8 @@ static void receive_events(GlobalContext *glb, TickType_t wait_ticks)
 
 void sys_consume_pending_events(GlobalContext *glb)
 {
+    // delay 1 tick in order to allow this task to respond to the IDF task watchdog timer
+    vTaskDelay(1);
     receive_events(glb, 0);
 }
 


### PR DESCRIPTION
Adding a 1-tick delay will allow the task to periodically yield when the scheduler pre-empts a running process (every 1024 reductions).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
