### PR TITLE
ESP32: allow adding new port drivers without editing any source file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New function for translating an atom term to an int value, according to a given translation table.
   This function can be used for translating an atom term to an enum const before doing a switch.
 - New no-op `ATOM_STR(...)` macro for avoiding issues with clang-format.
+- [ESP32] `REGISTER_PORT_DRIVER` for registering additional port drivers without editing any
+  source file. This allows adding new components by just copying them to the components directory.
 
 ### Fixed
 - Fix `gen_statem`: Cancel outstanding timers during state transitions in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New no-op `ATOM_STR(...)` macro for avoiding issues with clang-format.
 - [ESP32] `REGISTER_PORT_DRIVER` for registering additional port drivers without editing any
   source file. This allows adding new components by just copying them to the components directory.
+- [ESP32] `REGISTER_NIF_COLLECTION` for registering additional NIFs sets without editing any
+  source file. This allows adding new NIFs by just copying them to the components directory.
 
 ### Fixed
 - Fix `gen_statem`: Cancel outstanding timers during state transitions in

--- a/src/platforms/esp32/main/esp32_sys.h
+++ b/src/platforms/esp32/main/esp32_sys.h
@@ -26,6 +26,23 @@
 
 #include <time.h>
 
+#define REGISTER_PORT_DRIVER(NAME, INIT_CB, CREATE_CB)                \
+    struct PortDriverDef NAME##_port_driver_def = {                   \
+        .port_driver_name = #NAME,                                    \
+        .port_driver_init_cb = INIT_CB,                               \
+        .port_driver_create_port_cb = CREATE_CB                       \
+    };                                                                \
+                                                                      \
+    struct PortDriverDefListItem NAME##_port_driver_def_list_item = { \
+        .def = &NAME##_port_driver_def                                \
+    };                                                                \
+                                                                      \
+    __attribute__((constructor)) void NAME##register_port_driver()    \
+    {                                                                 \
+        NAME##_port_driver_def_list_item.next = port_driver_list;     \
+        port_driver_list = &NAME##_port_driver_def_list_item;         \
+    }
+
 #define EVENT_DESCRIPTORS_COUNT 16
 
 typedef struct EventListener EventListener;
@@ -47,6 +64,24 @@ struct ESP32PlatformData
     struct ListHead sockets_list_head;
 };
 
+typedef void (*port_driver_init_t)(GlobalContext *global);
+typedef Context *(*port_driver_create_port_t)(GlobalContext *global, term opts);
+
+struct PortDriverDef
+{
+    const char *port_driver_name;
+    const port_driver_init_t port_driver_init_cb;
+    const port_driver_create_port_t port_driver_create_port_cb;
+};
+
+struct PortDriverDefListItem
+{
+    struct PortDriverDefListItem *next;
+    const struct PortDriverDef *const def;
+};
+
+extern struct PortDriverDefListItem *port_driver_list;
+
 extern QueueSetHandle_t event_set;
 extern xQueueHandle event_queue;
 void esp32_sys_queue_init();
@@ -54,5 +89,7 @@ void esp32_sys_queue_init();
 void sys_event_listener_init(EventListener *listener, void *sender, event_handler_t handler, void *data);
 
 void socket_init(Context *ctx, term opts);
+
+void port_driver_init_all(GlobalContext *global);
 
 #endif

--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -79,6 +79,7 @@ void app_main()
     GlobalContext *glb = globalcontext_new();
 
     component_ports_init(glb);
