### PR TITLE
Fix clang warnings

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -212,7 +212,7 @@ int globalcontext_insert_atom_maybe_copy(GlobalContext *glb, AtomString atom_str
 
 bool globalcontext_is_atom_index_equal_to_atom_string(GlobalContext *glb, int atom_index_a, AtomString atom_string_b)
 {
-    AtomString atom_string_a = (AtomString) valueshashtable_get_value(glb->atoms_ids_table, atom_index_a, NULL);
+    AtomString atom_string_a = (AtomString) valueshashtable_get_value(glb->atoms_ids_table, atom_index_a, 0UL);
     return atom_are_equals(atom_string_a, atom_string_b);
 }
 

--- a/src/libAtomVM/term_typedef.h
+++ b/src/libAtomVM/term_typedef.h
@@ -101,7 +101,11 @@ typedef uint64_t avm_uint64_t;
 #if INT64_MAX == INT_MAX
     #define AVM_INT64_FMT "%i"
 #elif INT64_MAX == LONG_MAX
-    #define AVM_INT64_FMT "%li"
+    #if defined(__clang__) && defined(__APPLE__)
+        #define AVM_INT64_FMT "%lli"
+    #else
+        #define AVM_INT64_FMT "%li"
+    #endif
 #elif INT64_MAX == LLONG_MAX
     #define AVM_INT64_FMT "%lli"
 #else


### PR DESCRIPTION
This PR fixes some but not all of the clang warnings.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
