### PR TITLE
Fixed leak in gpio interrupt functions.

### DIFF
--- a/libs/eavmlib/src/gpio.erl
+++ b/libs/eavmlib/src/gpio.erl
@@ -128,10 +128,10 @@ digital_write(_GPIONum, _Level) ->
 digital_read(_GPIONum) ->
     throw(nif_error).
 
-%% TODO should we deprecate?  It looks like a memory leak
+-spec attach_interrupt(GPIONum :: pin(), Mode :: direction()) -> ok | error.
 attach_interrupt(GPIONum, Mode) ->
-    set_int(open(), GPIONum, Mode).
+    set_int(start(), GPIONum, Mode).
 
-%% TODO should we deprecate?  It looks like a memory leak
+-spec detach_interrupt(GPIONum :: pin()) -> ok | error.
 detach_interrupt(GPIONum) ->
-    remove_int(open(), GPIONum).
+    remove_int(whereis(gpio), GPIONum).


### PR DESCRIPTION
attach_interrupt() and detach_interrupt() both used open() which could lead to a new process being created each time, this changes attach_interrupt() to use start() instead which checks for a previously started "gpio" process. detach_interrupt() has ben modified to use whereis(gpio), since that should already be started when the interrupt was attached.

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
