### PR TITLE
Fix bug in gen_server's handling of call timeouts

### DIFF
--- a/tests/libs/estdlib/test_gen_server.erl
+++ b/tests/libs/estdlib/test_gen_server.erl
@@ -126,6 +126,17 @@ test_late_reply() ->
     ok = gen_server:call(Pid, {reply_after, 0, ok}),
     {message_queue_len, 0} = erlang:process_info(self(), message_queue_len),
     %%
+    %% test that timed out message is properly flushed
+    %%
+    timeout =
+        try gen_server:call(Pid, {reply_after, 300, ok}, 200) of
+            unexpected -> unexpected
+        catch
+            exit:timeout -> timeout;
+            _:_ -> unexpected
+        end,
+    %%
+    ok2 = gen_server:call(Pid, {reply_after, 0, ok2}),
     gen_server:stop(Pid),
     ok.
 


### PR DESCRIPTION
- Timeout can be infinity
- Process messages already in message queue before giving up

Signed-off-by: Paul Guyot <pguyot@kallisys.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
