### PR TITLE
Fix logic of gen_statem timer_map state

### DIFF
--- a/libs/estdlib/src/gen_statem.erl
+++ b/libs/estdlib/src/gen_statem.erl
@@ -248,22 +248,22 @@ do_handle_state(EventType, Request, State) ->
             {noreply, State#state{
                 current_state = NextState,
                 data = NewData,
-                timer_map = maps:merge(TimerMap, TimerRefs)
+                timer_map = maps:merge(NewTimerMap, TimerRefs)
             }};
         {stop, Reason} ->
-            maybe_cancel_timer(CurrentState, TimerMap),
-            {stop, Reason, State};
+            NewTimerMap = maybe_cancel_timer(CurrentState, TimerMap),
+            {stop, Reason, State#state{timer_map = NewTimerMap}};
         {stop, Reason, NewData} ->
-            maybe_cancel_timer(CurrentState, TimerMap),
-            {stop, Reason, State#state{data = NewData}};
+            NewTimerMap = maybe_cancel_timer(CurrentState, TimerMap),
+            {stop, Reason, State#state{data = NewData, timer_map = NewTimerMap}};
         {stop_and_reply, Reason, Replies} ->
-            maybe_cancel_timer(CurrentState, TimerMap),
+            NewTimerMap = maybe_cancel_timer(CurrentState, TimerMap),
             handle_actions(Replies, []),
-            {stop, Reason, State};
+            {stop, Reason, State#state{timer_map = NewTimerMap}};
         {stop_and_reply, Reason, Replies, NewData} ->
-            maybe_cancel_timer(CurrentState, TimerMap),
+            NewTimerMap = maybe_cancel_timer(CurrentState, TimerMap),
             handle_actions(Replies, []),
-            {stop, Reason, State#state{data = NewData}};
+            {stop, Reason, State#state{data = NewData, timer_map = NewTimerMap}};
         Reply ->
             {error, {unexpected_reply, Reply}}
     end.


### PR DESCRIPTION
Signed-off-by: Paul Guyot <pguyot@kallisys.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
