### PR TITLE
fix alisp beams missing from atomvmlib.avm

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -30,4 +30,4 @@ else()
     message("Unable to find elixirc -- skipping Elixir libs")
 endif()
 
-pack_lib(atomvmlib eavmlib estdlib)
+pack_lib(atomvmlib eavmlib estdlib alisp)


### PR DESCRIPTION
This adds alisp to the list of library beams to be packed into atomvmlib.avm

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
