### PR TITLE
Make libAtomVM compatible with C++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ BraceWrapping:
   AfterObjCDeclaration: true
   AfterStruct:     true
   AfterUnion:      true
-  AfterExternBlock: true
+  AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
   IndentBraces:    false

--- a/src/libAtomVM/atom.h
+++ b/src/libAtomVM/atom.h
@@ -28,6 +28,10 @@
 #ifndef _ATOM_H_
 #define _ATOM_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -96,5 +100,9 @@ static inline const void *atom_string_data(AtomString atom_str)
  * @param   arity the function arity
  */
 void atom_write_mfa(char *buf, size_t buf_size, AtomString module, AtomString function, int arity);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/atomshashtable.h
+++ b/src/libAtomVM/atomshashtable.h
@@ -21,6 +21,10 @@
 #ifndef _ATOMSHASHTABLE_H_
 #define _ATOMSHASHTABLE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "atom.h"
 
 struct AtomsHashTable
@@ -36,5 +40,9 @@ unsigned long atomshashtable_get_value(const struct AtomsHashTable *hash_table, 
 int atomshashtable_has_key(const struct AtomsHashTable *hash_table, AtomString string);
 
 #define TO_ATOMSHASHTABLE_VALUE(value) ((unsigned long) (value))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/avmpack.h
+++ b/src/libAtomVM/avmpack.h
@@ -26,6 +26,10 @@
 #ifndef _AVMPACK_H_
 #define _AVMPACK_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "list.h"
 #include <stdint.h>
 
@@ -98,5 +102,9 @@ int avmpack_is_valid(const void *avmpack_binary, uint32_t size);
  * @param fold_fun function that will be called for each AVM section.
  */
 void *avmpack_fold(void *accum, const void *avmpack_binary, avmpack_fold_fun fold_fun);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -26,6 +26,10 @@
 #ifndef _BIF_H_
 #define _BIF_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdbool.h>
 
 #include "atom.h"
@@ -100,5 +104,9 @@ term bif_erlang_less_than_or_equal_2(Context *ctx, term arg1, term arg2);
 term bif_erlang_greater_than_or_equal_2(Context *ctx, term arg1, term arg2);
 
 term bif_erlang_get_1(Context *ctx, term arg1);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/bitstring.h
+++ b/src/libAtomVM/bitstring.h
@@ -22,6 +22,10 @@
 #ifndef _BITSTRING_H_
 #define _BITSTRING_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "term.h"
 
 #include <stdbool.h>
@@ -291,5 +295,9 @@ static inline bool bitstring_insert_integer(term dst_bin, size_t offset, avm_int
 
     return bitstring_insert_any_integer((uint8_t *) term_binary_data(dst_bin), offset, value, n, bs_flags);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -28,6 +28,10 @@
 #ifndef _CONTEXT_H_
 #define _CONTEXT_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "globalcontext.h"
 #include "linkedlist.h"
 #include "term.h"
@@ -40,7 +44,7 @@ struct Module;
 typedef struct Module Module;
 #endif
 
-typedef void (*native_handler)(Context *ctx);
+typedef void (*native_handler_f)(Context *ctx);
 
 enum ContextFlags
 {
@@ -86,8 +90,8 @@ struct Context
 
     GlobalContext *global;
 
-    //Ports support
-    native_handler native_handler;
+    // Ports support
+    native_handler_f native_handler;
 
     uint64_t reductions;
 
@@ -299,5 +303,9 @@ size_t context_size(Context *ctx);
 
 uint64_t context_monitor(Context *ctx, term monitor_pid, bool linked);
 void context_demonitor(Context *ctx, term monitor_pid, bool linked);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/debug.h
+++ b/src/libAtomVM/debug.h
@@ -28,6 +28,10 @@
 #ifndef _DEBUG_H_
 #define _DEBUG_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "context.h"
 
 /**
@@ -94,6 +98,10 @@ void debug_print_processes_list(struct ListHead *processes);
     #define DEBUG_DUMP_STACK debug_dump_stack
 #else
     #define DEBUG_DUMP_STACK(...)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/src/libAtomVM/defaultatoms.h
+++ b/src/libAtomVM/defaultatoms.h
@@ -21,6 +21,10 @@
 #ifndef _DEFAULTATOMS_H_
 #define _DEFAULTATOMS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "globalcontext.h"
 
 #define FALSE_ATOM_INDEX 0
@@ -178,5 +182,9 @@
 void defaultatoms_init(GlobalContext *glb);
 
 void platform_defaultatoms_init(GlobalContext *glb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/dictionary.h
+++ b/src/libAtomVM/dictionary.h
@@ -21,6 +21,10 @@
 #ifndef _DICTIONARY_H_
 #define _DICTIONARY_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "list.h"
 #include "term.h"
 
@@ -35,5 +39,9 @@ term dictionary_put(struct ListHead *dict, Context *ctx, term key, term value);
 term dictionary_get(struct ListHead *dict, Context *ctx, term key);
 term dictionary_erase(struct ListHead *dict, Context *ctx, term key);
 void dictionary_destroy(struct ListHead *dict);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/externalterm.h
+++ b/src/libAtomVM/externalterm.h
@@ -28,6 +28,10 @@
 #ifndef _EXTERNALTERM_H_
 #define _EXTERNALTERM_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "term.h"
 
 enum ExternalTermResult
@@ -82,5 +86,9 @@ enum ExternalTermResult externalterm_from_binary(Context *ctx, term *dst, term b
  * deserialization fails.
  */
 term externalterm_to_binary(Context *ctx, term t);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -28,6 +28,10 @@
 #ifndef _GLOBALCONTEXT_H_
 #define _GLOBALCONTEXT_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 #include "atom.h"
@@ -43,7 +47,9 @@ struct Context;
 typedef struct Context Context;
 #endif
 
+#ifndef __cplusplus
 struct GlobalContext;
+#endif
 
 #ifndef TYPEDEF_MODULE
 #define TYPEDEF_MODULE
@@ -234,5 +240,9 @@ static inline uint64_t globalcontext_get_ref_ticks(GlobalContext *global)
 {
     return ++global->ref_ticks;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/iff.h
+++ b/src/libAtomVM/iff.h
@@ -28,6 +28,10 @@
 #ifndef _IFF_H_
 #define _IFF_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 /** UTF-8 Atoms table section */
@@ -77,5 +81,9 @@ void scan_iff(const void *iff_binary, int file_size, unsigned long *offsets, uns
  * @returns 1 if beam_data points to a valid binary, otherwise 0 is returned.
  */
 int iff_is_valid_beam(const void *beam_data);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -21,6 +21,10 @@
 #ifndef _INTEROP_H_
 #define _INTEROP_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "context.h"
 #include "term.h"
 
@@ -67,5 +71,9 @@ int interop_write_iolist(term t, char *p);
  * @returns the found int value which corresponds to the given atom.
  */
 int interop_atom_term_select_int(GlobalContext *global, const AtomStringIntPair *table, term atom);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -28,6 +28,10 @@
 #ifndef _MAILBOX_H_
 #define _MAILBOX_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "context.h"
 #include "list.h"
 #include "term.h"
@@ -93,5 +97,9 @@ void mailbox_remove(Context *c);
  * @param m the message to free.
  */
 void mailbox_destroy_message(Message *m);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/memory.h
+++ b/src/libAtomVM/memory.h
@@ -21,6 +21,10 @@
 #ifndef _MEMORY_H_
 #define _MEMORY_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "term_typedef.h"
 #include "utils.h"
 
@@ -115,5 +119,9 @@ unsigned long memory_estimate_usage(term t);
  * @param mso_list the list of mark-sweep object in a heap "space"
  */
 void memory_sweep_mso_list(term mso_list);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -28,6 +28,10 @@
 #ifndef _MODULE_H_
 #define _MODULE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 #include "atom.h"
@@ -237,5 +241,9 @@ static inline const uint8_t *module_get_str(Module *mod, size_t offset, size_t *
     *remaining = mod->str_table_len - offset;
     return ((const uint8_t *) mod->str_table) + 8 + offset;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/nifs.h
+++ b/src/libAtomVM/nifs.h
@@ -26,6 +26,10 @@
 #ifndef _NIFS_H_
 #define _NIFS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "atom.h"
 #include "context.h"
 #include "exportedfunction.h"
@@ -43,5 +47,9 @@
     return term_invalid_term();
 
 const struct Nif *nifs_get(AtomString module, AtomString function, int arity);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/platform_nifs.h
+++ b/src/libAtomVM/platform_nifs.h
@@ -21,6 +21,10 @@
 #ifndef _PLATFORM_NIFS_H_
 #define _PLATFORM_NIFS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "exportedfunction.h"
 #include "module.h"
 
@@ -35,5 +39,9 @@
  *           NULL, if there is no such Nif.
  */
 const struct Nif *platform_nifs_get_nif(const char *nifname);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/port.h
+++ b/src/libAtomVM/port.h
@@ -21,6 +21,10 @@
 #ifndef _PORT_H_
 #define _PORT_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "context.h"
 #include "defaultatoms.h"
 #include "globalcontext.h"
@@ -36,5 +40,9 @@ void port_send_reply(Context *ctx, term pid, term ref, term reply);
 void port_send_message(Context *ctx, term pid, term msg);
 void port_ensure_available(Context *ctx, size_t size);
 int port_is_standard_port_command(term msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/refc_binary.h
+++ b/src/libAtomVM/refc_binary.h
@@ -21,6 +21,10 @@
 #ifndef _REFC_BINARY_H_
 #define _REFC_BINARY_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "list.h"
 #include <stdbool.h>
 #include <stdlib.h>
@@ -72,5 +76,9 @@ bool refc_binary_decrement_refcount(struct RefcBinary *ptr);
  * TODO consider implementing erlang:memory/0,1 instead
  */
 term refc_binary_create_binary_info(Context *ctx);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _REFC_BINARY_H_

--- a/src/libAtomVM/scheduler.h
+++ b/src/libAtomVM/scheduler.h
@@ -28,6 +28,10 @@
 #ifndef _SCHEDULER_H_
 #define _SCHEDULER_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "context.h"
 #include "globalcontext.h"
 #include "linkedlist.h"
@@ -101,5 +105,9 @@ Context *scheduler_next(GlobalContext *global, Context *c);
 void scheduler_set_timeout(Context *ctx, uint32_t timeout);
 
 void scheduler_cancel_timeout(Context *ctx);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/sys.h
+++ b/src/libAtomVM/sys.h
@@ -28,6 +28,10 @@
 #ifndef _SYS_H_
 #define _SYS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "globalcontext.h"
 #include "linkedlist.h"
 #include "module.h"
@@ -91,5 +95,9 @@ void sys_stop_millis_timer();
 uint32_t sys_millis();
 
 void sys_sleep(GlobalContext *glb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -28,6 +28,10 @@
 #ifndef _TERM_H_
 #define _TERM_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -1655,5 +1659,9 @@ static inline term term_get_sub_binary_ref(term t)
     const term *boxed_value = term_to_const_term_ptr(t);
     return boxed_value[3];
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/term_typedef.h
+++ b/src/libAtomVM/term_typedef.h
@@ -28,9 +28,13 @@
 #ifndef _TERM_TYPEDEF_H_
 #define _TERM_TYPEDEF_H_
 
+#ifdef __cplusplus
+#include <climits>
+#else
 #include <limits.h>
-#include <stdint.h>
+#endif
 #include <inttypes.h>
+#include <stdint.h>
 
 /**
  * A value of any data type, types bigger than a machine word will require some additional space on heap.

--- a/src/libAtomVM/timer_wheel.h
+++ b/src/libAtomVM/timer_wheel.h
@@ -21,6 +21,10 @@
 #ifndef _TIMER_WHEEL_H_
 #define _TIMER_WHEEL_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -84,5 +88,9 @@ static inline uint64_t timer_wheel_expiry_to_monotonic(const struct TimerWheel *
 {
     return tw->monotonic_time + expiry;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/valueshashtable.h
+++ b/src/libAtomVM/valueshashtable.h
@@ -21,6 +21,10 @@
 #ifndef _VALUESHASHTABLE_H_
 #define _VALUESHASHTABLE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct ValuesHashTable
 {
     int capacity;
@@ -32,5 +36,9 @@ struct ValuesHashTable *valueshashtable_new();
 int valueshashtable_insert(struct ValuesHashTable *hash_table, unsigned long key, unsigned long value);
 unsigned long valueshashtable_get_value(const struct ValuesHashTable *hash_table, unsigned long key, unsigned long default_value);
 int valueshashtable_has_key(const struct ValuesHashTable *hash_table, unsigned long key);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Required to build some NIFs/Ports that rely on C++-based components (e.g. [M5Unified](https://github.com/M5Stack/M5Unified))

Signed-off-by: Paul Guyot <pguyot@kallisys.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
