### PR TITLE
Updated documentation of erlang:system_info/1 atoms.

### DIFF
--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -394,7 +394,9 @@ As noted above, the `erlang:system_info/1` function can be used to obtain system
 
 You can request ESP32-specific information using using the following input atoms:
 
-* `esp_free_heap_size` Returns the available free space in the ESP32 heap
+* `esp_free_heap_size` Returns the available free space in the ESP32 heap.
+* `esp_largest_free_block` Returns the size of the largest free continuous block in the ESP32 heap.
+* `esp_get_minimum_free_size` Returns the smallest ever free space available in the ESP32 heap since boot, this will tell you how close you have come to running out of free memory.
 * `esp_chip_info` Returns 4-tuple of the form `{esp32, Features, Cores, Revision}`, where `Features` is a bit mask of features enabled in the chip, `Cores` is the number of CPU cores on the chip, and `Revision` is the chip version.
 * `esp_idf_version` Return the IDF SDK version, as a string.
 

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -142,6 +142,8 @@ process_info(_Pid, _Key) ->
 %% The following keys are supported on the ESP32 platform:
 %% <ul>
 %%      <li><b>esp32_free_heap_size</b> the number of (noncontiguous) free bytes in the ESP32 heap (integer)</li>
+%%      <li><b>esp_largest_free_block</b> the number of the largest contiguous free bytes in the ESP32 heap (integer)</li>
+%%      <li><b>esp_get_minimum_free_size</b> the smallest number of free bytes in the ESP32 heap since boot (integer)</li>
 %% </ul>
 %%
 %% Additional keys may be supported on some platforms that are not documented here.


### PR DESCRIPTION
This adds documentation for the erlang:system_info/1 esp32_largest_free_block
and esp32_minimum_free_size atoms.

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
