### PR TITLE
Changed the esp32_chip_info structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `controlling_process/2` in `gen_udp` and `gen_tcp` modules.
 - Added ability to get the atomvm version via `erlang:system_info`.
 
-### Changed
+### Breaking Changes
+
+> IMPORTANT: These changes are incompatible with previous releases of AtomVM.
 
 - Changed the configuration model of the SPI driver, in order to allow for multiple "follower"
-  devices to be attached to the same SPI Bus. IMPORTANT: These changes are source-incompatible with
-  previous releases of AtomVM.
+  devices to be attached to the same SPI Bus.
+- Changed the return value from `erlang:system_info(esp32_chip_info)` from a tuple to a map, with
+additional information.
 
 ## [0.5.1] - Unreleased
 ### Fixed

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -398,7 +398,7 @@ You can request ESP32-specific information using using the following input atoms
 * `esp_free_heap_size` Returns the available free space in the ESP32 heap.
 * `esp_largest_free_block` Returns the size of the largest free continuous block in the ESP32 heap.
 * `esp_get_minimum_free_size` Returns the smallest ever free space available in the ESP32 heap since boot, this will tell you how close you have come to running out of free memory.
-* `esp_chip_info` Returns 4-tuple of the form `{esp32, Features, Cores, Revision}`, where `Features` is a bit mask of features enabled in the chip, `Cores` is the number of CPU cores on the chip, and `Revision` is the chip version.
+* `esp_chip_info` Returns map of the form `#{features := Features, cores := Cores, revision := Revision, model := Model}`, where `Features` is a list of features enabled in the chip, from among the following atoms: `[emb_flash, bgn, ble, bt]`; `Cores` is the number of CPU cores on the chip; `Revision` is the chip version; and `Model` is one of the following atoms: `esp32`, `esp32_s2`, `esp32_s3`, `esp32_c3`.
 * `esp_idf_version` Return the IDF SDK version, as a string.
 
 For example,


### PR DESCRIPTION
This PR changes the esp32_chip_info structure returned from erlang:system_info to a map which includes the chip model, as well as to return the features as a list of atoms.

WARNING: This is a source-incompatible change, as it changes the structure of a term returned from erlang:system_info.

This PR resolves issue #318 

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
