### PR TITLE
Update .gitignore to track changes to esp32/components/avm_builtins.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@ src/platforms/esp32/build/**
 src/platforms/esp32/build/**/*.d
 src/platforms/esp32/components/**
 !src/platforms/esp32/components/libatomvm/
+!src/platforms/esp32/components/avm_builtins/
+!src/platforms/esp32/components/avm_builtins/**
 .idea/**
 .vscode/**


### PR DESCRIPTION
Changes to the contents of AtomVM/src/platforms/esp32/components/avm_builtins
were ignored by the gitignore rules.  This updates the rules to track changes
to the avm_builtins directory.

Closes issue #330.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
