### PR TITLE
Run tests with BEAM & OTP so we are sure our API is compatible

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -48,4 +48,3 @@ src/platforms/stm32/src/lib/platform_defaultatoms.c
 src/platforms/stm32/src/lib/platform_nifs.c
 src/platforms/stm32/build/*
 tests/test-structs.c
-tests/test.c

--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -20,7 +20,7 @@ jobs:
         submodules: 'recursive'
 
     - name: "Install deps"
-      run: brew install cmake gperf doxygen erlang@21 ninja
+      run: brew install gperf doxygen erlang@21 ninja
 
     # Builder info
     - name: "System info"
@@ -37,17 +37,11 @@ jobs:
     - name: "Build: create build dir"
       run: mkdir build
 
-    # TODO: remove this workaround as soon as the issue is fixed.
-    - name: "Apply workarounds"
-      run: |
-        sed -i'.orig1' -e 's/{"test_map.beam", 0},//g' tests/test.c
-        sed -i'.orig2' -e 's/{"test_base64.beam", 0},//g' tests/test.c
-
     - name: "Build: run cmake"
       working-directory: build
       run: |
         export PATH="/usr/local/opt/erlang@21/bin:$PATH"
-        cmake -G Ninja ..
+        cmake -G Ninja -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl ..
 
     - name: "Build: run ninja"
       working-directory: build

--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -9,7 +9,7 @@ name: Build and Test on Other Architectures
 on: [push, pull_request]
 
 env:
-  otp_version: 21.0
+  otp_version: 21
   elixir_version: 1.9
 
 jobs:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,7 +17,7 @@ jobs:
         cc: ["gcc-4.8", "gcc-5", "gcc-6", "gcc-7", "gcc-8", "gcc-9", "gcc-10", "clang-3.9",
         "clang-10"]
         cflags: ["-Os", "-O2", "-O3"]
-        otp: ["21.0", "22.0", "23.0"]
+        otp: ["21", "22", "23"]
 
         exclude:
         - os: "ubuntu-18.04"
@@ -91,15 +91,15 @@ jobs:
           cxx: "clang++-10"
           compiler_pkgs: "clang-10"
 
-        - otp: "21.0"
+        - otp: "21"
           elixir_version: "1.7"
           cmake_opts: ""
 
-        - otp: "22.0"
+        - otp: "22"
           elixir_version: "1.8"
           cmake_opts: "-DAVM_DISABLE_FP=on"
 
-        - otp: "23.0"
+        - otp: "23"
           elixir_version: "1.10.4"
           cmake_opts: "-DAVM_DISABLE_FP=on"
 
@@ -107,7 +107,7 @@ jobs:
           cc: "gcc-4.8"
           cxx: "g++-4.8"
           cflags: "-m32 -O2"
-          otp: "21.0"
+          otp: "21"
           elixir_version: "1.7"
           cmake_opts: "-DOPENSSL_CRYPTO_LIBRARY=/usr/lib/i386-linux-gnu/libcrypto.so"
           arch: "i386"
@@ -118,7 +118,7 @@ jobs:
           cc: "gcc-10"
           cxx: "g++-10"
           cflags: "-m32 -O3"
-          otp: "23.0"
+          otp: "23"
           elixir_version: "1.10.4"
           cmake_opts: "-DOPENSSL_CRYPTO_LIBRARY=/usr/lib/i386-linux-gnu/libcrypto.so
           -DAVM_DISABLE_FP=on"

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -1,0 +1,62 @@
+#
+#  Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+name: Run tests with BEAM
+
+on: [push, pull_request]
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp: ["21", "22", "23"]
+
+    steps:
+    # Setup
+    - name: "Checkout repo"
+      uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ matrix.otp }}
+
+    - name: "APT update"
+      run: sudo apt update -y
+
+    - name: "Install deps"
+      run: sudo apt install -y cmake gperf zlib1g-dev ninja-build
+
+    # Build
+    - name: "Build: create build dir"
+      run: mkdir build
+
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: 'build/tests/**/*.beam'
+        key: ${{ matrix.otp }}-${{ hashFiles('**/run-tests-with-beam.yaml', 'tests/**/*.erl') }}
+
+    - name: "Build: run cmake"
+      working-directory: build
+      run: |
+        cmake -G Ninja ..
+        # git clone will use more recent timestamps than cached beam files
+        # touch them so we can benefit from the cache and avoid costly beam file rebuild.
+        find . -name '*.beam' -exec touch {} \;
+
+    - name: "Build: run ninja"
+      working-directory: build
+      run: ninja
+
+    # Test
+    - name: "Test: test-erlang with BEAM"
+      timeout-minutes: 10
+      working-directory: build
+      run: |
+        ./tests/test-erlang -b

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -60,3 +60,10 @@ jobs:
       working-directory: build
       run: |
         ./tests/test-erlang -b
+
+    # Test
+    - name: "Test: estdlib/ with BEAM"
+      timeout-minutes: 10
+      working-directory: build
+      run: |
+        erl -pa tests/libs/estdlib/ -pa tests/libs/estdlib/beams/ -pa libs/etest/src/beams -s tests -s init stop -noshell

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -909,7 +909,7 @@ For example:
 
     %% erlang
     Port = 44404,
-    case gen_udp:open(Port, [{active, true}]) of
+    case gen_udp:open(Port, [{active, true}, binary]) of
         {ok, Socket} ->
             {ok, SockName} = inet:sockname(Socket)
             io:format("Opened UDP socket on ~p.~n", [SockName])
@@ -917,7 +917,7 @@ For example:
             io:format("An error occurred opening UDP socket: ~p~n", [Error])
     end
 
-If the port is active, you can receive UDP messages in your application.  They will be delivered as a 5-tuple, starting with the `udp` atom, and containing the socket, address and port from which the message was sent, as well as the datagram packet, itself, as a binary.
+If the port is active, you can receive UDP messages in your application.  They will be delivered as a 5-tuple, starting with the `udp` atom, and containing the socket, address and port from which the message was sent, as well as the datagram packet, itself, as a list (by default) or a binary. To choose the format, pass `list` or `binary` in options, as with Erlang/OTP.
 
     %% erlang
     receive

--- a/examples/erlang/tcp_client.erl
+++ b/examples/erlang/tcp_client.erl
@@ -25,7 +25,7 @@
 start() ->
     Address = "localhost",
     Port = 44404,
-    case gen_tcp:connect(Address, Port, []) of
+    case gen_tcp:connect(Address, Port, [{active, true}, binary]) of
         {ok, Socket} ->
             io:format("Connected to ~p from ~p~n", [peer_address(Socket), local_address(Socket)]),
             loop(Socket);

--- a/examples/erlang/tcp_server.erl
+++ b/examples/erlang/tcp_server.erl
@@ -23,7 +23,7 @@
 -export([start/0]).
 
 start() ->
-    case gen_tcp:listen(44404, []) of
+    case gen_tcp:listen(44404, [{active, true}, binary]) of
         {ok, ListenSocket} ->
             io:format("Listening on ~p.~n", [local_address(ListenSocket)]),
             spawn(fun() -> accept(ListenSocket) end),

--- a/examples/erlang/udp_client.erl
+++ b/examples/erlang/udp_client.erl
@@ -23,7 +23,7 @@
 -export([start/0]).
 
 start() ->
-    case gen_udp:open(0) of
+    case gen_udp:open(0, [{active, false}, binary]) of
         {ok, Socket} ->
             io:format("Opened UDP socket on ~p.~n", [local_address(Socket)]),
             loop(Socket);

--- a/examples/erlang/udp_server.erl
+++ b/examples/erlang/udp_server.erl
@@ -23,7 +23,7 @@
 -export([start/0]).
 
 start() ->
-    case gen_udp:open(44404, [{active, true}]) of
+    case gen_udp:open(44404, [{active, true}, binary]) of
         {ok, Socket} ->
             io:format("Opened UDP socket on ~p.~n", [local_address(Socket)]),
             active_loop();

--- a/libs/estdlib/src/gen_tcp.erl
+++ b/libs/estdlib/src/gen_tcp.erl
@@ -44,7 +44,7 @@
     connect/3, send/2, recv/2, recv/3, close/1, listen/2, accept/1, accept/2, controlling_process/2
 ]).
 
--define(DEFAULT_PARAMS, [{active, true}, {buffer, 512}, {binary, true}, {timeout, infinity}]).
+-define(DEFAULT_PARAMS, [{active, true}, {buffer, 512}, {timeout, infinity}]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Address the address to which to connect
@@ -59,8 +59,9 @@
 %%          The following options are supported:
 %%          <ul>
 %%              <li><b>active</b> Active mode (default: true)</li>
-%%              <li><b>buffer</b> Size of the receive buffer to use in active mode (default: 128)</li>
-%%              <li><b>binary</b> If true, receive data as binaries, as opposed to strings (default: true)</li>
+%%              <li><b>buffer</b> Size of the receive buffer to use in active mode (default: 512)</li>
+%%              <li><b>binary</b> data is received as binaries (as opposed to lists)</li>
+%%              <li><b>list</b> data is received as lists (default)</li>
 %%          </ul>
 %%
 %%          If the socket is connected in active mode, then the calling process

--- a/libs/estdlib/src/gen_udp.erl
+++ b/libs/estdlib/src/gen_udp.erl
@@ -47,7 +47,7 @@
 -type packet() :: string() | binary().
 -type reason() :: term().
 
--define(DEFAULT_PARAMS, [{active, false}, {buffer, 128}, {binary, true}, {timeout, infinity}]).
+-define(DEFAULT_PARAMS, [{active, true}, {buffer, 128}, {timeout, infinity}]).
 
 %%-----------------------------------------------------------------------------
 %% @doc     Create a UDP socket.  This function will instantiate a UDP socket

--- a/libs/estdlib/src/io_lib.erl
+++ b/libs/estdlib/src/io_lib.erl
@@ -49,7 +49,7 @@
 %% @doc     Format string and data to a string.
 %%          Approximates features of OTP io_lib:format/2, but
 %%          only supports ~p and ~n format specifiers.
-%%          Raises bad_format error if the number of format specifiers
+%%          Raises `badarg` error if the number of format specifiers
 %%          does not match the length of the Args.
 %% @end
 %%-----------------------------------------------------------------------------
@@ -61,7 +61,7 @@ format(Format, Args) ->
             StringList = interleave(FormatTokens, Instr, Args, []),
             lists:flatten(StringList);
         false ->
-            throw(bad_format)
+            throw(badarg)
     end.
 
 %%

--- a/libs/estdlib/src/maps.erl
+++ b/libs/estdlib/src/maps.erl
@@ -18,23 +18,6 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
-%%
-%% Copyright (c) 2021 dushin.net
-%% All rights reserved.
-%%
-%% Licensed under the Apache License, Version 2.0 (the "License");
-%% you may not use this file except in compliance with the License.
-%% You may obtain a copy of the License at
-%%
-%%     http://www.apache.org/licenses/LICENSE-2.0
-%%
-%% Unless required by applicable law or agreed to in writing, software
-%% distributed under the License is distributed on an "AS IS" BASIS,
-%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-%% See the License for the specific language governing permissions and
-%% limitations under the License.
-%%
-
 %%-----------------------------------------------------------------------------
 %% @doc A <em>naive</em> implementation of the Erlang/OTP `maps' interface.
 %%
@@ -446,14 +429,14 @@ remove(_Key, Map) when not is_map(Map) ->
 %% @throws {badmap, Map}
 %% @doc Returns a new map with an updated key-value association.
 %%
-%% This function throws a `badmap' exception if `Map' is not a map.
+%% This function throws a `badmap' exception if `Map' is not a map and
+%% `{badkey, Key}` if key doesn't exist
 %% @end
 %%-----------------------------------------------------------------------------
 -spec update(Key :: key(), Value :: value(), Map :: map()) -> map().
-update(Key, Value, Map) when is_map(Map) ->
-    Map#{Key => Value};
-update(_Key, _Value, Map) when not is_map(Map) ->
-    throw({badmap, Map}).
+update(Key, Value, Map) ->
+    _ = ?MODULE:get(Key, Map),
+    Map#{Key => Value}.
 
 %%
 %% Internal functions

--- a/libs/include/etest.hrl
+++ b/libs/include/etest.hrl
@@ -51,6 +51,17 @@
             fail
     end
 ).
