### PR TITLE
ESP32 SPI: Add spi_driver_get_peripheral function

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/CMakeLists.txt
+++ b/src/platforms/esp32/components/avm_builtins/CMakeLists.txt
@@ -29,8 +29,11 @@ set(AVM_BUILTIN_COMPONENT_SRCS
     "uart_driver.c"
 )
 
-idf_component_register(SRCS ${AVM_BUILTIN_COMPONENT_SRCS}
-    PRIV_REQUIRES "libatomvm" "avm_sys" "nvs_flash")
+idf_component_register(
+    SRCS ${AVM_BUILTIN_COMPONENT_SRCS}
+    INCLUDE_DIRS "include"
+    PRIV_REQUIRES "libatomvm" "avm_sys" "nvs_flash"
+)
 
 idf_build_set_property(
     LINK_OPTIONS "-Wl,--whole-archive ${CMAKE_CURRENT_BINARY_DIR}/lib${COMPONENT_NAME}.a -Wl,--no-whole-archive"

--- a/src/platforms/esp32/components/avm_builtins/include/spi_driver.h
+++ b/src/platforms/esp32/components/avm_builtins/include/spi_driver.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2022 Davide Bettio <davide@uninstall.it>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _SPI_DRIVER_H_
+#define _SPI_DRIVER_H_
+
+#include <stdbool.h>
+
+#include <driver/spi_master.h>
+
+#include <globalcontext.h>
+
+// This function is meant for integrating native drivers with the SPI port driver
+bool spi_driver_get_peripheral(term spi_port, spi_host_device_t *host_dev, GlobalContext *global);
+
+#endif


### PR DESCRIPTION
This change is required to allow sharing the same SPI bus between Erlang devices and native ones, such as the display driver.