### PR TITLE
Added support for `i2c:close/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   version 4.1.x through 4.4.x.
 - Added support for `controlling_process/2` in `gen_udp` and `gen_tcp` modules.
 - Added ability to get the atomvm version via `erlang:system_info`.
-- Added erlang:is_boolean/1 Bif.
-- Added support for esp:partition_erase_range/2
+- Added `erlang:is_boolean/1` Bif.
+- Added support for `esp:partition_erase_range/2`
+- Added support for `i2c:close/1`
 
 ### Breaking Changes
 

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -584,6 +584,12 @@ Reading bytes is more straightforward.  Simply use `i2c:read_bytes/3,4`, specify
     %% erlang
     BinaryData = i2c:read_bytes(I2C, DeviceAddress, Register, Len)
 
+To close the I2C driver and free any resources in use by it, use the `i2c:close/1` function, supplying a reference to the I2C driver instance created via `i2c:open/1`:
+
+    %% erlang
+    ok = i2c:close(I2C)
+
+Once the I2C driver is closed, any calls to `i2c` functions using a reference to the I2C driver instance should return with the value `{error, noproc}`.
 
 ### SPI
 

--- a/libs/eavmlib/src/i2c.erl
+++ b/libs/eavmlib/src/i2c.erl
@@ -34,6 +34,7 @@
 -module(i2c).
 -export([
     open/1,
+    close/1,
     begin_transmission/2,
     write_byte/2,
     end_transmission/1,
@@ -60,6 +61,19 @@
 -spec open(Param :: params()) -> i2c().
 open(Param) ->
     open_port({spawn, "i2c"}, Param).
+
+%%-----------------------------------------------------------------------------
+%% @param   I2C I2C instance created via `open/1'
+%% @returns `ok' atom
+%% @doc     Closes the connection to the I2C driver
+%%
+%%          This function will close the connection to the I2C driver and
+%%          free any resources in use by it.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec close(I2C :: i2c()) -> ok | {error, Reason :: term()}.
+close(I2C) ->
+    port:call(I2C, {close}).
 
 %%-----------------------------------------------------------------------------
 %% @param   I2C I2C instance created via `open/1'


### PR DESCRIPTION
Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
