### PR TITLE
Updates depreciated tcpip_adapter to replacement esp_netif component

### DIFF
--- a/src/platforms/esp32/main/network_driver.c
+++ b/src/platforms/esp32/main/network_driver.c
@@ -40,7 +40,7 @@
 #include <esp_event_loop.h>
 #include <esp_log.h>
 #include <esp_wifi.h>
-#include <tcpip_adapter.h>
+#include <esp_netif.h>
 
 #include <freertos/event_groups.h>
 
@@ -480,7 +480,7 @@ static void send_term(ClientData *data, term t)
     port_send_reply(ctx, pid, ref, t);
 }
 
-static void send_got_ip(ClientData *data, tcpip_adapter_ip_info_t *info)
+static void send_got_ip(ClientData *data, esp_netif_ip_info_t *info)
 {
     TRACE("Sending got_ip back to AtomVM\n");
     Context *ctx = data->ctx;
@@ -604,7 +604,7 @@ static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)
 
 void network_driver_init(GlobalContext *global)
 {
-    tcpip_adapter_init();
+    esp_netif_init();
 }
 
 Context *network_driver_create_port(GlobalContext *global, term opts)

--- a/src/platforms/esp32/main/socket_driver.c
+++ b/src/platforms/esp32/main/socket_driver.c
@@ -43,7 +43,7 @@
 #include <lwip/api.h>
 #include <lwip/inet.h>
 #include <lwip/ip_addr.h>
-#include <tcpip_adapter.h>
+#include <esp_netif.h>
 
 //#define ENABLE_TRACE 1
 #include "trace.h"


### PR DESCRIPTION
The tcpip_adapter component in versions after 4.1 has been depteciated and is
acuallly a wraper to the new esp_netif interface, this commit switches to using
the new interface directly and eliminates compiler warnings and the unnecessary
headers from the depreciated component.
Complete documentation for the new interface can be found at:
https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-reference/network/esp_netif.html

Closes issue #294.

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
