### PR TITLE
Corrected state timeout logic in gen_statem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - Unreleased
+ ### Fixed
+ - Fix `gen_statem`: Cancel outstanding timers during state transitions in
+   order to prevent spurious timeout messages from being sent to `gen_statem`
+   process.
+
 ## [0.5.0] - 2022-03-22

--- a/libs/eavmlib/src/timer_manager.erl
+++ b/libs/eavmlib/src/timer_manager.erl
@@ -154,10 +154,11 @@ do_start_timer(Time, Dest, Msg) ->
 
 %% @private
 run_timer(MgrPid, Time, TimerRef, Dest, Msg) ->
-    Start = erlang:timestamp(),
+    Start = erlang:system_time(millisecond),
     receive
         {cancel, From} ->
-            gen_server:reply(From, Time - timestamp_util:delta_ms(erlang:timestamp(), Start))
+            %% TODO return {ok, cancel}
+            gen_server:reply(From, Time - (erlang:system_time(millisecond) - Start))
     after Time ->
         Dest ! {timeout, TimerRef, Msg}
     end,

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -41,6 +41,13 @@
     max/2
 ]).
 
+%%
+%% TODO Correct the following bugs
+%% * cancel_timer should be renamed cancel, per the OTP documentation
+%% * return value needs to be {ok, cancel} or {error, Reason}
+%% * review API documentation for timer functions in this module
+%%
+
 %%-----------------------------------------------------------------------------
 %% @param   Time time in milliseconds after which to send the timeout message.
 %% @param   Dest Pid or server name to which to send the timeout message.

--- a/tests/libs/eavmlib/test_timer_manager.erl
+++ b/tests/libs/eavmlib/test_timer_manager.erl
@@ -38,6 +38,7 @@ test_cancel_timer() ->
     ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
     TimerRef = timer_manager:start_timer(60000, self(), test_cancel_timer),
     ?ASSERT_MATCH(timer_manager:get_timer_refs(), [TimerRef]),
+    %% TODO check return value
     timer_manager:cancel_timer(TimerRef),
     %?TIMER:sleep(100),
     ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),


### PR DESCRIPTION
This PR fixes the timeout logic in the gen_statem module, by cancelling any timers that have been set on the state machine, if the gen_statem implementation transitions out of the state in which the timer was set. Test added. This PR also simplifies the timeout calculation in the timer manager to use erlang:system_time/1.

Closes #303.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
