### PR TITLE
Fixed potential VM crash when parsing external terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,5 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bit length is not a multiple of 8.
 - Fixed `esp:deep_sleep/1` that did not accept values above 31 minutes.
 - Fixed a bug that could cause processes to hang indefinitely when calling ports that have terminated.
+- Fixed potential VM crash when parsing external terms.
 
 ## [0.5.0] - 2022-03-22

--- a/src/libAtomVM/externalterm.h
+++ b/src/libAtomVM/externalterm.h
@@ -50,7 +50,7 @@ enum ExternalTermResult
  * store the generated terms.
  * @returns a term.
  */
-term externalterm_to_term(const void *external_term, Context *ctx, int use_heap_fragment);
+term externalterm_to_term(const void *external_term, size_t size, Context *ctx, int use_heap_fragment);
 
 /**
  * @brief Create a term from a binary.

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -50,6 +50,12 @@ typedef struct
 
 struct ExportedFunction;
 
+struct LiteralEntry
+{
+    uint32_t size;
+    void const *data;
+};
+
 struct Module
 {
     GlobalContext *global;
@@ -70,7 +76,8 @@ struct Module
     void **labels;
 
     void *literals_data;
-    void const **literals_table;
+
+    struct LiteralEntry *literals_table;
 
     int *local_atoms_to_global_table;
 


### PR DESCRIPTION
This change set adds range checking to the parsing of external term, for example, when loading modules or when converting binaries to terms.  If an external term contains encodings that do not fit within the range of an allocated buffer, then the conversion will halt with an error.  In the case of `binary_to_term/1`, the function will raise an `error:badarg`.

Without this change, the VM may crash on a malformed or maliciously crafted binary.  In cases where binaries are exchanged between VM instances (e.g., via TCP), this could result in an attack vector (buffer overflow).

This PR fixed Issue #256 

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