+-define(ASSERT_FAILURE(A),
+    case etest:assert_failure(fun() -> A end) of
+        ok ->
+            ok;
+        fail ->
+            erlang:display(
+                {failed_assert_failure, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, A}
+            ),
+            fail
+    end
+).
 -define(ASSERT_FAILURE(A, E),
     case etest:assert_failure(fun() -> A end, E) of
         ok ->

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -280,9 +280,12 @@ term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
         }
         term err = term_alloc_tuple(2, ctx);
         term_put_tuple_element(err, 0, BADKEY_ATOM);
-        // TODO elt(2) of err term is supposed to be arg1 but may be invalidated by GC
-        term_put_tuple_element(err, 1, UNSUPPORTED_ATOM);
-
+        if (term_is_atom(arg1)) {
+            term_put_tuple_element(err, 1, arg1);
+        } else {
+            // TODO elt(2) of err term is supposed to be arg1 but may be invalidated by GC
+            term_put_tuple_element(err, 1, UNSUPPORTED_ATOM);
+        }
         RAISE_ERROR(err);
     }
     return term_get_map_value(arg2, pos);

--- a/src/platforms/generic_unix/socket_driver.c
+++ b/src/platforms/generic_unix/socket_driver.c
@@ -1032,8 +1032,8 @@ static void socket_consume_mailbox(Context *ctx)
         socket_driver_do_accept(ctx, pid, ref, timeout);
     } else if (cmd_name == context_make_atom(ctx, close_a)) {
         TRACE("close\n");
-        socket_driver_do_close(ctx);
         port_send_reply(ctx, pid, ref, OK_ATOM);
+        socket_driver_do_close(ctx);
         // TODO handle shutdown
         // socket_driver_delete_data(ctx->platform_data);
         // context_destroy(ctx);

--- a/tests/erlang_tests/ceilfloatovf.erl
+++ b/tests/erlang_tests/ceilfloatovf.erl
@@ -23,14 +23,24 @@
 -export([start/0]).
 
 start() ->
-    to_int(id(id([1.0e+65, 0]))).
+    to_int(id(id([1.0e+20, 0]))).
 
 to_int(A) ->
     try ceil(id(A)) of
-        B -> B
+        B when is_integer(B) ->
+            "BEAM" = erlang:system_info(machine),
+            "100000000000000000000" = integer_to_list(B),
+            0;
+        _Other ->
+            1
     catch
-        error:overflow -> -1;
-        _:_ -> 1
+        error:overflow ->
+            case erlang:system_info(machine) of
+                "BEAM" -> 2;
+                _ -> 0
+            end;
+        _:_ ->
+            3
     end.
 
 id([I | _T]) -> id(I);

--- a/tests/erlang_tests/floorfloatovf.erl
+++ b/tests/erlang_tests/floorfloatovf.erl
@@ -23,14 +23,24 @@
 -export([start/0]).
 
 start() ->
-    to_int(id(id([1.0e+65, 0]))).
+    to_int(id(id([1.0e+20, 0]))).
 
 to_int(A) ->
     try floor(id(A)) of
-        B -> B
+        B when is_integer(B) ->
+            "BEAM" = erlang:system_info(machine),
+            "100000000000000000000" = integer_to_list(B),
+            0;
+        _Other ->
+            1
     catch
-        error:overflow -> -1;
-        _:_ -> 1
+        error:overflow ->
+            case erlang:system_info(machine) of
+                "BEAM" -> 2;
+                _ -> 0
+            end;
+        _:_ ->
+            3
     end.
 
 id([I | _T]) -> id(I);

--- a/tests/erlang_tests/roundfloatovf.erl
+++ b/tests/erlang_tests/roundfloatovf.erl
@@ -23,14 +23,24 @@
 -export([start/0]).
 
 start() ->
-    to_int(id(id([1.0e+65, 0]))).
+    to_int(id(id([1.0e+20, 0]))).
 
 to_int(A) ->
     try round(id(A)) of
-        B -> B
+        B when is_integer(B) ->
+            "BEAM" = erlang:system_info(machine),
+            "100000000000000000000" = integer_to_list(B),
+            0;
+        _Other ->
+            1
     catch
-        error:overflow -> -1;
-        _:_ -> 1
+        error:overflow ->
+            case erlang:system_info(machine) of
+                "BEAM" -> 2;
+                _ -> 0
+            end;
+        _:_ ->
+            3
     end.
 
 id([I | _T]) -> id(I);

--- a/tests/erlang_tests/test_map.erl
+++ b/tests/erlang_tests/test_map.erl
@@ -293,7 +293,7 @@ generate_random_entry() ->
     {random_term(), random_term()}.
 
 random_term() ->
-    case random(5) of
+    case random_uniform(5) of
         1 ->
             random_atom();
         2 ->
@@ -307,17 +307,17 @@ random_term() ->
     end.
 
 random_atom() ->
-    case random(3) of
+    case random_uniform(3) of
         1 -> foo;
         2 -> bar;
         3 -> tapas
     end.
 
 random_int() ->
-    random(256).
+    random_uniform(256).
 
 random_tuple() ->
-    case random(3) of
+    case random_uniform(3) of
         1 ->
             {random_atom()};
         2 ->
@@ -327,14 +327,11 @@ random_tuple() ->
     end.
 
 random_binary() ->
-    Size = random(3) * 50,
-    atomvm:rand_bytes(Size).
+    Size = random_uniform(3) * 50,
+    rand_bytes(Size).
 
 random_list() ->
     binary_to_list(random_binary()).
-
-random(N) ->
-    (abs(atomvm:random()) rem N) + 1.
 
 remove_duplicates(KVList) ->
     reverse(remove_duplicates(reverse(KVList), [])).
@@ -369,3 +366,15 @@ create_test_map([{K, V} | T], Accum) ->
     create_test_map(T, Accum#{K => V}).
 
 id(X) -> X.
+
+rand_bytes(I) ->
+    case erlang:system_info(machine) of
+        "BEAM" -> crypto:strong_rand_bytes(I);
+        _ -> atomvm:rand_bytes(I)
+    end.
+
+random_uniform(N) ->
+    case erlang:system_info(machine) of
+        "BEAM" -> rand:uniform(N);
+        _ -> (abs(atomvm:random()) rem N) + 1
+    end.

--- a/tests/erlang_tests/test_min_heap_size.erl
+++ b/tests/erlang_tests/test_min_heap_size.erl
@@ -33,7 +33,10 @@ start() ->
         ok
     end,
     {memory, Pid1MemorySize} = process_info(Pid1, memory),
-    assert(Pid1MemorySize < 1024),
+    case erlang:system_info(machine) of
+        "BEAM" -> ok;
+        _ -> assert(Pid1MemorySize < 1024)
+    end,
     Pid2 = spawn_opt(?MODULE, loop, [Self], [{min_heap_size, 1024}]),
     receive
         ok -> ok

--- a/tests/erlang_tests/test_process_info.erl
+++ b/tests/erlang_tests/test_process_info.erl
@@ -56,8 +56,14 @@ test_message_queue_len(Pid, Self) ->
     end,
     {heap_size, HeapSize2} = process_info(Pid, heap_size),
     assert(MessageQueueLen < MessageQueueLen2),
-    assert(Memory < Memory2),
-    assert(HeapSize < HeapSize2).
+    case erlang:system_info(machine) of
+        "BEAM" ->
+            assert(Memory =< Memory2),
+            assert(HeapSize =< HeapSize2);
+        _ ->
+            assert(Memory < Memory2),
+            assert(HeapSize < HeapSize2)
+    end.
 
 loop(undefined, Accum) ->
     receive

--- a/tests/erlang_tests/test_sub_binaries.erl
+++ b/tests/erlang_tests/test_sub_binaries.erl
@@ -38,6 +38,22 @@
 ).
 
 start() ->
+    case erlang:system_info(machine) of
+        "BEAM" ->
+            ok = test_common();
+        _ ->
+            ok = test_common(),
+            ok = test_atom()
+    end,
+    0.
+
+test_common() ->
+    ok = run_test(fun() -> test_count_binary() end),
+    ok.
+
+test_atom() ->
+    % Most of these tests rely on a property of heap size that isn't
+    % verified with BEAM
     ok = run_test(fun() -> test_heap_sub_binary() end),
     ok = run_test(fun() -> test_const_sub_binary() end),
     ok = run_test(fun() -> test_non_const_sub_binary() end),
@@ -47,8 +63,7 @@ start() ->
     ok = run_test(fun() -> test_split_sub_binary() end),
     ok = run_test(fun() -> test_bit_syntax_tail() end),
     ok = run_test(fun() -> test_bit_syntax_get_binary() end),
-    ok = run_test(fun() -> test_count_binary() end),
-    0.
+    ok.
 
 test_heap_sub_binary() ->
     HeapSize0 = get_heap_size(),

--- a/tests/erlang_tests/truncfloatovf.erl
+++ b/tests/erlang_tests/truncfloatovf.erl
@@ -23,14 +23,24 @@
 -export([start/0]).
 
 start() ->
-    to_int(id(id([1.0e+65, 0]))).
+    to_int(id(id([1.0e+20, 0]))).
 
 to_int(A) ->
     try trunc(id(A)) of
-        B -> B
+        B when is_integer(B) ->
+            "BEAM" = erlang:system_info(machine),
+            "100000000000000000000" = integer_to_list(B),
+            0;
+        _Other ->
+            1
     catch
-        error:overflow -> -1;
-        _:_ -> 1
+        error:overflow ->
+            case erlang:system_info(machine) of
+                "BEAM" -> 2;
+                _ -> 0
+            end;
+        _:_ ->
+            3
     end.
 
 id([I | _T]) -> id(I);

--- a/tests/libs/estdlib/ping_pong_server.erl
+++ b/tests/libs/estdlib/ping_pong_server.erl
@@ -31,9 +31,8 @@ init([Parent]) ->
     Parent ! {ping_pong_server_ready, self()},
     {ok, nil}.
 
-handle_call(exit, From, State) ->
-    gen_server:reply(From, ok),
-    {stop, exit, noreply, State};
+handle_call({stop, Reason}, _From, State) ->
+    {stop, Reason, ok, State};
 handle_call(ping, From, State) ->
     gen_server:reply(From, pong),
     {noreply, State}.

--- a/tests/libs/estdlib/test_gen_statem.erl
+++ b/tests/libs/estdlib/test_gen_statem.erl
@@ -21,7 +21,7 @@
 -module(test_gen_statem).
 
 -export([test/0]).
--export([init/1, initial/3, jail/3, free/3, terminate/3]).
+-export([init/1, initial/3, jail/3, free/3, terminate/3, callback_mode/0]).
 
 -record(data, {
     num_casts = 0,
@@ -31,9 +31,25 @@
 
 test() ->
     ok = test_call(),
+    receive
+        X1 -> io:format("test_call, got ~p\n", [X1])
+    after 0 -> ok
+    end,
     ok = test_cast(),
+    receive
+        X2 -> io:format("test_cast, got ~p\n", [X2])
+    after 0 -> ok
+    end,
     ok = test_info(),
+    receive
+        X3 -> io:format("test_info, got ~p\n", [X3])
+    after 0 -> ok
+    end,
     ok = test_timeout(),
+    receive
+        X4 -> io:format("test_timeout, got ~p\n", [X4])
+    after 0 -> ok
+    end,
     ok.
 
 test_call() ->
@@ -72,7 +88,6 @@ test_info() ->
 
 test_timeout() ->
     {ok, Pid} = gen_statem:start(?MODULE, [], []),
-
     ok = gen_statem:call(Pid, {go_to_jail, 250}),
     no = gen_statem:call(Pid, are_you_free),
     timer:sleep(251),
@@ -91,6 +106,8 @@ test_timeout() ->
 %%
 %% callbacks
 %%
+
+callback_mode() -> state_functions.
 
 init(_) ->
     {ok, initial, #data{}}.

--- a/tests/libs/estdlib/test_io_lib.erl
+++ b/tests/libs/estdlib/test_io_lib.erl
@@ -24,41 +24,47 @@
 
 -include("etest.hrl").
 
-test() ->
-    ?ASSERT_MATCH(io_lib:format("", []), ""),
-    ?ASSERT_MATCH(io_lib:format("foo", []), "foo"),
-    ?ASSERT_MATCH(io_lib:format("foo~n", []), "foo\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [bar]), "foo: bar\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", ["bar"]), "foo: \"bar\"\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~s~n", ["bar"]), "foo: bar\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [123]), "foo: 123\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [-123]), "foo: -123\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [[1, 2, 3]]), "foo: [1,2,3]\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [[1, 2, [3]]]), "foo: [1,2,[3]]\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [[65, 116, 111, 109, 86, 77]]), "foo: \"AtomVM\"\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~s~n", [[65, 116, 111, 109, 86, 77]]), "foo: AtomVM\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [<<"bar">>]), "foo: <<\"bar\">>\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [<<1, 2, 3>>]), "foo: <<1,2,3>>\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [{bar, tapas}]), "foo: {bar,tapas}\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [{bar, "tapas"}]), "foo: {bar,\"tapas\"}\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [#{}]), "foo: #{}\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p~n", [#{a => 1}]), "foo: #{a => 1}\n"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p", [#{a => 1, b => 2}]), "foo: #{a => 1,b => 2}"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p", [#{b => 2, a => 1}]), "foo: #{a => 1,b => 2}"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p", [#{{x, y} => z}]), "foo: #{{x,y} => z}"),
-    ?ASSERT_MATCH(io_lib:format("foo: ~p", [#{"foo" => "bar"}]), "foo: #{\"foo\" => \"bar\"}"),
+-define(FLT(L), lists:flatten(L)).
 
-    ?ASSERT_MATCH(io_lib:format("~p", [foo]), "foo"),
-    ?ASSERT_MATCH(io_lib:format("\t~p", [bar]), "\tbar"),
+test() ->
+    ?ASSERT_MATCH(?FLT(io_lib:format("", [])), ""),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo", [])), "foo"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo~n", [])), "foo\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [bar])), "foo: bar\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", ["bar"])), "foo: \"bar\"\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~s~n", ["bar"])), "foo: bar\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [123])), "foo: 123\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [-123])), "foo: -123\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [[1, 2, 3]])), "foo: [1,2,3]\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [[1, 2, [3]]])), "foo: [1,2,[3]]\n"),
+    ?ASSERT_MATCH(
+        ?FLT(io_lib:format("foo: ~p~n", [[65, 116, 111, 109, 86, 77]])), "foo: \"AtomVM\"\n"
+    ),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~s~n", [[65, 116, 111, 109, 86, 77]])), "foo: AtomVM\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [<<"bar">>])), "foo: <<\"bar\">>\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [<<1, 2, 3>>])), "foo: <<1,2,3>>\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [{bar, tapas}])), "foo: {bar,tapas}\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [{bar, "tapas"}])), "foo: {bar,\"tapas\"}\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [#{}])), "foo: #{}\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [#{a => 1}])), "foo: #{a => 1}\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p", [#{a => 1, b => 2}])), "foo: #{a => 1,b => 2}"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p", [#{b => 2, a => 1}])), "foo: #{a => 1,b => 2}"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p", [#{{x, y} => z}])), "foo: #{{x,y} => z}"),
+    ?ASSERT_MATCH(
+        ?FLT(io_lib:format("foo: ~p", [#{"foo" => "bar"}])), "foo: #{\"foo\" => \"bar\"}"
+    ),
+
+    ?ASSERT_MATCH(?FLT(io_lib:format("~p", [foo])), "foo"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("\t~p", [bar])), "\tbar"),
 
     ?ASSERT_MATCH(
-        io_lib:format("a ~p ~p of ~p patterns", [small, number, interesting]),
+        ?FLT(io_lib:format("a ~p ~p of ~p patterns", [small, number, interesting])),
         "a small number of interesting patterns"
     ),
-    ?ASSERT_MATCH(io_lib:format("escape ~~p~n", []), "escape ~p\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("escape ~~p~n", [])), "escape ~p\n"),
 
-    ?ASSERT_FAILURE(io_lib:format("no pattern", [foo]), bad_format),
-    ?ASSERT_FAILURE(io_lib:format("too ~p many ~p patterns", [foo]), bad_format),
-    ?ASSERT_FAILURE(io_lib:format("not enough ~p patterns", [foo, bar]), bad_format),
+    ?ASSERT_FAILURE(io_lib:format("no pattern", [foo]), badarg),
+    ?ASSERT_FAILURE(io_lib:format("too ~p many ~p patterns", [foo]), badarg),
+    ?ASSERT_FAILURE(io_lib:format("not enough ~p patterns", [foo, bar]), badarg),
 
     ok.

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -193,14 +193,14 @@ test_seq() ->
     ?ASSERT_MATCH(lists:seq(5, 1, -1), [5, 4, 3, 2, 1]),
     ?ASSERT_MATCH(lists:seq(1, 1, 0), [1]),
 
-    ?ASSERT_FAILURE(lists:seq(foo, 1), badarg),
-    ?ASSERT_FAILURE(lists:seq(1, bar), badarg),
-    ?ASSERT_FAILURE(lists:seq(foo, bar), badarg),
-    ?ASSERT_FAILURE(lists:seq(1, 2, tapas), badarg),
-    ?ASSERT_FAILURE(lists:seq(1, -1), badarg),
-    ?ASSERT_FAILURE(lists:seq(-1, 1, -1), badarg),
-    ?ASSERT_FAILURE(lists:seq(1, -1, 1), badarg),
-    ?ASSERT_FAILURE(lists:seq(1, 2, 0), badarg),
+    ?ASSERT_FAILURE(lists:seq(foo, 1)),
+    ?ASSERT_FAILURE(lists:seq(1, bar)),
+    ?ASSERT_FAILURE(lists:seq(foo, bar)),
+    ?ASSERT_FAILURE(lists:seq(1, 2, tapas)),
+    ?ASSERT_FAILURE(lists:seq(1, -1)),
+    ?ASSERT_FAILURE(lists:seq(-1, 1, -1)),
+    ?ASSERT_FAILURE(lists:seq(1, -1, 1)),
+    ?ASSERT_FAILURE(lists:seq(1, 2, 0)),
 
     ok.
 

--- a/tests/libs/estdlib/test_maps.erl
+++ b/tests/libs/estdlib/test_maps.erl
@@ -171,11 +171,11 @@ test_remove() ->
     ok.
 
 test_update() ->
-    ?ASSERT_EQUALS(maps:update(foo, bar, maps:new()), #{foo => bar}),
+    ?ASSERT_FAILURE(maps:update(foo, bar, maps:new()), {badkey, foo}),
     ?ASSERT_EQUALS(maps:update(a, 10, #{a => 1, b => 2, c => 3}), #{a => 10, b => 2, c => 3}),
     ?ASSERT_EQUALS(maps:update(b, 20, #{a => 1, b => 2, c => 3}), #{a => 1, b => 20, c => 3}),
     ?ASSERT_EQUALS(maps:update(c, 30, #{a => 1, b => 2, c => 3}), #{a => 1, b => 2, c => 30}),
-    ?ASSERT_EQUALS(maps:update(d, 40, #{a => 1, b => 2, c => 3}), #{a => 1, b => 2, c => 3, d => 40}),
+    ?ASSERT_FAILURE(maps:update(d, 40, #{a => 1, b => 2, c => 3}), {badkey, d}),
     ok = check_bad_map(fun() -> maps:update(foo, bar, id(not_a_map)) end),
     ok.
 

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -23,7 +23,7 @@
 -export([start/0]).
 
 start() ->
-    etest:test([
+    ok = etest:test([
         test_lists,
         test_gen_server,
         test_gen_statem,

--- a/tests/test.c
+++ b/tests/test.c
@@ -20,479 +20,571 @@
 
 #include <assert.h>
 #include <libgen.h>
-#include <stdio.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
 
+#include "../platforms/generic_unix/mapped_file.h"
 #include "atom.h"
 #include "bif.h"
 #include "context.h"
-#include "../platforms/generic_unix/mapped_file.h"
-#include "module.h"
 #include "iff.h"
+#include "module.h"
 #include "term.h"
 #include "utils.h"
 
-struct Test{
-    const char *test_file;
+struct Test
+{
+    const char *test_module;
     int32_t expected_value;
+    bool skip_atom;
+    bool skip_beam;
 };
 
-struct Test tests[] =
-{
-    {"add.beam", 17},
-    {"fact.beam", 120},
-    {"mutrec.beam", 6},
-    {"morelabels.beam", 6},
-    {"biggerintegers.beam", 550},
-    {"biggerdifference.beam", 250},
-    {"moreintegertests.beam", 32},
-    {"send_receive.beam", 18},
-    {"send_to_dead_process.beam", 20},
-    {"byte_size_test.beam", 10},
-    {"tuple.beam", 6},
-    {"len_test.beam", 5},
-    {"count_char.beam", 2},
-    {"makelist_test.beam", 532},
-    {"test_echo_driver.beam", 84},
-    {"test_regecho_driver.beam", 11},
-    {"test_send_nif_and_echo.beam", 11},
-    {"state_test.beam", 3},
-    {"booleans_test.beam", 4},
-    {"booleans2_test.beam", 2},
-    {"rem_and_comp_test.beam", 4},
-    {"lowercase.beam", 15},
-    {"huge.beam", 31},
-    {"patternmatchfunc.beam", 102},
-    {"moda.beam", 44},
-    {"state_test2.beam", 3},
-    {"state_test3.beam", 3},
-    {"guards1.beam", 261},
-    {"guards2.beam", 36},
-    {"guards3.beam", 405},
-    {"guards4.beam", 16},
-    {"guards5.beam", 3},
-    {"prime.beam", 1999},
-    {"match.beam", 5},
-    {"if_test.beam", 5},
-    {"sleep.beam", 0},
-    {"hello_world.beam", 10},
-    {"whereis_fail.beam", 2},
-    {"try_noerror.beam", 1},
-    {"catch_badmatch.beam", 1},
-    {"catch_nocasematch.beam", 1},
-    {"catch_noifmatch.beam", 1},
-    {"try_catch_test.beam", 109},
-    {"list_concat.beam", 2270},
-    {"make_ref_test.beam", 130},
-    {"is_ref_test.beam", 3},
-    {"tagged_tuple_test.beam", 48},
-    {"call_with_ref_test.beam", 3},
-    {"just_receive_test.beam", 11},
-    {"gen_server_like_test.beam", 3},
-    {"external_proplist_test.beam", 3},
-    {"compact15bitsinteger.beam", 1567888},
-    {"negatives.beam", -55996},
-    {"compact23bitsinteger.beam",  47769328},
-    {"compact27bitsinteger.beam",  61837935},
-    {"compact23bitsneginteger.beam", -47376112},
-    {"negatives2.beam", -500},
-    {"datetime.beam", 3},
-    {"timestamp.beam", 1},
-    {"is_type.beam", 255},
-    {"test_bitshift.beam", 0},
-    {"test_bitwise.beam", -4},
-    {"test_bitwise2.beam", 0},
-    {"test_boolean.beam", 0},
-    {"test_gt_and_le.beam", 255},
-    {"test_tuple_size.beam", 6},
-    {"test_element.beam", 7},
-    {"test_setelement.beam", 121},
-    {"test_insert_element.beam", 121},
-    {"test_delete_element.beam", 421},
-    {"test_tuple_to_list.beam", 300},
-    {"test_make_tuple.beam", 4},
-    {"test_make_list.beam", 5},
-    {"test_list_gc.beam", 2},
-    {"test_list_processes.beam", 3},
-    {"test_tl.beam", 5},
-    {"test_list_to_atom.beam", 9},
-    {"test_list_to_existing_atom.beam", 9},
-    {"test_binary_to_atom.beam", 9},
-    {"test_binary_to_existing_atom.beam", 9},
-    {"test_atom_to_list.beam", 1},
-    {"test_display.beam", 0},
-    {"test_integer_to_list.beam", 1},
-    {"test_list_to_integer.beam", 99},
-    {"test_abs.beam", 5},
-    {"test_is_process_alive.beam", 121},
-    {"test_is_not_type.beam", 255},
-    {"test_badarith.beam", -87381},
-    {"test_badarith2.beam", -87381},
-    {"test_badarith3.beam", -1365},
-    {"test_badarith4.beam", -1365},
-    {"test_bif_badargument.beam", -5592405},
-    {"test_bif_badargument2.beam", -85},
-    {"test_bif_badargument3.beam", -85},
-    {"test_tuple_nifs_badargs.beam", -1398101},
-    {"long_atoms.beam", 4},
-    {"test_concat_badarg.beam", 4},
-    {"register_and_whereis_badarg.beam", 333},
-    {"test_send.beam", -3},
-    {"test_open_port_badargs.beam", -21},
-    {"pingpong.beam", 1},
-    {"prime_ext.beam", 1999},
-    {"test_try_case_end.beam", 256},
-    {"test_recursion_and_try_catch.beam", 3628800},
-    {"test_func_info.beam", 89},
-    {"test_func_info2.beam", 1},
-    {"test_func_info3.beam", 120},
-    {"test_process_info.beam", 0},
-    {"test_min_heap_size.beam", 0},
-    {"test_system_info.beam", 0},
-    {"test_funs0.beam", 20},
-    {"test_funs1.beam", 517},
-    {"test_funs2.beam", 52},
-    {"test_funs3.beam", 40},
-    {"test_funs4.beam", 6},
-    {"test_funs5.beam", 1000},
-    {"test_funs6.beam", 16},
-    {"test_funs7.beam", 9416},
-    {"test_funs8.beam", 22000},
-    {"test_funs9.beam", 3555},
-    {"test_funs10.beam", 6817},
-    {"test_funs11.beam", 817},
-
-    {"nested_list_size0.beam", 0},
-    {"nested_list_size1.beam", 2},
-    {"nested_list_size2.beam", 8},
-    {"nested_list_size3.beam", 68},
-    {"nested_list_size4.beam", 408},
-
-    {"simple_list_size0.beam", 2},
-    {"simple_list_size1.beam", 10},
-
-    {"tuple_size0.beam", 1},
-    {"tuple_size1.beam", 2},
-    {"tuple_size2.beam", 3},
-    {"tuple_size3.beam", 4},
-    {"tuple_size4.beam", 13},
-    {"tuple_size5.beam", 7},
-    {"tuple_size6.beam", 17},
-
-    {"tuples_and_list_size0.beam", 3},
-    {"tuples_and_list_size1.beam", 5},
-    {"tuples_and_list_size2.beam", 10},
-
-    {"nested_tuple_size0.beam", 12},
-    {"nested_tuple_size1.beam", 44},
-    {"nested_tuple_size2.beam", 76},
-    {"nested_tuple_size3.beam", 80},
-    {"nested_tuple_size4.beam", 80},
-
-    {"complex_struct_size0.beam", 43},
-    {"complex_struct_size1.beam", 37},
-    {"complex_struct_size2.beam", 105},
-    {"complex_struct_size3.beam", 23},
-    {"complex_struct_size4.beam", 126},
-
-    {"make_garbage0.beam", -19},
-    {"make_garbage1.beam", -18},
-    {"make_garbage2.beam", -56},
-    {"make_garbage3.beam", -7},
-    {"make_garbage4.beam", -438},
-    {"make_garbage5.beam", 6},
-    {"make_garbage6.beam", -210},
-    {"make_garbage7.beam", -210},
-
-
-    {"copy_terms0.beam", 0},
-    {"copy_terms1.beam", 1},
-    {"copy_terms2.beam", 2},
-    {"copy_terms3.beam", 5},
-    {"copy_terms4.beam", 2465},
-    {"copy_terms5.beam", 32},
-    {"copy_terms6.beam", 2},
-    {"copy_terms7.beam", 10},
-    {"copy_terms8.beam", 4},
-    {"copy_terms9.beam", -19},
-    {"copy_terms10.beam", -18},
-    {"copy_terms11.beam", 36757},
-    {"copy_terms12.beam", 36757},
-    {"copy_terms13.beam", 37037},
-    {"copy_terms14.beam", -210},
-    {"copy_terms15.beam", -438},
-    {"copy_terms16.beam", 6},
-    {"copy_terms17.beam", 11},
-    {"copy_terms18.beam", -19},
-
-    {"test_apply.beam", 17},
-    {"test_apply_last.beam", 17},
-    {"test_timestamp.beam", 1},
-    {"test_set_tuple_element.beam", 0},
-
-    {"spawn_fun1.beam", 42},
-    {"spawn_fun2.beam", 33},
-    {"spawn_fun3.beam", 10},
-
-    {"binary_at_test.beam", 121},
-    {"binary_first_test.beam", 82},
-    {"binary_last_test.beam", 110},
-
-    {"test_integer_to_binary.beam", 2},
-    {"test_list_to_binary.beam", 1},
-    {"test_binary_to_list.beam", 1},
-    {"test_atom_to_binary.beam", 1},
-
-    {"test_binary_part.beam", 12},
-    {"test_binary_split.beam", 16},
-
-    #if LONG_MAX == 9223372036854775807
-        {"plusone.beam", 134217728},
-    #endif
-
-    {"plusone2.beam", 1},
-    {"minusone.beam", -134217729},
-    {"minusone2.beam", -16},
-    {"int28mul.beam", 134217728},
-    {"int28mulneg.beam", -268435456},
-    {"int28mulneg2.beam", 268435448},
-    {"negdiv.beam", 134217728},
-    {"absovf.beam", 134217728},
-    {"negovf.beam", 134217728},
-
-    {"plusone3.beam", 134217726},
-    {"plusone4.beam", 134217728},
-    {"bigfact.beam", 1860480},
-    {"bigfact2.beam", 189907211},
-    {"bigfact3.beam", 3078559},
-    {"boxedabs.beam", 15},
-    {"boxedneg.beam", 15},
-    {"boxedmul.beam", 15},
-    {"boxedlit.beam", 1073741824},
-    {"pow32.beam", 528},
-    {"pow64.beam", 1794},
-    {"pow32_is_integer.beam", 528},
-    {"pow64_is_integer.beam", 1794},
-    {"addovf32.beam", 791},
-    {"subovf32.beam", 282},
-    {"negovf32.beam", -1935},
-    {"addovf64.beam", 2781},
-    {"subovf64.beam", 282},
-    {"negovf64.beam", -6865},
-    {"powsquare.beam", 1572},
-    {"minuspow31minusone.beam", -566},
-    {"pow31plusone.beam", 547},
-    {"minuspow31divminusone.beam", 547},
-    {"pow31abs.beam", 547},
-    {"minuspow31abs.beam", 547},
-    {"pow31minusoneabs.beam", 528},
-    {"minuspow31plusoneabs.beam", 528},
-    {"minuspow31plustwoabs.beam", 509},
-    {"minuspow63plusoneabs.beam", 1794},
-    {"minuspow63plustwoabs.beam", 1757},
-
-    {"literal_test0.beam", 333575620},
-    {"literal_test1.beam", 1680},
-
-    {"test_list_eq.beam", 1},
-    {"test_tuple_eq.beam", 1},
-    {"test_tuple_list_eq.beam", 1},
-    {"test_list_tuple_eq.beam", 1},
-    {"test_ref_eq.beam", 1},
-    {"test_binary_eq.beam", 1},
-    {"test_bigint_eq.beam", 1},
-
-    {"test_binaries_ordering.beam", 15},
-    {"test_lists_ordering.beam", 7},
-    {"test_tuples_ordering.beam", 7},
-    {"test_types_ordering.beam", 1},
-    {"test_bigintegers_ordering.beam", 7},
-    {"test_refs_ordering.beam", 7},
-    {"test_atom_ordering.beam", 7},
-    {"test_pids_ordering.beam", 7},
-    {"test_list_match.beam", 31},
-    {"test_match.beam", 0},
-    {"test_ordering_0.beam", 1},
-    {"test_ordering_1.beam", 1},
-    {"test_binary_to_term.beam", 0},
-    {"test_selective_receive.beam", 0},
-#ifndef AVM_NO_FP
-    {"test_timeout_not_integer.beam", 0},
-#endif
-    {"test_bs.beam", 0},
-    {"test_bs_int.beam", 0},
-    {"test_bs_int_unaligned.beam", 0},
-    {"test_catch.beam", 0},
-    {"test_gc.beam", 0 },
-    {"test_raise.beam", 7},
-    {"test_map.beam", 0},
-    {"test_refc_binaries.beam", 0},
-    {"test_sub_binaries.beam", 0},
-
-    {"ceilint.beam", 1},
-    {"ceilbadarg.beam", -1},
-    {"floorint.beam", 1},
-    {"floorbadarg.beam", -1},
-    {"roundint.beam", 1},
-    {"roundbadarg.beam", -1},
-    {"truncint.beam", 1},
-    {"truncbadarg.beam", -1},
-#ifndef AVM_NO_FP
-    {"ceilfloat.beam", -2},
-    {"ceilfloatovf.beam", -1},
-    {"floorfloat.beam", -3},
-    {"floorfloatovf.beam", -1},
-    {"roundfloat.beam", -3},
-    {"roundfloatovf.beam", -1},
-    {"truncfloat.beam", -2},
-    {"truncfloatovf.beam", -1},
-
-    {"floataddovf.beam", -2},
-    {"floatadd.beam", 2},
-    {"floatsubovf.beam", -2},
-    {"floatsub.beam", 2},
-    {"floatmulovf.beam", -2},
-    {"floatmul.beam", 50},
-    {"floatneg.beam", -2},
-    {"floatabs.beam", 3},
-
-    {"boxed_is_not_float.beam", 16},
-    {"float_is_float.beam", 32},
-    {"float_is_number.beam", 32},
-
-    {"float2bin.beam", 31},
-    {"float2list.beam", 31},
-    {"float2bin2scientific.beam", 31},
-    {"float2bin2decimals.beam", 255},
-    {"float2bin2.beam", 31},
-    {"float2list2scientific.beam", 31},
-    {"float2list2decimals.beam", 255},
-    {"float2list2.beam", 31},
-    {"bin2float.beam", 511},
-    {"list2float.beam", 511},
-#endif
-
-    {"improper_concat.beam", 7},
-    {"improper_cmp.beam", 3},
-    {"improper_literal.beam", 3},
-    {"improper_length.beam", 3},
+// Favor modules that return 0
+#define TEST_CASE(module)        \
+    {                            \
+#module, 0, false, false \
+    }
+#define TEST_CASE_EXPECTED(module, expected) \
+    {                                        \
+#module, expected, false, false      \
+    }
+#define TEST_CASE_ATOMVM_ONLY(module, expected) \
+    {                                           \
+#module, expected, false, true          \
+    }
+#define TEST_CASE_COND(module, expected, skip) \
+    {                                          \
+#module, expected, skip, false         \
+    }
 
 #ifndef AVM_NO_FP
-    {"jsonish_encode.beam", 1058},
+#define SKIP_NO_FP false
+#define SKIP_FP true
 #else
-    {"jsonish_encode_no_fp.beam", 1046},
+#define SKIP_NO_FP true
+#define SKIP_FP false
 #endif
-    {"iolist_concat_bin.beam", 71006},
-    {"binary_is_iolist.beam", 1006},
 
-    {"catch_from_other_module.beam", 7},
-    {"throwtest.beam", -10},
+struct Test tests[] = {
+    TEST_CASE_EXPECTED(add, 17),
+    TEST_CASE_EXPECTED(fact, 120),
+    TEST_CASE_EXPECTED(mutrec, 6),
+    TEST_CASE_EXPECTED(morelabels, 6),
+    TEST_CASE_EXPECTED(biggerintegers, 550),
+    TEST_CASE_EXPECTED(biggerdifference, 250),
+    TEST_CASE_EXPECTED(moreintegertests, 32),
+    TEST_CASE_EXPECTED(send_receive, 18),
+    TEST_CASE_EXPECTED(send_to_dead_process, 20),
+    TEST_CASE_EXPECTED(byte_size_test, 10),
+    TEST_CASE_EXPECTED(tuple, 6),
+    TEST_CASE_EXPECTED(len_test, 5),
+    TEST_CASE_EXPECTED(count_char, 2),
+    TEST_CASE_EXPECTED(makelist_test, 532),
+    TEST_CASE_EXPECTED(state_test, 3),
+    TEST_CASE_EXPECTED(booleans_test, 4),
+    TEST_CASE_EXPECTED(booleans2_test, 2),
+    TEST_CASE_EXPECTED(rem_and_comp_test, 4),
+    TEST_CASE_EXPECTED(lowercase, 15),
+    TEST_CASE_EXPECTED(huge, 31),
+    TEST_CASE_EXPECTED(patternmatchfunc, 102),
+    TEST_CASE_EXPECTED(moda, 44),
+    TEST_CASE_EXPECTED(state_test2, 3),
+    TEST_CASE_EXPECTED(state_test3, 3),
+    TEST_CASE_EXPECTED(guards1, 261),
+    TEST_CASE_EXPECTED(guards2, 36),
+    // This tests depends on echo port, but it works sufficiently on Unix
+    // as BEAM will start echo(1)
+    TEST_CASE_EXPECTED(guards3, 405),
+    TEST_CASE_EXPECTED(guards4, 16),
+    TEST_CASE_EXPECTED(guards5, 3),
+    TEST_CASE_EXPECTED(prime, 1999),
+    TEST_CASE_EXPECTED(match, 5),
+    TEST_CASE_EXPECTED(if_test, 5),
+    TEST_CASE(sleep),
+    TEST_CASE_EXPECTED(whereis_fail, 2),
+    TEST_CASE_EXPECTED(try_noerror, 1),
+    TEST_CASE_EXPECTED(catch_badmatch, 1),
+    TEST_CASE_EXPECTED(catch_nocasematch, 1),
+    TEST_CASE_EXPECTED(catch_noifmatch, 1),
+    TEST_CASE_EXPECTED(try_catch_test, 109),
+    TEST_CASE_EXPECTED(list_concat, 2270),
+    TEST_CASE_EXPECTED(make_ref_test, 130),
+    TEST_CASE_EXPECTED(is_ref_test, 3),
+    TEST_CASE_EXPECTED(tagged_tuple_test, 48),
+    TEST_CASE_EXPECTED(call_with_ref_test, 3),
+    TEST_CASE_EXPECTED(just_receive_test, 11),
+    TEST_CASE_EXPECTED(gen_server_like_test, 3),
+    TEST_CASE_EXPECTED(external_proplist_test, 3),
+    TEST_CASE_EXPECTED(compact15bitsinteger, 1567888),
+    TEST_CASE_EXPECTED(negatives, -55996),
+    TEST_CASE_EXPECTED(compact23bitsinteger, 47769328),
+    TEST_CASE_EXPECTED(compact27bitsinteger, 61837935),
+    TEST_CASE_EXPECTED(compact23bitsneginteger, -47376112),
+    TEST_CASE_EXPECTED(negatives2, -500),
+    TEST_CASE_EXPECTED(datetime, 3),
+    TEST_CASE_EXPECTED(timestamp, 1),
+    TEST_CASE_EXPECTED(is_type, 255),
+    TEST_CASE(test_bitshift),
+    TEST_CASE_EXPECTED(test_bitwise, -4),
+    TEST_CASE(test_bitwise2),
+    TEST_CASE(test_boolean),
+    TEST_CASE_EXPECTED(test_gt_and_le, 255),
+    TEST_CASE_EXPECTED(test_tuple_size, 6),
+    TEST_CASE_EXPECTED(test_element, 7),
+    TEST_CASE_EXPECTED(test_setelement, 121),
+    TEST_CASE_EXPECTED(test_insert_element, 121),
+    TEST_CASE_EXPECTED(test_delete_element, 421),
+    TEST_CASE_EXPECTED(test_tuple_to_list, 300),
+    TEST_CASE_EXPECTED(test_make_tuple, 4),
+    TEST_CASE_EXPECTED(test_make_list, 5),
+    TEST_CASE_EXPECTED(test_list_gc, 2),
+    TEST_CASE_EXPECTED(test_list_processes, 3),
+    TEST_CASE_EXPECTED(test_tl, 5),
+    TEST_CASE_EXPECTED(test_list_to_atom, 9),
+    TEST_CASE_EXPECTED(test_list_to_existing_atom, 9),
+    TEST_CASE_EXPECTED(test_binary_to_atom, 9),
+    TEST_CASE_EXPECTED(test_binary_to_existing_atom, 9),
+    TEST_CASE_EXPECTED(test_atom_to_list, 1),
+    TEST_CASE(test_display),
+    TEST_CASE_EXPECTED(test_integer_to_list, 1),
+    TEST_CASE_EXPECTED(test_list_to_integer, 99),
+    TEST_CASE_EXPECTED(test_abs, 5),
+    TEST_CASE_EXPECTED(test_is_process_alive, 121),
+    TEST_CASE_EXPECTED(test_is_not_type, 255),
+    TEST_CASE_EXPECTED(test_badarith, -87381),
+    TEST_CASE_EXPECTED(test_badarith2, -87381),
+    TEST_CASE_EXPECTED(test_badarith3, -1365),
+    TEST_CASE_EXPECTED(test_badarith4, -1365),
+    TEST_CASE_EXPECTED(test_bif_badargument, -5592405),
+    TEST_CASE_EXPECTED(test_bif_badargument2, -85),
+    TEST_CASE_EXPECTED(test_bif_badargument3, -85),
+    TEST_CASE_EXPECTED(test_tuple_nifs_badargs, -1398101),
+    TEST_CASE_EXPECTED(long_atoms, 4),
+    TEST_CASE_EXPECTED(test_concat_badarg, 4),
+    TEST_CASE_EXPECTED(register_and_whereis_badarg, 333),
+    TEST_CASE_EXPECTED(test_send, -3),
+    TEST_CASE_EXPECTED(test_open_port_badargs, -21),
+    TEST_CASE_EXPECTED(prime_ext, 1999),
+    TEST_CASE_EXPECTED(test_try_case_end, 256),
+    TEST_CASE_EXPECTED(test_recursion_and_try_catch, 3628800),
+    TEST_CASE_EXPECTED(test_func_info, 89),
+    TEST_CASE_EXPECTED(test_func_info2, 1),
+    TEST_CASE_EXPECTED(test_func_info3, 120),
+    TEST_CASE(test_process_info),
+    TEST_CASE(test_min_heap_size),
+    TEST_CASE(test_system_info),
+    TEST_CASE_EXPECTED(test_funs0, 20),
+    TEST_CASE_EXPECTED(test_funs1, 517),
+    TEST_CASE_EXPECTED(test_funs2, 52),
+    TEST_CASE_EXPECTED(test_funs3, 40),
+    TEST_CASE_EXPECTED(test_funs4, 6),
+    TEST_CASE_EXPECTED(test_funs5, 1000),
+    TEST_CASE_EXPECTED(test_funs6, 16),
+    TEST_CASE_EXPECTED(test_funs7, 9416),
+    TEST_CASE_EXPECTED(test_funs8, 22000),
+    TEST_CASE_EXPECTED(test_funs9, 3555),
+    TEST_CASE_EXPECTED(test_funs10, 6817),
+    TEST_CASE_EXPECTED(test_funs11, 817),
 
-    {"test_tuple_is_not_map.beam", 16},
+    TEST_CASE(nested_list_size0),
+    TEST_CASE_EXPECTED(nested_list_size1, 2),
+    TEST_CASE_EXPECTED(nested_list_size2, 8),
+    TEST_CASE_EXPECTED(nested_list_size3, 68),
+    TEST_CASE_EXPECTED(nested_list_size4, 408),
 
-    {"try_error_nif.beam", 13},
-    {"try_error2_nif.beam", 13},
+    TEST_CASE_EXPECTED(simple_list_size0, 2),
+    TEST_CASE_EXPECTED(simple_list_size1, 10),
 
-    {"is_fun_2_with_frozen.beam", 24},
-    {"is_fun_2_with_frozen2.beam", 24},
+    TEST_CASE_EXPECTED(tuple_size0, 1),
+    TEST_CASE_EXPECTED(tuple_size1, 2),
+    TEST_CASE_EXPECTED(tuple_size2, 3),
+    TEST_CASE_EXPECTED(tuple_size3, 4),
+    TEST_CASE_EXPECTED(tuple_size4, 13),
+    TEST_CASE_EXPECTED(tuple_size5, 7),
+    TEST_CASE_EXPECTED(tuple_size6, 17),
 
-    {"function_reference_decode.beam", 5},
-    {"makefunref.beam", 3},
-    {"fail_apply.beam", 17},
-    {"fail_apply_last.beam", 17},
+    TEST_CASE_EXPECTED(tuples_and_list_size0, 3),
+    TEST_CASE_EXPECTED(tuples_and_list_size1, 5),
+    TEST_CASE_EXPECTED(tuples_and_list_size2, 10),
 
-    {"pid_to_list_test.beam", 63},
-    {"ref_to_list_test.beam", 386},
-    {"test_binary_to_integer.beam", 99},
+    TEST_CASE_EXPECTED(nested_tuple_size0, 12),
+    TEST_CASE_EXPECTED(nested_tuple_size1, 44),
+    TEST_CASE_EXPECTED(nested_tuple_size2, 76),
+    TEST_CASE_EXPECTED(nested_tuple_size3, 80),
+    TEST_CASE_EXPECTED(nested_tuple_size4, 80),
 
-    {"count_char_bs.beam", 2},
-    {"count_char2_bs.beam", 1002},
-    {"count_char3_bs.beam", 1},
-    {"count_pairs.beam", 3},
-    {"decode_mqtt.beam", 120948},
-    {"decode_int24.beam", 725246},
-    {"decode_int32.beam", 289273},
-    {"decode_int48.beam", 858867},
+    TEST_CASE_EXPECTED(complex_struct_size0, 43),
+    TEST_CASE_EXPECTED(complex_struct_size1, 37),
+    TEST_CASE_EXPECTED(complex_struct_size2, 105),
+    TEST_CASE_EXPECTED(complex_struct_size3, 23),
+    TEST_CASE_EXPECTED(complex_struct_size4, 126),
 
-    {"large_int_literal.beam", 5953},
+    TEST_CASE_EXPECTED(make_garbage0, -19),
+    TEST_CASE_EXPECTED(make_garbage1, -18),
+    TEST_CASE_EXPECTED(make_garbage2, -56),
+    TEST_CASE_EXPECTED(make_garbage3, -7),
+    TEST_CASE_EXPECTED(make_garbage4, -438),
+    TEST_CASE_EXPECTED(make_garbage5, 6),
+    TEST_CASE_EXPECTED(make_garbage6, -210),
+    TEST_CASE_EXPECTED(make_garbage7, -210),
 
-    {"test_base64.beam", 0},
-    {"test_dict.beam", 2020},
+    TEST_CASE(copy_terms0),
+    TEST_CASE_EXPECTED(copy_terms1, 1),
+    TEST_CASE_EXPECTED(copy_terms2, 2),
+    TEST_CASE_EXPECTED(copy_terms3, 5),
+    TEST_CASE_EXPECTED(copy_terms4, 2465),
+    TEST_CASE_EXPECTED(copy_terms5, 32),
+    TEST_CASE_EXPECTED(copy_terms6, 2),
+    TEST_CASE_EXPECTED(copy_terms7, 10),
+    TEST_CASE_EXPECTED(copy_terms8, 4),
+    TEST_CASE_EXPECTED(copy_terms9, -19),
+    TEST_CASE_EXPECTED(copy_terms10, -18),
+    TEST_CASE_EXPECTED(copy_terms11, 36757),
+    TEST_CASE_EXPECTED(copy_terms12, 36757),
+    TEST_CASE_EXPECTED(copy_terms13, 37037),
+    TEST_CASE_EXPECTED(copy_terms14, -210),
+    TEST_CASE_EXPECTED(copy_terms15, -438),
+    TEST_CASE_EXPECTED(copy_terms16, 6),
+    TEST_CASE_EXPECTED(copy_terms17, 11),
+    TEST_CASE_EXPECTED(copy_terms18, -19),
 
-    {"alisp.beam", 42},
-    {"test_function_exported.beam", 7},
-    {"test_list_to_tuple.beam", 69},
+    TEST_CASE_EXPECTED(test_apply, 17),
+    TEST_CASE_EXPECTED(test_apply_last, 17),
+    TEST_CASE_EXPECTED(test_timestamp, 1),
+    TEST_CASE(test_set_tuple_element),
 
-    {"bs_context_to_binary_with_offset.beam", 42},
-#ifndef AVM_NO_FP
-    {"bs_restore2_start_offset.beam", 823},
-#else
-    {"bs_restore2_start_offset_no_fp.beam", 823},
-#endif
+    TEST_CASE_EXPECTED(spawn_fun1, 42),
+    TEST_CASE_EXPECTED(spawn_fun2, 33),
+    TEST_CASE_EXPECTED(spawn_fun3, 10),
+
+    TEST_CASE_EXPECTED(binary_at_test, 121),
+    TEST_CASE_EXPECTED(binary_first_test, 82),
+    TEST_CASE_EXPECTED(binary_last_test, 110),
+
+    TEST_CASE_EXPECTED(test_integer_to_binary, 2),
+    TEST_CASE_EXPECTED(test_list_to_binary, 1),
+    TEST_CASE_EXPECTED(test_binary_to_list, 1),
+    TEST_CASE_EXPECTED(test_atom_to_binary, 1),
+
+    TEST_CASE_EXPECTED(test_binary_part, 12),
+    TEST_CASE_EXPECTED(test_binary_split, 16),
+
+    TEST_CASE_COND(plusone, 134217728, LONG_MAX != 9223372036854775807),
+
+    TEST_CASE_EXPECTED(plusone2, 1),
+    TEST_CASE_EXPECTED(minusone, -134217729),
+    TEST_CASE_EXPECTED(minusone2, -16),
+    TEST_CASE_EXPECTED(int28mul, 134217728),
+    TEST_CASE_EXPECTED(int28mulneg, -268435456),
+    TEST_CASE_EXPECTED(int28mulneg2, 268435448),
+    TEST_CASE_EXPECTED(negdiv, 134217728),
+    TEST_CASE_EXPECTED(absovf, 134217728),
+    TEST_CASE_EXPECTED(negovf, 134217728),
+
+    TEST_CASE_EXPECTED(plusone3, 134217726),
+    TEST_CASE_EXPECTED(plusone4, 134217728),
+    TEST_CASE_EXPECTED(bigfact, 1860480),
+    TEST_CASE_EXPECTED(bigfact2, 189907211),
+    TEST_CASE_EXPECTED(bigfact3, 3078559),
+    TEST_CASE_EXPECTED(boxedabs, 15),
+    TEST_CASE_EXPECTED(boxedneg, 15),
+    TEST_CASE_EXPECTED(boxedmul, 15),
+    TEST_CASE_EXPECTED(boxedlit, 1073741824),
+    TEST_CASE_EXPECTED(pow32, 528),
+    TEST_CASE_EXPECTED(pow64, 1794),
+    TEST_CASE_EXPECTED(pow32_is_integer, 528),
+    TEST_CASE_EXPECTED(pow64_is_integer, 1794),
+    TEST_CASE_EXPECTED(addovf32, 791),
+    TEST_CASE_EXPECTED(subovf32, 282),
+    TEST_CASE_EXPECTED(negovf32, -1935),
+    TEST_CASE_EXPECTED(addovf64, 2781),
+    TEST_CASE_EXPECTED(subovf64, 282),
+    TEST_CASE_EXPECTED(negovf64, -6865),
+    TEST_CASE_EXPECTED(powsquare, 1572),
+    TEST_CASE_EXPECTED(minuspow31minusone, -566),
+    TEST_CASE_EXPECTED(pow31plusone, 547),
+    TEST_CASE_EXPECTED(minuspow31divminusone, 547),
+    TEST_CASE_EXPECTED(pow31abs, 547),
+    TEST_CASE_EXPECTED(minuspow31abs, 547),
+    TEST_CASE_EXPECTED(pow31minusoneabs, 528),
+    TEST_CASE_EXPECTED(minuspow31plusoneabs, 528),
+    TEST_CASE_EXPECTED(minuspow31plustwoabs, 509),
+    TEST_CASE_EXPECTED(minuspow63plusoneabs, 1794),
+    TEST_CASE_EXPECTED(minuspow63plustwoabs, 1757),
+
+    TEST_CASE_EXPECTED(literal_test0, 333575620),
+    TEST_CASE_EXPECTED(literal_test1, 1680),
+
+    TEST_CASE_EXPECTED(test_list_eq, 1),
+    TEST_CASE_EXPECTED(test_tuple_eq, 1),
+    TEST_CASE_EXPECTED(test_tuple_list_eq, 1),
+    TEST_CASE_EXPECTED(test_list_tuple_eq, 1),
+    TEST_CASE_EXPECTED(test_ref_eq, 1),
+    TEST_CASE_EXPECTED(test_binary_eq, 1),
+    TEST_CASE_EXPECTED(test_bigint_eq, 1),
+
+    TEST_CASE_EXPECTED(test_binaries_ordering, 15),
+    TEST_CASE_EXPECTED(test_lists_ordering, 7),
+    TEST_CASE_EXPECTED(test_tuples_ordering, 7),
+    TEST_CASE_EXPECTED(test_types_ordering, 1),
+    TEST_CASE_EXPECTED(test_bigintegers_ordering, 7),
+    TEST_CASE_EXPECTED(test_refs_ordering, 7),
+    TEST_CASE_EXPECTED(test_atom_ordering, 7),
+    TEST_CASE_EXPECTED(test_pids_ordering, 7),
+    TEST_CASE_EXPECTED(test_list_match, 31),
+    TEST_CASE(test_match),
+    TEST_CASE_EXPECTED(test_ordering_0, 1),
+    TEST_CASE_EXPECTED(test_ordering_1, 1),
+    TEST_CASE(test_binary_to_term),
+    TEST_CASE(test_selective_receive),
+    TEST_CASE_COND(test_timeout_not_integer, 0, SKIP_NO_FP),
+    TEST_CASE(test_bs),
+    TEST_CASE(test_bs_int),
+    TEST_CASE(test_bs_int_unaligned),
+    TEST_CASE(test_catch),
+    TEST_CASE(test_gc),
+    TEST_CASE_EXPECTED(test_raise, 7),
+    TEST_CASE(test_map),
+    TEST_CASE_ATOMVM_ONLY(test_refc_binaries, 0),
+    TEST_CASE(test_sub_binaries),
+
+    TEST_CASE_EXPECTED(ceilint, 1),
+    TEST_CASE_EXPECTED(ceilbadarg, -1),
+    TEST_CASE_EXPECTED(floorint, 1),
+    TEST_CASE_EXPECTED(floorbadarg, -1),
+    TEST_CASE_EXPECTED(roundint, 1),
+    TEST_CASE_EXPECTED(roundbadarg, -1),
+    TEST_CASE_EXPECTED(truncint, 1),
+    TEST_CASE_EXPECTED(truncbadarg, -1),
+
+    TEST_CASE_COND(ceilfloat, -2, SKIP_NO_FP),
+    TEST_CASE_COND(ceilfloatovf, 0, SKIP_NO_FP),
+    TEST_CASE_COND(floorfloat, -3, SKIP_NO_FP),
+    TEST_CASE_COND(floorfloatovf, 0, SKIP_NO_FP),
+    TEST_CASE_COND(roundfloat, -3, SKIP_NO_FP),
+    TEST_CASE_COND(roundfloatovf, 0, SKIP_NO_FP),
+    TEST_CASE_COND(truncfloat, -2, SKIP_NO_FP),
+    TEST_CASE_COND(truncfloatovf, 0, SKIP_NO_FP),
+
+    TEST_CASE_COND(floataddovf, -2, SKIP_NO_FP),
+    TEST_CASE_COND(floatadd, 2, SKIP_NO_FP),
+    TEST_CASE_COND(floatsubovf, -2, SKIP_NO_FP),
+    TEST_CASE_COND(floatsub, 2, SKIP_NO_FP),
+    TEST_CASE_COND(floatmulovf, -2, SKIP_NO_FP),
+    TEST_CASE_COND(floatmul, 50, SKIP_NO_FP),
+    TEST_CASE_COND(floatneg, -2, SKIP_NO_FP),
+    TEST_CASE_COND(floatabs, 3, SKIP_NO_FP),
+
+    TEST_CASE_COND(boxed_is_not_float, 16, SKIP_NO_FP),
+    TEST_CASE_COND(float_is_float, 32, SKIP_NO_FP),
+    TEST_CASE_COND(float_is_number, 32, SKIP_NO_FP),
+
+    TEST_CASE_COND(float2bin, 31, SKIP_NO_FP),
+    TEST_CASE_COND(float2list, 31, SKIP_NO_FP),
+    TEST_CASE_COND(float2bin2scientific, 31, SKIP_NO_FP),
+    TEST_CASE_COND(float2bin2decimals, 255, SKIP_NO_FP),
+    TEST_CASE_COND(float2bin2, 31, SKIP_NO_FP),
+    TEST_CASE_COND(float2list2scientific, 31, SKIP_NO_FP),
+    TEST_CASE_COND(float2list2decimals, 255, SKIP_NO_FP),
+    TEST_CASE_COND(float2list2, 31, SKIP_NO_FP),
+    TEST_CASE_COND(bin2float, 511, SKIP_NO_FP),
+    TEST_CASE_COND(list2float, 511, SKIP_NO_FP),
+
+    TEST_CASE_EXPECTED(improper_concat, 7),
+    TEST_CASE_EXPECTED(improper_cmp, 3),
+    TEST_CASE_EXPECTED(improper_literal, 3),
+    TEST_CASE_EXPECTED(improper_length, 3),
+
+    TEST_CASE_COND(jsonish_encode, 1058, SKIP_NO_FP),
+    TEST_CASE_COND(jsonish_encode_no_fp, 1046, SKIP_FP),
+
+    TEST_CASE_EXPECTED(iolist_concat_bin, 71006),
+    TEST_CASE_EXPECTED(binary_is_iolist, 1006),
+
+    TEST_CASE_EXPECTED(catch_from_other_module, 7),
+    TEST_CASE_EXPECTED(throwtest, -10),
+
+    TEST_CASE_EXPECTED(test_tuple_is_not_map, 16),
+
+    TEST_CASE_EXPECTED(try_error_nif, 13),
+    TEST_CASE_EXPECTED(try_error2_nif, 13),
+
+    TEST_CASE_EXPECTED(is_fun_2_with_frozen, 24),
+    TEST_CASE_EXPECTED(is_fun_2_with_frozen2, 24),
+
+    TEST_CASE_EXPECTED(function_reference_decode, 5),
+    TEST_CASE_EXPECTED(makefunref, 3),
+    TEST_CASE_EXPECTED(fail_apply, 17),
+    TEST_CASE_EXPECTED(fail_apply_last, 17),
+
+    TEST_CASE_EXPECTED(pid_to_list_test, 63),
+    TEST_CASE_EXPECTED(ref_to_list_test, 386),
+    TEST_CASE_EXPECTED(test_binary_to_integer, 99),
+
+    TEST_CASE_EXPECTED(count_char_bs, 2),
+    TEST_CASE_EXPECTED(count_char2_bs, 1002),
+    TEST_CASE_EXPECTED(count_char3_bs, 1),
+    TEST_CASE_EXPECTED(count_pairs, 3),
+    TEST_CASE_EXPECTED(decode_mqtt, 120948),
+    TEST_CASE_EXPECTED(decode_int24, 725246),
+    TEST_CASE_EXPECTED(decode_int32, 289273),
+    TEST_CASE_EXPECTED(decode_int48, 858867),
+
+    TEST_CASE_EXPECTED(large_int_literal, 5953),
+
+    TEST_CASE(test_base64),
+    TEST_CASE_EXPECTED(test_dict, 2020),
+
+    TEST_CASE_EXPECTED(alisp, 42),
+    TEST_CASE_EXPECTED(test_function_exported, 7),
+    TEST_CASE_EXPECTED(test_list_to_tuple, 69),
+
+    TEST_CASE_EXPECTED(bs_context_to_binary_with_offset, 42),
+    TEST_CASE_COND(bs_restore2_start_offset, 823, SKIP_NO_FP),
+    TEST_CASE_COND(bs_restore2_start_offset_no_fp, 823, SKIP_FP),
+
+    // Tests relying on echo driver
+    TEST_CASE_ATOMVM_ONLY(pingpong, 1),
+
+    // Tests relying on console driver
+    TEST_CASE_ATOMVM_ONLY(hello_world, 10),
+    TEST_CASE_ATOMVM_ONLY(test_echo_driver, 84),
+    TEST_CASE_ATOMVM_ONLY(test_regecho_driver, 11),
+    TEST_CASE_ATOMVM_ONLY(test_send_nif_and_echo, 11),
 
     // noisy tests, keep them at the end
-    {"spawn_opt_monitor_normal.beam", 1},
-    {"spawn_opt_link_normal.beam", 1},
-    {"spawn_opt_monitor_throw.beam", 1},
-    {"spawn_opt_demonitor_normal.beam", 1},
-    {"spawn_opt_link_throw.beam", 1},
-    {"spawn_opt_monitor_error.beam", 1},
-    {"link_kill_parent.beam", 1},
-    {"link_throw.beam", 1},
-    {"unlink_error.beam", 1},
-    {"trap_exit_flag.beam", 1},
+    TEST_CASE_EXPECTED(spawn_opt_monitor_normal, 1),
+    TEST_CASE_EXPECTED(spawn_opt_link_normal, 1),
+    TEST_CASE_EXPECTED(spawn_opt_monitor_throw, 1),
+    TEST_CASE_EXPECTED(spawn_opt_demonitor_normal, 1),
+    TEST_CASE_EXPECTED(spawn_opt_link_throw, 1),
+    TEST_CASE_EXPECTED(spawn_opt_monitor_error, 1),
+    TEST_CASE_EXPECTED(link_kill_parent, 1),
+    TEST_CASE_EXPECTED(link_throw, 1),
+    TEST_CASE_EXPECTED(unlink_error, 1),
+    TEST_CASE_EXPECTED(trap_exit_flag, 1),
 
-    //TEST CRASHES HERE: {"memlimit.beam", 0},
+    // TEST CRASHES HERE: TEST_CASE(memlimit),
 
-    {NULL, 0}
+    { NULL, 0, false, false }
 };
 
-int test_modules_execution()
+static int test_atom(struct Test *test)
 {
-    struct Test *test = tests;
+    int result = 0;
+    char module_file[128];
+    snprintf(module_file, sizeof(module_file), "%s.beam", test->test_module);
+    MappedFile *beam_file = mapped_file_open_beam(module_file);
+    assert(beam_file != NULL);
 
+    GlobalContext *glb = globalcontext_new();
+    glb->avmpack_platform_data = NULL;
+    Module *mod = module_new_from_iff_binary(glb, beam_file->mapped, beam_file->size);
+    if (IS_NULL_PTR(mod)) {
+        fprintf(stderr, "Cannot load startup module: %s\n", test->test_module);
+        return -1;
+    }
+    globalcontext_insert_module_with_filename(glb, mod, module_file);
+    Context *ctx = context_new(glb);
+    ctx->leader = 1;
+
+    context_execute_loop(ctx, mod, "start", 0);
+
+    if (!term_is_any_integer(ctx->x[0])) {
+        fprintf(stderr, "\x1b[1;31mExpected %i but result is not an integer\x1b[0m\n", test->expected_value);
+        result = -1;
+    } else {
+        int32_t value = (int32_t) term_maybe_unbox_int(ctx->x[0]);
+        if (value != test->expected_value) {
+            fprintf(stderr, "\x1b[1;31mExpected %i, got: %i\x1b[0m\n", test->expected_value, value);
+            result = -1;
+        }
+    }
+
+    context_destroy(ctx);
+    globalcontext_destroy(glb);
+    module_destroy(mod);
+    mapped_file_close(beam_file);
+    return result;
+}
+
+static int test_beam(struct Test *test)
+{
+    char command[512];
+    snprintf(command, sizeof(command),
+        "erl -pa . -eval '"
+        "erlang:process_flag(trap_exit, false), " /* init(3) traps exists */
+        "R = %s:start(), "
+        "S = if"
+        " R =:= %i -> 0;"
+        " true -> io:format(\"Expected ~B, got ~p\n\", [%i, R]) "
+        "end, "
+        "erlang:halt(S).' -noshell",
+        test->test_module,
+        test->expected_value,
+        test->expected_value);
+    return system(command);
+}
+
+int test_module_execution(bool beam, struct Test *test)
+{
+    if (beam ? test->skip_beam : test->skip_atom) {
+        fprintf(stderr, "%s:\x1b[34GSKIPPED\n", test->test_module);
+        return 0;
+    }
+    fprintf(stderr, "%s:\r", test->test_module);
+    int result = beam ? test_beam(test) : test_atom(test);
+    if (result) {
+        fprintf(stderr, "\x1b[2K\x1b[1;31m%s:\x1b[34GFAILED\x1b[0m\n", test->test_module);
+        return 1;
+    }
+    fprintf(stderr, "\x1b[2K%s:\x1b[34GOK\n", test->test_module);
+    return 0;
+}
+
+int test_modules_execution(bool beam, bool skip, int count, char **item)
+{
     if (chdir("erlang_tests")) {
         return EXIT_FAILURE;
     }
 
     int failed_tests = 0;
 
-    do {
-        fprintf(stderr, "-- EXECUTING TEST: %s\n", test->test_file);
-        MappedFile *beam_file = mapped_file_open_beam(test->test_file);
-        assert(beam_file != NULL);
+    if (count) {
+        for (int ix = 0; ix < count; ix++) {
+            struct Test *test = tests;
+            do {
+                if (strcmp(test->test_module, item[ix]) == 0) {
+                    if (skip) {
+                        test->skip_beam = true;
+                        test->skip_atom = true;
+                    } else {
+                        failed_tests += test_module_execution(beam, test);
+                    }
+                    break;
+                }
+                test++;
+            } while (test->test_module);
+            if (test->test_module == NULL) {
+                fprintf(stderr, "Unknown test module %s\n", item[ix]);
+                return EXIT_FAILURE;
+            }
+        }
+    }
 
-        GlobalContext *glb = globalcontext_new();
-        glb->avmpack_platform_data = NULL;
-        Module *mod = module_new_from_iff_binary(glb, beam_file->mapped, beam_file->size);
-        if (IS_NULL_PTR(mod)) {
-            fprintf(stderr, "Cannot load startup module: %s\n", test->test_file);
+    if (count == 0 || skip) {
+        struct Test *test = tests;
+        do {
+            failed_tests += test_module_execution(beam, test);
             test++;
-            continue;
-        }
-        globalcontext_insert_module_with_filename(glb, mod, test->test_file);
-        Context *ctx = context_new(glb);
-        ctx->leader = 1;
-
-        context_execute_loop(ctx, mod, "start", 0);
-
-        avm_int_t value = term_maybe_unbox_int(ctx->x[0]);
-        if (value != test->expected_value) {
-            fprintf(stderr, "\x1b[1;31mFailed test module %s, got value: %li\x1b[0m\n", test->test_file, value);
-            failed_tests++;
-        }
-
-        context_destroy(ctx);
-        globalcontext_destroy(glb);
-        module_destroy(mod);
-        mapped_file_close(beam_file);
-
-        test++;
-    } while (test->test_file);
+        } while (test->test_module);
+    }
 
     if (failed_tests == 0) {
         fprintf(stderr, "Success.\n");
@@ -503,15 +595,81 @@ int test_modules_execution()
     }
 }
 
+static void usage(const char *name)
+{
+    fprintf(stdout, "%s: run AtomVM tests\n", name);
+    fprintf(stdout, "%s [-h] [-s test1,test2] [-b] [test1 test2...]\n", name);
+    fprintf(stdout, "  -h: display this message\n");
+    fprintf(stdout, "  -s test1,test2: skip these tests\n");
+    fprintf(stdout, "  -b: run tests against BEAM instead of AtomVM (erl in the PATH)\n");
+    fprintf(stdout, "  test1 .. test2: specify tests to run (default to all)\n");
+}
+
+static void syntax_error(const char *name, const char *message)
+{
+    fprintf(stderr, "%s: syntax error\n%s\nTry %s -h for help\n", name, message, name);
+}
+
 int main(int argc, char **argv)
 {
-    UNUSED(argc)
-
+    char *name = argv[0];
     time_t seed = time(NULL);
     fprintf(stderr, "Seed is %li\n", seed);
     srand(seed);
 
-    chdir(dirname(argv[0]));
+    chdir(dirname(name));
 
-    return test_modules_execution();
+    int opt;
+    bool beam = false;
+    bool skip = false;
+    char *skip_list = NULL;
+    while ((opt = getopt(argc, argv, "hbs:")) != -1) {
+        switch (opt) {
+            case 'b':
+                beam = true;
+                break;
+            case 's':
+                skip_list = optarg;
+                break;
+            case 'h':
+                usage(name);
+                return 0;
+            case ':':
+            case '?':
+                syntax_error(name, "Unknown option");
+                return 1;
+        }
+    }
+    int count = argc - optind;
+    char **list = argv + optind;
+    char **allocated_skip_list = NULL;
+    if (count > 1 && skip_list != NULL) {
+        syntax_error(name, "Option -s is incompatible with module names");
+    }
+    if (skip_list) {
+        skip = true;
+        // tokenize the list, first counting elements.
+        char *skip_list_c = skip_list;
+        count = 1;
+        while (*skip_list_c) {
+            if (*skip_list_c == ',') {
+                count++;
+            }
+            skip_list_c++;
+        }
+        allocated_skip_list = malloc(count * sizeof(char *));
+        int ix = 0;
+        char *token = strtok(skip_list, ",");
+        while (token && ix < count) {
+            allocated_skip_list[ix++] = token;
+            token = strtok(NULL, ",");
+        }
+        list = allocated_skip_list;
+    }
+
+    int result = test_modules_execution(beam, skip, count, list);
+    if (allocated_skip_list) {
+        free(allocated_skip_list);
+    }
+    return result;
 }


### PR DESCRIPTION
Run test-erlang with BEAM and estdlib tests against OTP.
Improve test-erlang command line interface to allow for skipping and running only some tests.
Fix estdlib API so it matches OTP as far as tests are concerned.
Fix running of test_map and test_base64 on macOS (needed to tell CMake to pick up OpenSSL).
Upgrade OTP in the CI to versions 21, 22 and 23 instead of 21.0, 22.0 and 23.0 as a test doesn't pass with 21.0 but passes with 22.0, 23.0 and latest 21.x.

Signed-off-by: Paul Guyot <pguyot@kallisys.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
