### PR TITLE
Move the generated version.h into the build directory

### DIFF
--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -140,7 +140,7 @@ else()
     set(ATOMVM_VERSION ${ATOMVM_BASE_VERSION})
 endif()
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 set(

--- a/src/platforms/esp32/components/libatomvm/component.mk
+++ b/src/platforms/esp32/components/libatomvm/component.mk
@@ -27,7 +27,7 @@ CPPFLAGS := -Og -ggdb -ffunction-sections -fdata-sections -fstrict-volatile-bitf
 
 INCLUDE_FIXUP_DIR := $(IDF_PATH)/components/lwip/include/lwip/posix
 
-COMPONENT_ADD_INCLUDEDIRS := ../../../../libAtomVM
+COMPONENT_ADD_INCLUDEDIRS := ../../../../libAtomVM $(COMPONENT_PATH)/../../build/libatomvm
 
 COMPONENT_ADD_LDFLAGS := $(LIBRARY)
 

--- a/src/platforms/esp32/main/component.mk
+++ b/src/platforms/esp32/main/component.mk
@@ -49,3 +49,6 @@ component_ports.h: $(COMPONENT_PATH)/component_ports.h.in $(if $(wildcard $(COMP
 default_component_ports:
 	@echo "# GENERATED FILE -- EDIT TO ADD OR REMOVE COMPONENT DRIVERS" > $(COMPONENT_PATH)/component_ports.txt
 	for i in $$(echo $(DEFAULT_COMPONENT_PORTS)); do echo "$${i}_driver" >> $(COMPONENT_PATH)/component_ports.txt; done
+
+## Add the libatomvm build component to the include path for generated headers (e.g., version.h)
+COMPONENT_INCLUDES += $(COMPONENT_PATH)/../build/libatomvm


### PR DESCRIPTION
Prevents incorrect version information in mixed build environments.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
