### PR TITLE
Fix interop_kv_get_value signature

### DIFF
--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -90,7 +90,7 @@ term interop_kv_get_value_default(term kv, AtomString key, term default_value, G
  *
  * @returns the value term in case given key exists, otherwise the invalid term.
  */
-static inline term interop_kv_get_value(term kv, AtomString key, term default_value, GlobalContext *glb)
+static inline term interop_kv_get_value(term kv, AtomString key, GlobalContext *glb)
 {
     return interop_kv_get_value_default(kv, key, term_invalid_term(), glb);
 }


### PR DESCRIPTION
interop_kv_get_value function doesn't require a default_value parameter.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
