### PR TITLE
Add ability to boot from multiple AVM partitions (ESP32 only).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for FP opcodes 94-102 thus removing the need for `AVM_DISABLE_FP=On` with OTP-22+
 - Added support for stacktraces
 - Added support for `utf-8`, `utf-16`, and `utf-32` bit syntax modifiers (put and match)
-
+- Added ability to boot from multiple AVM partitions. (ESP32 only)
 
 ### Fixed
 - Fixed issue with formatting integers with io:format() on STM32 platform

--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -286,3 +286,18 @@ term interop_kv_get_value_default(term kv, AtomString key, term default_value, G
         return default_value;
     }
 }
+
+term interop_string_to_atom(Context *ctx, const char *str, size_t len)
+{
+    if (len > 255) {
+        return term_invalid_term();
+    }
+    AtomString atom = malloc(len + 1);
+    if (IS_NULL_PTR(atom)) {
+        return term_invalid_term();
+    }
+    ((uint8_t *) atom)[0] = len;
+    memcpy(((char *) atom) + 1, str, len);
+
+    return context_make_atom(ctx, atom);
+}

--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -61,6 +61,7 @@ term interop_proplist_get_value(term list, term key);
 term interop_proplist_get_value_default(term list, term key, term default_value);
 term interop_map_get_value(Context *ctx, term map, term key);
 term interop_map_get_value_default(Context *ctx, term map, term key, term default_value);
+term interop_string_to_atom(Context *ctx, const char *str, size_t len);
 
 NO_DISCARD InteropFunctionResult interop_iolist_size(term t, size_t *size);
 NO_DISCARD InteropFunctionResult interop_write_iolist(term t, char *p);

--- a/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
+++ b/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
@@ -125,5 +125,6 @@ void socket_init(Context *ctx, term opts);
 void port_driver_init_all(GlobalContext *global);
 void nif_collection_init_all(GlobalContext *global);
 const struct Nif *nif_collection_resolve_nif(const char *name);
+const void *avm_partition(const char *partition_name, int *size);
 
 #endif

--- a/src/platforms/esp32/main/Kconfig.projbuild
+++ b/src/platforms/esp32/main/Kconfig.projbuild
@@ -26,4 +26,9 @@ menu "AtomVM configuration"
         help
             Reboot the ESP32 device if the start/0 entrypoint does not return the `ok` atom.
 
+    config RESET_BOOT_PARTITION_ON_NOT_OK
+        bool  "Reset the boot partition on not ok return value from start/0"
+        default n
+        help
+            Reset the boot partition to the default if the start/0 entrypoint does not return the `ok` atom.
 endmenu

--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -35,8 +35,6 @@
 #include <globalcontext.h>
 #include <iff.h>
 #include <module.h>
-#include <nvs.h>
-#include <nvs_flash.h>
 #include <term.h>
 #include <utils.h>
 #include <version.h>
@@ -44,12 +42,6 @@
 #include "esp32_sys.h"
 
 #define TAG "AtomVM"
-
-#define ATOMVM_NAMESPACE "atomvm"
-#define BOOT_PARTITION_KEY "boot_partition"
-#define APP1_PARTITION_NAME "app1.avm"
-#define APP2_PARTITION_NAME "app2.avm"
-#define MAX_PARTITION_NAME_SIZE 64
 
 #define ATOMVM_BANNER                                                   \
     "\n"                                                                \
@@ -66,10 +58,6 @@
     "    ###########################################################\n" \
     "\n"
 
