### PR TITLE
Propagate parameters to listening socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the return value from `erlang:system_info(esp32_chip_info)` from a tuple to a map, with
 additional information.
 
+### Fixed
+
+- Fixed a bug in gen_tcp that prevents an accepting socket from inheriting settings on the listening socket.
+
 ## [0.5.1] - Unreleased
 ### Fixed
 - Fix `gen_statem`: Cancel outstanding timers during state transitions in

--- a/libs/estdlib/src/gen_tcp.erl
+++ b/libs/estdlib/src/gen_tcp.erl
@@ -42,7 +42,7 @@
 
 -export([connect/3, send/2, recv/2, recv/3, close/1, listen/2, accept/1, accept/2, controlling_process/2]).
 
--define(DEFAULT_PARAMS, [{active, true}, {buffer, 128}, binary, {timeout, infinity}]).
+-define(DEFAULT_PARAMS, [{active, true}, {buffer, 512}, {binary, true}, {timeout, infinity}]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Address the address to which to connect
@@ -180,23 +180,7 @@ accept(ListenSocket) ->
     {ok, Socket :: inet:socket()} | {error, Reason :: term()}.
 accept(ListenSocket, Timeout) ->
     case call(ListenSocket, {accept, Timeout}) of
-        {ok, FD} when is_integer(FD) ->
-            Socket = open_port({spawn, "socket"}, []),
-            InitParams = [
-                {proto, tcp},
-                {accept, true},
-                {controlling_process, self()},
-                {fd, FD}
-                | ?DEFAULT_PARAMS
-            ],
-            case call(Socket, {init, InitParams}) of
-                ok ->
-                    {ok, Socket};
-                ErrorReason ->
-                    %% TODO close port
-                    ErrorReason
-            end;
-        {ok, Socket} ->
+        {ok, Socket} when is_pid(Socket) ->
             {ok, Socket};
         ErrorReason ->
             %% TODO close port

--- a/src/platforms/generic_unix/socket_driver.c
+++ b/src/platforms/generic_unix/socket_driver.c
@@ -81,6 +81,7 @@ static void active_recv_callback(EventListener *listener);
 static void passive_recv_callback(EventListener *listener);
 static void active_recvfrom_callback(EventListener *listener);
 static void passive_recvfrom_callback(EventListener *listener);
+static void socket_consume_mailbox(Context *ctx);
 
 uint32_t socket_tuple_to_addr(term addr_tuple)
 {
@@ -150,7 +151,7 @@ static term do_bind(Context *ctx, term address, term port)
     if (bind(socket_data->sockfd, (struct sockaddr *) &serveraddr, address_len) == -1) {
         return port_create_sys_error_tuple(ctx, BIND_ATOM, errno);
     } else {
-        TRACE("socket_driver: bound to %ld\n", p);
+        TRACE("socket_driver|do_bind: bound to %ld\n", p);
         if (getsockname(socket_data->sockfd, (struct sockaddr *) &serveraddr, &address_len) == -1) {
             return port_create_sys_error_tuple(ctx, GETSOCKNAME_ATOM, errno);
         } else {
@@ -218,7 +219,7 @@ static term do_connect(SocketDriverData *socket_data, Context *ctx, term address
     }
     char port_str[32];
     snprintf(port_str, 32, "%u", (unsigned short) term_to_int(port));
-    TRACE("socket_driver: resolving to %s:%s over socket fd %i\n", addr_str, port_str, term_to_int32(socket_data->sockfd));
+    TRACE("socket_driver:do_connect: resolving to %s:%s over socket fd %i\n", addr_str, port_str, term_to_int32(socket_data->sockfd));
 
     struct addrinfo *server_info;
     int status = getaddrinfo(addr_str, port_str, &hints, &server_info);
@@ -247,7 +248,7 @@ static term do_connect(SocketDriverData *socket_data, Context *ctx, term address
     if (status == -1) {
         return port_create_sys_error_tuple(ctx, CONNECT_ATOM, errno);
     } else {
-        TRACE("socket_driver: connected.\n");
+        TRACE("socket_driver|do_connect: connected.\n");
         return OK_ATOM;
     }
 }
@@ -332,32 +333,43 @@ static term init_server_tcp_socket(Context *ctx, SocketDriverData *socket_data, 
         if (ret != OK_ATOM) {
             close(sockfd);
         } else {
-            TRACE("socket_driver: listening on port %u\n", (unsigned) term_to_int(port));
+            TRACE("socket_driver|init_server_tcp_socket: listening on port %u\n", (unsigned) term_to_int(port));
         }
     }
     return ret;
 }
 
-static term init_accepting_socket(Context *ctx, SocketDriverData *socket_data, term fd, term active)
+static Context *create_accepting_socket(GlobalContext *glb, SocketDriverData *socket_data, int fd, term controlling_process)
 {
-    GlobalContext *glb = ctx->global;
     struct GenericUnixPlatformData *platform = glb->platform_data;
 
-    socket_data->sockfd = term_to_int(fd);
+    Context *new_ctx = context_new(glb);
+    new_ctx->native_handler = socket_consume_mailbox;
+    scheduler_make_waiting(glb, new_ctx);
 
-    if (active == TRUE_ATOM) {
+    SocketDriverData *new_socket_data = socket_driver_create_data();
+    new_socket_data->sockfd = fd;
+    new_socket_data->proto = socket_data->proto;
+    new_socket_data->active = socket_data->active;
+    new_socket_data->binary = socket_data->binary;
+    new_socket_data->buffer = socket_data->buffer;
+    new_socket_data->controlling_process = controlling_process;
+
+    new_ctx->platform_data = new_socket_data;
+
+    if (new_socket_data->active == TRUE_ATOM) {
         EventListener *listener = malloc(sizeof(EventListener));
         if (IS_NULL_PTR(listener)) {
             fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
             AVM_ABORT();
         }
-        listener->fd = socket_data->sockfd;
-        listener->data = ctx;
+        listener->fd = new_socket_data->sockfd;
+        listener->data = new_ctx;
         listener->handler = active_recv_callback;
         linkedlist_append(&platform->listeners, &listener->listeners_list_head);
-        socket_data->active_listener = listener;
+        new_socket_data->active_listener = listener;
     }
-    return OK_ATOM;
+    return new_ctx;
 }
 
 term socket_driver_do_init(Context *ctx, term params)
@@ -415,17 +427,7 @@ term socket_driver_do_init(Context *ctx, term params)
             if (listen == TRUE_ATOM) {
                 return init_server_tcp_socket(ctx, socket_data, params);
             } else {
-                term accept = interop_proplist_get_value_default(params, ACCEPT_ATOM, FALSE_ATOM);
-                if (accept == TRUE_ATOM) {
-                    term fd = interop_proplist_get_value(params, FD_ATOM);
-                    if (!term_is_integer(fd)) {
-                        return port_create_error_tuple(ctx, BADARG_ATOM);
-                    } else {
-                        return init_accepting_socket(ctx, socket_data, fd, active);
-                    }
-                } else {
-                    return port_create_error_tuple(ctx, BADARG_ATOM);
-                }
+                return port_create_error_tuple(ctx, BADARG_ATOM);
             }
         }
     } else {
@@ -448,9 +450,9 @@ void socket_driver_do_close(Context *ctx)
         }
     }
     if (close(socket_data->sockfd) == -1) {
-        TRACE("socket: close failed");
+        TRACE("socket_driver|socket_driver_do_close: close failed");
     } else {
-        TRACE("socket_driver: closed socket\n");
+        TRACE("socket_driver|socket_driver_do_close: closed socket\n");
     }
     scheduler_terminate(ctx);
 }
