### PR TITLE
Fix mkimage script to support make and idf.py builds

### DIFF
--- a/src/platforms/esp32/mkimage.config
+++ b/src/platforms/esp32/mkimage.config
@@ -23,22 +23,22 @@
         #{
             name => "bootloader",
             offset => "0x1000",
-            path => "${ROOT_DIR}/src/platforms/esp32/build/bootloader/bootloader.bin"
+            path => ["${ROOT_DIR}/src/platforms/esp32/build/bootloader/bootloader.bin"]
         },
         #{
             name => "partition-table",
             offset => "0x8000",
-            path => "${ROOT_DIR}/src/platforms/esp32/build/partitions.bin"
+            path => ["${ROOT_DIR}/src/platforms/esp32/build/partition_table/partition-table.bin", "${ROOT_DIR}/src/platforms/esp32/build/partitions.bin"]
         },
         #{
             name => "AtomVM Virtual Machine",
             offset => "0x10000",
-            path => "${ROOT_DIR}/src/platforms/esp32/build/atomvvm-esp32.bin"
+            path => ["${ROOT_DIR}/src/platforms/esp32/build/atomvm-esp32.bin", "${ROOT_DIR}/src/platforms/esp32/build/atomvvm-esp32.bin"]
         },
         #{
             name => "AtomVM Core BEAM Library",
             offset =>  "0x1D0000",
-            path => "${BUILD_DIR}/libs/atomvmlib.avm"
+            path => ["${BUILD_DIR}/libs/atomvmlib.avm"]
         }
     ]
 }.


### PR DESCRIPTION
This change set allows the mkimage script to work with both make and idf.py builds.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
