### PR TITLE
Added macro for calls to abort()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the ability to specify the HSPI or VSPI ESP32 hardware interfaces when initializing the SPI
   Bus.
 - Added support for the `spi:close/1` function.
+- Added AVM_VERBOSE_ABORT CMake define, which when set to on, will print the C module and line
+  number when a VM abort occurs.  This define is off by default.
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ if (AVM_USE_32BIT_FLOAT)
     add_definitions(-DAVM_USE_SINGLE_PRECISION)
 endif()
 
+option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
+if (AVM_VERBOSE_ABORT)
+    add_definitions(-DAVM_VERBOSE_ABORT)
+endif()
+
 add_subdirectory(src)
 add_subdirectory(tests)
 add_subdirectory(tools/packbeam)

--- a/src/libAtomVM/atom.c
+++ b/src/libAtomVM/atom.c
@@ -64,7 +64,7 @@ void atom_write_mfa(char *buf, size_t buf_size, AtomString module, AtomString fu
     unsigned int function_name_len = atom_string_len(function);
     if (UNLIKELY((arity > 9) || (module_name_len + function_name_len + 4 > buf_size))) {
         fprintf(stderr, "Insufficient room to write mfa.\n");
-        abort();
+        AVM_ABORT();
     }
     memcpy(buf + module_name_len + 1, atom_string_data(function), function_name_len);
 

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -385,7 +385,7 @@ static term add_boxed_helper(Context *ctx, term arg1, term arg2)
     switch (size) {
         case 0: {
             //BUG
-            abort();
+            AVM_ABORT();
         }
 
         case 1: {
@@ -502,7 +502,7 @@ static term sub_boxed_helper(Context *ctx, term arg1, term arg2)
     switch (size) {
         case 0: {
             //BUG
-            abort();
+            AVM_ABORT();
         }
 
         case 1: {
@@ -633,7 +633,7 @@ static term mul_boxed_helper(Context *ctx, term arg1, term arg2)
     switch (size) {
         case 0: {
             //BUG
-            abort();
+            AVM_ABORT();
         }
 
         case 1: {
@@ -715,7 +715,7 @@ static term div_boxed_helper(Context *ctx, term arg1, term arg2)
     switch (size) {
         case 0: {
             //BUG
-            abort();
+            AVM_ABORT();
         }
 
         case 1: {
@@ -804,7 +804,7 @@ static term neg_boxed_helper(Context *ctx, term arg1)
         switch (term_boxed_size(arg1)) {
             case 0:
                 //BUG
-                abort();
+                AVM_ABORT();
 
             case 1: {
                 avm_int_t val = term_unbox_int(arg1);
@@ -893,7 +893,7 @@ static term abs_boxed_helper(Context *ctx, term arg1)
         switch (term_boxed_size(arg1)) {
             case 0:
                 //BUG
-                abort();
+                AVM_ABORT();
 
             case 1: {
                 avm_int_t val = term_unbox_int(arg1);
@@ -984,7 +984,7 @@ static term rem_boxed_helper(Context *ctx, term arg1, term arg2)
     switch (size) {
         case 0: {
             //BUG
-            abort();
+            AVM_ABORT();
         }
 
         case 1: {

--- a/src/libAtomVM/ccontext.h
+++ b/src/libAtomVM/ccontext.h
@@ -93,11 +93,11 @@ static inline term_ref ccontext_make_term_ref(struct CContext *ccontext, term t)
             case MEMORY_GC_ERROR_FAILED_ALLOCATION:
                 // TODO Improve error handling
                 fprintf(stderr, "Failed to allocate additional heap storage: [%s:%i]\n", __FILE__, __LINE__);
-                abort();
+                AVM_ABORT();
             case MEMORY_GC_DENIED_ALLOCATION:
                 // TODO Improve error handling
                 fprintf(stderr, "Not permitted to allocate additional heap storage: [%s:%i]\n", __FILE__, __LINE__);
-                abort();
+                AVM_ABORT();
         }
     }
 

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -171,7 +171,7 @@ static void context_monitors_handle_terminate(Context *ctx)
                 if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(3)) != MEMORY_GC_OK)) {
                     //TODO: handle out of memory here
                     fprintf(stderr, "Cannot handle out of memory.\n");
-                    abort();
+                    AVM_ABORT();
                 }
 
                 // TODO: move it out of heap
@@ -193,7 +193,7 @@ static void context_monitors_handle_terminate(Context *ctx)
             if (UNLIKELY(memory_ensure_free(ctx, required_terms) != MEMORY_GC_OK)) {
                 //TODO: handle out of memory here
                 fprintf(stderr, "Cannot handle out of memory.\n");
-                abort();
+                AVM_ABORT();
             }
 
             // TODO: move it out of heap

--- a/src/libAtomVM/defaultatoms.c
+++ b/src/libAtomVM/defaultatoms.c
@@ -169,7 +169,7 @@ void defaultatoms_init(GlobalContext *glb)
     ok &= globalcontext_insert_atom(glb, lowercase_exit_atom) == LOWERCASE_EXIT_ATOM_INDEX;
 
     if (!ok) {
-        abort();
+        AVM_ABORT();
     }
 
     platform_defaultatoms_init(glb);

--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -144,7 +144,7 @@ static int externalterm_from_term(Context *ctx, uint8_t **buf, size_t *len, term
     *buf = malloc(*len);
     if (UNLIKELY(IS_NULL_PTR(*buf))) {
         fprintf(stderr, "Unable to allocate %zu bytes for externalized term.\n", *len);
-        abort();
+        AVM_ABORT();
     }
     size_t k = serialize_term(ctx, *buf + 1, t);
     *buf[0] = EXTERNAL_TERM_TAG;
@@ -214,7 +214,7 @@ static int serialize_term(Context *ctx, uint8_t *buf, term t)
         size_t arity = term_get_tuple_arity(t);
         if (arity > 255) {
             fprintf(stderr, "Tuple arity greater than 255: %zu\n", arity);
-            abort();
+            AVM_ABORT();
         }
         if (!IS_NULL_PTR(buf)) {
             buf[0] = SMALL_TUPLE_EXT;
@@ -302,7 +302,7 @@ static int serialize_term(Context *ctx, uint8_t *buf, term t)
 
     } else {
         fprintf(stderr, "Unknown external term type: %li\n", t);
-        abort();
+        AVM_ABORT();
     }
 }
 

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -127,7 +127,7 @@ void globalcontext_register_process(GlobalContext *glb, int atom_index, int loca
     struct RegisteredProcess *registered_process = malloc(sizeof(struct RegisteredProcess));
     if (IS_NULL_PTR(registered_process)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     registered_process->atom_index = atom_index;
     registered_process->local_process_id = local_process_id;
@@ -171,7 +171,7 @@ int globalcontext_insert_atom_maybe_copy(GlobalContext *glb, AtomString atom_str
             uint8_t *buf = malloc(1 + len);
             if (UNLIKELY(IS_NULL_PTR(buf))) {
                 fprintf(stderr, "Unable to allocate memory for atom string\n");
-                abort();
+                AVM_ABORT();
             }
             memcpy(buf, atom_string, 1 + len);
             atom_string = buf;
@@ -191,7 +191,7 @@ int globalcontext_insert_atom_maybe_copy(GlobalContext *glb, AtomString atom_str
 AtomString globalcontext_atomstring_from_term(GlobalContext *glb, term t)
 {
     if (!term_is_atom(t)) {
-        abort();
+        AVM_ABORT();
     }
     unsigned long atom_index = term_to_atom_index(t);
     unsigned long ret = valueshashtable_get_value(glb->atoms_ids_table, atom_index, ULONG_MAX);
@@ -212,7 +212,7 @@ int globalcontext_insert_module(GlobalContext *global, Module *module, AtomStrin
     Module **new_modules_by_index = calloc(module_index + 1, sizeof(Module *));
     if (IS_NULL_PTR(new_modules_by_index)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     if (global->modules_by_index) {
         for (int i = 0; i < module_index; i++) {
@@ -237,19 +237,19 @@ void globalcontext_insert_module_with_filename(GlobalContext *glb, Module *modul
 
     if (strcmp(filename + len_without_ext, ".beam") != 0) {
         printf("File isn't a .beam file\n");
-        abort();
+        AVM_ABORT();
     }
 
     char *atom_string = malloc(len_without_ext + 1);
     if (IS_NULL_PTR(atom_string)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     memcpy(atom_string + 1, filename, len_without_ext);
     atom_string[0] = len_without_ext;
 
     if (UNLIKELY(globalcontext_insert_module(glb, module, atom_string) < 0)) {
-        abort();
+        AVM_ABORT();
     }
 }
 

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -284,7 +284,7 @@ unsigned long memory_estimate_usage(term t)
                 int boxed_size = term_boxed_size(t) + 1;
                 fprintf(stderr, "boxed header: 0x%lx, size: %i\n", boxed_value[0], boxed_size);
             }
-            abort();
+            AVM_ABORT();
         }
     }
 
@@ -398,7 +398,7 @@ static void memory_scan_and_copy(term *mem_start, const term *mem_end, term **ne
 
                 default:
                     fprintf(stderr, "- Found unknown boxed type: %lx\n", (t >> 2) & 0xF);
-                    abort();
+                    AVM_ABORT();
             }
 
             ptr += term_get_size_from_boxed_header(t) + 1;
@@ -415,7 +415,7 @@ static void memory_scan_and_copy(term *mem_start, const term *mem_end, term **ne
 
         } else {
             fprintf(stderr, "bug: found unknown term type: 0x%lx\n", t);
-            abort();
+            AVM_ABORT();
         }
     }
 
@@ -501,7 +501,7 @@ HOT_FUNC static term memory_shallow_copy_term(term t, term **new_heap, int move)
 
     } else {
         fprintf(stderr, "Unexpected term. Term is: %lx\n", t);
-        abort();
+        AVM_ABORT();
     }
 }
 

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -131,7 +131,7 @@ void module_get_imported_function_module_and_name(const Module *this_module, int
     int functions_count = READ_32_ALIGNED(table_data + 8);
 
     if (UNLIKELY(index > functions_count)) {
-        abort();
+        AVM_ABORT();
     }
     int local_module_atom_index = READ_32_ALIGNED(table_data + index * 12 + 12);
     int local_function_atom_index = READ_32_ALIGNED(table_data + index * 12 + 4 + 12);
@@ -313,7 +313,7 @@ term module_load_literal(Module *mod, int index, Context *ctx)
     term t = externalterm_to_term(mod->literals_table[index], ctx, 1);
     if (term_is_invalid_term(t)) {
         fprintf(stderr, "Invalid term reading literals_table[%i] from module\n", index);
-        abort();
+        AVM_ABORT();
     }
     return t;
 }

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -199,7 +199,7 @@ static inline uint32_t module_get_fun_freeze(const Module *this_module, int fun_
     int funs_count = READ_32_ALIGNED(table_data + 8);
 
     if (UNLIKELY(fun_index >= funs_count)) {
-        abort();
+        AVM_ABORT();
     }
 
     // fun atom index
@@ -218,7 +218,7 @@ static inline void module_get_fun(const Module *this_module, int fun_index, uint
     int funs_count = READ_32_ALIGNED(table_data + 8);
 
     if (UNLIKELY(fun_index >= funs_count)) {
-        abort();
+        AVM_ABORT();
     }
 
     // fun atom index

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -610,7 +610,7 @@ const struct Nif *nifs_get(AtomString module, AtomString function, int arity)
 
     int function_name_len = atom_string_len(function);
     if (UNLIKELY((arity > 9) || (module_name_len + function_name_len + 4 > MAX_NIF_NAME_LEN))) {
-        abort();
+        AVM_ABORT();
     }
     memcpy(nifname + module_name_len + 1, atom_string_data(function), function_name_len);
 
@@ -905,7 +905,7 @@ static term nif_erlang_spawn_fun(Context *ctx, int argc, term argv[])
         // it is not possible to spawn a function reference except for those having
         // 0 arity, however right now they are not supported.
         // TODO: implement for funs having arity 0.
-        abort();
+        AVM_ABORT();
     }
     uint32_t fun_index = term_to_int32(index_or_module);
 
@@ -923,7 +923,7 @@ static term nif_erlang_spawn_fun(Context *ctx, int argc, term argv[])
     if (UNLIKELY(memory_ensure_free(new_ctx, size) != MEMORY_GC_OK)) {
         //TODO: new process should be terminated, however a new pid is returned anyway
         fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
-        abort();
+        AVM_ABORT();
     }
     for (uint32_t i = 0; i < n_freeze; i++) {
         new_ctx->x[i + arity - n_freeze] = memory_copy_term_tree(&new_ctx->heap_ptr, boxed_value[i + 3], &new_ctx->mso_list);
@@ -980,7 +980,7 @@ static term nif_erlang_spawn(Context *ctx, int argc, term argv[])
     int label = module_search_exported_function(found_module, function_string, args_len);
     //TODO: fail here if no function has been found
     if (UNLIKELY(label == 0)) {
-        abort();
+        AVM_ABORT();
     }
     new_ctx->saved_module = found_module;
     new_ctx->saved_ip = found_module->labels[label];
@@ -994,7 +994,7 @@ static term nif_erlang_spawn(Context *ctx, int argc, term argv[])
     if (min_heap_size_term != term_nil()) {
         if (UNLIKELY(!term_is_integer(min_heap_size_term))) {
             //TODO: gracefully handle this error
-            abort();
+            AVM_ABORT();
         }
         new_ctx->has_min_heap_size = 1;
         new_ctx->min_heap_size = term_to_int(min_heap_size_term);
@@ -1004,7 +1004,7 @@ static term nif_erlang_spawn(Context *ctx, int argc, term argv[])
     if (max_heap_size_term != term_nil()) {
         if (UNLIKELY(!term_is_integer(max_heap_size_term))) {
             //TODO: gracefully handle this error
-            abort();
+            AVM_ABORT();
         }
         new_ctx->has_max_heap_size = 1;
         new_ctx->max_heap_size = term_to_int(max_heap_size_term);
@@ -1022,7 +1022,7 @@ static term nif_erlang_spawn(Context *ctx, int argc, term argv[])
         int res = context_monitor(new_ctx, term_from_local_process_id(ctx->process_id), true);
         if (UNLIKELY(res == 0)) {
             fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
-            abort();
+            AVM_ABORT();
         }
         // This is a really simple hack to get the parent - child linking
         // I don't really like how it is implemented but it works nicely.
@@ -1030,13 +1030,13 @@ static term nif_erlang_spawn(Context *ctx, int argc, term argv[])
         res = context_monitor(ctx, term_from_local_process_id(new_ctx->process_id), true);
         if (UNLIKELY(res == 0)) {
             fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
-            abort();
+            AVM_ABORT();
         }
     } else if (monitor_term == TRUE_ATOM) {
         ref_ticks = context_monitor(new_ctx, term_from_local_process_id(ctx->process_id), false);
         if (UNLIKELY(ref_ticks == 0)) {
             fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
-            abort();
+            AVM_ABORT();
         }
     }
 
@@ -1047,7 +1047,7 @@ static term nif_erlang_spawn(Context *ctx, int argc, term argv[])
     if (UNLIKELY(memory_ensure_free(new_ctx, size) != MEMORY_GC_OK)) {
         //TODO: new process should be terminated, however a new pid is returned anyway
         fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
-        abort();
+        AVM_ABORT();
     }
     while (term_is_nonempty_list(t)) {
         new_ctx->x[reg_index] = memory_copy_term_tree(&new_ctx->heap_ptr, term_get_list_head(t), &new_ctx->mso_list);
@@ -1066,7 +1066,7 @@ static term nif_erlang_spawn(Context *ctx, int argc, term argv[])
         if (UNLIKELY(memory_ensure_free(ctx, res_size) != MEMORY_GC_OK)) {
             //TODO: new process should be terminated, however a new pid is returned anyway
             fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
-            abort();
+            AVM_ABORT();
         }
 
         term ref = term_from_ref_ticks(ref_ticks, ctx);
@@ -1615,7 +1615,7 @@ static term binary_to_atom(Context *ctx, int argc, term argv[], int create_new)
     char *atom_string = interop_binary_to_string(a_binary);
     if (IS_NULL_PTR(atom_string)) {
         fprintf(stderr, "Failed to alloc temporary string\n");
-        abort();
+        AVM_ABORT();
     }
     int atom_string_len = strlen(atom_string);
     if (UNLIKELY(atom_string_len > 255)) {
@@ -1665,7 +1665,7 @@ term list_to_atom(Context *ctx, int argc, term argv[], int create_new)
     char *atom_string = interop_list_to_string(a_list, &ok);
     if (UNLIKELY(!ok)) {
         fprintf(stderr, "Failed to alloc temporary string\n");
-        abort();
+        AVM_ABORT();
     }
     int atom_string_len = strlen(atom_string);
     if (UNLIKELY(atom_string_len > 255)) {

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -106,7 +106,7 @@ typedef union
                                                                                         \
                 default:                                                                \
                     fprintf(stderr, "Operand not literal: %x, or unsupported encoding\n", (first_byte)); \
-                    abort();                                                            \
+                    AVM_ABORT();                                                        \
                     break;                                                              \
             }                                                                           \
             break;                                                                      \
@@ -127,13 +127,13 @@ typedef union
                     }else if (ext == 0x8) {                                             \
                         next_operand_offset += 3;                                       \
                     } else {                                                            \
-                        abort();                                                        \
+                        AVM_ABORT();                                                    \
                     }                                                                   \
                     break;                                                              \
                 }                                                                       \
                 default:                                                                \
                     printf("Unexpected %i\n", (int) first_byte);                        \
-                    abort();                                                            \
+                    AVM_ABORT();                                                        \
                     break;                                                              \
             }                                                                           \
             break;                                                                      \
@@ -162,7 +162,7 @@ typedef union
                                                                                         \
         default:                                                                        \
             fprintf(stderr, "unknown compect term type: %i\n", ((first_byte) & 0xF));   \
-            abort();                                                                    \
+            AVM_ABORT();                                                                \
             break;                                                                      \
     }                                                                                   \
 }
@@ -183,7 +183,7 @@ typedef union
             next_operand_offset += 2;                                                               \
             break;                                                                                  \
         default:                                                                                    \
-            abort();                                                                                \
+            AVM_ABORT();                                                                            \
     }                                                                                               \
 }
 #endif
@@ -213,7 +213,7 @@ typedef union
                                                                                                                         \
                 default:                                                                                                \
                     fprintf(stderr, "Operand not a literal: %x, or unsupported encoding\n", (first_byte));              \
-                    abort();                                                                                            \
+                    AVM_ABORT();                                                                                        \
                     break;                                                                                              \
             }                                                                                                           \
             break;                                                                                                      \
@@ -373,7 +373,7 @@ typedef union
                                                                                                     \
         default:                                                                                    \
             fprintf(stderr, "Operand not a label: %x, or unsupported encoding\n", (first_byte));    \
-            abort();                                                                                \
+            AVM_ABORT();                                                                            \
             break;                                                                                  \
     }                                                                                               \
 }
@@ -395,7 +395,7 @@ typedef union
                                                                                                     \
         default:                                                                                    \
             fprintf(stderr, "Operand not a label: %x, or unsupported encoding\n", (first_byte));    \
-            abort();                                                                                \
+            AVM_ABORT();                                                                            \
             break;                                                                                  \
     }                                                                                               \
 }
@@ -417,7 +417,7 @@ typedef union
                                                                                                     \
         default:                                                                                    \
             fprintf(stderr, "Operand not an integer: %x, or unsupported encoding\n", (first_byte)); \
-            abort();                                                                                \
+            AVM_ABORT();                                                                            \
             break;                                                                                  \
     }                                                                                               \
 }
@@ -1210,7 +1210,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         }
                         default: {
                             fprintf(stderr, "Invalid function type %i at index: %i\n", func->type, index);
-                            abort();
+                            AVM_ABORT();
                         }
                     }
                 #endif
@@ -1278,7 +1278,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         }
                         default: {
                             fprintf(stderr, "Invalid function type %i at index: %i\n", func->type, index);
-                            abort();
+                            AVM_ABORT();
                         }
                     }
                 #endif
@@ -1402,7 +1402,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 #ifdef IMPL_EXECUTE_LOOP
                     if (live > ctx->avail_registers) {
                         fprintf(stderr, "Cannot use more than 16 registers.");
-                        abort();
+                        AVM_ABORT();
                     }
 
                     context_clean_registers(ctx, live);
@@ -1436,7 +1436,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 #ifdef IMPL_EXECUTE_LOOP
                     if (live > ctx->avail_registers) {
                         fprintf(stderr, "Cannot use more than 16 registers.");
-                        abort();
+                        AVM_ABORT();
                     }
 
                     context_clean_registers(ctx, live);
@@ -1467,7 +1467,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 #ifdef IMPL_EXECUTE_LOOP
                     if (live > ctx->avail_registers) {
                         fprintf(stderr, "Cannot use more than 16 registers.");
-                        abort();
+                        AVM_ABORT();
                     }
 
                     context_clean_registers(ctx, live);
@@ -1505,7 +1505,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 #ifdef IMPL_EXECUTE_LOOP
                     if (live > ctx->avail_registers) {
                         fprintf(stderr, "Cannot use more than 16 registers.");
-                        abort();
+                        AVM_ABORT();
                     }
 
                     context_clean_registers(ctx, live);
@@ -2546,7 +2546,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
                 #ifdef IMPL_EXECUTE_LOOP
                     if (UNLIKELY(!term_is_tuple(src_value) || (element < 0) || (element >= term_get_tuple_arity(src_value)))) {
-                        abort();
+                        AVM_ABORT();
                     }
 
                     term t = term_get_tuple_element(src_value, element);
@@ -2574,7 +2574,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
 #ifdef IMPL_EXECUTE_LOOP
                 if (UNLIKELY(!term_is_tuple(tuple) || (position < 0) || (position >= term_get_tuple_arity(tuple)))) {
-                    abort();
+                    AVM_ABORT();
                 }
 
                 term_put_tuple_element(tuple, position, new_element);
@@ -2639,7 +2639,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 for (int j = 0; j < size; j++) {
                     if (code[i + next_off] != OP_PUT) {
                         fprintf(stderr, "Expected put, got opcode: %i\n", code[i + next_off]);
-                        abort();
+                        AVM_ABORT();
                     }
                     next_off++;
                     term put_value;
@@ -2928,7 +2928,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                             break;
                         }
                         default: {
-                            abort();
+                            AVM_ABORT();
                         }
                     }
                 #endif
