### PR TITLE
Fix interop_atom_term_select_int params order

### DIFF
--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -230,7 +230,7 @@ term interop_map_get_value_default(Context *ctx, term map, term key, term defaul
     }
 }
 
-int interop_atom_term_select_int(GlobalContext *global, const AtomStringIntPair *table, term atom)
+int interop_atom_term_select_int(const AtomStringIntPair *table, term atom, GlobalContext *global)
 {
     int i;
     for (i = 0; table[i].as_val != NULL; i++) {

--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -65,7 +65,7 @@ int interop_write_iolist(term t, char *p);
  * @param atom the atom used for comparison.
  * @returns the found int value which corresponds to the given atom.
  */
-int interop_atom_term_select_int(GlobalContext *global, const AtomStringIntPair *table, term atom);
+int interop_atom_term_select_int(const AtomStringIntPair *table, term atom, GlobalContext *global);
 
 /**
  * @brief Get a value given a key (as AtomString) from any proplist or map


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
