### PR TITLE
Update README to include link to atomvm.net

### DIFF
--- a/README.Md
+++ b/README.Md
@@ -24,6 +24,7 @@ might be supported in a near future.
 
 Getting Started
 ===============
+There is much more information, including a more complete "Getting Started Guide," extensive documentation, examples, and contact information available on the [AtomVM](https://atomvm.net) project website.
 
 Dependencies
 ------------


### PR DESCRIPTION
This adds information about the documentation available on https://AtomVM.net.
This closes issue #300

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
