### PR TITLE
Add error check to gpiodriver_set_int

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -348,7 +348,10 @@ static term gpiodriver_set_int(Context *ctx, Context *target, term cmd)
     gpio_set_direction(gpio_num, GPIO_MODE_INPUT);
     gpio_set_intr_type(gpio_num, interrupt_type);
 
-    gpio_isr_handler_add(gpio_num, gpio_isr_handler, data);
+    esp_err_t ret = gpio_isr_handler_add(gpio_num, gpio_isr_handler, data);
+    if (UNLIKELY(ret != ESP_OK)) {
+        return ERROR_ATOM;
+    }
 
     return OK_ATOM;
 }


### PR DESCRIPTION
Instead of always returning an OK_ATOM there is now a check to return an ERROR_ATOM if setting the interrupt fails.

Closes Issue #354

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
