### PR TITLE
Fix deep_sleep nif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,5 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug in gen_tcp that prevents an accepting socket from inheriting settings on the listening socket.
 - Fixed a bug in packing and unpacking integers into and from binaries when the
   bit length is not a multiple of 8.
+- Fixed `esp:deep_sleep/1` that did not accept values above 31 minutes.
 
 ## [0.5.0] - 2022-03-22

--- a/src/platforms/esp32/main/platform_nifs.c
+++ b/src/platforms/esp32/main/platform_nifs.c
@@ -227,10 +227,10 @@ static term nif_esp_deep_sleep(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);
 
-    VALIDATE_VALUE(argv[0], term_is_integer);
-    avm_int_t msecs = term_to_int(argv[0]);
+    VALIDATE_VALUE(argv[0], term_is_any_integer);
+    avm_int64_t msecs = term_maybe_unbox_int64(argv[0]);
 
-    esp_deep_sleep(msecs * 1000);
+    esp_deep_sleep(msecs * 1000ULL);
 
     // technically, this function does not return
     return OK_ATOM;


### PR DESCRIPTION
Allow for values above 31 minutes by accepting 64 bits integer, which is what esp_deep_sleep accepts.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
