### PR TITLE
Added support for esp:partition_erase_range/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `controlling_process/2` in `gen_udp` and `gen_tcp` modules.
 - Added ability to get the atomvm version via `erlang:system_info`.
 - Added erlang:is_boolean/1 Bif.
+- Added support for esp:partition_erase_range/2
 
 ### Breaking Changes
 

--- a/src/platforms/esp32/main/platform_nifs.c
+++ b/src/platforms/esp32/main/platform_nifs.c
@@ -191,8 +191,13 @@ static term nif_esp_partition_erase_range(Context *ctx, int argc, term argv[])
     VALIDATE_VALUE(argv[1], term_is_integer);
     avm_int_t offset = term_to_int(argv[1]);
 
-    VALIDATE_VALUE(argv[2], term_is_integer);
-    avm_int_t size = term_to_int(argv[2]);
+    avm_int_t size = 0;
+    if (argc == 3) {
+        VALIDATE_VALUE(argv[2], term_is_integer);
+        size = term_to_int(argv[2]);
+    } else {
+        size = partition->size - offset;
+    }
 
     esp_err_t res = esp_partition_erase_range(partition, offset, size);
     if (UNLIKELY(res != ESP_OK)) {
@@ -372,6 +377,10 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
     if (strcmp("esp:freq_hz/0", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &esp_freq_hz_nif;
+    }
+    if (strcmp("esp:partition_erase_range/2", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &esp_partition_erase_range_nif;
     }
     if (strcmp("esp:partition_erase_range/3", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);


### PR DESCRIPTION
This change set adds support for the arity-2 version of `esp:partition_erase_range`, alllowing users to erase the remainder of a partition, when the partition size is not known, e.g.,
```
esp:partition_erase_range(Partition, Offset)
```
Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