@@ -581,7 +583,7 @@ term socket_driver_do_send(Context *ctx, term buffer)
     if (sent_data == -1) {
         return port_create_sys_error_tuple(ctx, SEND_ATOM, errno);
     } else {
-        TRACE("socket_driver: sent data with len: %li\n", len);
+        TRACE("socket_driver_do_send: sent data with len %li to fd %i\n", len, socket_data->sockfd);
         term sent_atom = term_from_int(sent_data);
         return port_create_ok_tuple(ctx, sent_atom);
     }
@@ -621,7 +623,7 @@ term socket_driver_do_sendto(Context *ctx, term dest_address, term dest_port, te
     if (sent_data == -1) {
         return port_create_sys_error_tuple(ctx, SENDTO_ATOM, errno);
     } else {
-        TRACE("socket_driver: sent data with len: %li, to: %i, port: %i\n", len, ntohl(addr.sin_addr.s_addr), ntohs(addr.sin_port));
+        TRACE("socket_driver_do_sendto: sent data with len: %li, to: %i, port: %i\n", len, ntohl(addr.sin_addr.s_addr), ntohs(addr.sin_port));
         term sent_atom = term_from_int32(sent_data);
         return port_create_ok_tuple(ctx, sent_atom);
     }
@@ -636,6 +638,7 @@ typedef struct RecvFromData
     Context *ctx;
     term pid;
     term length;
+    term controlling_process;
     uint64_t ref_ticks;
 } RecvFromData;
 
