### PR TITLE
Use clang-format-13 for nicer comments alignment, update doc

### DIFF
--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -21,14 +21,17 @@ jobs:
 
     - name: "Install run-clang-format"
       run: |
+        wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" | sudo tee -a /etc/apt/sources.list
+        echo "deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get update
-        sudo apt-get install -y clang-format
+        sudo apt-get install -y clang-format-13
         curl -sSfL https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-clang-format.py -o run-clang-format
         chmod +x run-clang-format
 
     - name: "Check formatting with clang-format"
       run: |
-        ./run-clang-format --style=file -r src/ tests/
+        ./run-clang-format --style=file --clang-format-executable=clang-format-13 -r src/ tests/
 
     - name: "Check formatting with Erlang fmt"
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,11 @@ Last but not least, **do not use GitHub issues for vulnerability reports**, read
 
 ### C Code
 
+Style is enforced with clang-format-13. To automatically fix a file, run:
+```
+clang-format-13 --style=file -i file.c
+```
+
 #### Identation
 
 * [K&R identation and braces style](https://en.wikipedia.org/wiki/Indentation_style#K&R_style)


### PR DESCRIPTION
Signed-off-by: Paul Guyot <pguyot@kallisys.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
