### PR TITLE
Fix compiler warnings

### DIFF
--- a/examples/elixir/esp32/Ledc_x4.ex
+++ b/examples/elixir/esp32/Ledc_x4.ex
@@ -19,6 +19,9 @@
 #
 
 defmodule Ledc_x4 do
+  # this compiler option is to suppress warnings when compiling the VM
+  # it is not needed or recommended for user apps.
+  @compile {:no_warn_undefined, [LEDC]}
   @moduledoc """
   Ledc_example for Elixir.
   """

--- a/libs/eavmlib/src/console.erl
+++ b/libs/eavmlib/src/console.erl
@@ -91,7 +91,7 @@ flush(Console) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec print(string()) -> ok | error.
-print(String) ->
+print(_String) ->
     throw(nif_error).
 
 %% Internal operations

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2734,6 +2734,8 @@ static term nif_erlang_error(Context *ctx, int argc, term argv[])
 
 static term nif_erlang_exit(Context *ctx, int argc, term argv[])
 {
+    UNUSED(argc);
+
     term reason = argv[0];
     ctx->exit_reason = reason;
     RAISE(LOWERCASE_EXIT_ATOM, reason);
@@ -2799,6 +2801,8 @@ static term nif_erlang_monitor(Context *ctx, int argc, term argv[])
 
 static term nif_erlang_demonitor(Context *ctx, int argc, term argv[])
 {
+    UNUSED(argc);
+
     term ref = argv[0];
 
     VALIDATE_VALUE(ref, term_is_reference);
@@ -2841,6 +2845,8 @@ static term nif_erlang_link(Context *ctx, int argc, term argv[])
 
 static term nif_erlang_unlink(Context *ctx, int argc, term argv[])
 {
+    UNUSED(argc);
+
     term target_pid = argv[0];
 
     VALIDATE_VALUE(target_pid, term_is_pid);

--- a/tests/erlang_tests/test_process_info.erl
+++ b/tests/erlang_tests/test_process_info.erl
@@ -31,7 +31,7 @@ start() ->
     test_message_queue_len(Pid, Self),
     Pid ! {Self, stop},
     receive
-        X -> 0
+        _X -> 0
     end.
 
 test_message_queue_len(Pid, Self) ->

--- a/tests/libs/eavmlib/test_timer_manager.erl
+++ b/tests/libs/eavmlib/test_timer_manager.erl
@@ -25,6 +25,7 @@
 test() ->
     ok = test_start_timer(),
     ok = test_cancel_timer(),
+    pong = test_send_after(),
     ok.
 
 -include("etest.hrl").


### PR DESCRIPTION
This set of changes is to take a step towards addressing issue #255. These changes address warnings about unused variables and parameters in functions, and one unused function in the test suite, when compiling the unix_port of the VM.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
