### PR TITLE
Update ESP32 build tests

### DIFF
--- a/.github/workflows/esp-idf-v4.1.3-dockerfile
+++ b/.github/workflows/esp-idf-v4.1.3-dockerfile
@@ -4,7 +4,7 @@
 #  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-FROM espressif/idf:v4.4
+FROM espressif/idf:v4.1.3
 
 ADD esp32-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/.github/workflows/esp-idf-v4.4.1-dockerfile
+++ b/.github/workflows/esp-idf-v4.4.1-dockerfile
@@ -4,7 +4,7 @@
 #  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-FROM espressif/idf:v4.1.2
+FROM espressif/idf:v4.4.1
 
 ADD esp32-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf: [v3.3.6, v4.1.2, v4.2.3, v4.3.2, v4.4]
+        idf: [v3.3.6, v4.1.3, v4.2.3, v4.3.2, v4.4.1]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2


### PR DESCRIPTION
Updates to ESP32 build tests for the latest Espressif ESP-IDF releases.
ESP-IDF v4.4    ->  v4.4.1
ESP-IDF v4.1.2  ->  v4.1.3

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
