### PR TITLE
Udpade CI esp-idf build matrix to include v4.3.x and v4.4

### DIFF
--- a/.github/workflows/esp-idf-v4.3.2-dockerfile
+++ b/.github/workflows/esp-idf-v4.3.2-dockerfile
@@ -1,0 +1,11 @@
+#
+#  Copyright 2022 Winford <dwinford@pm.me>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+FROM espressif/idf:v4.3.2
+
+ADD esp32-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/.github/workflows/esp-idf-v4.4-dockerfile
+++ b/.github/workflows/esp-idf-v4.4-dockerfile
@@ -1,0 +1,11 @@
+#
+#  Copyright 2022 Winford <dwinford@pm.me>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+FROM espressif/idf:v4.4
+
+ADD esp32-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf: [v3.3.6, v4.1.2, v4.2.3]
+        idf: [v3.3.6, v4.1.2, v4.2.3, v4.3.2, v4.4]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2


### PR DESCRIPTION
This updates the CI build matrix testes for ESP-IDF to include all if the
currently supported ESP-IDF releases.

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
