### PR TITLE
Socket fixes

### DIFF
--- a/libs/estdlib/src/gen_tcp.erl
+++ b/libs/estdlib/src/gen_tcp.erl
@@ -283,6 +283,7 @@ merge(Config, [H | T], Accum) ->
     end.
 
 %% @private
+normalize_address(localhost) -> "127.0.0.1";
 normalize_address(loopback) -> "127.0.0.1";
 normalize_address(Address) when is_list(Address) -> Address;
 normalize_address({A,B,C,D}) when is_integer(A) and is_integer(B) and is_integer(C) and is_integer(D) ->

--- a/src/platforms/esp32/main/network_driver.c
+++ b/src/platforms/esp32/main/network_driver.c
@@ -455,6 +455,17 @@ static term network_driver_ifconfig(Context *ctx)
     return port_create_error_tuple(ctx, UNDEFINED_ATOM);
 }
 
+static term tuple_from_addr(Context *ctx, uint32_t addr)
+{
+    term terms[4];
+    terms[0] = term_from_int32((addr >> 24) & 0xFF);
+    terms[1] = term_from_int32((addr >> 16) & 0xFF);
+    terms[2] = term_from_int32((addr >> 8) & 0xFF);
+    terms[3] = term_from_int32(addr & 0xFF);
+
+    return port_create_tuple_n(ctx, 4, terms);
+}
+
 //
 // Event handlers
 //
@@ -475,9 +486,9 @@ static void send_got_ip(ClientData *data, tcpip_adapter_ip_info_t *info)
     Context *ctx = data->ctx;
 
     port_ensure_available(ctx, ((4 + 1) * 3 + (2 + 1) + (2 + 1)) * 2);
-    term ip = socket_tuple_from_addr(ctx, ntohl(info->ip.addr));
-    term netmask = socket_tuple_from_addr(ctx, ntohl(info->netmask.addr));
-    term gw = socket_tuple_from_addr(ctx, ntohl(info->gw.addr));
+    term ip = tuple_from_addr(ctx, ntohl(info->ip.addr));
+    term netmask = tuple_from_addr(ctx, ntohl(info->netmask.addr));
+    term gw = tuple_from_addr(ctx, ntohl(info->gw.addr));
 
     term ip_info = port_create_tuple3(ctx, ip, netmask, gw);
     term reply = port_create_tuple2(ctx, STA_GOT_IP_ATOM, ip_info);
@@ -530,7 +541,7 @@ static void send_ap_sta_ip_acquired(ClientData *data, ip4_addr_t *ip)
     TRACE("Sending ap_sta_ip_acquired back to AtomVM\n");
     Context *ctx = data->ctx;
     port_ensure_available(ctx, ((4 + 1) + (2 + 1)) * 2);
-    term ip_term = socket_tuple_from_addr(ctx, ntohl(ip->addr));
+    term ip_term = tuple_from_addr(ctx, ntohl(ip->addr));
     term reply = port_create_tuple2(ctx, AP_STA_IP_ASSIGNED_ATOM, ip_term);
     send_term(data, reply);
 }

--- a/src/platforms/esp32/main/socket_driver.h
+++ b/src/platforms/esp32/main/socket_driver.h
@@ -21,13 +21,10 @@
 #ifndef _SOCKET_DRIVER_H_
 #define _SOCKET_DRIVER_H_
 
-#include "context.h"
 #include "globalcontext.h"
 #include "term.h"
 
 void socket_driver_init(GlobalContext *global);
 Context *socket_driver_create_port(GlobalContext *global, term opts);
-
-term socket_tuple_from_addr(Context *ctx, uint32_t addr);
 
 #endif

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -26,6 +26,7 @@ set(ERLANG_MODULES
     test_gen_server
     test_gen_statem
     test_gen_udp
+    test_gen_tcp
     test_io_lib
     test_lists
     test_maps

--- a/tests/libs/estdlib/test_gen_tcp.erl
+++ b/tests/libs/estdlib/test_gen_tcp.erl
@@ -1,0 +1,96 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_gen_tcp).
+
+-export([test/0]).
+
+-include("etest.hrl").
+
+test() ->
+    ok = test_echo_server(),
+    ok = test_echo_server(),
+    ok.
+
+test_echo_server() ->
+    {ok, ListenSocket} = gen_tcp:listen(0, []),
+    {ok, {_Address, Port}} = inet:sockname(ListenSocket),
+
+    Self = self(),
+    spawn(fun() -> Self ! ready, accept(Self, ListenSocket) end),
+    receive
+        ready ->
+            ok
+    end,
+
+    test_send_receive(Port, 100),
+
+    %% TODO bug closing listening socket
+    % gen_tcp:close(ListenSocket),
+
+    ok.
+
+
+accept(Pid, ListenSocket) ->
+    case gen_tcp:accept(ListenSocket) of
+        {ok, Socket} ->
+            spawn(fun() -> accept(Pid, ListenSocket) end),
+            echo(Pid, Socket);
+        {error, closed} ->
+            ok
+    end.
+
+
+echo(Pid, Socket) ->
+    receive
+        {tcp_closed, _Socket} ->
+            Pid ! server_closed,
+            ok;
+        {tcp, Socket, Packet} ->
+            ok = gen_tcp:send(Socket, Packet),
+            echo(Pid, Socket)
+    end.
+
+
+test_send_receive(Port, N) ->
+    {ok, Socket} = gen_tcp:connect(localhost, Port, [{active, true}]),
+
+    loop(Socket, N),
+
+    gen_tcp:close(Socket),
+    receive
+        server_closed -> ok
+    after 1000 ->
+        throw(timeout)
+    end.
+
+
+loop(_Socket, 0) ->
+    ok;
+loop(Socket, I) ->
+    Packet = list_to_binary(pid_to_list(self()) ++ ":" ++ integer_to_list(I)),
+    ok = gen_tcp:send(Socket, Packet),
+    receive
+        {tcp_closed, _Socket} ->
+            ok;
+        {tcp, _Socket, Packet} ->
+            loop(Socket, I - 1)
+    end,
+    ok.

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -28,6 +28,7 @@ start() ->
         , test_gen_server
         , test_gen_statem
         , test_gen_udp
+        , test_gen_tcp
         , test_io_lib
         , test_maps
         , test_proplists


### PR DESCRIPTION
This change set makes the following fixes to the generic_unix and esp32 socket drivers:

* Fixed a pid leak in both drivers, so that the sockets are properly closed and processes and memory deleted when a socket is closed.
* Fixed an error in the ESP32 driver that prevented multiple listening sockets to initialize properly.
* Cleaned up interdependencies between socket and network code that should not be there. 
* Properly passed off the binary and active flags to from listening socket to accepting socket.
* Set the listening sockets to reuse address and disabled linger
* Added `localhost` atom as a valid address when initializing a socket
* Added a simple test for gen_tcp

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
