### PR TITLE
Allow other flash modes and speeds

### DIFF
--- a/tools/dev/flash.sh
+++ b/tools/dev/flash.sh
@@ -37,13 +37,13 @@ echo "%% Flashing ${1} (size=${filesize}k)"
 echo "%%"
 
 exec "${IDF_PATH}/components/esptool_py/esptool/esptool.py" \
-    --chip esp32 \
+    --chip auto \
     --port "${FLASH_SERIAL_PORT}" \
     --baud "${FLASH_BAUD_RATE}" \
     --before default_reset \
     --after hard_reset \
     write_flash \
-    -u --flash_mode dio --flash_freq 40m \
+    -u --flash_mode keep --flash_freq keep \
     --flash_size detect \
     ${FLASH_OFFSET} \
     "${1}"


### PR DESCRIPTION
Changes harcoded settings in `tools/dev/flash.sh` to use settings that can be configured using `idf.py menuconfig`.

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
