### PR TITLE
Add support for `uart:close/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `esp:partition_erase_range/2`
 - Added support for `i2c:close/1`
 - Added support for `erlang:unregister/1`
+- Added support for `uart:close/1`
 
 ### Breaking Changes
 

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -756,6 +756,13 @@ To write data to the UART channel, use the `uart_write/2` function.  The input d
 
 Consult your local device data sheet for information about the format of data to be read from or written to the UART channel.
 
+To close the UART driver and free any resources in use by it, use the `uart:close/1` function, supplying a reference to the UART driver instance created via `uart:open/2`:
+
+    %% erlang
+    ok = uart:close(UART)
+
+Once the UART driver is closed, any calls to `uart` functions using a reference to the UART driver instance should return with the value `{error, noproc}`.
+
 ### LED Control
 
 The LED Control API can be used to drive LEDs, as well as generate PWM signals on GPIO pins.

--- a/src/platforms/esp32/components/avm_builtins/uart_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/uart_driver.c
@@ -25,6 +25,7 @@
 
 #include <driver/uart.h>
 
+#include <esp_log.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
@@ -38,6 +39,7 @@
 #include "mailbox.h"
 #include "module.h"
 #include "platform_defaultatoms.h"
+#include "scheduler.h"
 #include "term.h"
 #include "utils.h"
 
@@ -46,12 +48,13 @@
 #include "esp32_sys.h"
 #include "sys.h"
 
-static void uart_driver_init(GlobalContext *global);
 static Context *uart_driver_create_port(GlobalContext *global, term opts);
 
-static const char *const ealready_atom = "\x8" "ealready";
+static const char *const ealready_atom = ATOM_STR("\x8", "ealready");
+static const char *const no_proc_atom = ATOM_STR("\x7", "no_proc");
 static void uart_driver_consume_mailbox(Context *ctx);
 
+#define TAG "uart_driver"
 #define UART_BUF_SIZE 256
 
 struct UARTData
@@ -82,12 +85,14 @@ enum uart_cmd
 {
     UARTInvalidCmd = 0,
     UARTReadCmd = 1,
-    UARTWriteCmd = 2
+    UARTWriteCmd = 2,
+    UARTCloseCmd = 3
 };
 
 static const AtomStringIntPair cmd_table[] = {
     { ATOM_STR("\x4", "read"), UARTReadCmd },
     { ATOM_STR("\x5", "write"), UARTWriteCmd },
+    { ATOM_STR("\x5", "close"), UARTCloseCmd },
     SELECT_INT_DEFAULT(UARTInvalidCmd)
 };
 
@@ -388,12 +393,67 @@ static void uart_driver_do_write(Context *ctx, term msg)
     send_message(pid, result_tuple, glb);
 }
 
+static void uart_driver_do_close(Context *ctx, term msg)
+{
+    GlobalContext *glb = ctx->global;
+    struct UARTData *uart_data = ctx->platform_data;
+
+    term pid = term_get_tuple_element(msg, 0);
+    term ref = term_get_tuple_element(msg, 1);
+    uint64_t ref_ticks = term_to_ref_ticks(ref);
+
+    list_remove(&uart_data->listener.listeners_list_head);
+
+    if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2) + REF_SIZE) != MEMORY_GC_OK)) {
+        ESP_LOGE(TAG, "[uart_driver_do_close] Failed to allocate space for return value");
+        send_message(pid, MEMORY_ATOM, glb);
+    }
+
+    term result_tuple = term_alloc_tuple(2, ctx);
+    term_put_tuple_element(result_tuple, 0, term_from_ref_ticks(ref_ticks, ctx));
+    term_put_tuple_element(result_tuple, 1, OK_ATOM);
+    send_message(pid, result_tuple, glb);
+
+    esp_err_t err = uart_driver_delete(uart_data->uart_num);
+    if (UNLIKELY(err != ESP_OK)) {
+        ESP_LOGW(TAG, "Failed to delete UART driver.  err=%i\n", err);
+    }
+
+    free(uart_data);
+}
+
 static void uart_driver_consume_mailbox(Context *ctx)
 {
+    GlobalContext *glb = ctx->global;
+    bool is_closed = false;
     while (!list_is_empty(&ctx->mailbox)) {
         Message *message = mailbox_dequeue(ctx);
         term msg = message->message;
+        term pid = term_get_tuple_element(msg, 0);
+        term ref = term_get_tuple_element(msg, 1);
         term req = term_get_tuple_element(msg, 2);
+        uint64_t ref_ticks = term_to_ref_ticks(ref);
+
+        if (is_closed) {
+            if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2) * 2 + REF_SIZE) != MEMORY_GC_OK)) {
+                ESP_LOGE(TAG, "[uart_driver_consume_mailbox] Failed to allocate space for error tuple");
+                send_message(pid, MEMORY_ATOM, glb);
+            }
+
+            term no_proc = context_make_atom(ctx, no_proc_atom);
+            term error_tuple = term_alloc_tuple(2, ctx);
+            term_put_tuple_element(error_tuple, 0, ERROR_ATOM);
+            term_put_tuple_element(error_tuple, 1, no_proc);
+
+            term result_tuple = term_alloc_tuple(2, ctx);
+            term_put_tuple_element(result_tuple, 0, term_from_ref_ticks(ref_ticks, ctx));
+            term_put_tuple_element(result_tuple, 1, error_tuple);
+
+            send_message(pid, result_tuple, glb);
+
+            mailbox_destroy_message(message);
+            continue;
+        }
 
         term cmd_term = term_is_atom(req) ? req : term_get_tuple_element(req, 0);
 
@@ -409,11 +469,20 @@ static void uart_driver_consume_mailbox(Context *ctx)
                 uart_driver_do_write(ctx, msg);
                 break;
 
+            case UARTCloseCmd:
+                TRACE("close\n");
+                uart_driver_do_close(ctx, msg);
+                is_closed = true;
+                break;
+
             default:
                 TRACE("uart: error: unrecognized command.\n");
         }
 
         mailbox_destroy_message(message);
+    }
+    if (is_closed) {
+        scheduler_terminate(ctx);
     }
 }
 


### PR DESCRIPTION
This changeset also changes the processing of messages on the inbound mailbox queue for the UART port, so that only one message is processed at a time, in order to ensure that if the port is closed, clients will get a proper {error, noproc} if a message is sent after a close message has been processed.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
