### PR TITLE
Fixes a bug with packing and unpacking integers unaligned on byte boundaries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,5 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix binaries concat (`bs_append` instruction) that was adding some extra zeroes at the end of
   built binaries.
 - Fixed a bug in gen_tcp that prevents an accepting socket from inheriting settings on the listening socket.
+- Fixed a bug in packing and unpacking integers into and from binaries when the
+  bit length is not a multiple of 8.
 
 ## [0.5.0] - 2022-03-22

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -52,6 +52,7 @@ In addition, several features are supported specifically for integration with mi
 While the list of supported features is long and growing, the currently unsupported Erlang/OTP and BEAM features include (but are not limited to):
 
 * Bingnums.  Integer values are restricted to 64-bit values.
+* Bit Syntax.  While packing and unpacking of arbitrary (but less than 64-) bit values is support, packing and unpacking of integer values at the start of end of a binary, or bordering binary packing or extraction must align on 8-bit boundaries.  Arbitrary-bitlength binaries are not currently supported.
 * SMP support.  The AtomVM VM is currently a single-threaded process.
 * The `epmd` and the `disterl` protocols are not supported.
 * There is no support for code hot swapping.

--- a/src/libAtomVM/bitstring.h
+++ b/src/libAtomVM/bitstring.h
@@ -197,9 +197,11 @@ static inline bool bitstring_extract_integer(term src_bin, size_t offset, avm_in
             default:
                 return bitstring_extract_any_integer(src, 0, n, bs_flags, dst);
         }
+    } else {
+        int byte_offset = offset / 8;
+        const uint8_t *src = (const uint8_t *) term_binary_data(src_bin) + byte_offset;
+        return bitstring_extract_any_integer(src, offset - (byte_offset * 8), n, bs_flags, dst);
     }
-
-    return false;
 }
 
 static inline bool bitstring_insert_integer(term dst_bin, size_t offset, avm_int64_t value, size_t n, enum BitstringFlags bs_flags)
@@ -283,7 +285,7 @@ static inline bool bitstring_insert_integer(term dst_bin, size_t offset, avm_int
             }
 
             default:
-                return bitstring_insert_any_integer(dst, offset, value, n, bs_flags);
+                return bitstring_insert_any_integer(dst, offset - (byte_offset * 8), value, n, bs_flags);
         }
     }
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -3807,10 +3807,6 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         RAISE_ERROR(UNSUPPORTED_ATOM);
                     }
                     avm_int_t size_val = term_to_int(size);
-                    if ((size_val * unit) % 8 != 0) {
-                        TRACE("bs_skip_bits2: Unsupported unit (must be evenly divisible by 8). unit=%li\n", unit);
-                        RAISE_ERROR(UNSUPPORTED_ATOM);
-                    }
 
                     TRACE("bs_skip_bits2/5, fail=%i src=0x%lx size=0x%lx unit=0x%lx flags=0x%lx\n", fail, src, size, unit, flags);
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -311,6 +311,7 @@ compile_erlang(test_ordering_0)
 compile_erlang(test_ordering_1)
 compile_erlang(test_bs)
 compile_erlang(test_bs_int)
+compile_erlang(test_bs_int_unaligned)
 compile_erlang(test_catch)
 compile_erlang(test_gc)
 compile_erlang(test_raise)
@@ -711,6 +712,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_ordering_1.beam
     test_bs.beam
     test_bs_int.beam
+    test_bs_int_unaligned.beam
     test_catch.beam
     test_gc.beam
     test_raise.beam

--- a/tests/erlang_tests/test_bs_int_unaligned.erl
+++ b/tests/erlang_tests/test_bs_int_unaligned.erl
@@ -1,0 +1,91 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_bs_int_unaligned).
+
+-export([start/0]).
+
+start() ->
+    %% two aligned bytes
+    ok = test_pack_unpack(3, 5, 1, 7, false),
+    ok = test_pack_unpack(5, 3, 7, 1, false),
+    %% still adds up to 2 bytes (16 bits)
+    ok = test_pack_unpack(3, 1, 5, 7, false),
+    ok = test_pack_unpack(5, 7, 3, 1, false),
+    %% expressions that traverse a byte boundary
+    ok = test_pack_unpack(13, 3, 1, 7, false),
+    ok = test_pack_unpack(3, 13, 1, 7, false),
+    %% expressions not aligned on 8 bit boundary (expect failure)
+    ok = test_pack_unpack(1, 1, 1, 1, true),
+    ok = test_pack_unpack(3, 13, 1, 1, true),
+    0.
+
+test_pack_unpack(ALen, BLen, CLen, DLen, ExpectFailure) ->
+    try_test_pack_unpack(
+        {random(pow(2, ALen)), ALen},
+        {random(pow(2, BLen)), BLen},
+        {random(pow(2, CLen)), CLen},
+        {random(pow(2, DLen)), DLen},
+        ExpectFailure
+    ).
+
+try_test_pack_unpack({A, ALen}, {B, BLen}, {C, CLen}, {D, DLen}, ExpectFailure) ->
+    try
+        Bin = <<A:ALen, B:BLen, C:CLen, D:DLen>>,
+        <<A1:ALen, B1:BLen, C1:CLen, D1:DLen>> = id(Bin),
+        ok = check(A, A1),
+        ok = check(B, B1),
+        ok = check(C, C1),
+        ok = check(D, D1),
+        case ExpectFailure of
+            true ->
+                expected_failure;
+            _ ->
+                ok
+        end
+    catch
+        _:E ->
+            case ExpectFailure of
+                true ->
+                    ok;
+                _ ->
+                    {expected_ok, E}
+            end
+    end.
+
+check(A, A) ->
+    ok;
+check(A, B) ->
+    throw({expected_equal, A, B}).
+
+random(N) ->
+    {MegaSecs, Secs, MicroSecs} = erlang:timestamp(),
+    ((MegaSecs bxor Secs bxor MicroSecs) rem N) + 1.
+
+pow(B, N) ->
+    pow(B, N, 1).
+
+pow(_B, 1, Accum) ->
+    Accum;
+pow(B, N, Accum) ->
+    pow(B, N - 1, B * Accum).
+
+id(X) ->
+    X.

--- a/tests/test.c
+++ b/tests/test.c
@@ -331,6 +331,7 @@ struct Test tests[] =
     {"test_selective_receive.beam", 0},
     {"test_bs.beam", 0},
     {"test_bs_int.beam", 0},
+    {"test_bs_int_unaligned.beam", 0},
     {"test_catch.beam", 0},
     {"test_gc.beam", 0 },
     {"test_raise.beam", 7},


### PR DESCRIPTION
This PR fixes a bug with packing and unpacking integers that are not aligned on byte boundaries.

Here is an example expression for both packing and unpacking this PR allows.:

`<<A:1, B:7, C:10, D:6, Rest/binary>>`

Note that currently (and for the foreseeable future) in AtomVM, the sizes of contiguous sequences of unaligned integer expressions must still sum to a value that is a factor of 8.  Thus for example `A:1, B:7, C:10, D:6` in the above example is legal, because the sizes sum to 24, but `A:1, B:7, C:10, D:5` would not be.

Previously, there wasn't really any support for unpacking integer values that were not of a size that is a multiple of 8.  That is now fixed.

In addition, there was a bug in the packing of non-aligned ints in some cases, which has also been fixed.

This PR also removes use of atomvm:rand* in tests (in case the project is not built with OpenSSL)

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
