### PR TITLE
Fix REGISTER_NIF_COLLECTION

### DIFF
--- a/src/platforms/esp32/main/esp32_sys.h
+++ b/src/platforms/esp32/main/esp32_sys.h
@@ -53,7 +53,7 @@
         .def = &NAME##_nif_collection_def                                   \
     };                                                                      \
                                                                             \
-    __attribute__((constructor)) void NAME##register_port_driver()          \
+    __attribute__((constructor)) void NAME##register_nif_collection()       \
     {                                                                       \
         NAME##_nif_collection_def_list_item.next = nif_collection_list;     \
         nif_collection_list = &NAME##_nif_collection_def_list_item;         \


### PR DESCRIPTION
A name clash with port drivers was happening due to a copy&paste
mistake.

Signed-off-by: Davide Bettio <davide@uninstall.it>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
