### PR TITLE
Add timeouts to test steps

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -57,26 +57,31 @@ jobs:
 
     # Test
     - name: "Test: test-erlang"
+      timeout-minutes: 10
       working-directory: build
       run: |
         ./tests/test-erlang
 
     - name: "Test: test-structs"
+      timeout-minutes: 10
       working-directory: build
       run: |
         ./tests/test-structs
 
     - name: "Test: test_estdlib.avm"
+      timeout-minutes: 10
       working-directory: build
       run: |
         ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
 
     - name: "Test: test_eavmlib.avm"
+      timeout-minutes: 10
       working-directory: build
       run: |
         ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
 
     - name: "Test: test_alisp.avm"
+      timeout-minutes: 10
       working-directory: build
       run: |
         ./src/AtomVM ./tests/libs/alisp/test_alisp.avm

--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -93,6 +93,7 @@ jobs:
         make test_alisp
 
     - name: "Build and Test: AtomVM on foreign arch"
+      timeout-minutes: 15
       run: |
         docker run --rm -v $PWD:/atomvm -w /atomvm \
         -e CFLAGS="${{ matrix.cflags }}" -e CXXFLAGS="${{ matrix.cflags }}" \

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -195,30 +195,35 @@ jobs:
 
     # Test
     - name: "Test: test-erlang"
+      timeout-minutes: 10
       working-directory: build
       run: |
         ./tests/test-erlang
         valgrind ./tests/test-erlang
 
     - name: "Test: test-structs"
+      timeout-minutes: 10
       working-directory: build
       run: |
         ./tests/test-structs
         valgrind ./tests/test-structs
 
     - name: "Test: test_estdlib.avm"
+      timeout-minutes: 10
       working-directory: build
       run: |
         ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
         valgrind ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
 
     - name: "Test: test_eavmlib.avm"
+      timeout-minutes: 10
       working-directory: build
       run: |
         ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
         valgrind ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
 
     - name: "Test: test_alisp.avm"
+      timeout-minutes: 10
       working-directory: build
       run: |
         ./src/AtomVM ./tests/libs/alisp/test_alisp.avm

--- a/.github/workflows/esp32-test.yaml
+++ b/.github/workflows/esp32-test.yaml
@@ -40,6 +40,7 @@ jobs:
       run: docker save -o esp32-test.tar atomvm/esp32-test
 
     - name: "Run ESP32 tests using qemu-system-xtensa on Docker"
+      timeout-minutes: 10
       run: |
         docker run --rm -v $PWD:/atomvm -w /atomvm/src/platforms/esp32/test atomvm/esp32-test /bin/bash -c '
         idf.py build


### PR DESCRIPTION
Total GitHub timeout for jobs is 6 hours, but this is very long. Especially useful with SMP code that is more likely to deadlock.

Signed-off-by: Paul Guyot <pguyot@kallisys.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
