### PR TITLE
Fix multiple incorrect fprintf() format types.

### DIFF
--- a/src/libAtomVM/debug.c
+++ b/src/libAtomVM/debug.c
@@ -56,7 +56,7 @@ static COLD_FUNC void debug_dump_term(Context *ctx, term *pos, const char *regio
     // TODO use TERM_BITS instead
     char buf[32 + 1];
     debug_dump_binary_mem(buf, *pos, 32);
-    fprintf(stderr, "DEBUG: %s 0x%lx %3i: (%s)b 0x%09lx: ", region, (unsigned long) pos, i, buf, t);
+    fprintf(stderr, "DEBUG: %s 0x%lx %3i: (%s)b 0x%09u: ", region, (unsigned long) pos, i, buf, t);
     debug_display_type(t, ctx);
     fprintf(stderr, "\n");
 }

--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -301,7 +301,7 @@ static int serialize_term(Context *ctx, uint8_t *buf, term t)
         return k;
 
     } else {
-        fprintf(stderr, "Unknown external term type: %li\n", t);
+        fprintf(stderr, "Unknown external term type: %u\n", t);
         abort();
     }
 }

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -278,11 +278,11 @@ unsigned long memory_estimate_usage(term t)
             }
 
         } else {
-            fprintf(stderr, "bug: found unknown term type: 0x%lx\n", t);
+            fprintf(stderr, "bug: found unknown term type: 0x%u\n", t);
             if (term_is_boxed(t)) {
                 const term *boxed_value = term_to_const_term_ptr(t);
                 int boxed_size = term_boxed_size(t) + 1;
-                fprintf(stderr, "boxed header: 0x%lx, size: %i\n", boxed_value[0], boxed_size);
+                fprintf(stderr, "boxed header: 0x%u, size: %i\n", boxed_value[0], boxed_size);
             }
             abort();
         }
@@ -397,7 +397,7 @@ static void memory_scan_and_copy(term *mem_start, const term *mem_end, term **ne
                     break;
 
                 default:
-                    fprintf(stderr, "- Found unknown boxed type: %lx\n", (t >> 2) & 0xF);
+                    fprintf(stderr, "- Found unknown boxed type: %u\n", (t >> 2) & 0xF);
                     abort();
             }
 
@@ -414,7 +414,7 @@ static void memory_scan_and_copy(term *mem_start, const term *mem_end, term **ne
             ptr++;
 
         } else {
-            fprintf(stderr, "bug: found unknown term type: 0x%lx\n", t);
+            fprintf(stderr, "bug: found unknown term type: 0x%u\n", t);
             abort();
         }
     }
@@ -500,7 +500,7 @@ HOT_FUNC static term memory_shallow_copy_term(term t, term **new_heap, int move)
         return new_term;
 
     } else {
-        fprintf(stderr, "Unexpected term. Term is: %lx\n", t);
+        fprintf(stderr, "Unexpected term. Term is: %u\n", t);
         abort();
     }
 }

--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -195,7 +195,7 @@ void term_display(FILE *fd, term t, const Context *ctx)
 #endif
 
     } else {
-        fprintf(fd, "Unknown term type: %li", t);
+        fprintf(fd, "Unknown term type: %u", t);
     }
 }
 


### PR DESCRIPTION
  When compiling for ESP32 this fixes multiple "warning: format __ expects
argument of type (VARIOUS)"

Signed-off-by: Winford <69995513+UncleGrumpy@users.noreply.github.com>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
