### PR TITLE
ESP32 build matrix for supported IDF versions

### DIFF
--- a/.github/workflows/esp-idf-v3.3.6-dockerfile
+++ b/.github/workflows/esp-idf-v3.3.6-dockerfile
@@ -1,0 +1,11 @@
+#
+#  Copyright 2022 Davide Bettio <davide@uninstall.it>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+FROM espressif/idf:v3.3.6
+
+ADD esp32-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/.github/workflows/esp-idf-v4.1.2-dockerfile
+++ b/.github/workflows/esp-idf-v4.1.2-dockerfile
@@ -1,0 +1,11 @@
+#
+#  Copyright 2022 Winford <dwinford@pm.me>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+FROM espressif/idf:v4.1.2
+
+ADD esp32-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/.github/workflows/esp-idf-v4.2.3-dockerfile
+++ b/.github/workflows/esp-idf-v4.2.3-dockerfile
@@ -1,0 +1,11 @@
+#
+#  Copyright 2022 Winford <dwinford@pm.me>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+FROM espressif/idf:v4.2.3
+
+ADD esp32-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -4,20 +4,24 @@
 #  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-name: ESP32 Build
+name: ESP32 Build with ESP-IDF v4.x
 
 on: [push, pull_request]
 
 jobs:
-  esp32-build:
+  Build with esp-idf:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        idf: [v3.3.6, v4.1.2, v4.2.3]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
       with:
         submodules: 'recursive'
-    - name: "Build: customized esp-idf container"
-      run: docker build -t atomvm/ci-idf:v3.3.2 -f esp32-dockerfile .
+    - name: "Build: customized esp-idf-${{matrix.idf}} container"
+      run: docker build -t atomvm/ci-idf:${{matrix.idf}} -f esp-idf-${{matrix.idf}}-dockerfile .
       working-directory: .github/workflows
-    - name: "Build: AtomVM (ESP32 platform)"
-      run: docker run --rm -v $PWD:/atomvm -w /atomvm atomvm/ci-idf:v3.3.2 src/platforms/esp32
+    - name: "Build: AtomVM (ESP32 platform IDF-${{matrix.idf}})"
+      run: docker run --rm -v $PWD:/atomvm -w /atomvm atomvm/ci-idf:${{matrix.idf}} src/platforms/esp32


### PR DESCRIPTION
Creates a build matrix that includes Espressif supported version 4.1.2 and 4.2.3
of ESP-IDF and updates 3.x tests to the final release version 3.3.6 of the 3.x
series.

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
