### PR TITLE
Fix bs_append extra zeroes bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,5 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ESP32] [UART]: Allow using different pins for rx, tx, cts and rts.
 - [ESP32] [UART]: Replace custom UART handling with esp-idf UART event queues, hence other UARTs
   than UART0 are supported, with better performances and stability.
+- Fix binaries concat (`bs_append` instruction) that was adding some extra zeroes at the end of
+  built binaries.
 
 ## [0.5.0] - 2022-03-22

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -3306,11 +3306,12 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     TRACE("bs_append/7, fail=%i size=%li unit=%li src=0x%lx dreg=%c%i\n", fail, size_val, unit, src, T_DEST_REG(dreg_type, dreg));
 
                     size_t src_size = term_binary_size(src);
+                    // TODO: further investigate extra_val
                     if (UNLIKELY(memory_ensure_free(ctx, src_size + term_binary_data_size_in_terms(size_val / 8) + extra_val + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     DECODE_COMPACT_TERM(src, code, i, src_off, src_off)
-                    term t = term_create_empty_binary(src_size + size_val / 8 + extra_val, ctx);
+                    term t = term_create_empty_binary(src_size + size_val / 8, ctx);
                     memcpy((void *) term_binary_data(t), (void *) term_binary_data(src), src_size);
 
                     ctx->bs = t;

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -414,6 +414,7 @@ compile_erlang(bs_restore2_start_offset)
 compile_erlang(bs_restore2_start_offset_no_fp)
 compile_erlang(test_refc_binaries)
 compile_erlang(test_sub_binaries)
+compile_erlang(bs_append_extra_words)
 
 compile_erlang(spawn_opt_monitor_normal)
 compile_erlang(spawn_opt_monitor_throw)
@@ -814,6 +815,7 @@ add_custom_target(erlang_test_modules DEPENDS
     bs_context_to_binary_with_offset.beam
     bs_restore2_start_offset.beam
     bs_restore2_start_offset_no_fp.beam
+    bs_append_extra_words.beam
 
     spawn_opt_monitor_normal.beam
     spawn_opt_monitor_throw.beam

--- a/tests/erlang_tests/bs_append_extra_words.erl
+++ b/tests/erlang_tests/bs_append_extra_words.erl
@@ -1,0 +1,43 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(bs_append_extra_words).
+
+-export([start/0]).
+
+start() ->
+    {ok, Parsed} = parse_digits(<<"234907.00">>),
+    case binary_to_list(Parsed) of
+        "234907" -> 1;
+        _ -> -1
+    end.
+
+parse_digits(In) ->
+    parse_digits(In, 1).
+
+parse_digits(In, Len) when is_binary(In) and is_integer(Len) ->
+    case In of
+        <<S1:Len/binary, S2:2/binary, $., _Rest/binary>> ->
+            {ok, <<S1/binary, S2/binary>>};
+        <<_S:Len/binary, _Rest/binary>> ->
+            parse_digits(In, Len + 1);
+        _Invalid ->
+            {ok, <<"">>}
+    end.


### PR DESCRIPTION
Fix bs_append bug.

See also #322 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