-static const void *avm_partition(const char *partition_name, int *size);
-static const char *get_start_partition();
-static esp_err_t reset_boot_partition();
-
 void app_main()
 {
     esp32_sys_queue_init();
@@ -77,49 +65,36 @@ void app_main()
     fprintf(stdout, "%s", ATOMVM_BANNER);
     ESP_LOGI(TAG, "Starting AtomVM revision " ATOMVM_VERSION);
 
-    const char *start_partition = get_start_partition();
     int size;
-    const void *main_avm = avm_partition(start_partition, &size);
+    const void *lib_avm = avm_partition("lib.avm", &size);
 
     uint32_t startup_beam_size;
     const void *startup_beam;
-    const char *startup_module_name;
+    const char *startup_module_name = "esp.beam";
 
     GlobalContext *glb = globalcontext_new();
 
     port_driver_init_all(glb);
     nif_collection_init_all(glb);
 
-    if (!avmpack_is_valid(main_avm, size)) {
-        ESP_LOGE(TAG, "Invalid main.avm packbeam.  size=%u", size);
+    if (!avmpack_is_valid(lib_avm, size)) {
+        ESP_LOGE(TAG, "Invalid lib_avm packbeam.  size=%u", size);
         AVM_ABORT();
     }
-    if (!avmpack_find_section_by_flag(main_avm, BEAM_START_FLAG, &startup_beam, &startup_beam_size, &startup_module_name)) {
-        ESP_LOGE(TAG, "Error: Failed to locate start module in main.avm packbeam.  (Did you flash a library by mistake?)");
+    if (!avmpack_find_section_by_name(lib_avm, startup_module_name, &startup_beam, &startup_beam_size)) {
+        ESP_LOGE(TAG, "Error: Failed to locate esp.beam in lib.avm partition.  (Did you flash a library by mistake?)");
         AVM_ABORT();
     }
     ESP_LOGI(TAG, "Found startup beam %s", startup_module_name);
     struct AVMPackData *avmpack_data = malloc(sizeof(struct AVMPackData));
     if (IS_NULL_PTR(avmpack_data)) {
-        ESP_LOGE(TAG, "Memory error: Cannot allocate AVMPackData for main.avm.");
+        ESP_LOGE(TAG, "Memory error: Cannot allocate AVMPackData for lib.avm.");
         AVM_ABORT();
     }
-    avmpack_data->data = main_avm;
+    avmpack_data->data = lib_avm;
     list_append(&glb->avmpack_data, (struct ListHead *) avmpack_data);
     glb->avmpack_platform_data = NULL;
 
-    const void *lib_avm = avm_partition("lib.avm", &size);
-    if (!IS_NULL_PTR(lib_avm) && avmpack_is_valid(lib_avm, size)) {
-        avmpack_data = malloc(sizeof(struct AVMPackData));
-        if (IS_NULL_PTR(avmpack_data)) {
-            ESP_LOGE(TAG, "Memory error: Cannot allocate AVMPackData for lib.avm.");
-            AVM_ABORT();
-        }
-        avmpack_data->data = lib_avm;
-        list_append(&glb->avmpack_data, (struct ListHead *) avmpack_data);
-    } else {
-        ESP_LOGW(TAG, "Unable to mount lib.avm partition.  Hopefully the AtomVM core libraries are included in your application.");
-    }
     term ret_value = term_nil();
     Module *mod = module_new_from_iff_binary(glb, startup_beam, startup_beam_size);
     if (IS_NULL_PTR(mod)) {
@@ -132,26 +107,12 @@ void app_main()
         ESP_LOGI(TAG, "Starting %s...", startup_module_name);
         fprintf(stdout, "---\n");
 
-        context_execute_loop(ctx, mod, "start", 0);
+        context_execute_loop(ctx, mod, "boot", 0);
         ret_value = ctx->x[0];
 
         fprintf(stdout, "AtomVM finished with return value: ");
         term_display(stdout, ret_value, ctx);
         fprintf(stdout, "\n");
-    }
-
-    bool reset_boot_partition_on_not_ok =
-#if defined(CONFIG_RESET_BOOT_PARTITION_ON_NOT_OK)
-        CONFIG_RESET_BOOT_PARTITION_ON_NOT_OK ? true : false;
-#else
-        false;
-#endif
-    if (reset_boot_partition_on_not_ok && ret_value != OK_ATOM) {
-        if (reset_boot_partition() != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to reset boot partition.");
-        } else {
-            ESP_LOGI(TAG, "Reset boot partition.");
-        }
     }
 
     bool reboot_on_not_ok =
@@ -171,101 +132,4 @@ void app_main()
             vTaskDelay(5000 / portTICK_PERIOD_MS);
         }
     }
-}
-
-const char *get_start_partition()
-{
-    esp_err_t err;
-
-    err = nvs_flash_init();
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "Unable to initialize NVS flash.  Using default partition name %s", APP1_PARTITION_NAME);
-        return APP1_PARTITION_NAME;
-    }
-
-    nvs_handle nvs;
-    err = nvs_open(ATOMVM_NAMESPACE, NVS_READONLY, &nvs);
-    if (err != ESP_OK) {
-        ESP_LOGI(TAG, "Unable to open NVS namespace %s.  Using default partition name %s", ATOMVM_NAMESPACE, APP1_PARTITION_NAME);
-        return APP1_PARTITION_NAME;
-    }
-
-    size_t size = 0;
-    err = nvs_get_blob(nvs, BOOT_PARTITION_KEY, NULL, &size);
-    if (err != ESP_OK) {
-        ESP_LOGI(TAG, "Unable to get NVS key %s in namespace %s.  Using default partition name %s", BOOT_PARTITION_KEY, ATOMVM_NAMESPACE, APP1_PARTITION_NAME);
-        nvs_close(nvs);
-        return APP1_PARTITION_NAME;
-    }
-    if (size == 0 || size > MAX_PARTITION_NAME_SIZE) {
-        ESP_LOGW(TAG, "NVS key %s in namespace %s has an unexpected size: %u.  Using default partition name %s", BOOT_PARTITION_KEY, ATOMVM_NAMESPACE, size, APP1_PARTITION_NAME);
-        nvs_close(nvs);
-        return APP1_PARTITION_NAME;
-    }
-    char buf[MAX_PARTITION_NAME_SIZE + 1];
-    err = nvs_get_blob(nvs, BOOT_PARTITION_KEY, buf, &size);
-    buf[size] = '\0';
-    nvs_close(nvs);
-
-    if (strcmp(buf, APP1_PARTITION_NAME) == 0) {
-        return APP1_PARTITION_NAME;
-    } else if (strcmp(buf, APP2_PARTITION_NAME) == 0) {
-        return APP2_PARTITION_NAME;
-    } else {
-        ESP_LOGW(TAG, "NVS key %s in namespace %s has an unexpected value: %s.  Using default partition name %s", BOOT_PARTITION_KEY, ATOMVM_NAMESPACE, buf, APP1_PARTITION_NAME);
-        return APP1_PARTITION_NAME;
-    }
-}
-
-static esp_err_t reset_boot_partition()
-{
-    esp_err_t err;
-
-    err = nvs_flash_init();
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "Unable to initialize NVS flash.");
-        return err;
-    }
-
-    nvs_handle nvs;
-    err = nvs_open(ATOMVM_NAMESPACE, NVS_READWRITE, &nvs);
-    if (err != ESP_OK) {
-        ESP_LOGI(TAG, "Unable to open NVS namespace %s.", ATOMVM_NAMESPACE);
-        return err;
-    }
-
-    err = nvs_erase_key(nvs, BOOT_PARTITION_KEY);
-    if (err != ESP_OK) {
-        ESP_LOGI(TAG, "Unable to erase key %s in NVS namespace %s.", BOOT_PARTITION_KEY, ATOMVM_NAMESPACE);
-        return err;
-    }
-
-    nvs_close(nvs);
-
-    return ESP_OK;
-}
-
-static const void *avm_partition(const char *partition_name, int *size)
-{
-    const esp_partition_t *partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, partition_name);
-    if (!partition) {
-        ESP_LOGW(TAG, "AVM partition not found for %s", partition_name);
-        *size = 0;
-        return NULL;
-    } else {
-        *size = partition->size;
-    }
-
-    const void *mapped_memory;
-    spi_flash_mmap_handle_t unmap_handle;
-    if (esp_partition_mmap(partition, 0, partition->size, SPI_FLASH_MMAP_DATA, &mapped_memory, &unmap_handle) != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to map BEAM partition for %s", partition_name);
-        AVM_ABORT();
-        return NULL;
-    }
-    ESP_LOGI(TAG, "Loaded BEAM partition %s at address 0x%x (size=%i bytes)", partition_name, partition->address, partition->size);
-
-    UNUSED(unmap_handle);
-
-    return mapped_memory;
 }

