### PR TITLE
Fix .gitignore missing file that should be tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ src/platforms/esp32/components/**
 src/platforms/esp32/main/component_nifs.txt
 src/platforms/esp32/main/component_ports.txt
 !src/platforms/esp32/components/libatomvm/
+!src/platforms/esp32/components/libatomvm/**
 .idea/**
 .vscode/**


### PR DESCRIPTION
Added rule to track the files inside src/platforms/esp32/components/libatomvm/
that were previously being ignored when changes are made. The existing rule
is still required to track the directory, otherwise the wildcard for the files
would still miss the changes.

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