+    port_driver_init_all(glb);
     component_nifs_init(glb);
 
     if (!avmpack_is_valid(main_avm, size)) {

--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -81,6 +81,7 @@ void app_main()
     component_ports_init(glb);
     port_driver_init_all(glb);
     component_nifs_init(glb);
+    nif_collection_init_all(glb);
 
     if (!avmpack_is_valid(main_avm, size)) {
         ESP_LOGE(TAG, "Invalid main.avm packbeam.  size=%u", size);

--- a/src/platforms/esp32/main/platform_nifs.c
+++ b/src/platforms/esp32/main/platform_nifs.c
@@ -23,6 +23,7 @@
 #include "atom.h"
 #include "component_nifs.h"
 #include "defaultatoms.h"
+#include "esp32_sys.h"
 #include "interop.h"
 #include "memory.h"
 #include "nifs.h"
@@ -383,6 +384,9 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
     }
     const struct Nif *nif = NULL;
     if ((nif = component_nifs_get_nif(nifname)) != NULL) {
+        return nif;
+    }
+    if ((nif = nif_collection_resolve_nif(nifname)) != NULL) {
         return nif;
     }
     return NULL;

--- a/src/platforms/esp32/main/sys.c
+++ b/src/platforms/esp32/main/sys.c
@@ -50,6 +50,7 @@ static const char *const esp_idf_version_atom = "\xF" "esp_idf_version";
 static const char *const esp32_atom = "\x5" "esp32";
 
 struct PortDriverDefListItem *port_driver_list;
+struct NifCollectionDefListItem *nif_collection_list;
 
 xQueueHandle event_queue = NULL;
 QueueSetHandle_t event_set = NULL;
@@ -254,6 +255,27 @@ static Context *port_driver_create_port(const char *port_name, GlobalContext *gl
     for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
         if (strcmp(port_name, item->def->port_driver_name) == 0) {
             return item->def->port_driver_create_port_cb(global, opts);
+        }
+    }
+
+    return NULL;
+}
+
+void nif_collection_init_all(GlobalContext *global)
+{
+    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
+        if (item->def->nif_collection_init_cb) {
+            item->def->nif_collection_init_cb(global);
+        }
+    }
+}
+
+const struct Nif *nif_collection_resolve_nif(const char *name)
+{
+    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
+        const struct Nif *res = item->def->nif_collection_resove_nif_cb(name);
+        if (res) {
+            return res;
         }
     }
 

--- a/src/platforms/esp32/main/sys.c
+++ b/src/platforms/esp32/main/sys.c
@@ -40,12 +40,16 @@
 
 #define EVENT_QUEUE_LEN 16
 
+static Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts);
+
 static const char *const esp_free_heap_size_atom = "\x14" "esp32_free_heap_size";
 static const char *const esp_largest_free_block_atom = "\x18" "esp32_largest_free_block";
 static const char *const esp_get_minimum_free_size_atom = "\x17" "esp32_minimum_free_size";
 static const char *const esp_chip_info_atom = "\xF" "esp32_chip_info";
 static const char *const esp_idf_version_atom = "\xF" "esp_idf_version";
 static const char *const esp32_atom = "\x5" "esp32";
+
+struct PortDriverDefListItem *port_driver_list;
 
 xQueueHandle event_queue = NULL;
 QueueSetHandle_t event_set = NULL;
@@ -186,7 +190,10 @@ Context *sys_create_port(GlobalContext *glb, const char *port_name, term opts)
 {
     Context *new_ctx = component_ports_create_port(port_name, glb, opts);
     if (IS_NULL_PTR(new_ctx)) {
-        return sys_create_port_fallback(port_name, glb, opts);
+        new_ctx = port_driver_create_port(port_name, glb, opts);
+    }
+    if (IS_NULL_PTR(new_ctx)) {
+        new_ctx = sys_create_port_fallback(port_name, glb, opts);
     }
     return new_ctx;
 }
@@ -231,4 +238,24 @@ void sys_sleep(GlobalContext *glb)
     UNUSED(glb);
 
     vTaskDelay(1);
+}
+
+void port_driver_init_all(GlobalContext *global)
+{
+    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
+        if (item->def->port_driver_init_cb) {
+            item->def->port_driver_init_cb(global);
+        }
+    }
+}
+
+static Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts)
+{
+    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
+        if (strcmp(port_name, item->def->port_driver_name) == 0) {
+            return item->def->port_driver_create_port_cb(global, opts);
+        }
+    }
+
+    return NULL;
 }


### PR DESCRIPTION
Insead of having a list of available port drivers, which gets converted
into a C source file at build time, rely on the newly introduced
`REGISTER_PORT_DRIVER` macro.

This new mechanism doesn't rely on any additional script or build system
feature, but it just make use of `constructor` gcc attribute, which
allows defining a number of functions that are called at startup time.

How to use this new feature:

Just add to your port driver main source file:
```c
REGISTER_PORT_DRIVER(my_port, my_port_driver_init, my_port_driver_create_port)
```

It is also required to add some additional linker flags to `component.mk`:
```
CFLAGS += -fno-function-sections -fno-data-sections
COMPONENT_ADD_LDFLAGS = -Wl,--whole-archive -l$(COMPONENT_NAME) -Wl,--no-whole-archive
```

Same approach has been implemented for NIFs.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
