### PR TITLE
Enforce the min_heap_space setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,5 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `esp:deep_sleep/1` that did not accept values above 31 minutes.
 - Fixed a bug that could cause processes to hang indefinitely when calling ports that have terminated.
 - Fixed potential VM crash when parsing external terms.
+- Fixed the enforcement of `min_free_space` process option.
 
 ## [0.5.0] - 2022-03-22

--- a/tests/erlang_tests/test_min_heap_size.erl
+++ b/tests/erlang_tests/test_min_heap_size.erl
@@ -28,11 +28,19 @@ start() ->
     receive
         ok -> ok
     end,
+    receive
+    after 100 ->
+        ok
+    end,
     {memory, Pid1MemorySize} = process_info(Pid1, memory),
     assert(Pid1MemorySize < 1024),
     Pid2 = spawn_opt(?MODULE, loop, [Self], [{min_heap_size, 1024}]),
     receive
         ok -> ok
+    end,
+    receive
+    after 100 ->
+        ok
     end,
     {memory, Pid2MemorySize} = process_info(Pid2, memory),
     assert(1024 =< Pid2MemorySize),
@@ -50,6 +58,9 @@ loop(undefined) ->
     receive
         {Pid, stop} ->
             Pid ! ok
+    after 10 ->
+        erlang:garbage_collect(),
+        loop(undefined)
     end;
 loop(Pid) ->
     Pid ! ok,


### PR DESCRIPTION
This change set enforces the min_heap_size option when spawning a process so that the heap size never shrinks below the specified amount, if it is specified in spawn_opt.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