@@ -3737,7 +3737,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     } else if (term_is_integer(index)) {
                         index_val = term_to_int(index);
                     } else {
-                        abort();
+                        AVM_ABORT();
                     }
                     term_match_state_save_offset(src, index_val);
 
@@ -3769,7 +3769,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     } else if (term_is_integer(index)) {
                         index_val = term_to_int(index);
                     } else {
-                        abort();
+                        AVM_ABORT();
                     }
                     term_match_state_restore_offset(src, index_val);
 
@@ -4958,7 +4958,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     fprintf(stderr, "failed at %i\n", i);
                 #endif
 
-                abort();
+                AVM_ABORT();
                 return 1;
         }
 

--- a/src/libAtomVM/port.c
+++ b/src/libAtomVM/port.c
@@ -92,11 +92,11 @@ void port_ensure_available(Context *ctx, size_t size)
             case MEMORY_GC_ERROR_FAILED_ALLOCATION:
                 // TODO Improve error handling
                 fprintf(stderr, "Failed to allocate additional heap storage: [%s:%i]\n", __FILE__, __LINE__);
-                abort();
+                AVM_ABORT();
             case MEMORY_GC_DENIED_ALLOCATION:
                 // TODO Improve error handling
                 fprintf(stderr, "Not permitted to allocate additional heap storage: [%s:%i]\n", __FILE__, __LINE__);
