### PR TITLE
Add efficient atom comparison helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.1] - Unreleased
 ### Added
 - New function for atom comparison, useful when writing 3rd party components.
+- New function for translating an atom term to an int value, according to a given translation table.
+  This function can be used for translating an atom term to an enum const before doing a switch.
 
 ### Fixed
 - Fix `gen_statem`: Cancel outstanding timers during state transitions in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New function for atom comparison, useful when writing 3rd party components.
 - New function for translating an atom term to an int value, according to a given translation table.
   This function can be used for translating an atom term to an enum const before doing a switch.
+- New no-op `ATOM_STR(...)` macro for avoiding issues with clang-format.
 
 ### Fixed
 - Fix `gen_statem`: Cancel outstanding timers during state transitions in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.5.1] - Unreleased
+### Added
+- New function for atom comparison, useful when writing 3rd party components.
+
 ### Fixed
 - Fix `gen_statem`: Cancel outstanding timers during state transitions in
   order to prevent spurious timeout messages from being sent to `gen_statem`

--- a/src/libAtomVM/atom.h
+++ b/src/libAtomVM/atom.h
@@ -31,6 +31,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+/**
+ * No-op macro: just syntax sugar for avoiding mistakes or clang-format dividing atoms in multiple
+ * lines. Usage: ATOM_STR("\x5", "hello").
+ */
+#define ATOM_STR(LENSTR, STR) (LENSTR STR)
+
 typedef const void *AtomString;
 
 /**

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -267,6 +267,21 @@ static inline term context_make_atom(Context *ctx, AtomString string)
 }
 
 /**
+ * @brief Compares a term with an AtomString.
+ *
+ * @details Checks if the given term and the given AtomString refers to the same atom.
+ * This function is just a shortcut that uses the corresponding funtion from globalcontext.
+ * @param ctx the current Context.
+ * @param atom_a any term of any type, when it is not an atom false is always returned.
+ * @param AtomString an atom string, which is the atom length followed by atom characters.
+ * @returns true if they both refer to the same atom, otherwise false.
+ */
+static inline bool context_is_term_equal_to_atom_string(Context *ctx, term atom_a, AtomString atom_string_b)
+{
+    return globalcontext_is_term_equal_to_atom_string(ctx->global, atom_a, atom_string_b);
+}
+
+/**
  * @brief Returns number of messages in the process's mailbox
  *
  * @param ctx a valid context.

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -188,6 +188,12 @@ int globalcontext_insert_atom_maybe_copy(GlobalContext *glb, AtomString atom_str
     return (int) atom_index;
 }
 
+bool globalcontext_is_atom_index_equal_to_atom_string(GlobalContext *glb, int atom_index_a, AtomString atom_string_b)
+{
+    AtomString atom_string_a = (AtomString) valueshashtable_get_value(glb->atoms_ids_table, atom_index_a, NULL);
+    return atom_are_equals(atom_string_a, atom_string_b);
+}
+
 AtomString globalcontext_atomstring_from_term(GlobalContext *glb, term t)
 {
     if (!term_is_atom(t)) {

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -153,6 +153,36 @@ int globalcontext_insert_atom(GlobalContext *glb, AtomString atom_string);
 int globalcontext_insert_atom_maybe_copy(GlobalContext *glb, AtomString atom_string, int copy);
 
 /**
+ * @brief Compares an atom table index with an AtomString.
+ *
+ * @details Checks if the given atom table index and the given AtomString refers to the same atom.
+ * @param glb the global context.
+ * @param atom_index_a an atom table index.
+ * @param AtomString an atom string, which is the atom length followed by atom characters.
+ * @returns true if they both refer to the same atom, otherwise false.
+ */
+bool globalcontext_is_atom_index_equal_to_atom_string(GlobalContext *glb, int atom_index_a, AtomString atom_string_b);
+
+/**
+ * @brief Compares a term with an AtomString.
+ *
+ * @details Checks if the given term and the given AtomString refers to the same atom.
+ * @param glb the global context.
+ * @param atom_a any term of any type, when it is not an atom false is always returned.
+ * @param AtomString an atom string, which is the atom length followed by atom characters.
+ * @returns true if they both refer to the same atom, otherwise false.
+ */
+static inline bool globalcontext_is_term_equal_to_atom_string(GlobalContext *global, term atom_a, AtomString atom_string_b)
+{
+    if (!term_is_atom(atom_a)) {
+        return false;
+    }
+
+    int atom_index_a = term_to_atom_index(atom_a);
+    return globalcontext_is_atom_index_equal_to_atom_string(global, atom_index_a, atom_string_b);
+}
+
+/**
  * @brief   Returns the AtomString value of a term.
  *
  * @details This function fetches the AtomString value of the atom associated

--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -229,3 +229,14 @@ term interop_map_get_value_default(Context *ctx, term map, term key, term defaul
         return term_get_map_value(map, pos);
     }
 }
+
+int interop_atom_term_select_int(GlobalContext *global, const AtomStringIntPair *table, term atom)
+{
+    int i;
+    for (i = 0; table[i].as_val != NULL; i++) {
+        if (globalcontext_is_term_equal_to_atom_string(global, atom, table[i].as_val)) {
+            return table[i].i_val;
+        }
+    }
+    return table[i].i_val;
+}

--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -24,6 +24,24 @@
 #include "context.h"
 #include "term.h"
 
+/**
+ * An idiomatic macro for marking an AtomStringIntPair table entry as a
+ * interop_atom_term_select_int default.
+ */
+#define SELECT_INT_DEFAULT(i_val) \
+    {                             \
+        .as_val = NULL, i_val     \
+    }
+
+/**
+ * A structure to represent atom strings and int pairs. Such as {"\x8" "universe", 42}.
+ */
+typedef struct
+{
+    AtomString as_val;
+    int i_val;
+} AtomStringIntPair;
+
 char *interop_term_to_string(term t, int *ok);
 char *interop_binary_to_string(term binary);
 char *interop_list_to_string(term list, int *ok);
@@ -34,5 +52,19 @@ term interop_map_get_value_default(Context *ctx, term map, term key, term defaul
 
 int interop_iolist_size(term t, int *ok);
 int interop_write_iolist(term t, char *p);
+
+/**
+ * @brief Finds on a table the first matching atom string.
+ *
+ * @details Allows to quickly translate atoms to any integer constant. This function is useful for
+ * creating switch statements for atom values.
+ * A linear search is performed, so table entries should be sorted by frequency.
+ * @param glb the global context.
+ * @param table an array AtomStringIntPair structs, teminated with a default entry marked with
+ * SELECT_INT_DEFAULT macro.
+ * @param atom the atom used for comparison.
+ * @returns the found int value which corresponds to the given atom.
+ */
+int interop_atom_term_select_int(GlobalContext *global, const AtomStringIntPair *table, term atom);
 
 #endif


### PR DESCRIPTION
This PR aims to address 2 different issues:
- Atoms table gets quickly cluttered with rarely used atoms due to comparisons
- Comparing a term with an atom string is a boring task, that requires a lot of boilerplate.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
