### PR TITLE
Propagate parameters from listening socket to accepted socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,5 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than UART0 are supported, with better performances and stability.
 - Fix binaries concat (`bs_append` instruction) that was adding some extra zeroes at the end of
   built binaries.
+- Fixed a bug in gen_tcp that prevents an accepting socket from inheriting settings on the listening socket.
 
 ## [0.5.0] - 2022-03-22

--- a/libs/estdlib/src/gen_tcp.erl
+++ b/libs/estdlib/src/gen_tcp.erl
@@ -62,7 +62,7 @@
 
 -export([connect/3, send/2, recv/2, recv/3, close/1, listen/2, accept/1, accept/2]).
 
--define(DEFAULT_PARAMS, [{active, true}, {buffer, 128}, binary, {timeout, infinity}]).
+-define(DEFAULT_PARAMS, [{active, true}, {buffer, 512}, {binary, true}, {timeout, infinity}]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Address the address to which to connect
@@ -200,23 +200,7 @@ accept(ListenSocket) ->
     {ok, Socket :: inet:socket()} | {error, Reason :: term()}.
 accept(ListenSocket, Timeout) ->
     case call(ListenSocket, {accept, Timeout}) of
-        {ok, FD} when is_integer(FD) ->
-            Socket = open_port({spawn, "socket"}, []),
-            InitParams = [
-                {proto, tcp},
-                {accept, true},
-                {controlling_process, self()},
-                {fd, FD}
-                | ?DEFAULT_PARAMS
-            ],
-            case call(Socket, {init, InitParams}) of
-                ok ->
-                    {ok, Socket};
-                ErrorReason ->
-                    %% TODO close port
-                    ErrorReason
-            end;
-        {ok, Socket} ->
+        {ok, Socket} when is_pid(Socket) ->
             {ok, Socket};
         ErrorReason ->
             %% TODO close port

--- a/src/platforms/esp32/main/socket_driver.c
+++ b/src/platforms/esp32/main/socket_driver.c
@@ -132,6 +132,7 @@ struct SocketData
 
     uint16_t port;
 
+    size_t buffer;
     bool active : 1;
     bool binary : 1;
 };
@@ -260,7 +261,8 @@ static void socket_data_init(struct SocketData *data, Context *ctx, struct netco
     data->controlling_process_pid = term_invalid_term();
     data->port = 0;
     data->active = true;
-    data->binary = false;
+    data->binary = true;
+    data->buffer = 512;
 
     list_append(&platform->sockets_list_head, &data->sockets_head);
 
@@ -370,8 +372,11 @@ void accept_conn(struct TCPServerAccepter *accepter, Context *ctx)
     if (IS_NULL_PTR(new_tcp_data)) {
         abort();
     }
+    new_tcp_data->socket_data.active = tcp_data->socket_data.active;
+    new_tcp_data->socket_data.binary = tcp_data->socket_data.binary;
+    new_tcp_data->socket_data.buffer = tcp_data->socket_data.buffer;
 
-    //TODO
+    // TODO
     if (UNLIKELY(memory_ensure_free(ctx, 128) != MEMORY_GC_OK)) {
         abort();
     }
@@ -806,6 +811,7 @@ static void do_listen(Context *ctx, term msg)
     term backlog_term = interop_proplist_get_value(params, BACKLOG_ATOM);
     term binary_term = interop_proplist_get_value(params, BINARY_ATOM);
     term active_term = interop_proplist_get_value(params, ACTIVE_ATOM);
+    term buffer_term = interop_proplist_get_value(params, BUFFER_ATOM);
 
     avm_int_t port = term_to_int(port_term);
     avm_int_t backlog = term_to_int(backlog_term);
@@ -818,6 +824,7 @@ static void do_listen(Context *ctx, term msg)
     if (UNLIKELY(!ok)) {
         abort();
     }
+    avm_int_t buffer = term_to_int(buffer_term);
 
     struct netconn *conn = netconn_new_with_proto_and_callback(NETCONN_TCP, 0, socket_callback);
 
@@ -851,6 +858,7 @@ static void do_listen(Context *ctx, term msg)
     tcp_data->socket_data.port = nport;
     tcp_data->socket_data.active = active;
     tcp_data->socket_data.binary = binary;
+    tcp_data->socket_data.buffer = buffer;
     if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
         abort();
     }

--- a/tests/libs/estdlib/test_gen_tcp.erl
+++ b/tests/libs/estdlib/test_gen_tcp.erl
@@ -27,6 +27,7 @@
 test() ->
     ok = test_echo_server(),
     ok = test_echo_server(),
+    ok = test_accept_parameters(),
     ok.
 
 test_echo_server() ->
@@ -77,7 +78,7 @@ test_send_receive(Port, N) ->
     gen_tcp:close(Socket),
     receive
         server_closed -> ok
-    after 1000 -> throw(timeout)
+    after 1000 -> throw({timeout, waiting, recv, server_closed})
     end.
 
 loop(_Socket, 0) ->
@@ -86,9 +87,59 @@ loop(Socket, I) ->
     Packet = list_to_binary(pid_to_list(self()) ++ ":" ++ integer_to_list(I)),
     ok = gen_tcp:send(Socket, Packet),
     receive
-        {tcp_closed, _Socket} ->
+        {tcp_closed, _OtherSocket} ->
             ok;
-        {tcp, _Socket, Packet} ->
+        {tcp, _OtherSocket, _OtherPacket} ->
             loop(Socket, I - 1)
+    end,
+    ok.
+
+sleep(Ms) ->
+    receive after Ms -> ok end.
+
+
+test_accept_parameters() ->
+    {ok, ListenSocket} = gen_tcp:listen(0, [{binary, false}, {buffer, 10}]),
+    {ok, {_Address, Port}} = inet:sockname(ListenSocket),
+
+    Self = self(),
+    spawn(fun() ->
+        Self ! ready,
+        accept(Self, ListenSocket)
+    end),
+    receive
+        ready ->
+            ok
+    end,
+
+    {ok, Socket} = gen_tcp:connect(localhost, Port, [{active, true}]),
+
+    sleep(100),
+
+    ok = test_accept_parameters_loop(Socket, 10),
+
+    gen_tcp:close(Socket),
+    receive
+        server_closed -> ok
+    after 1000 -> throw({timeout, waiting, recv, server_closed})
+    end,
+
+    ok.
+
+test_accept_parameters_loop(_Socket, 0) ->
+    ok;
+test_accept_parameters_loop(Socket, I) ->
+    Packet = list_to_binary(pid_to_list(self()) ++ ":" ++ integer_to_list(I)),
+    ok = gen_tcp:send(Socket, Packet),
+    receive
+        {tcp_closed, _OtherSocket} ->
+            ok;
+        {tcp, _OtherSocket, OtherPacket} ->
+            case is_binary(OtherPacket) of
+                true ->
+                    {error, expected_binary_packet};
+                false ->
+                    loop(Socket, I - 1)
+            end
     end,
     ok.


### PR DESCRIPTION
 Fixes an issue where the parameters set on a listening socket were not propagated to the accepting socket.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