-                abort();
+                AVM_ABORT();
         }
     }
 }

--- a/src/libAtomVM/scheduler.c
+++ b/src/libAtomVM/scheduler.c
@@ -153,7 +153,7 @@ void scheduler_set_timeout(Context *ctx, uint32_t timeout)
 
     struct TimerWheelItem *twi = &ctx->timer_wheel_head;
     if (UNLIKELY(twi->callback)) {
-        abort();
+        AVM_ABORT();
     }
 
     uint64_t expiry = timer_wheel_expiry_to_monotonic(tw, timeout);

--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -185,7 +185,7 @@ void term_display(FILE *fd, term t, const Context *ctx)
 #endif
 
             default:
-                abort();
+                AVM_ABORT();
         }
 
 #ifndef AVM_NO_FP
@@ -235,7 +235,7 @@ static int term_type_to_index(term t)
         return 11;
 
     } else {
-        abort();
+        AVM_ABORT();
     }
 }
 
@@ -439,7 +439,7 @@ term term_alloc_refc_binary(Context *ctx, size_t size, bool is_const)
         if (IS_NULL_PTR(refc)) {
             // TODO propagate error to callers of this function, e.g., as an invalid term
             fprintf(stderr, "memory_create_refc_binary: Unable to allocate %zu bytes for refc_binary.\n", size);
-            abort();
+            AVM_ABORT();
         }
         boxed_value[3] = (term) refc;
         ctx->mso_list = term_list_init_prepend(boxed_value + 4, ret, ctx->mso_list);

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -625,7 +625,7 @@ static inline term term_from_int32(int32_t value)
     if (UNLIKELY((value > 268435455) || (value < -268435455))) {
         //TODO: unimplemented on heap integer value
         fprintf(stderr, "term_from_int32: unimplemented: term should be moved to heap.");
-        abort();
+        AVM_ABORT();
 
     } else {
         return (value << 4) | 0xF;
@@ -646,7 +646,7 @@ static inline term term_from_int64(int64_t value)
     if (UNLIKELY((value > 268435455) || (value < -268435455))) {
         //TODO: unimplemented on heap integer value
         fprintf(stderr, "term_from_int64: unimplemented: term should be moved to heap.");
-        abort();
+        AVM_ABORT();
 
     } else {
         return (value << 4) | 0xF;
@@ -657,7 +657,7 @@ static inline term term_from_int64(int64_t value)
     if (UNLIKELY((value > 1152921504606846975) || (value < -1152921504606846975))) {
         //TODO: unimplemented on heap integer value
         fprintf(stderr, "unimplemented: term should be moved to heap.");
-        abort();
+        AVM_ABORT();
 
     } else {
         return (value << 4) | 0xF;

--- a/src/libAtomVM/utils.h
+++ b/src/libAtomVM/utils.h
@@ -164,4 +164,15 @@ static inline void *rand_fail_calloc(int n, unsigned long alloc_size)
 
 #endif
 
+#ifdef AVM_BERBOSE_ABORT
+#include <stdio.h>
+#define AVM_ABORT()                                                       \
+{                                                                         \
+    fprintf(stderr, "Abort in file %s at line %i\n", __FILE__, __LINE__); \
+    abort();                                                              \
+}
+#else
+#define AVM_ABORT() abort()
+#endif
+
 #endif

--- a/src/platforms/esp32/main/gpio_driver.c
+++ b/src/platforms/esp32/main/gpio_driver.c
@@ -225,7 +225,7 @@ void gpio_interrupt_callback(EventListener *listener)
     if (UNLIKELY(memory_ensure_free(global_gpio_ctx, 3) != MEMORY_GC_OK)) {
         //TODO: it must not fail
         ESP_LOGE(TAG, "gpio_interrupt_callback: Failed to ensure free heap space.");
-        abort();
+        AVM_ABORT();
     }
 
     term int_msg = term_alloc_tuple(2, global_gpio_ctx);
@@ -323,7 +323,7 @@ static term gpiodriver_set_int(Context *ctx, Context *target, term cmd)
     struct GPIOListenerData *data = malloc(sizeof(struct GPIOListenerData));
     if (IS_NULL_PTR(data)) {
         ESP_LOGE(TAG, "gpiodriver_set_int: Failed to ensure free heap space.");
-        abort();
+        AVM_ABORT();
     }
     list_append(&gpio_data->gpio_listeners, &data->gpio_listener_list_head);
     data->gpio = gpio_num;

--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -83,17 +83,17 @@ void app_main()
 
     if (!avmpack_is_valid(main_avm, size)) {
         ESP_LOGE(TAG, "Invalid main.avm packbeam.  size=%u", size);
-        abort();
+        AVM_ABORT();
     }
     if (!avmpack_find_section_by_flag(main_avm, BEAM_START_FLAG, &startup_beam, &startup_beam_size, &startup_module_name)) {
         ESP_LOGE(TAG, "Error: Failed to locate start module in main.avm packbeam.  (Did you flash a library by mistake?)");
-        abort();
+        AVM_ABORT();
     }
     ESP_LOGI(TAG, "Found startup beam %s", startup_module_name);
     struct AVMPackData *avmpack_data = malloc(sizeof(struct AVMPackData));
     if (IS_NULL_PTR(avmpack_data)) {
         ESP_LOGE(TAG, "Memory error: Cannot allocate AVMPackData for main.avm.");
-        abort();
+        AVM_ABORT();
     }
     avmpack_data->data = main_avm;
     list_append(&glb->avmpack_data, (struct ListHead *) avmpack_data);
@@ -104,7 +104,7 @@ void app_main()
         avmpack_data = malloc(sizeof(struct AVMPackData));
         if (IS_NULL_PTR(avmpack_data)) {
             ESP_LOGE(TAG, "Memory error: Cannot allocate AVMPackData for lib.avm.");
-            abort();
+            AVM_ABORT();
         }
         avmpack_data->data = lib_avm;
         list_append(&glb->avmpack_data, (struct ListHead *) avmpack_data);
@@ -115,7 +115,7 @@ void app_main()
     Module *mod = module_new_from_iff_binary(glb, startup_beam, startup_beam_size);
     if (IS_NULL_PTR(mod)) {
         ESP_LOGE(TAG, "Error!  Unable to load startup module %s", startup_module_name);
-        abort();
+        AVM_ABORT();
     }
     globalcontext_insert_module_with_filename(glb, mod, startup_module_name);
     Context *ctx = context_new(glb);
@@ -166,7 +166,7 @@ const void *avm_partition(const char *partition_name, int *size)
     spi_flash_mmap_handle_t unmap_handle;
     if (esp_partition_mmap(partition, 0, partition->size, SPI_FLASH_MMAP_DATA, &mapped_memory, &unmap_handle) != ESP_OK) {
         ESP_LOGE(TAG, "Failed to map BEAM partition for %s", partition_name);
-        abort();
+        AVM_ABORT();
         return NULL;
     }
     ESP_LOGI(TAG, "Loaded BEAM partition %s at address 0x%x (size=%i bytes)", partition_name, partition->address, partition->size);

--- a/src/platforms/esp32/main/network_driver.c
+++ b/src/platforms/esp32/main/network_driver.c
@@ -155,7 +155,7 @@ static wifi_config_t *get_sta_wifi_config(term sta_config)
     wifi_config_t *wifi_config = malloc(sizeof(wifi_config_t));
     if (IS_NULL_PTR(wifi_config)) {
         fprintf(stderr, "Failed to allocate wifi_config_t %s:%d\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     if (UNLIKELY(strlen(ssid) > sizeof(wifi_config->sta.ssid))) {
         fprintf(stderr, "ssid cannot be more than %d characters\n", sizeof(wifi_config->sta.ssid));
@@ -195,7 +195,7 @@ static char *get_default_device_name()
     char *buf = malloc(buf_size);
     if (IS_NULL_PTR(buf)) {
         fprintf(stderr, "Failed to allocate buf %s:%d\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     snprintf(buf, buf_size,
         "atomvm-%02x%02x%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
@@ -246,7 +246,7 @@ static wifi_config_t *get_ap_wifi_config(term ap_config)
     wifi_config_t *wifi_config = malloc(sizeof(wifi_config_t));
     if (IS_NULL_PTR(wifi_config)) {
         fprintf(stderr, "Failed to allocate wifi_config_t %s:%d\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     if (UNLIKELY(strlen(ssid) > sizeof(wifi_config->ap.ssid))) {
         fprintf(stderr, "ssid cannot be more than %d characters\n", sizeof(wifi_config->ap.ssid));
@@ -362,7 +362,7 @@ static void network_driver_start(Context *ctx, term pid, term ref, term config)
     ClientData *data = (ClientData *) malloc(sizeof(ClientData));
     if (IS_NULL_PTR(data)) {
         fprintf(stderr, "Failed to allocate ClientData %s:%d\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     data->ctx = ctx;
     data->pid = pid;

--- a/src/platforms/esp32/main/platform_defaultatoms.c
+++ b/src/platforms/esp32/main/platform_defaultatoms.c
@@ -231,6 +231,6 @@ void platform_defaultatoms_init(GlobalContext *glb)
     ok &= globalcontext_insert_atom(glb, odd_atom) == ODD_ATOM_INDEX;
 
     if (!ok) {
-        abort();
+        AVM_ABORT();
     }
 }

--- a/src/platforms/esp32/main/socket_driver.c
+++ b/src/platforms/esp32/main/socket_driver.c
@@ -368,12 +368,12 @@ void accept_conn(struct TCPServerAccepter *accepter, Context *ctx)
 
     struct TCPClientSocketData *new_tcp_data = tcp_client_socket_data_new(new_ctx, accepted_conn, platform, pid);
     if (IS_NULL_PTR(new_tcp_data)) {
-        abort();
+        AVM_ABORT();
     }
 
     //TODO
     if (UNLIKELY(memory_ensure_free(ctx, 128) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
     term ref = term_from_ref_ticks(accepter->ref_ticks, ctx);
     term return_tuple = term_alloc_tuple(2, ctx);
@@ -426,7 +426,7 @@ static void do_accept(Context *ctx, term msg)
 static void close_tcp_socket(Context *ctx, struct TCPClientSocketData *tcp_data)
 {
     if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
     term pid = tcp_data->socket_data.controlling_process_pid;
     term msg = term_alloc_tuple(2, ctx);
@@ -507,7 +507,7 @@ static void tcp_client_handler(Context *ctx)
         tuples_size = 3 + 3;
     }
     if (UNLIKELY(memory_ensure_free(ctx, tuples_size + recv_terms_size) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
 
     term recv_data;
@@ -638,7 +638,7 @@ static void udp_handler(Context *ctx)
         tuples_size = 4 + 5 + 3 + 3;
     }
     if (UNLIKELY(memory_ensure_free(ctx, tuples_size + recv_terms_size) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
 
     term recv_data;
@@ -732,18 +732,18 @@ static void do_connect(Context *ctx, term msg)
     int ok_int;
     char *address_string = interop_term_to_string(address_term, &ok_int);
     if (UNLIKELY(!ok_int)) {
-        abort();
+        AVM_ABORT();
     }
 
     avm_int_t port = term_to_int(port_term);
     bool ok;
     bool active = bool_term_to_bool(active_term, &ok);
     if (UNLIKELY(!ok)) {
-        abort();
+        AVM_ABORT();
     }
     bool binary = bool_term_to_bool(binary_term, &ok);
     if (UNLIKELY(!ok)) {
-        abort();
+        AVM_ABORT();
     }
 
     TRACE("tcp: connecting to: %s\n", address_string);
@@ -763,7 +763,7 @@ static void do_connect(Context *ctx, term msg)
 
     struct netconn *conn = netconn_new_with_proto_and_callback(NETCONN_TCP, 0, socket_callback);
     if (IS_NULL_PTR(conn)) {
-        abort();
+        AVM_ABORT();
     }
 
     status = netconn_connect(conn, &remote_ip, port);
@@ -776,12 +776,12 @@ static void do_connect(Context *ctx, term msg)
 
     struct TCPClientSocketData *tcp_data = tcp_client_socket_data_new(ctx, conn, platform, controlling_process_term);
     if (IS_NULL_PTR(tcp_data)) {
-        abort();
+        AVM_ABORT();
     }
     tcp_data->socket_data.active = active;
     tcp_data->socket_data.binary = binary;
     if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
     term return_tuple = term_alloc_tuple(2, ctx);
 
@@ -812,11 +812,11 @@ static void do_listen(Context *ctx, term msg)
     bool ok;
     bool active = bool_term_to_bool(active_term, &ok);
     if (UNLIKELY(!ok)) {
-        abort();
+        AVM_ABORT();
     }
     bool binary = bool_term_to_bool(binary_term, &ok);
     if (UNLIKELY(!ok)) {
-        abort();
+        AVM_ABORT();
     }
 
     struct netconn *conn = netconn_new_with_proto_and_callback(NETCONN_TCP, 0, socket_callback);
@@ -846,13 +846,13 @@ static void do_listen(Context *ctx, term msg)
 
     struct TCPServerSocketData *tcp_data = tcp_server_socket_data_new(ctx, conn, platform);
     if (IS_NULL_PTR(tcp_data)) {
-        abort();
+        AVM_ABORT();
     }
     tcp_data->socket_data.port = nport;
     tcp_data->socket_data.active = active;
     tcp_data->socket_data.binary = binary;
     if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
     term return_tuple = term_alloc_tuple(2, ctx);
 
@@ -882,22 +882,22 @@ void do_udp_open(Context *ctx, term msg)
     bool ok;
     bool active = bool_term_to_bool(active_term, &ok);
     if (UNLIKELY(!ok)) {
-        abort();
+        AVM_ABORT();
     }
     bool binary = bool_term_to_bool(binary_term, &ok);
     if (UNLIKELY(!ok)) {
-        abort();
+        AVM_ABORT();
     }
 
     struct netconn *conn = netconn_new_with_proto_and_callback(NETCONN_UDP, 0, socket_callback);
     if (IS_NULL_PTR(conn)) {
         fprintf(stderr, "failed to open conn\n");
-        abort();
+        AVM_ABORT();
     }
 
     struct UDPSocketData *udp_data = udp_socket_data_new(ctx, conn, platform, controlling_process);
     if (IS_NULL_PTR(udp_data)) {
-        abort();
+        AVM_ABORT();
     }
     udp_data->socket_data.active = active;
     udp_data->socket_data.binary = binary;
@@ -921,7 +921,7 @@ void do_udp_open(Context *ctx, term msg)
     udp_data->socket_data.port = nport;
 
     if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
     term return_tuple = term_alloc_tuple(2, ctx);
 
@@ -983,7 +983,7 @@ static void do_send(Context *ctx, term msg)
     free(buffer);
 
     if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
     term return_tuple = term_alloc_tuple(2, ctx);
 
@@ -1035,7 +1035,7 @@ static void do_sendto(Context *ctx, term msg)
     free(buffer);
 
     if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
     term return_tuple = term_alloc_tuple(2, ctx);
 
@@ -1063,7 +1063,7 @@ static void do_close(Context *ctx, term msg)
     list_remove(&tcp_data->socket_data.sockets_head);
 
     if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
     term return_tuple = term_alloc_tuple(2, ctx);
 
@@ -1087,7 +1087,7 @@ static void do_recvfrom(Context *ctx, term msg)
     if (socket_data->passive_receiver_process_pid != term_invalid_term()) {
         // 3 (error_tuple) + 3 (result_tuple)
         if (UNLIKELY(memory_ensure_free(ctx, 3 + 3) != MEMORY_GC_OK)) {
-            abort();
+            AVM_ABORT();
         }
 
         term ealready = context_make_atom(ctx, ealready_atom);
@@ -1138,7 +1138,7 @@ static void do_recvfrom(Context *ctx, term msg)
 
         // 4 (recv_ret size) + 3 (ok_tuple size) + 3 (result_tuple size) + recv_terms_size
         if (UNLIKELY(memory_ensure_free(ctx, 4 + 3 + 3 + recv_terms_size) != MEMORY_GC_OK)) {
-            abort();
+            AVM_ABORT();
         }
 
         term recv_data;
@@ -1185,7 +1185,7 @@ static void do_get_port(Context *ctx, term msg)
 
     // 3 (error_ok_tuple) + 3 (result_tuple)
     if (UNLIKELY(memory_ensure_free(ctx, 3 + 3) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
 
     term error_ok_tuple = term_alloc_tuple(2, ctx);
@@ -1218,14 +1218,14 @@ static void do_sockname(Context *ctx, term msg)
     term return_msg;
     if (result != ERR_OK) {
         if (UNLIKELY(memory_ensure_free(ctx, 3 + 3) != MEMORY_GC_OK)) {
-            abort();
+            AVM_ABORT();
         }
         return_msg = term_alloc_tuple(2, ctx);
         term_put_tuple_element(return_msg, 0, ERROR_ATOM);
         term_put_tuple_element(return_msg, 1, term_from_int(result));
     } else {
         if (UNLIKELY(memory_ensure_free(ctx, 3 + 3 + 8) != MEMORY_GC_OK)) {
-            abort();
+            AVM_ABORT();
         }
         return_msg = term_alloc_tuple(2, ctx);
         term addr_term = socket_addr_to_tuple(ctx, &addr);
@@ -1257,14 +1257,14 @@ static void do_peername(Context *ctx, term msg)
     term return_msg;
     if (result != ERR_OK) {
         if (UNLIKELY(memory_ensure_free(ctx, 3 + 3) != MEMORY_GC_OK)) {
-            abort();
+            AVM_ABORT();
         }
         return_msg = term_alloc_tuple(2, ctx);
         term_put_tuple_element(return_msg, 0, ERROR_ATOM);
         term_put_tuple_element(return_msg, 1, term_from_int(result));
     } else {
         if (UNLIKELY(memory_ensure_free(ctx, 3 + 3 + 8) != MEMORY_GC_OK)) {
-            abort();
+            AVM_ABORT();
         }
         return_msg = term_alloc_tuple(2, ctx);
         term addr_term = socket_addr_to_tuple(ctx, &addr);

--- a/src/platforms/esp32/main/sys.c
+++ b/src/platforms/esp32/main/sys.c
@@ -108,7 +108,7 @@ void sys_time(struct timespec *t)
     struct timeval tv;
     if (UNLIKELY(gettimeofday(&tv, NULL))) {
         fprintf(stderr, "Failed gettimeofday.\n");
-        abort();
+        AVM_ABORT();
     }
 
     t->tv_sec = tv.tv_sec;

--- a/src/platforms/esp32/main/uart_driver.c
+++ b/src/platforms/esp32/main/uart_driver.c
@@ -115,7 +115,7 @@ void uart_interrupt_callback(EventListener *listener)
         int ref_size = (sizeof(uint64_t) / sizeof(term)) + 1;
         int bin_size = term_binary_data_size_in_terms(count) + BINARY_HEADER_SIZE + ref_size;
         if (UNLIKELY(memory_ensure_free(uart_data->ctx, bin_size + ref_size + 3 + 3) != MEMORY_GC_OK)) {
-            abort();
+            AVM_ABORT();
         }
 
         term bin = term_create_uninitialized_binary(count, uart_data->ctx);
@@ -170,7 +170,7 @@ Context *uart_driver_create_port(GlobalContext *global, term opts)
     int ok;
     char *uart_name = interop_term_to_string(uart_name_term, &ok);
     if (!uart_name || !ok) {
-        abort();
+        AVM_ABORT();
     }
 
     uint8_t uart_num;
@@ -181,7 +181,7 @@ Context *uart_driver_create_port(GlobalContext *global, term opts)
     } else if (!strcmp(uart_name, "UART2")) {
         uart_num = UART_NUM_2;
     } else {
-        abort();
+        AVM_ABORT();
     }
     free(uart_name);
 
@@ -202,7 +202,7 @@ Context *uart_driver_create_port(GlobalContext *global, term opts)
             data_bits = UART_DATA_5_BITS;
             break;
         default:
-            abort();
+            AVM_ABORT();
     }
 
     int stop_bits;
@@ -214,7 +214,7 @@ Context *uart_driver_create_port(GlobalContext *global, term opts)
             stop_bits = UART_STOP_BITS_2;
             break;
         default:
-            abort();
+            AVM_ABORT();
     }
 
     int flow_control;
@@ -227,7 +227,7 @@ Context *uart_driver_create_port(GlobalContext *global, term opts)
             break;
         case SOFTWARE_ATOM:
         default:
-            abort();
+            AVM_ABORT();
     }
 
     int parity;
@@ -242,7 +242,7 @@ Context *uart_driver_create_port(GlobalContext *global, term opts)
             parity = UART_PARITY_ODD;
             break;
         default:
-            abort();
+            AVM_ABORT();
     }
 
     uart_config_t uart_config = {
@@ -262,7 +262,7 @@ Context *uart_driver_create_port(GlobalContext *global, term opts)
     struct UARTData *uart_data = malloc(sizeof(struct UARTData));
     if (IS_NULL_PTR(uart_data)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     uart_data->listener.sender = uart_data;
     uart_data->listener.data = uart_data;
@@ -297,7 +297,7 @@ static void uart_driver_do_read(Context *ctx, term msg)
     if (uart_data->reader_process_pid != term_invalid_term()) {
         // 3 (error_tuple) + 3 (result_tuple)
         if (UNLIKELY(memory_ensure_free(ctx, 3 + 3) != MEMORY_GC_OK)) {
-            abort();
+            AVM_ABORT();
         }
 
         term ealready = context_make_atom(ctx, ealready_atom);
@@ -320,7 +320,7 @@ static void uart_driver_do_read(Context *ctx, term msg)
     if (count > 0) {
         int bin_size = term_binary_data_size_in_terms(count) + BINARY_HEADER_SIZE;
         if (UNLIKELY(memory_ensure_free(uart_data->ctx, bin_size + 3 + 3) != MEMORY_GC_OK)) {
-            abort();
+            AVM_ABORT();
         }
 
         term bin = term_create_uninitialized_binary(count, uart_data->ctx);
@@ -374,7 +374,7 @@ static void uart_driver_do_write(Context *ctx, term msg)
     free(buffer);
 
     if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
-        abort();
+        AVM_ABORT();
     }
 
     term result_tuple = term_alloc_tuple(2, ctx);

--- a/src/platforms/generic_unix/platform_defaultatoms.c
+++ b/src/platforms/generic_unix/platform_defaultatoms.c
@@ -91,6 +91,6 @@ void platform_defaultatoms_init(GlobalContext *glb)
     ok &= globalcontext_insert_atom(glb, generic_unix_atom) == GENERIC_UNIX_ATOM_INDEX;
 
     if (!ok) {
-        abort();
+        AVM_ABORT();
     }
 }

--- a/src/platforms/generic_unix/socket_driver.c
+++ b/src/platforms/generic_unix/socket_driver.c
@@ -172,7 +172,7 @@ static term init_udp_socket(Context *ctx, SocketDriverData *socket_data, term pa
             EventListener *listener = malloc(sizeof(EventListener));
             if (IS_NULL_PTR(listener)) {
                 fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-                abort();
+                AVM_ABORT();
             }
             listener->fd = socket_data->sockfd;
             listener->data = ctx;
@@ -257,7 +257,7 @@ static term init_client_tcp_socket(Context *ctx, SocketDriverData *socket_data, 
             EventListener *listener = malloc(sizeof(EventListener));
             if (IS_NULL_PTR(listener)) {
                 fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-                abort();
+                AVM_ABORT();
             }
             listener->fd = socket_data->sockfd;
             listener->data = ctx;
@@ -334,7 +334,7 @@ static term init_accepting_socket(Context *ctx, SocketDriverData *socket_data, t
         EventListener *listener = malloc(sizeof(EventListener));
         if (IS_NULL_PTR(listener)) {
             fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-            abort();
+            AVM_ABORT();
         }
         listener->fd = socket_data->sockfd;
         listener->data = ctx;
@@ -608,7 +608,7 @@ static void active_recv_callback(EventListener *listener)
     char *buf = malloc(buf_size);
     if (IS_NULL_PTR(buf)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     //
     // receive the data
@@ -660,7 +660,7 @@ static void passive_recv_callback(EventListener *listener)
     char *buf = malloc(buf_size);
     if (IS_NULL_PTR(buf)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     //
     // receive the data
@@ -709,7 +709,7 @@ static void active_recvfrom_callback(EventListener *listener)
     char *buf = malloc(buf_size);
     if (IS_NULL_PTR(buf)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     //
     // receive the data
@@ -760,7 +760,7 @@ static void passive_recvfrom_callback(EventListener *listener)
     char *buf = malloc(buf_size);
     if (IS_NULL_PTR(buf)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     //
     // receive the data
@@ -823,7 +823,7 @@ static void do_recv(Context *ctx, term pid, term ref, term length, term timeout,
     RecvFromData *data = (RecvFromData *) malloc(sizeof(RecvFromData));
     if (IS_NULL_PTR(data)) {
         fprintf(stderr, "Unable to allocate space for RecvFromData: %s:%i\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     data->ctx = ctx;
     data->pid = pid;
@@ -835,7 +835,7 @@ static void do_recv(Context *ctx, term pid, term ref, term length, term timeout,
     EventListener *listener = malloc(sizeof(EventListener));
     if (IS_NULL_PTR(listener)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     listener->fd = socket_data->sockfd;
     listener->handler = handler;
@@ -908,7 +908,7 @@ void socket_driver_do_accept(Context *ctx, term pid, term ref, term timeout)
     RecvFromData *data = (RecvFromData *) malloc(sizeof(RecvFromData));
     if (IS_NULL_PTR(data)) {
         fprintf(stderr, "Unable to allocate space for RecvFromData: %s:%i\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     data->ctx = ctx;
     data->pid = pid;
@@ -920,7 +920,7 @@ void socket_driver_do_accept(Context *ctx, term pid, term ref, term timeout)
     EventListener *listener = malloc(sizeof(EventListener));
     if (IS_NULL_PTR(listener)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        abort();
+        AVM_ABORT();
     }
     listener->fd = socket_data->sockfd;
     listener->handler = accept_callback;
@@ -945,7 +945,7 @@ static void socket_consume_mailbox(Context *ctx)
 {
     TRACE("START socket_consume_mailbox\n");
     if (UNLIKELY(ctx->native_handler != socket_consume_mailbox)) {
-        abort();
+        AVM_ABORT();
     }
 
     port_ensure_available(ctx, 16);

--- a/src/platforms/generic_unix/sys.c
+++ b/src/platforms/generic_unix/sys.c
@@ -137,7 +137,7 @@ void sys_time(struct timespec *t)
 {
     if (UNLIKELY(clock_gettime(CLOCK_REALTIME, t))) {
         fprintf(stderr, "Failed clock_gettime.\n");
-        abort();
+        AVM_ABORT();
     }
 }
 
@@ -222,7 +222,7 @@ void sys_init_platform(GlobalContext *global)
 
     struct GenericUnixPlatformData *platform = malloc(sizeof(struct GenericUnixPlatformData));
     if (UNLIKELY(!platform)) {
-        abort();
+        AVM_ABORT();
     }
     platform->listeners = 0;
     global->platform_data = platform;

--- a/src/platforms/stm32/src/lib/platform_defaultatoms.c
+++ b/src/platforms/stm32/src/lib/platform_defaultatoms.c
@@ -53,6 +53,6 @@ void platform_defaultatoms_init(GlobalContext *glb)
     ok &= globalcontext_insert_atom(glb, stm32_atom) == STM32_ATOM_INDEX;
 
     if (!ok) {
-        abort();
+        AVM_ABORT();
     }
 }

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -391,7 +391,7 @@ static void *uncompress_literals(const uint8_t *litT, int size, size_t *uncompre
     uint8_t *outBuf = malloc(required_buf_size);
     if (!outBuf) {
         fprintf(stderr, "Cannot allocate temporary buffer (size = %u)", required_buf_size);
-        abort();
+        AVM_ABORT();
     }
 
     z_stream infstream;
@@ -406,12 +406,12 @@ static void *uncompress_literals(const uint8_t *litT, int size, size_t *uncompre
     int ret = inflateInit(&infstream);
     if (ret != Z_OK) {
         fprintf(stderr, "Failed inflateInit\n");
-        abort();
+        AVM_ABORT();
     }
     ret = inflate(&infstream, Z_NO_FLUSH);
     if (ret != Z_OK) {
         fprintf(stderr, "Failed inflate\n");
-        abort();
+        AVM_ABORT();
     }
     inflateEnd(&infstream);
 


### PR DESCRIPTION
This change set adds macro for calls to abort() which will print the module and line number of the abort occurrence to stderr.  This will greatly improve the ability to diagnose failures that occur on devices.

Closes #278

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
