### PR TITLE
Add ability to stop gpio driver port and free resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for FP opcodes 94-102 thus removing the need for `AVM_DISABLE_FP=On` with OTP-22+
 - Added support for stacktraces
 - Added support for `utf-8`, `utf-16`, and `utf-32` bit syntax modifiers (put and match)
-
+- Added `stop/0` and `stop/1` to erlang and elixir GPIO drivers.
 
 ### Fixed
 - Fixed issue with formatting integers with io:format() on STM32 platform

--- a/libs/eavmlib/src/gpio.erl
+++ b/libs/eavmlib/src/gpio.erl
@@ -47,7 +47,9 @@
 %%-----------------------------------------------------------------------------
 -module(gpio).
 
--export([start/0, open/0, read/2, set_direction/3, set_level/3, set_int/3, remove_int/2]).
+-export([
+    start/0, open/0, read/2, set_direction/3, set_level/3, set_int/3, remove_int/2, stop/0, close/1
+]).
 -export([
     set_pin_mode/2,
     set_pin_pull/2,
@@ -180,6 +182,30 @@ remove_int(GPIO, GPIONum) ->
     port:call(GPIO, {remove_int, GPIONum}).
 
 %%-----------------------------------------------------------------------------
+%% @param   GPIO pid that was returned from gpio:start/0
+%% @returns ok atom
+%% @doc     Stop the GPIO interrupt port
+%%
+%%          This function disables any interrupts that are set, stops
+%%          the listening port, and frees all of its resources.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec close(GPIO :: gpio()) -> ok | error.
+close(GPIO) ->
+    port:call(GPIO, {close}).
+
+%%-----------------------------------------------------------------------------
+%% @returns ok atom
+%% @doc     Stop the GPIO interrupt port
+%%
+%%          This function disables any interrupts that are set, stops
+%%          the listening port, and frees all of its resources.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec stop() -> ok | error.
+stop() ->
+    port:call(whereis(gpio), {close}).
+
 %% @param   Pin number to set operational mode
 %% @param   Direction is `input', `output', or `output_od'
 %% @returns ok | error

--- a/libs/exavmlib/lib/GPIO.ex
+++ b/libs/exavmlib/lib/GPIO.ex
@@ -233,6 +233,24 @@ defmodule GPIO do
     do: remove_int(:erlang.whereis(:gpio), gpio_num)
 
   @doc """
+  Stop the gpio driver and remove any interrupts that have been set.
+
+  Use the pid returned from GPIO.start/0 as a parameter.
+  """
+  @spec close(pid()) :: :ok | :error
+  def close(gpio),
+    do: AVMPort.call(gpio, {:close})
+
+  @doc """
+  Stop the gpio driver and remove any interrupts that have been set.
+
+  Takes no parameters.
+  """
+  @spec stop() :: :ok | :error
+  def stop(),
+    do: AVMPort.call(:erlang.whereis(:gpio), {:close})
+
+  @doc """
   Set the directional mode of a gpio pin.
 
   ## Parameters


### PR DESCRIPTION
Adds `gpio:stop/0` and `gpio:close/1` to eavmlib gpio.erl. Adds `GPIO.stop/0` and `GPIO.close/1` to exavmlib GPIO.ex.

Closes Issue #277

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
