### PR TITLE
Added support for spi:close/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the ability to specify the HSPI or VSPI ESP32 hardware interfaces when initializing the SPI
   Bus.
+- Added support for the `spi:close/1` function.
 
 ### Changed
 

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -656,6 +656,11 @@ To write a byte at a given address on the device, use the `spi_write_at/5` funct
 
 Consult your local device data sheet for information about various device addresses to read from or write to, and their semantics.
 
+Use the `spi:close/1` function to close the SPI driver and free any resources in use by it, supplying a reference to a previously opened SPI driver instance.  Any references to the closed SPI instance are no longer valid after a successful call to this function.
+
+    %% erlang
+    ok = spi:close(SPI).
+
 
 ### UART
 

--- a/libs/eavmlib/src/spi.erl
+++ b/libs/eavmlib/src/spi.erl
@@ -40,7 +40,7 @@
 %%
 -module(spi).
 
--export([open/1, read_at/4, write_at/5]).
+-export([open/1, close/1, read_at/4, write_at/5]).
 
 -type spi_peripheral() :: hspi | vspi.
 -type bus_config() :: [
@@ -129,6 +129,19 @@
 -spec open(Params :: params()) -> spi().
 open(Params) ->
     open_port({spawn, "spi"}, validate_params(Params)).
+
+%%-----------------------------------------------------------------------------
+%% @param   SPI SPI instance created via `open/1'
+%% @doc     Close the SPI driver.
+%%
+%% Close the SPI driver and free any resources in use by the driver.
+%%
+%% The SPI instance will no longer be valid and usable after this function has been called.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec close(SPI::spi()) -> ok.
+close(SPI) ->
+    port:call(SPI, {close}).
 
 %%-----------------------------------------------------------------------------
 %% @param   SPI SPI instance created via `open/1'


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

This PR addresses issue #275

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