--- a/src/platforms/esp32/partitions.csv
+++ b/src/platforms/esp32/partitions.csv
@@ -9,4 +9,5 @@ nvs,      data, nvs,       0x9000,     0x6000,
 phy_init, data, phy,       0xf000,     0x1000,
 factory,  app,  factory,  0x10000,   0x1C0000,
 lib.avm,  data, phy,     0x1D0000,    0x40000,
-main.avm, data, phy,     0x210000,   0x100000
+app1.avm, data, phy,     0x210000,    0xF8000,
+app2.avm, data, phy,     0x308000,    0xF8000,


### PR DESCRIPTION
This change set modifies the partitioning scheme on ESP32 flash modules, to allow multiple application (data) partitions to be flashed to the device.  An NVS key (`boot_partition`) in the `atomvm` namespace is used to control which partition should be used to boot the application.  By default, the first partition (`app1.avm`) is used, which has the same address as the `main.avm` application it replaces.

This change set also adds a KConfiguration entry to tell the AtomVM application to revert to booting off the first partition if the running application fails to return the atom `ok`.  This entry is disabled by default.

These changes are intended to provide support for "soft" (meaning only the Erlang/Elixir code) over-the-air updates of AtomVM applications.

This change is backwards-compatible with previous releases; however, the allowable partition size of an AtomVM application is reduced from 2MB to just under 1MB.  Most users should find this reduction permissible.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
