### PR TITLE
Add support for `unregister/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `erlang:is_boolean/1` Bif.
 - Added support for `esp:partition_erase_range/2`
 - Added support for `i2c:close/1`
+- Added `erlang:is_boolean/1` Bif.
+- Added support for `esp:partition_erase_range/2`
+- Added support for `i2c:close/1`
+- Added support for `unregister/1`
 
 ### Breaking Changes
 

--- a/libs/exavmlib/lib/Process.ex
+++ b/libs/exavmlib/lib/Process.ex
@@ -217,8 +217,32 @@ defmodule Process do
   @spec list() :: [pid]
   defdelegate list(), to: :erlang, as: :processes
 
+  @doc """
+  Register a PID or port identifier under `name`.
+
+  See `:erlang.register/2` for more information.
+
+  ## Examples
+
+    Process.register(self(), :test)
+
+  """
   def register(pid_or_port, name) when is_atom(name) do
     :erlang.register(name, pid_or_port)
+  end
+
+  @doc """
+  Unregister a registered process by `name`.
+
+  See `:erlang.unregister/1` for more information.
+
+  ## Examples
+
+    Process.unregister(:test)
+
+  """
+  def unregister(name) when is_atom(name) do
+    :erlang.unregister(name)
   end
 
   @doc """

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -135,6 +135,28 @@ void globalcontext_register_process(GlobalContext *glb, int atom_index, int loca
     linkedlist_append(&glb->registered_processes, &registered_process->registered_processes_list_head);
 }
 
+bool globalcontext_unregister_process(GlobalContext *glb, int atom_index)
+{
+    if (!glb->registered_processes) {
+        return false;
+    }
+
+    struct RegisteredProcess *registered_processes = GET_LIST_ENTRY(glb->registered_processes, struct RegisteredProcess, registered_processes_list_head);
+
+    struct RegisteredProcess *p = registered_processes;
+
+    do {
+        if (p->atom_index == atom_index) {
+            linkedlist_remove(&glb->registered_processes, &p->registered_processes_list_head);
+            free(p);
+            return true;
+        }
+        p = GET_LIST_ENTRY(p->registered_processes_list_head.next, struct RegisteredProcess, registered_processes_list_head);
+    } while (p != registered_processes);
+
+    return false;
+}
+
 int globalcontext_get_registered_process(GlobalContext *glb, int atom_index)
 {
     if (!glb->registered_processes) {

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -141,6 +141,15 @@ void globalcontext_register_process(GlobalContext *glb, int atom_index, int loca
 int globalcontext_get_registered_process(GlobalContext *glb, int atom_index);
 
 /**
+ * @brief Unregister a process
+ *
+ * @details Unregister a process with a certain name (atom).
+ * @param glb the global context, each registered process will be globally available for that context.
+ * @param atom_index the atom table index.
+ */
+bool globalcontext_unregister_process(GlobalContext *glb, int atom_index);
+
+/**
  * @brief equivalent to globalcontext_insert_atom_maybe_copy(glb, atom_string, 0);
  */
 int globalcontext_insert_atom(GlobalContext *glb, AtomString atom_string);

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -762,8 +762,15 @@ static term nif_erlang_register_2(Context *ctx, int argc, term argv[])
     int atom_index = term_to_atom_index(reg_name_term);
     int32_t pid = term_to_local_process_id(pid_or_port_term);
 
-    // TODO: pid must be existing, not already registered.
-    // TODO: reg_name_term must not be the atom undefined and not already registered.
+    // pid must be existing, not already registered.
+    if (UNLIKELY(globalcontext_get_process(ctx->global, pid) == NULL)){
+        RAISE_ERROR(BADARG_ATOM);
+    } else if (UNLIKELY(globalcontext_get_registered_process(ctx->global, atom_index) != 0)) {
+        RAISE_ERROR(BADARG_ATOM);
+    // reg_name_term must not be the atom undefined.
+    } else if (UNLIKELY(atom_index == UNDEFINED_ATOM_INDEX)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
 
     globalcontext_register_process(ctx->global, atom_index, pid);
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -767,7 +767,7 @@ static term nif_erlang_register_2(Context *ctx, int argc, term argv[])
 
     globalcontext_register_process(ctx->global, atom_index, pid);
 
-    return term_nil();
+    return TRUE_ATOM;
 }
 
 static term nif_erlang_whereis_1(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -760,7 +760,7 @@ static term nif_erlang_register_2(Context *ctx, int argc, term argv[])
     VALIDATE_VALUE(pid_or_port_term, term_is_pid);
 
     int atom_index = term_to_atom_index(reg_name_term);
-    int pid = term_to_local_process_id(pid_or_port_term);
+    int32_t pid = term_to_local_process_id(pid_or_port_term);
 
     // TODO: pid must be existing, not already registered.
     // TODO: reg_name_term must not be the atom undefined and not already registered.

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -118,6 +118,7 @@ static term nif_erlang_iolist_size_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_iolist_to_binary_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_open_port_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_register_2(Context *ctx, int argc, term argv[]);
+static term nif_erlang_unregister_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_send_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_setelement_3(Context *ctx, int argc, term argv[]);
 static term nif_erlang_spawn(Context *ctx, int argc, term argv[]);
@@ -362,6 +363,12 @@ static const struct Nif register_nif =
 {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_erlang_register_2
+};
+
+static const struct Nif unregister_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_erlang_unregister_1
 };
 
 static const struct Nif spawn_nif =
@@ -762,17 +769,31 @@ static term nif_erlang_register_2(Context *ctx, int argc, term argv[])
     int atom_index = term_to_atom_index(reg_name_term);
     int32_t pid = term_to_local_process_id(pid_or_port_term);
 
-    // pid must be existing, not already registered.
-    if (UNLIKELY(globalcontext_get_process(ctx->global, pid) == NULL)){
-        RAISE_ERROR(BADARG_ATOM);
-    } else if (UNLIKELY(globalcontext_get_registered_process(ctx->global, atom_index) != 0)) {
-        RAISE_ERROR(BADARG_ATOM);
-    // reg_name_term must not be the atom undefined.
-    } else if (UNLIKELY(atom_index == UNDEFINED_ATOM_INDEX)) {
+    // pid must be existing, not already registered, and not the atom undefined.
+    if (UNLIKELY(globalcontext_get_process(ctx->global, pid) == NULL) ||
+        globalcontext_get_registered_process(ctx->global, atom_index) != 0 ||
+        reg_name_term == UNDEFINED_ATOM){
         RAISE_ERROR(BADARG_ATOM);
     }
 
     globalcontext_register_process(ctx->global, atom_index, pid);
+
+    return TRUE_ATOM;
+}
+
+static term nif_erlang_unregister_1(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+
+    term reg_name_term = argv[0];
+    VALIDATE_VALUE(reg_name_term, term_is_atom);
+
+    int atom_index = term_to_atom_index(reg_name_term);
+
+    bool unregistered = globalcontext_unregister_process(ctx->global, atom_index);
+    if (UNLIKELY(!unregistered)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
 
     return TRUE_ATOM;
 }

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -73,6 +73,7 @@ erlang:monitor/2, &monitor_nif
 erlang:demonitor/1, &demonitor_nif
 erlang:is_process_alive/1, &is_process_alive_nif
 erlang:register/2, &register_nif
+erlang:unregister/1, &unregister_nif
 erlang:send/2, &send_nif
 erlang:setelement/3, &setelement_nif
 erlang:spawn/1, &spawn_fun_nif

--- a/tests/erlang_tests/register_unregister.erl
+++ b/tests/erlang_tests/register_unregister.erl
@@ -39,10 +39,10 @@ start() ->
     %% register as atom "undefined"
     T7 = reg_bad_arg(undefined, self()),
     %% test unregister an atom that has not been registered
-    T8 =  unreg_not_registered(something),
+    T8 = unreg_not_registered(something),
     T1 + T2 + T3 + T4 + T5 + T6 + T7 + T8.
 
-do_reg(Pid, Name)->
+do_reg(Pid, Name) ->
     Res = register(Pid, Name),
     case Res of
         true ->
@@ -51,7 +51,7 @@ do_reg(Pid, Name)->
             0
     end.
 
-test_reg(Name)->
+test_reg(Name) ->
     Pid = whereis(Name),
     Res = is_process_alive(Pid),
     case Res of
@@ -61,7 +61,7 @@ test_reg(Name)->
             0
     end.
 
-do_unreg(Name)->
+do_unreg(Name) ->
     Res = unregister(Name),
     case Res of
         true ->
@@ -70,7 +70,7 @@ do_unreg(Name)->
             0
     end.
 
-test_unreg(Name)->
+test_unreg(Name) ->
     Res = whereis(Name),
     case Res of
         undefined ->
@@ -79,7 +79,7 @@ test_unreg(Name)->
             0
     end.
 
-reg_bad_arg(Name, Pid)->
+reg_bad_arg(Name, Pid) ->
     try register(Name, Pid) of
         true ->
             0
@@ -88,7 +88,7 @@ reg_bad_arg(Name, Pid)->
             1
     end.
 
-test_already_registered(Name)->
+test_already_registered(Name) ->
     try register(Name, self()) of
         true ->
             0
@@ -97,7 +97,7 @@ test_already_registered(Name)->
             1
     end.
 
-unreg_not_registered(Name)->
+unreg_not_registered(Name) ->
     try unregister(Name) of
         true ->
             0

--- a/tests/erlang_tests/register_unregister.erl
+++ b/tests/erlang_tests/register_unregister.erl
@@ -1,0 +1,107 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2017-2022 Davide Bettio <davide@uninstall.it>
+% Copyright 2022 Winford (Uncle Grumpy) <dwinford@pm.me>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(register_unregister).
+
+-export([start/0]).
+
+start() ->
+    %% test register result
+    T1 = do_reg(test, self()),
+    %% confirm that registered atom is retrievable
+    T2 = test_reg(test),
+    %% test register with atom already registered
+    T3 = test_already_registered(test),
+    %% test unregister result
+    T4 = do_unreg(test),
+    %% confirm name was unregistered
+    T5 = test_unreg(test),
+    %% test register with invalid PID
+    T6 = reg_bad_arg(test, 1000),
+    %% register as atom "undefined"
+    T7 = reg_bad_arg(undefined, self()),
+    %% test unregister an atom that has not been registered
+    T8 =  unreg_not_registered(something),
+    T1 + T2 + T3 + T4 + T5 + T6 + T7 + T8.
+
+do_reg(Pid, Name)->
+    Res = register(Pid, Name),
+    case Res of
+        true ->
+            1;
+        _ ->
+            0
+    end.
+
+test_reg(Name)->
+    Pid = whereis(Name),
+    Res = is_process_alive(Pid),
+    case Res of
+        true ->
+            1;
+        _ ->
+            0
+    end.
+
+do_unreg(Name)->
+    Res = unregister(Name),
+    case Res of
+        true ->
+            1;
+        _ ->
+            0
+    end.
+
+test_unreg(Name)->
+    Res = whereis(Name),
+    case Res of
+        undefined ->
+            1;
+        _ ->
+            0
+    end.
+
+reg_bad_arg(Name, Pid)->
+    try register(Name, Pid) of
+        true ->
+            0
+    catch
+        error:badarg ->
+            1
+    end.
+
+test_already_registered(Name)->
+    try register(Name, self()) of
+        true ->
+            0
+    catch
+        error:badarg ->
+            1
+    end.
+
+unreg_not_registered(Name)->
+    try unregister(Name) of
+        true ->
+            0
+    catch
+        error:badarg ->
+            1
+    end.


### PR DESCRIPTION
These changes add `unregister/1` as well as some minor enhancements to error returns to match expected otp behavior, and address the TODOs in the `nif_erlang_register_2` function in src/libAtomVM.nifs.c. Also adds test for `register/2` and `unregister/1` return values, functionality, and error returns - designed to test the conditions raised in the previously addressed TODOs (existing process pid, not already registered, not the atom "undefined").

Closes issue #358

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
