### PR TITLE
Corrected state timeout logic in gen_statem

### DIFF
--- a/libs/eavmlib/src/timer_manager.erl
+++ b/libs/eavmlib/src/timer_manager.erl
@@ -154,10 +154,10 @@ do_start_timer(Time, Dest, Msg) ->
 
 %% @private
 run_timer(MgrPid, Time, TimerRef, Dest, Msg) ->
-    Start = erlang:timestamp(),
+    Start = erlang:system_time(millisecond),
     receive
         {cancel, From} ->
-            gen_server:reply(From, Time - timestamp_util:delta_ms(erlang:timestamp(), Start))
+            gen_server:reply(From, Time - (erlang:system_time(millisecond) - Start))
     after Time ->
         Dest ! {timeout, TimerRef, Msg}
     end,

--- a/libs/estdlib/src/gen_statem.erl
+++ b/libs/estdlib/src/gen_statem.erl
@@ -68,7 +68,8 @@
 -record(state, {
     mod :: module(),
     current_state :: atom(),
-    data :: term()
+    data :: term(),
+    timer_map = #{} :: map()
 }).
 
 -include("logger.hrl").
@@ -222,16 +223,8 @@ handle_cast(Request, State) ->
     do_handle_state(cast, Request, State).
 
 %% @hidden
-handle_info(
-    {timeout, _TimerRef, {state_timeout, State, Msg}},
-    #state{current_state = CurrentState} = State
-) ->
-    case State of
-        CurrentState ->
-            do_handle_state(state_timeout, Msg, State);
-        _ ->
-            ok
-    end;
+handle_info({timeout, _TimerRef, {state_timeout, CurrentState, Msg}}, #state{current_state=CurrentState} = State) ->
+    do_handle_state(state_timeout, Msg, State);
 handle_info(Request, State) ->
     do_handle_state(info, Request, State).
 
@@ -245,25 +238,41 @@ terminate(Reason, #state{mod = Module, current_state = CurrentState, data = Data
 %%
 
 %% @private
-do_handle_state(
-    EventType,
-    Request,
-    #state{mod = Module, current_state = CurrentState, data = Data} = State
-) ->
+do_handle_state(EventType, Request, State) ->
+    #state{
+        mod=Module,
+        current_state=CurrentState,
+        data=Data,
+        timer_map = TimerMap
+    } = State,
     case Module:CurrentState(EventType, Request, Data) of
+        {next_state, CurrentState, NewData} ->
+            {noreply, State#state{data=NewData}};
+        {next_state, CurrentState, NewData, Actions} ->
+            TimerRefs = handle_actions(Actions, [{next_state, CurrentState}]),
+            {noreply, State#state{data=NewData, timer_map=maps:merge(TimerMap, TimerRefs)}};
+        %%
+        %% if we are transitioning to a new state, cancel any timers associated with this state
+        %%
         {next_state, NextState, NewData} ->
-            {noreply, State#state{current_state = NextState, data = NewData}};
+            NewTimerMap = maybe_cancel_timer(CurrentState, TimerMap),
+            {noreply, State#state{current_state=NextState, data=NewData, timer_map=NewTimerMap}};
         {next_state, NextState, NewData, Actions} ->
-            handle_actions(Actions, [{current_state, CurrentState}, {next_state, NextState}]),
-            {noreply, State#state{current_state = NextState, data = NewData}};
+            NewTimerMap = maybe_cancel_timer(CurrentState, TimerMap),
+            TimerRefs = handle_actions(Actions, [{next_state, NextState}]),
+            {noreply, State#state{current_state=NextState, data=NewData, timer_map=maps:merge(TimerMap, TimerRefs)}};
         {stop, Reason} ->
+            maybe_cancel_timer(CurrentState, TimerMap),
             {stop, Reason, State};
         {stop, Reason, NewData} ->
-            {stop, Reason, State#state{data = NewData}};
+            maybe_cancel_timer(CurrentState, TimerMap),
+            {stop, Reason, State#state{data=NewData}};
         {stop_and_reply, Reason, Replies} ->
+            maybe_cancel_timer(CurrentState, TimerMap),
             handle_actions(Replies, []),
             {stop, Reason, State};
         {stop_and_reply, Reason, Replies, NewData} ->
+            maybe_cancel_timer(CurrentState, TimerMap),
             handle_actions(Replies, []),
             {stop, Reason, State#state{data = NewData}};
         Reply ->
@@ -271,17 +280,27 @@ do_handle_state(
     end.
 
 %% @private
-handle_actions([], _Context) ->
-    ok;
-handle_actions([{reply, From, Reply} | T], Context) ->
+handle_actions(Actions, Context) ->
+    handle_actions(Actions, Context, #{}).
+
+%% @private
+handle_actions([], _Context, Accum) ->
+    Accum;
+handle_actions([{reply, From, Reply} | T], Context, Accum) ->
     reply(From, Reply),
-    handle_actions(T, Context);
-handle_actions([{state_timeout, Timeout, Msg} | T], Context) ->
-    timer_manager:start_timer(
-        Timeout,
-        self(),
-        {state_timeout, proplists:get_value(next_state, Context), Msg}
-    ),
-    handle_actions(T, Context);
-handle_actions([_ | T], Context) ->
-    handle_actions(T, Context).
+    handle_actions(T, Context, Accum);
+handle_actions([{state_timeout, Timeout, Msg} | T], Context, Accum) ->
+    NextState = proplists:get_value(next_state, Context),
+    TimerRef = erlang:start_timer(Timeout, self(), {state_timeout, NextState, Msg}),
+    handle_actions(T, Context, Accum#{NextState => TimerRef});
+handle_actions([_ | T], Context, Accum) ->
+    handle_actions(T, Context, Accum).
+
+maybe_cancel_timer(CurrentState, TimerMap) ->
+    case maps:find(CurrentState, TimerMap) of
+        {ok, TimerRef} ->
+            erlang:cancel_timer(TimerRef),
+            maps:remove(CurrentState, TimerMap);
+        _ ->
+            TimerMap
+    end.


### PR DESCRIPTION
This PR fixes the timeout logic in the `gen_statem` module, by cancelling any timers that have been set on the state machine, if the `gen_statem` implementation transitions out of the state in which the timer was set.  Test added.  This PR also simplifies the timeout calculation in the timer manager to use `erlang:system_time/1`.

This PR closes Issue #303.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
