### PR TITLE
Add is_boolean/1 bif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   version 4.1.x through 4.4.x.
 - Added support for `controlling_process/2` in `gen_udp` and `gen_tcp` modules.
 - Added ability to get the atomvm version via `erlang:system_info`.
+- Added erlang:is_boolean/1 Bif.
 
 ### Breaking Changes
 

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -112,6 +112,13 @@ term bif_erlang_is_binary_1(Context *ctx, term arg1)
     return term_is_binary(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
+term bif_erlang_is_boolean_1(Context *ctx, term arg1)
+{
+    UNUSED(ctx);
+
+    return (arg1 == TRUE_ATOM || arg1 == FALSE_ATOM) ? TRUE_ATOM : FALSE_ATOM;
+}
+
 term bif_erlang_is_integer_1(Context *ctx, term arg1)
 {
     UNUSED(ctx);

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -45,6 +45,7 @@ term bif_erlang_length_1(Context *ctx, int live, term arg1);
 
 term bif_erlang_is_atom_1(Context *ctx, term arg1);
 term bif_erlang_is_binary_1(Context *ctx, term arg1);
+term bif_erlang_is_boolean_1(Context *ctx, term arg1);
 term bif_erlang_is_integer_1(Context *ctx, term arg1);
 term bif_erlang_is_list_1(Context *ctx, term arg1);
 term bif_erlang_is_number_1(Context *ctx, term arg1);

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -39,6 +39,7 @@ erlang:bit_size/1, bif_erlang_bit_size_1, true
 erlang:get/1, bif_erlang_get_1, false
 erlang:is_atom/1, bif_erlang_is_atom_1, false
 erlang:is_binary/1, bif_erlang_is_binary_1, false
+erlang:is_boolean/1, bif_erlang_is_boolean_1, false
 erlang:is_integer/1, bif_erlang_is_integer_1, false
 erlang:is_list/1, bif_erlang_is_list_1, false
 erlang:is_number/1, bif_erlang_is_number_1, false

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -98,6 +98,7 @@ compile_erlang(is_type)
 compile_erlang(test_bitshift)
 compile_erlang(test_bitwise)
 compile_erlang(test_bitwise2)
+compile_erlang(test_boolean)
 compile_erlang(test_gt_and_le)
 compile_erlang(test_tuple_size)
 compile_erlang(test_element)
@@ -497,6 +498,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_bitshift.beam
     test_bitwise.beam
     test_bitwise2.beam
+    test_boolean.beam
     test_gt_and_le.beam
     test_tuple_size.beam
     test_element.beam

--- a/tests/erlang_tests/test_boolean.erl
+++ b/tests/erlang_tests/test_boolean.erl
@@ -1,0 +1,65 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_boolean).
+
+-export([start/0]).
+
+start() ->
+    ok = test_boolean_call(),
+    ok = test_boolean_guard(),
+    0.
+
+test_boolean_call() ->
+    true = is_boolean(true),
+    true = is_boolean(false),
+    false = is_boolean(0),
+    false = is_boolean(1),
+    false = is_boolean(1342),
+    false = is_boolean("true"),
+    false = is_boolean(<<"true">>),
+    false = is_boolean([]),
+    false = is_boolean([foo, bar]),
+    false = is_boolean({}),
+    false = is_boolean({foo, bar}),
+    false = is_boolean(#{}),
+    false = is_boolean(#{foo => bar}),
+    ok.
+
+test_boolean_guard() ->
+    true = check_boolean(true),
+    true = check_boolean(false),
+    false = check_boolean(0),
+    false = check_boolean(1),
+    false = check_boolean(1342),
+    false = check_boolean("true"),
+    false = check_boolean(<<"true">>),
+    false = check_boolean([]),
+    false = check_boolean([foo, bar]),
+    false = check_boolean({}),
+    false = check_boolean({foo, bar}),
+    false = check_boolean(#{}),
+    false = check_boolean(#{foo => bar}),
+    ok.
+
+check_boolean(B) when is_boolean(B) ->
+    true;
+check_boolean(_) ->
+    false.

--- a/tests/test.c
+++ b/tests/test.c
@@ -116,6 +116,7 @@ struct Test tests[] =
     {"test_bitshift.beam", 0},
     {"test_bitwise.beam", -4},
     {"test_bitwise2.beam", 0},
+    {"test_boolean.beam", 0},
     {"test_gt_and_le.beam", 255},
     {"test_tuple_size.beam", 6},
     {"test_element.beam", 7},


### PR DESCRIPTION
This change set adds the erlang:is_boolean/1 bif, which returns true if the supplied term is a boolean (the atom true or false), and false, otherwise.

This bif can be used in guard expressions.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
