### PR TITLE
Fix for bad job name id in IDF build matrix

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -4,12 +4,12 @@
 #  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-name: ESP32 Build with ESP-IDF v4.x
+name: ESP32 Builds
 
 on: [push, pull_request]
 
 jobs:
-  Build with esp-idf:
+  esp-idf:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
I accidentally pushed the wrong branch that had spaces in the job name that
cause a failure due to the yaml syntax.

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
