### PR TITLE
Added support for little endian and signed put operations on integers

### DIFF
--- a/src/libAtomVM/bitstring.c
+++ b/src/libAtomVM/bitstring.c
@@ -28,7 +28,7 @@ static inline uint64_t from_le64(uint64_t value)
          (((value) & 0xFF000000000000) >> 40) | (((value) & 0xFF00000000000000) >> 56));
 }
 
-bool extract_any_integer(const uint8_t *src, size_t offset, avm_int_t n,
+bool bitstring_extract_any_integer(const uint8_t *src, size_t offset, avm_int_t n,
     enum BitstringFlags bs_flags, union maybe_unsigned_int64 *dst)
 {
     uint64_t out = 0;
@@ -54,5 +54,25 @@ bool extract_any_integer(const uint8_t *src, size_t offset, avm_int_t n,
         dst->u = out;
     }
 
+    return true;
+}
+
+bool bitstring_insert_any_integer(uint8_t *dst, avm_int_t offset, avm_int64_t value, size_t n, enum BitstringFlags bs_flags)
+{
+    // TODO support big/little endian signedness flags
+    if (bs_flags != 0) {
+        return false;
+    }
+    for (int i = 0; i < n; ++i) {
+        int k = (n - 1) - i;
+        int bit_val = (value & (0x01 << k)) >> k;
+        if (bit_val) {
+            int bit_pos = offset + i;
+            int byte_pos = bit_pos >> 3; // div 8
+            uint8_t *pos = (uint8_t *) (dst + byte_pos);
+            int shift = 7 - (bit_pos & 7); // mod 8
+            *pos ^= (0x01 << shift);
+        }
+    }
     return true;
 }

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -1019,50 +1019,6 @@ static inline term term_create_empty_binary(uint32_t size, Context *ctx)
 }
 
 /**
-* @brief Insert an integer into a binary (using bit syntax).
-*
-* @details Insert the low order n bits on value into the binary stored in t, starting
-* at the bit position starting in offset.
-* @param t a term pointing to binary data. Fails if t is not a binary term.
-* @param offset the bitwise offset in t at which to start writing the integer value
-* @param value the integer value to write
-* @param n the number of low-order bits from value to write.
-* @return 0 on success; non-zero value if:
-*           t is not a binary term
-*           n is greater than the number of bits in an integer
-*           there is insufficient capacity in the binary to write these bits
-* In general, none of these conditions should apply, if this function is being
-* called in the context of generated bit syntax instructions.
-*/
-static inline int term_bs_insert_integer(term t, avm_int_t offset, avm_int_t value, avm_int_t n)
-{
-    if (!term_is_binary(t)) {
-        return -1;
-    }
-    if ((unsigned int) n > sizeof(avm_int_t) * 8) {
-        return -2;
-    }
-    unsigned long capacity = term_binary_size(t);
-    if (8 * capacity < (unsigned long) (offset + n)) {
-        return -3;
-    }
-    // TODO optimize by xor'ing by byte (or mask on boundaries)
-    // TODO support big/little endian flags
-    for (int i = 0; i < n; ++i) {
-        int k = (n - 1) - i;
-        int bit_val = (value & (0x01 << k)) >> k;
-        if (bit_val) {
-            int bit_pos = offset + i;
-            int byte_pos = bit_pos / 8;
-            uint8_t *pos = (uint8_t *) (term_binary_data(t) + byte_pos);
-            int shift = 7 - (bit_pos % 8);
-            *pos ^= (0x01 << shift);
-        }
-    }
-    return 0;
-}
-
-/**
 * @brief Insert an binary into a binary (using bit syntax).
 *
 * @details Insert the data from the input binary, starting

--- a/src/libAtomVM/utils.h
+++ b/src/libAtomVM/utils.h
@@ -41,6 +41,9 @@
         #define READ_64_UNALIGNED(ptr) \
             __builtin_bswap64(*((uint64_t *) (ptr)))
 
+        #define WRITE_64_UNALIGNED(ptr, val) \
+            *((uint64_t *) (ptr)) = __builtin_bswap64(val)
+
         #define READ_32_UNALIGNED(ptr) \
             __builtin_bswap32(*((uint32_t *) (ptr)))
 
@@ -59,6 +62,14 @@
               (((uint64_t) ((uint8_t *)(ptr))[2]) << 40) | (((uint64_t) ((uint8_t *) (ptr))[3]) << 32) | \
               (((uint64_t) ((uint8_t *)(ptr))[4]) << 24) | (((uint64_t) ((uint8_t *) (ptr))[5]) << 16) | \
               (((uint64_t) ((uint8_t *)(ptr))[6]) << 8) | (((uint64_t) ((uint8_t *) (ptr))[7])) )
+
+        #define WRITE_64_UNALIGNED(ptr, val) \
+            *((uint64_t *) (ptr)) = ( \
+                ((uint64_t) ((uint8_t *)(&val))[0] << 56) | ((uint64_t) ((uint8_t *) (&val))[1] << 48) | \
+                ((uint64_t) ((uint8_t *)(&val))[2] << 40) | ((uint64_t) ((uint8_t *) (&val))[3] << 32) | \
+                ((uint64_t) ((uint8_t *)(&val))[4] << 24) | ((uint64_t) ((uint8_t *) (&val))[5] << 16) | \
+                ((uint64_t) ((uint8_t *)(&val))[6] <<  8) | (            (uint8_t *) (&val))[7] \
+            )
 
         #define READ_32_UNALIGNED(ptr) \
             ( (((uint8_t *)(ptr))[0] << 24) | (((uint8_t *) (ptr))[1] << 16) | (((uint8_t *)(ptr))[2] << 8) | ((uint8_t *)(ptr))[3] )

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -310,6 +310,7 @@ compile_erlang(test_match)
 compile_erlang(test_ordering_0)
 compile_erlang(test_ordering_1)
 compile_erlang(test_bs)
+compile_erlang(test_bs_int)
 compile_erlang(test_catch)
 compile_erlang(test_gc)
 compile_erlang(test_raise)
@@ -705,6 +706,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_ordering_0.beam
     test_ordering_1.beam
     test_bs.beam
+    test_bs_int.beam
     test_catch.beam
     test_gc.beam
     test_raise.beam

--- a/tests/erlang_tests/test_bs.erl
+++ b/tests/erlang_tests/test_bs.erl
@@ -32,8 +32,8 @@ start() ->
     error = test_create_with_invalid_int_size(),
     error = test_create_with_unsupported_int_unit(),
     error = test_create_with_unaligned_int_size(),
-    error = test_create_with_int_little_endian(),
-    error = test_create_with_int_signed(),
+    ok = test_create_with_int_little_endian(),
+    ok = test_create_with_int_signed(),
     error = test_create_with_invalid_binary_value(),
     error = test_create_with_invalid_binary_size(),
     error = test_create_with_binary_size_out_of_range(),
@@ -46,8 +46,8 @@ start() ->
     error = test_get_with_invalid_int_value(),
     error = test_get_with_invalid_int_size(),
     error = test_get_with_unsupported_int_unit(),
-    error = test_get_with_int_little_endian(),
-    error = test_get_with_int_signed(),
+    ok = test_get_with_int_little_endian(),
+    ok = test_get_with_int_signed(),
     error = test_get_with_invalid_binary_value(),
     error = test_get_with_invalid_binary_size(),
     error = test_get_with_unaligned_binary(),
@@ -122,10 +122,14 @@ test_create_with_unaligned_int_size() ->
     expect_error(fun() -> create_int_binary(16#FFFF, id(28)) end, unsupported).
 
 test_create_with_int_little_endian() ->
-    expect_error(fun() -> create_int_binary_little_endian(16#FFFF, id(32)) end, unsupported).
+    ok = expect_equals(<<255,255,0,0>>, create_int_binary_little_endian(16#FFFF, 32)),
+    ok = expect_equals(<<0,4,0,0>>, create_int_binary_little_endian(1024, 32)),
+    ok = expect_equals(<<0>>, create_int_binary_little_endian(1024, 8)),
+    ok.
 
 test_create_with_int_signed() ->
-    expect_error(fun() -> create_int_binary_signed(16#FFFF, id(32)) end, unsupported).
+    ok = expect_equals(<<0,0,255,255>>, create_int_binary_signed(16#FFFF, 32)),
+    ok.
 
 test_create_with_invalid_binary_value() ->
     expect_error(fun() -> create_binary_binary(foo, id(32)) end, badarg).
@@ -151,10 +155,10 @@ test_get_with_unsupported_int_unit() ->
     expect_error(fun() -> get_integer_big_unsigned_unit_3(16#F, id(32)) end, unsupported).
 
 test_get_with_int_little_endian() ->
-    expect_error(fun() -> get_integer_little_unsigned(16#FFFF, id(32)) end, unsupported).
+    expect_equals(1024, get_integer_little_unsigned(<<0,4,0,0>>, 32)).
 
 test_get_with_int_signed() ->
-    expect_error(fun() -> get_integer_big_signed(16#FFFF, id(32)) end, unsupported).
+    expect_equals(-1024, get_integer_big_signed(<<255,255,252,0>>, 32)).
 
 test_get_with_invalid_binary_value() ->
     expect_error(fun() -> get_binary_binary(foo, id(32)) end, badarg).
@@ -208,6 +212,11 @@ get_binary_binary(Bin, Size) ->
 get_int_then_binary(Bin, IntSize, BinSize) ->
     <<IntValue:IntSize/integer, BinValue:BinSize/binary, _Rest/binary>> = Bin,
     {IntValue, BinValue}.
+
+expect_equals(A, A) ->
+    ok;
+expect_equals(A, B) ->
+    throw({not_equal, A, B}).
 
 expect_error(F, _Reason) ->
     error = try

--- a/tests/erlang_tests/test_bs_int.erl
+++ b/tests/erlang_tests/test_bs_int.erl
@@ -1,0 +1,163 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_bs_int).
+
+-export([start/0]).
+
+start() ->
+    Binaries = generate_binaries(10, 64, []),
+
+    [test_bs_ints(Binaries, Size, Endianness, Signedness) ||
+        Size <- [32, 16, 8],
+        Endianness <- [big, little],
+        Signedness <- [unsigned, signed]
+    ],
+
+    [test_bs_ints(Binaries, Size, Endianness, Signedness) ||
+        Size <- [64],
+        Endianness <- [big, little],
+        Signedness <- [unsigned]
+    ],
+
+    0.
+
+
+generate_binaries(0, _Size, Accum) ->
+    Accum;
+generate_binaries(I, Size, Accum) ->
+    generate_binaries(I - 1, Size, [generate_binary(I, Size, []) | Accum]).
+
+generate_binary(_I, 0, Accum) ->
+    list_to_binary(Accum);
+generate_binary(I, Size, Accum) ->
+    %% semi-random numbers to ensure a distribution of values
+    NextI = case I rem 2 of 0 -> I * 7; _ -> I rem 3 end,
+    generate_binary(NextI, Size - 8, [I rem 256 | Accum]).
+
+
+test_bs_ints(Binaries, Size, Endianness, Signedness) ->
+    [test_bs_int(Binary, Size, Endianness, Signedness) || Binary <- Binaries].
+
+test_bs_int(Binary, Size, Endianness, Signedness) ->
+    IntValue = get_int_value(Binary, Size, Endianness, Signedness),
+    ComputeValue = compute_value(Binary, Size, Endianness, Signedness),
+    case IntValue of
+        ComputeValue ->
+            ByteSize = Size div 8,
+            <<ChoppedBinary:ByteSize/binary, _/binary>> = Binary,
+            PutBinary = put_int_value(IntValue, Size, Endianness, Signedness),
+            case PutBinary of
+                ChoppedBinary ->
+                    {Binary, Size, Endianness, Signedness, IntValue, PutBinary};
+                _ ->
+                    throw({error_failed_put, [
+                        {binary, Binary},
+                        {size, Size},
+                        {endianness, Endianness},
+                        {signedness, Signedness},
+                        {chopped_binary, ChoppedBinary},
+                        {put_binary, PutBinary}
+                    ]})
+            end;
+        _ ->
+            throw({error_failed_get, [
+                {binary, Binary},
+                {size, Size},
+                {endianness, Endianness},
+                {signedness, Signedness},
+                {int_value, IntValue},
+                {compute_value, ComputeValue}
+            ]})
+    end.
+
+get_int_value(Binary, Size, big, unsigned) ->
+    <<Val:Size/integer-big-unsigned, _/binary>> = Binary,
+    Val;
+get_int_value(Binary, Size, big, signed) ->
+    <<Val:Size/integer-big-signed, _/binary>> = Binary,
+    Val;
+get_int_value(Binary, Size, little, unsigned) ->
+    <<Val:Size/integer-little-unsigned, _/binary>> = Binary,
+    Val;
+get_int_value(Binary, Size, little, signed) ->
+    <<Val:Size/integer-little-signed, _/binary>> = Binary,
+    Val.
+
+put_int_value(Val, Size, big, unsigned) ->
+    <<Val:Size/integer-big-unsigned>>;
+put_int_value(Val, Size, big, signed) ->
+    <<Val:Size/integer-big-signed>>;
+put_int_value(Val, Size, little, unsigned) ->
+    <<Val:Size/integer-little-unsigned>>;
+put_int_value(Val, Size, little, signed) ->
+    <<Val:Size/integer-little-signed>>.
+
+
+compute_value(Bin, Size, Endianness, Signedness) when Size rem 8 =:= 0 ->
+    Bytes = Size div 8,
+    <<Data:Bytes/binary, _/binary>> = Bin,
+    ByteList = binary_to_list(Data),
+    NewByteList = case Endianness of
+        big ->
+            reverse(ByteList);
+        little ->
+            ByteList
+    end,
+    get_value(Signedness, accumulate(NewByteList, 0, 0), Size).
+
+get_value(signed, Value, Size) ->
+    %% https://en.wikipedia.org/wiki/Two%27s_complement#Converting_from_two's_complement_representation
+    -1 * ho_bit(Value, Size) * raise_2(Size - 1) + lo_bits(Value, Size);
+get_value(unsigned, Value, _Size) ->
+    Value.
+
+ho_bit(Value, Size) ->
+    Value bsr (Size - 1).
+
+raise_2(N) ->
+    1 bsl N.
+
+lo_bits(Value, Size) ->
+    Value band ones(Size - 1).
+
+ones(N) ->
+    ones(N, 0).
+
+ones(0, Accum) ->
+    Accum bor 1;
+ones(N, Accum) ->
+    ones(N - 1, Accum bor (1 bsl (N-1))).
+
+accumulate([], _I, Accum) ->
+    Accum;
+accumulate([H|T], I, Accum) ->
+    %% NB. AtomVM treats H as a signed value, so we need to remove the signedness for this accumulator
+    IntValue = case H < 0 of true -> (H band 16#7F) bor 16#80; _ -> H end,
+    Addend = (IntValue bsl (I * 8)),
+    accumulate(T, I + 1, Accum + Addend).
+
+reverse(List) ->
+    reverse(List, []).
+
+reverse([], Accum) ->
+    Accum;
+reverse([H|T], Accum) ->
+    reverse(T, [H|Accum]).

--- a/tests/test.c
+++ b/tests/test.c
@@ -330,6 +330,7 @@ struct Test tests[] =
     {"test_binary_to_term.beam", 0},
     {"test_selective_receive.beam", 0},
     {"test_bs.beam", 0},
+    {"test_bs_int.beam", 0},
     {"test_catch.beam", 0},
     {"test_gc.beam", 0 },
     {"test_raise.beam", 7},


### PR DESCRIPTION
This PR adds support for little endian and signed put operations (8, 16, and 32-bit) on integers in bit syntax.  These changes bring put operations in parity with get/match operations.

Changes include:

* Modified the OP_BS_PUT_INTEGER opcode implementation to support little-endian and signed puts for 8, 16, and 32-bit integers
* Added macros to bitstring.h to support 16 and 32-bit little endian puts
* Added `bitstring_insert_any_integer` function to bustling module for writing 8, 16, and 32-bit signed and little-endian integers -- moved old function from term.h to bustling module.
* Renamed exported `extract_any_integer` to use C-naming convention (use `bitstring_` prefix)
* Added a test to exercise combinations of bit syntax integer operations, and modified `test_bs` test module to properly handle put operations for tests that now pass.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
