### PR TITLE
Fix port:call function to return an error if the target process is no longer alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,5 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug in gen_tcp that prevents an accepting socket from inheriting settings on the listening socket.
 - Fixed a bug in packing and unpacking integers into and from binaries when the
   bit length is not a multiple of 8.
+- Fixed a bug that could cause processes to hang indefinitely when calling ports that have terminated.
 
 ## [0.5.0] - 2022-03-22

--- a/libs/eavmlib/src/port.erl
+++ b/libs/eavmlib/src/port.erl
@@ -2,25 +2,6 @@
 % This file is part of AtomVM.
 %
 % Copyright 2018-2022 Davide Bettio <davide@uninstall.it>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
-%
-% This file is part of AtomVM.
-%
 % Copyright 2021 Fred Dushin <fred@dushin.net>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,19 +25,30 @@
 
 -spec call(pid(), Message :: term()) -> term().
 call(Pid, Message) ->
-    Ref = erlang:make_ref(),
-    Pid ! {self(), Ref, Message},
-    receive
-        {Ref, Reply} -> Reply
+    case erlang:is_process_alive(Pid) of
+        false ->
+            {error, noproc};
+        true ->
+            Ref = erlang:make_ref(),
+            Pid ! {self(), Ref, Message},
+            receive
+                out_of_memory -> out_of_memory;
+                {Ref, Reply} -> Reply
+            end
     end.
 
 -spec call(pid(), Message :: term(), TimeoutMs :: non_neg_integer()) -> term() | {error, timeout}.
 call(Pid, Message, TimeoutMs) ->
-    Ref = erlang:make_ref(),
-    Pid ! {self(), Ref, Message},
-    receive
-        out_of_memory -> out_of_memory;
-        {Ref, Reply} -> Reply
-    after TimeoutMs ->
-        {error, timeout}
+    case erlang:is_process_alive(Pid) of
+        false ->
+            {error, noproc};
+        true ->
+            Ref = erlang:make_ref(),
+            Pid ! {self(), Ref, Message},
+            receive
+                out_of_memory -> out_of_memory;
+                {Ref, Reply} -> Reply
+            after TimeoutMs ->
+                {error, timeout}
+            end
     end.

--- a/tests/libs/eavmlib/CMakeLists.txt
+++ b/tests/libs/eavmlib/CMakeLists.txt
@@ -24,6 +24,7 @@ include(BuildErlang)
 
 set(ERLANG_MODULES
     test_logger
+    test_port
     test_timer_manager
 )
 

--- a/tests/libs/eavmlib/test_port.erl
+++ b/tests/libs/eavmlib/test_port.erl
@@ -1,0 +1,60 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_port).
+
+-export([test/0]).
+
+
+test() ->
+    Pid = spawn(fun loop/0),
+
+    pong = port:call(Pid, ping),
+    pong = port:call(Pid, ping, 1000),
+    out_of_memory = port:call(Pid, out_of_memory),
+    out_of_memory = port:call(Pid, out_of_memory, 1000),
+
+    {error, timeout} = port:call(Pid, {sleep, 500}, 250),
+
+    ok = port:call(Pid, halt),
+
+    {error, noproc} = port:call(Pid, ping),
+    {error, noproc} = port:call(Pid, ping, 1000),
+
+    ok.
+
+loop() ->
+    receive
+        {Pid, Ref, ping} ->
+            Pid ! {Ref, pong},
+            loop();
+        {Pid, _Ref, out_of_memory} ->
+            Pid ! out_of_memory,
+            loop();
+        {Pid, Ref, {sleep, Ms}} ->
+            receive after Ms -> ok end,
+            Pid ! {Ref, ok},
+            loop();
+        {Pid, Ref, halt} ->
+            Pid ! {Ref, ok};
+        Garbage ->
+            erlang:display({unexpected_message, Garbage}),
+            loop()
+    end.

--- a/tests/libs/eavmlib/tests.erl
+++ b/tests/libs/eavmlib/tests.erl
@@ -25,5 +25,6 @@
 start() ->
     etest:test([
         test_logger,
+        test_port,
         test_timer_manager
     ]).


### PR DESCRIPTION

This change set changes the behavior of the internally used port:call function, to return an error if the target process is no longer alive.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