@@ -665,7 +668,7 @@ static void active_recv_callback(EventListener *listener)
         port_send_message(ctx, pid, msg);
         socket_driver_do_close(ctx);
     } else {
-        TRACE("socket_driver: received data of len: %li\n", len);
+        TRACE("socket_driver|active_recv_callback: received data of len %li from fd %i\n", len, socket_data->sockfd);
         int ensure_packet_avail;
         int binary;
         if (socket_data->binary == TRUE_ATOM) {
@@ -716,7 +719,7 @@ static void passive_recv_callback(EventListener *listener)
         port_send_reply(ctx, pid, ref, port_create_sys_error_tuple(ctx, RECV_ATOM, errno));
         socket_driver_do_close(ctx);
     } else {
-        TRACE("socket_driver: passive received data of len: %li\n", len);
+        TRACE("socket_driver|passive_recv_callback: passive received data of len: %li\n", len);
         int ensure_packet_avail;
         if (socket_data->binary == TRUE_ATOM) {
             ensure_packet_avail = term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE;
@@ -921,11 +924,16 @@ static void accept_callback(EventListener *listener)
         term ref = term_from_ref_ticks(recvfrom_data->ref_ticks, ctx);
         port_send_reply(ctx, pid, ref, port_create_sys_error_tuple(ctx, ACCEPT_ATOM, errno));
     } else {
-        // {Ref, {ok, Fd::int()}}
-        port_ensure_available(ctx, 10);
+        TRACE("socket_driver|accept_callback: accepted connection.  fd: %i\n", fd);
+
         term pid = recvfrom_data->pid;
+        Context *new_ctx = create_accepting_socket(glb, socket_data, fd, pid);
+
+        // {Ref, Socket}
+        term socket_pid = term_from_local_process_id(new_ctx->process_id);
+        port_ensure_available(ctx, 10);
         term ref = term_from_ref_ticks(recvfrom_data->ref_ticks, ctx);
-        term reply = port_create_ok_tuple(ctx, term_from_int(fd));
+        term reply = port_create_ok_tuple(ctx, socket_pid);
         port_send_reply(ctx, pid, ref, reply);
     }
     //
@@ -1038,6 +1046,8 @@ static void socket_consume_mailbox(Context *ctx)
         term reply = socket_driver_peername(ctx);
         port_send_reply(ctx, pid, ref, reply);
     } else if (cmd_name == context_make_atom(ctx, get_port_a)) {
+        // TODO This function is not supported in the gen_tcp or gen_udp APIs.
+        // It should be removed.  (Use inet:peername and inet:sockname instead)
         TRACE("get_port\n");
         term reply = socket_driver_get_port(ctx);
         port_send_reply(ctx, pid, ref, reply);

--- a/tests/libs/estdlib/test_gen_tcp.erl
+++ b/tests/libs/estdlib/test_gen_tcp.erl
@@ -28,6 +28,7 @@ test() ->
     ok = test_echo_server(),
     ok = test_echo_server(),
     ok = test_echo_server(true),
+    ok = test_accept_parameters(),
     ok.
 
 test_echo_server() ->
@@ -95,7 +96,7 @@ test_send_receive(Port, N, SpawnControllingProcess) ->
     gen_tcp:close(Socket),
     receive
         server_closed -> ok
-    after 1000 -> throw(timeout)
+    after 1000 -> throw({timeout, waiting, recv, server_closed})
     end.
 
 loop(_Socket, 0) ->
@@ -104,12 +105,59 @@ loop(Socket, I) ->
     Packet = list_to_binary(pid_to_list(self()) ++ ":" ++ integer_to_list(I)),
     ok = gen_tcp:send(Socket, Packet),
     receive
-        {tcp_closed, _Socket} ->
+        {tcp_closed, _OtherSocket} ->
             ok;
-        {tcp, _Socket, Packet} ->
+        {tcp, _OtherSocket, _OtherPacket} ->
             loop(Socket, I - 1)
     end,
     ok.
 
 sleep(Ms) ->
     receive after Ms -> ok end.
+
+
+test_accept_parameters() ->
+    {ok, ListenSocket} = gen_tcp:listen(0, [{binary, false}, {buffer, 10}]),
+    {ok, {_Address, Port}} = inet:sockname(ListenSocket),
+
+    Self = self(),
+    spawn(fun() ->
+        Self ! ready,
+        accept(Self, ListenSocket, false)
+    end),
+    receive
+        ready ->
+            ok
+    end,
+
+    {ok, Socket} = gen_tcp:connect(localhost, Port, [{active, true}]),
+
+    sleep(100),
+
+    ok = test_accept_parameters_loop(Socket, 10),
+
+    gen_tcp:close(Socket),
+    receive
+        server_closed -> ok
+    after 1000 -> throw({timeout, waiting, recv, server_closed})
+    end,
+
+    ok.
+
+test_accept_parameters_loop(_Socket, 0) ->
+    ok;
+test_accept_parameters_loop(Socket, I) ->
+    Packet = list_to_binary(pid_to_list(self()) ++ ":" ++ integer_to_list(I)),
+    ok = gen_tcp:send(Socket, Packet),
+    receive
+        {tcp_closed, _OtherSocket} ->
+            ok;
+        {tcp, _OtherSocket, OtherPacket} ->
+            case is_binary(OtherPacket) of
+                true ->
+                    {error, expected_binary_packet};
+                false ->
+                    loop(Socket, I - 1)
+            end
+    end,
+    ok.


### PR DESCRIPTION
Fixes an issue where the parameters set on a listening socket were not propagated to the accepting socket.

This PR closes issue #314 

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
