### PR TITLE
Fix missing cmake rule for `register_unregister.erl` test

### DIFF
--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -73,6 +73,7 @@ compile_erlang(if_test)
 compile_erlang(sleep)
 compile_erlang(hello_world)
 compile_erlang(whereis_fail)
+compile_erlang(register_unregister)
 compile_erlang(try_noerror)
 compile_erlang(catch_badmatch)
 compile_erlang(catch_nocasematch)
@@ -473,6 +474,7 @@ add_custom_target(erlang_test_modules DEPENDS
     sleep.beam
     hello_world.beam
     whereis_fail.beam
+    register_unregister.beam
     try_noerror.beam
     catch_badmatch.beam
     catch_nocasematch.beam


### PR DESCRIPTION
Include tests/erlang_tests/register_unregister.erl in tests/erlang_tests/CMakeLists.txt.

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
