### PR TITLE
Fixed interop_kv_get_value_default and added interop_kv_get_value

### DIFF
--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -245,7 +245,7 @@ term interop_kv_get_value_default(term kv, AtomString key, term default_value, G
 {
     term key_term = globalcontext_existing_term_from_atom_string(glb, key);
     if (term_is_invalid_term(key_term)) {
-        return key_term;
+        return default_value;
     }
 
     if (term_is_nonempty_list(kv)) {

--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -80,4 +80,19 @@ int interop_atom_term_select_int(GlobalContext *global, const AtomStringIntPair 
  */
 term interop_kv_get_value_default(term kv, AtomString key, term default_value, GlobalContext *glb);
 
+/**
+ * @brief Get a value given a key (as AtomString) from any proplist or map
+ *
+ * @details This function allows to easily get values from proplists or maps, without poluting the
+ * atom table.  This function returns the invalid term if there is no such entry in kv.
+ * @param kv any proplist or map.
+ * @param key an AtomString, such as ATOM_STR("\x3", "key").
+ *
+ * @returns the value term in case given key exists, otherwise the invalid term.
+ */
+static inline term interop_kv_get_value(term kv, AtomString key, term default_value, GlobalContext *glb)
+{
+    return interop_kv_get_value_default(kv, key, term_invalid_term(), glb);
+}
+
 #endif


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
