### PR TITLE
Git track changes to core ESP32 components.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ src/platforms/esp32/build/**
 src/platforms/esp32/build/**/*.d
 src/platforms/esp32/components/**
 src/platforms/esp32/sdkconfig
+!src/platforms/esp32/components/avm_builtins/
+!src/platforms/esp32/components/avm_builtins/**
+!src/platforms/esp32/components/avm_sys/
+!src/platforms/esp32/components/avm_sys/**
 !src/platforms/esp32/components/libatomvm/
 !src/platforms/esp32/components/libatomvm/**
 .idea/**


### PR DESCRIPTION
Adresses an issue where changes made to core component directories src/platforms/esp32/components/avm_builtins and
src/platforms/esp32/components/avm_sys are not tracked.

Closes Issue #355

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
