### PR TITLE
Fix ESP32 warnings

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -3319,6 +3319,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 DECODE_DEST_REGISTER(dreg, dreg_type, code, i, next_off, next_off);
 
                 #ifdef IMPL_CODE_LOADER
+                    UNUSED(src_off);
                     TRACE("bs_append/6\n");
                 #endif
 
@@ -3632,6 +3633,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 DECODE_COMPACT_TERM(live, code, i, next_off, next_off);
 
                 #ifdef IMPL_CODE_LOADER
+                    UNUSED(src_off);
                     TRACE("bs_get_tail/3\n");
                 #endif
 
@@ -4007,6 +4009,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 DECODE_DEST_REGISTER(dreg, dreg_type, code, i, next_off, next_off);
 
                 #ifdef IMPL_CODE_LOADER
+                    UNUSED(src_offset);
                     TRACE("bs_get_binary2/7\n");
                 #endif
 
@@ -4565,6 +4568,13 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         }
                     #endif
                 }
+
+                #ifdef IMPL_CODE_LOADER
+                    UNUSED(list_off);
+                    UNUSED(new_entries);
+                    UNUSED(src_offset);
+                #endif
+
                 #ifdef IMPL_EXECUTE_LOOP
                     //
                     // Maybe GC, and reset the src term in case it changed
@@ -4674,6 +4684,12 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         }
                     #endif
                 }
+
+                #ifdef IMPL_CODE_LOADER
+                    UNUSED(list_off);
+                    UNUSED(src_offset);
+                #endif
+
                 #ifdef IMPL_EXECUTE_LOOP
                     //
                     // Maybe GC, and reset the src term in case it changed

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -541,16 +541,6 @@ static void send_ap_sta_disconnected(ClientData *data, uint8_t *mac)
     send_atom_mac(data, AP_STA_DISCONNECTED_ATOM, mac);
 }
 
-static void send_ap_sta_ip_acquired(ClientData *data, ip4_addr_t *ip)
-{
-    TRACE("Sending ap_sta_ip_acquired back to AtomVM\n");
-    Context *ctx = data->ctx;
-    port_ensure_available(ctx, ((4 + 1) + (2 + 1)) * 2);
-    term ip_term = tuple_from_addr(ctx, ntohl(ip->addr));
-    term reply = port_create_tuple2(ctx, AP_STA_IP_ASSIGNED_ATOM, ip_term);
-    send_term(data, reply);
-}
-
 static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)
 {
     ClientData *data = (ClientData *) ctx;
@@ -563,7 +553,7 @@ static esp_err_t wifi_event_handler(void *ctx, system_event_t *event)
         case SYSTEM_EVENT_STA_GOT_IP:
             ESP_LOGI("NETWORK", "SYSTEM_EVENT_STA_GOT_IP: %s", inet_ntoa(event->event_info.got_ip.ip_info.ip));
             xEventGroupSetBits(wifi_event_group, CONNECTED_BIT);
-            send_got_ip(data, &event->event_info.got_ip.ip_info);
+            send_got_ip(data, (tcpip_adapter_ip_info_t *) &event->event_info.got_ip.ip_info);
             break;
 
         case SYSTEM_EVENT_STA_CONNECTED:

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -68,17 +68,6 @@ uint32_t socket_tuple_to_addr(term addr_tuple)
         | (term_to_int32(term_get_tuple_element(addr_tuple, 3)) & 0xFF);
 }
 
-static term socket_tuple_from_addr(Context *ctx, uint32_t addr)
-{
-    term terms[4];
-    terms[0] = term_from_int32((addr >> 24) & 0xFF);
-    terms[1] = term_from_int32((addr >> 16) & 0xFF);
-    terms[2] = term_from_int32((addr >> 8) & 0xFF);
-    terms[3] = term_from_int32(addr & 0xFF);
-
-    return port_create_tuple_n(ctx, 4, terms);
-}
-
 static void tuple_to_ip_addr(term address_tuple, ip_addr_t *out_addr)
 {
     out_addr->type = IPADDR_TYPE_V4;


### PR DESCRIPTION
This PR fixes some but not all of the ESP32 warnings.

Signed-off-by: Fred Dushin <fred@dushin.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
