### PR TITLE
Fix various compiler warnings

### DIFF
--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -129,7 +129,7 @@ term externalterm_to_term(const void *external_term, size_t size, Context *ctx, 
     return externalterm_to_term_internal(external_term, size, ctx, use_heap_fragment, &bytes_read, false);
 }
 
-enum ExternalTermResult externalterm_from_binary(Context *ctx, term *dst, term binary, size_t *bytes_read, size_t num_extra_terms)
+enum ExternalTermResult externalterm_from_binary(Context *ctx, term *dst, term binary, size_t *bytes_read)
 {
     if (!term_is_binary(binary)) {
         return EXTERNAL_TERM_BAD_ARG;

--- a/src/libAtomVM/externalterm.h
+++ b/src/libAtomVM/externalterm.h
@@ -71,7 +71,7 @@ term externalterm_to_term(const void *external_term, size_t size, Context *ctx, 
  * @returns the term deserialized from the input term, or an invalid term, if
  * deserialization fails.
  */
-enum ExternalTermResult externalterm_from_binary(Context *ctx, term *dst, term binary, size_t *bytes_read, size_t num_extra_terms);
+enum ExternalTermResult externalterm_from_binary(Context *ctx, term *dst, term binary, size_t *bytes_read);
 
 /**
  * @brief Create a binary from a term.

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2357,14 +2357,12 @@ static term nif_erlang_binary_to_term(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
     uint8_t return_used = 0;
-    size_t num_extra_terms = 0;
     if (argc == 2 && term_list_member(argv[1], USED_ATOM, ctx)) {
         return_used = 1;
-        num_extra_terms = 3;
     }
     term dst = term_invalid_term();
     size_t bytes_read = 0;
-    enum ExternalTermResult result = externalterm_from_binary(ctx, &dst, binary, &bytes_read, num_extra_terms);
+    enum ExternalTermResult result = externalterm_from_binary(ctx, &dst, binary, &bytes_read);
     switch (result) {
         case EXTERNAL_TERM_BAD_ARG:
             RAISE_ERROR(BADARG_ATOM);

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -4567,7 +4567,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     // and kv together into new map.  Both src and kv are sorted.
                     //
                     term map = term_alloc_map_maybe_shared(ctx, new_map_size, is_shared ? term_get_map_keys(src) : term_invalid_term());
-                    int src_pos = 0;
+                    size_t src_pos = 0;
                     int kv_pos = 0;
                     for (int j = 0; j < new_map_size; j++) {
                         if (src_pos >= src_size) {

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -4719,7 +4719,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 DECODE_INTEGER(list_len, code, i, next_off, next_off);
                 int fail = 0;
                 for (int j = 0;  j < list_len && !fail;  ++j) {
-                    term key, value;
+                    term key;
                     DECODE_COMPACT_TERM(key, code, i, next_off, next_off);
 
                     #ifdef IMPL_EXECUTE_LOOP
@@ -4750,7 +4750,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 int num_elements = list_len / 2;
                 int fail = 0;
                 for (int j = 0;  j < num_elements && !fail;  ++j) {
-                    term key, value;
+                    term key;
                     DECODE_COMPACT_TERM(key, code, i, next_off, next_off);
                     dreg_t dreg;
                     dreg_type_t dreg_type;

--- a/src/platforms/generic_unix/socket_driver.c
+++ b/src/platforms/generic_unix/socket_driver.c
@@ -457,7 +457,6 @@ void socket_driver_do_close(Context *ctx)
 
 static term socket_driver_controlling_process(Context *ctx, term pid, term new_pid_term)
 {
-    GlobalContext *glb = ctx->global;
     struct SocketDriverData *socket_data = ctx->platform_data;
 
     if (UNLIKELY(!term_is_pid(new_pid_term))) {


### PR DESCRIPTION
Fixes several compiler warnings for libAtomVM and the generic_unix port, part of the ongoing work to address issue #255.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
