### PR TITLE
Enable SNTP for ESP-IDF4.x

### DIFF
--- a/src/platforms/esp32/main/network_driver.c
+++ b/src/platforms/esp32/main/network_driver.c
@@ -51,6 +51,7 @@
 #endif
 
 #if ESP_IDF_VERSION_MAJOR >= 4
+#include <esp_sntp.h>
 #define TCPIP_HOSTNAME_MAX_SIZE 255
 #endif
 
@@ -287,7 +288,6 @@ static wifi_config_t *get_ap_wifi_config(term ap_config)
 
 static void maybe_set_sntp(term sntp_config)
 {
-#if ESP_IDF_VERSION_MAJOR < 4
     if (!term_is_nil(sntp_config) && !term_is_nil(interop_proplist_get_value(sntp_config, HOST_ATOM))) {
         int ok;
         char *host = interop_term_to_string(interop_proplist_get_value(sntp_config, HOST_ATOM), &ok);
@@ -301,9 +301,6 @@ static void maybe_set_sntp(term sntp_config)
             fprintf(stderr, "Unable to locate sntp host in configuration\n");
         }
     }
-#else
-    fprintf(stderr, "SNTP not yet supported on esp-idf 4.x\n");
-#endif
 }
 
 static void set_dhcp_hostname(term dhcp_hostname_term)


### PR DESCRIPTION
SNTP support is available in all 4.x versions of ESP-IDF, but the location and
name of the header file has changed. This change uses the updated header file.

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
