### PR TITLE
Fix multiple warning: comparison of integer expressions of different signedness

### DIFF
--- a/src/libAtomVM/bitstring.c
+++ b/src/libAtomVM/bitstring.c
@@ -63,7 +63,7 @@ bool bitstring_insert_any_integer(uint8_t *dst, avm_int_t offset, avm_int64_t va
     if (bs_flags != 0) {
         return false;
     }
-    for (int i = 0; i < n; ++i) {
+    for (uint8_t i = 0; i < n; ++i) {
         int k = (n - 1) - i;
         int bit_val = (value & (0x01 << k)) >> k;
         if (bit_val) {

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -4552,9 +4552,9 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     // and kv together into new map.  Both src and kv are sorted.
                     //
                     term map = term_alloc_map_maybe_shared(ctx, new_map_size, is_shared ? term_get_map_keys(src) : term_invalid_term());
-                    int src_pos = 0;
+                    uint8_t src_pos = 0;
                     int kv_pos = 0;
-                    for (int j = 0; j < new_map_size; j++) {
+                    for (uint8_t j = 0; j < new_map_size; j++) {
                         if (src_pos >= src_size) {
                             term new_key = kv[kv_pos].key;
                             term new_value = kv[kv_pos].value;
@@ -4642,7 +4642,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     // Create a new map of the same size as src and populate with entries from src
                     //
                     term map = term_alloc_map_maybe_shared(ctx, src_size, term_get_map_keys(src));
-                    for (int j = 0;  j < src_size;  ++j) {
+                    for (uint8_t j = 0;  j < src_size;  ++j) {
                         term_set_map_assoc(map, j, term_get_map_key(src, j), term_get_map_value(src, j));
                     }
                     //


### PR DESCRIPTION

  When compiling for ESP32 with ESP-IDF-v4.2.3 there were multiple warning:
"comparison of integer expressions of different signedness: 'int' and 'size_t'
{aka 'unsigned int'}"

Signed-off-by: Winford <69995513+UncleGrumpy@users.noreply.github.com>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
