### PR TITLE
Fix FreeBSD compilation error

### DIFF
--- a/src/platforms/generic_unix/socket_driver.c
+++ b/src/platforms/generic_unix/socket_driver.c
@@ -36,10 +36,11 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
+// FreeBSD 12 bug, sys/types must be included before netinet headers
+#include <sys/types.h>
 #include <netinet/in.h>
 #include <netinet/udp.h>
 #include <sys/socket.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 // #define ENABLE_TRACE


### PR DESCRIPTION
Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
