### PR TITLE
Support for Raspberry Pi Pico (fix #197)

### DIFF
--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -1,0 +1,44 @@
+#
+#  Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+name: Pico Build
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'libs/**'
+      - 'src/platforms/rp2040/**'
+      - 'src/libAtomVM/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'libs/**'
+      - 'src/platforms/rp2040/**'
+      - 'src/libAtomVM/**'
+
+
+jobs:
+  pico:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: "Install deps"
+      run: sudo apt install -y cmake gperf ninja-build gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+
+    - name: Build
+      shell: bash
+      working-directory: ./src/platforms/rp2040/
+      run: |
+        set -euo pipefail
+        mkdir build
+        cd build
+        cmake .. -G Ninja
+        ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ endif()
 
 add_subdirectory(tests)
 add_subdirectory(tools/packbeam)
+add_subdirectory(tools/uf2tool)
+
 if (NOT "${CMAKE_GENERATOR}" MATCHES "Xcode")
     add_subdirectory(libs)
     add_subdirectory(examples)

--- a/README.Md
+++ b/README.Md
@@ -18,6 +18,7 @@ Supported Platforms
 * Linux, macOS, FreeBSD ([generic unix](src/platforms/generic_unix))
 * ESP32 SoC (with IDF/FreeRTOS, see [README.ESP32.Md](README.ESP32.Md))
 * STM32 MCUs (with LibOpenCM3, see [README.STM32.Md](README.STM32.Md))
+* Raspberry Pi Pico (see [README.PICO.Md](README.PICO.Md))
 
 AtomVM aims to be easily portable to new platforms with a minimum effort, so additional platforms
 might be supported in a near future.

--- a/README.PICO.Md
+++ b/README.PICO.Md
@@ -1,0 +1,99 @@
+<!--
+ Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+
+ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+
+Building AtomVM for Raspberry Pico
+==================================
+
+* build:
+
+```
+cd src/platforms/rp2040/
+mkdir build
+cd build
+cmake .. -G Ninja
+ninja
+```
+
+> Note: requires cmake and ninja
+
+You may want to build with option `AVM_REBOOT_ON_NOT_OK` so Pico restarts on
+error.
+
+Installing AtomVM and programs on Raspberry Pico
+================================================
+
+The approach consists in installing various uf2 files which include the
+address they should be loaded to.
+
+You typically need three uf2 files:
+- `AtomVM.uf2` for the VM
+- `atomvmlib.uf2` for the standard libraries
+- your application's uf2.
+
+We provide an escript-based (what else?) tool to build uf2 files called
+`uf2tool` that you can use to bundle your `avm` into uf2.
+
+If you need to upgrade AtomVM or the standard libraries, simply copy them again.
+
+Installing AtomVM on Raspberry Pico
+===================================
+
+VM binary is file `src/platforms/rp2040/build/src/AtomVM.uf2`. Simply copy it
+to the pico. The VM will crash because there is no application.
+
+Installing atomvm library to Raspberry Pico
+===========================================
+
+AtomVM library must be installed as well.
+
+Building it
+-----------
+
+Build of standard libraries is part of the generic unix build.
+
+From the root of the project:
+
+```
+mkdir build
+cd build
+cmake .. -G Ninja
+ninja
+```
+
+> Note: requires cmake, ninja, Erlang/OTP and Elixir for elixir libs
+
+Installing it
+-------------
+
+The library to install is `build/libs/atomvmlib.uf2`
+
+Running Hello Pico
+==================
+
+This example will print a Hello Pico message repeatedly.
+
+It is built into `build/examples/erlang/rp2040/hello_pico.uf2`.
+
+You can install it and then connect to the serial port with minicom.
+
+Running your own BEAM code on Raspberry Pico
+============================================
+
+You need to create an avm file using PackBEAM binary (or rebar3 plugin).
+
+```
+./PackBEAM packed.avm module.beam
+```
+
+Then the BEAM file must be converted to UF2.
+The VM currently expects the application to be loaded at address 0x100A0000.
+
+```sh
+./uf2tool create -o packed.uf2 -s 0x100A0000 packed.avm
+```
+
+Copy this UF2 to the Pico after you copied the VM (`AtomVM.uf2`) and the
+standard libraries (`atomvmlib.uf2`).

--- a/examples/erlang/CMakeLists.txt
+++ b/examples/erlang/CMakeLists.txt
@@ -23,6 +23,7 @@ project(examples_erlang)
 include(BuildErlang)
 
 add_subdirectory(esp32)
+add_subdirectory(rp2040)
 
 pack_runnable(hello_world hello_world eavmlib)
 pack_runnable(udp_server udp_server estdlib eavmlib)

--- a/examples/erlang/rp2040/CMakeLists.txt
+++ b/examples/erlang/rp2040/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # This file is part of AtomVM.
 #
-# Copyright 2018-2021 Fred Dushin <fred@dushin.net>
+# Copyright 2022 Paul Guyot <pguyot@kallisys.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,28 +18,9 @@
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-project(eavmlib)
+project(examples_erlang_rp2040)
 
 include(BuildErlang)
 
-set(ERLANG_MODULES
-    atomvm
-    console
-    esp
-    gpio
-    i2c
-    http_server
-    json_encoder
-    ledc
-    logger
-    network
-    network_fsm
-    pico
-    port
-    spi
-    timer_manager
-    timestamp_util
-    uart
-)
-
-pack_archive(eavmlib ${ERLANG_MODULES})
+pack_uf2(hello_pico hello_pico eavmlib estdlib)
+pack_uf2(pico_rtc pico_rtc eavmlib estdlib)

--- a/examples/erlang/rp2040/hello_pico.erl
+++ b/examples/erlang/rp2040/hello_pico.erl
@@ -1,0 +1,35 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(hello_pico).
+-export([start/0]).
+
+start() ->
+    % Pico's serial may be too fast to use hello_world example, so this
+    % version loops.
+    hello_pico_loop().
+
+hello_pico_loop() ->
+    console:puts("Hello Pico\n"),
+    receive
+        ok -> ok
+    after 3000 -> ok
+    end,
+    hello_pico_loop().

--- a/examples/erlang/rp2040/pico_rtc.erl
+++ b/examples/erlang/rp2040/pico_rtc.erl
@@ -1,0 +1,68 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+% This example demonstrates the usage of the Pico's hardware RTC.
+
+-module(pico_rtc).
+-export([start/0]).
+
+-define(START_DATE, {{2022, 11, 16}, {22, 09, 00}}).
+
+start() ->
+    case atomvm:platform() of
+        pico ->
+            pico_rtc_loop();
+        Other ->
+            erlang:display({unexpected, Other})
+    end.
+
+pico_rtc_loop() ->
+    Date = erlang:universaltime(),
+    print_date(Date),
+    receive
+        ok -> ok
+    after 5000 -> ok
+    end,
+    if
+        Date < ?START_DATE ->
+            pico:rtc_set_datetime(?START_DATE);
+        true ->
+            ok
+    end,
+    pico_rtc_loop().
+
+print_date({{Year, Month, Day}, {Hour, Min, Sec}}) ->
+    % Only ~p and ~s seem to exist for now.
+    YearStr = integer_to_list(Year),
+    MonthStr = format_2_digits(Month),
+    DayStr = format_2_digits(Day),
+    HourStr = format_2_digits(Hour),
+    MinStr = format_2_digits(Min),
+    SecStr = format_2_digits(Sec),
+    console:puts(
+        lists:flatten([
+            YearStr, "-", MonthStr, "-", DayStr, "T", HourStr, ":", MinStr, ":", SecStr, "\n"
+        ])
+    ).
+
+format_2_digits(Num) when Num < 10 ->
+    ["0", integer_to_list(Num)];
+format_2_digits(Num) ->
+    integer_to_list(Num).

--- a/libs/eavmlib/src/pico.erl
+++ b/libs/eavmlib/src/pico.erl
@@ -1,0 +1,40 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%%-----------------------------------------------------------------------------
+%% @doc PICO-specific APIs
+%%
+%% This module contains functions that are specific to the PICO platform.
+%% @end
+%%-----------------------------------------------------------------------------
+-module(pico).
+
+-export([
+    rtc_set_datetime/1
+]).
+
+%%-----------------------------------------------------------------------------
+%% @doc     Set the datetime on the RTC.
+%%          The datetime can be obtained through bif erlang:localtime()
+%% @end
+%%-----------------------------------------------------------------------------
+-spec rtc_set_datetime(calendar:datetime()) -> ok.
+rtc_set_datetime(_Datetime) ->
+    throw(nif_error).

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -34,7 +34,9 @@
 
 #include "trace.h"
 
+#ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
 
 static void memory_scan_and_copy(HeapFragment *old_fragment, term *mem_start, const term *mem_end, term **new_heap_pos, term *mso_list, bool move);
 static term memory_shallow_copy_term(HeapFragment *old_fragment, term t, term **new_heap, bool move);

--- a/src/platforms/rp2040/.gitignore
+++ b/src/platforms/rp2040/.gitignore
@@ -1,7 +1,7 @@
 #
 # This file is part of AtomVM.
 #
-# Copyright 2018-2021 Fred Dushin <fred@dushin.net>
+# Copyright 2022 Paul Guyot <pguyot@kallisys.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,29 +17,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
-
-project(eavmlib)
-
-include(BuildErlang)
-
-set(ERLANG_MODULES
-    atomvm
-    console
-    esp
-    gpio
-    i2c
-    http_server
-    json_encoder
-    ledc
-    logger
-    network
-    network_fsm
-    pico
-    port
-    spi
-    timer_manager
-    timestamp_util
-    uart
-)
-
-pack_archive(eavmlib ${ERLANG_MODULES})
+build

--- a/src/platforms/rp2040/CMakeLists.txt
+++ b/src/platforms/rp2040/CMakeLists.txt
@@ -1,0 +1,53 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+cmake_minimum_required(VERSION 3.13)
+
+set(PICO_SDK_FETCH_FROM_GIT on)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+
+# pico_sdk_import.cmake is a single file copied from this SDK
+# note: this must happen before project()
+include(pico_sdk_import.cmake)
+
+project(AtomVM)
+
+# initialize the Raspberry Pi Pico SDK
+pico_sdk_init()
+
+# Pico SDK forces compiler, but we really want to know its features.
+include(${CMAKE_ROOT}/Modules/CMakeDetermineCompileFeatures.cmake)
+CMAKE_DETERMINE_COMPILE_FEATURES(C)
+
+enable_language( C CXX ASM )
+
+# Options that make sense for this platform
+option(AVM_DISABLE_SMP "Disable SMP support." OFF)
+option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
+option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
+
+option(AVM_REBOOT_ON_NOT_OK "Reboot Pico if result is not ok" OFF)
+
+set(
+    PLATFORM_LIB_SUFFIX
+    ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
+)
+
+add_subdirectory(src)

--- a/src/platforms/rp2040/pico_sdk_import.cmake
+++ b/src/platforms/rp2040/pico_sdk_import.cmake
@@ -1,0 +1,97 @@
+# This is a copy of <PICO_SDK_PATH>/external/pico_sdk_import.cmake
+#
+# Copyright 2020 (c) 2020 Raspberry Pi (Trading) Ltd.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+# following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+#    disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# This can be dropped into an external project to help locate this SDK
+# It should be include()ed prior to project()
+
+if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
+    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT} AND (NOT PICO_SDK_FETCH_FROM_GIT))
+    set(PICO_SDK_FETCH_FROM_GIT $ENV{PICO_SDK_FETCH_FROM_GIT})
+    message("Using PICO_SDK_FETCH_FROM_GIT from environment ('${PICO_SDK_FETCH_FROM_GIT}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_PATH))
+    set(PICO_SDK_FETCH_FROM_GIT_PATH $ENV{PICO_SDK_FETCH_FROM_GIT_PATH})
+    message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
+endif ()
+
+set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
+set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
+set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
+
+if (NOT PICO_SDK_PATH)
+    if (PICO_SDK_FETCH_FROM_GIT)
+        include(FetchContent)
+        set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
+        if (PICO_SDK_FETCH_FROM_GIT_PATH)
+            get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+        endif ()
+        # GIT_SUBMODULES_RECURSE was added in 3.17
+        if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/pguyot/pico-sdk   # revert to raspberrypi once PR 1101 is merged
+                    GIT_TAG w46/condition-variables                     # revert to master once PR 1101 is merged
+                    GIT_SUBMODULES_RECURSE FALSE
+            )
+        else ()
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/pguyot/pico-sdk   # revert to raspberrypi once PR 1101 is merged
+                    GIT_TAG w46/condition-variables                     # revert to master once PR 1101 is merged
+            )
+        endif ()
+
+        if (NOT pico_sdk)
+            message("Downloading Raspberry Pi Pico SDK")
+            FetchContent_Populate(pico_sdk)
+            set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
+        endif ()
+        set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+    else ()
+        message(FATAL_ERROR
+                "SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
+                )
+    endif ()
+endif ()
+
+get_filename_component(PICO_SDK_PATH "${PICO_SDK_PATH}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+if (NOT EXISTS ${PICO_SDK_PATH})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' not found")
+endif ()
+
+set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
+if (NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK")
+endif ()
+
+set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
+
+include(${PICO_SDK_INIT_CMAKE_FILE})

--- a/src/platforms/rp2040/src/CMakeLists.txt
+++ b/src/platforms/rp2040/src/CMakeLists.txt
@@ -1,0 +1,57 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+cmake_minimum_required (VERSION 3.13)
+
+add_executable(AtomVM main.c)
+
+target_compile_features(AtomVM PUBLIC c_std_11)
+if(CMAKE_COMPILER_IS_GNUCC)
+    target_compile_options(AtomVM PUBLIC -ggdb)
+    target_compile_options(AtomVM PRIVATE -Wall -pedantic -Wextra)
+endif()
+
+# libAtomVM needs to find Pico's platform_smp.h header
+set(HAVE_PLATFORM_SMP_H ON)
+add_subdirectory(../../../libAtomVM libAtomVM)
+target_link_libraries(AtomVM PUBLIC libAtomVM)
+# Also add lib where platform_smp.h header is
+target_include_directories(libAtomVM PUBLIC lib)
+
+target_link_libraries(AtomVM PUBLIC hardware_regs pico_stdlib pico_binary_info)
+
+if (AVM_REBOOT_ON_NOT_OK)
+    target_compile_definitions(AtomVM PRIVATE CONFIG_REBOOT_ON_NOT_OK)
+endif()
+
+set(
+    PLATFORM_LIB_SUFFIX
+    ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
+)
+
+add_subdirectory(lib)
+target_link_libraries(AtomVM PRIVATE libAtomVM${PLATFORM_LIB_SUFFIX})
+
+# enable usb output, disable uart output
+pico_enable_stdio_usb(AtomVM 1)
+pico_enable_stdio_uart(AtomVM 0)
+
+# create map/bin/hex/uf2 file in addition to ELF.
+pico_add_extra_outputs(AtomVM)

--- a/src/platforms/rp2040/src/lib/CMakeLists.txt
+++ b/src/platforms/rp2040/src/lib/CMakeLists.txt
@@ -1,0 +1,62 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+cmake_minimum_required (VERSION 3.13)
+
+set(HEADER_FILES
+    platform_defaultatoms.h
+    platform_smp.h
+    rp2040_sys.h
+)
+
+set(SOURCE_FILES
+    platform_defaultatoms.c
+    platform_nifs.c
+    smp.c
+    sys.c
+)
+
+set(
+    PLATFORM_LIB_SUFFIX
+    ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
+)
+
+add_library(libAtomVM${PLATFORM_LIB_SUFFIX} ${SOURCE_FILES} ${HEADER_FILES})
+target_compile_features(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC c_std_11)
+if(CMAKE_COMPILER_IS_GNUCC)
+    target_compile_options(libAtomVM${PLATFORM_LIB_SUFFIX} PRIVATE -Wall -pedantic -Wextra)
+endif()
+
+target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC libAtomVM)
+target_link_libraries(
+    libAtomVM${PLATFORM_LIB_SUFFIX}
+    PUBLIC
+        hardware_rtc
+        hardware_sync
+        pico_float
+        pico_multicore
+        pico_platform
+        pico_runtime
+        pico_sync
+        pico_time)
+
+if (NOT AVM_USE_32BIT_FLOAT)
+    target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC pico_double)
+endif()

--- a/src/platforms/rp2040/src/lib/platform_defaultatoms.c
+++ b/src/platforms/rp2040/src/lib/platform_defaultatoms.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include "platform_defaultatoms.h"
+
+static const char *const pico_atom = ATOM_STR("\x4", "pico");
+
+void platform_defaultatoms_init(GlobalContext *glb)
+{
+    int ok = 1;
+
+    ok &= globalcontext_insert_atom(glb, pico_atom) == PICO_ATOM_INDEX;
+
+    if (!ok) {
+        AVM_ABORT();
+    }
+}

--- a/src/platforms/rp2040/src/lib/platform_defaultatoms.h
+++ b/src/platforms/rp2040/src/lib/platform_defaultatoms.h
@@ -1,0 +1,30 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _PLATFORM_DEFAULTATOMS_H_
+#define _PLATFORM_DEFAULTATOMS_H_
+
+#include "defaultatoms.h"
+
+#define PICO_ATOM_INDEX (PLATFORM_ATOMS_BASE_INDEX + 0)
+
+#define PICO_ATOM TERM_FROM_ATOM_INDEX(PICO_ATOM_INDEX)
+
+#endif

--- a/src/platforms/rp2040/src/lib/platform_nifs.c
+++ b/src/platforms/rp2040/src/lib/platform_nifs.c
@@ -1,0 +1,130 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include "nifs.h"
+
+#include "platform_defaultatoms.h"
+#include "platform_nifs.h"
+#include "rp2040_sys.h"
+
+// Pico SDK
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+#include <hardware/rtc.h>
+
+#pragma GCC diagnostic pop
+
+//#define ENABLE_TRACE
+#include "trace.h"
+
+#define VALIDATE_VALUE(value, verify_function) \
+    if (UNLIKELY(!verify_function((value)))) { \
+        argv[0] = ERROR_ATOM;                  \
+        argv[1] = BADARG_ATOM;                 \
+        return term_invalid_term();            \
+    }
+
+static term nif_atomvm_platform(Context *ctx, int argc, term argv[])
+{
+    UNUSED(ctx);
+    UNUSED(argc);
+    UNUSED(argv);
+
+    return PICO_ATOM;
+}
+
+static term nif_pico_rtc_set_datetime(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    UNUSED(ctx);
+
+    term datetime_tuple = argv[0];
+    VALIDATE_VALUE(datetime_tuple, term_is_tuple);
+    if (UNLIKELY(term_get_tuple_arity(datetime_tuple) != 2)) {
+        argv[0] = ERROR_ATOM;
+        argv[1] = BADARG_ATOM;
+        return term_invalid_term();
+    }
+    term date_tuple = term_get_tuple_element(datetime_tuple, 0);
+    VALIDATE_VALUE(date_tuple, term_is_tuple);
+    if (UNLIKELY(term_get_tuple_arity(date_tuple) != 3)) {
+        argv[0] = ERROR_ATOM;
+        argv[1] = BADARG_ATOM;
+        return term_invalid_term();
+    }
+    term time_tuple = term_get_tuple_element(datetime_tuple, 1);
+    VALIDATE_VALUE(time_tuple, term_is_tuple);
+    if (UNLIKELY(term_get_tuple_arity(time_tuple) != 3)) {
+        argv[0] = ERROR_ATOM;
+        argv[1] = BADARG_ATOM;
+        return term_invalid_term();
+    }
+    term year = term_get_tuple_element(date_tuple, 0);
+    VALIDATE_VALUE(year, term_is_integer);
+    term month = term_get_tuple_element(date_tuple, 1);
+    VALIDATE_VALUE(month, term_is_integer);
+    term day = term_get_tuple_element(date_tuple, 2);
+    VALIDATE_VALUE(day, term_is_integer);
+    term hour = term_get_tuple_element(time_tuple, 0);
+    VALIDATE_VALUE(hour, term_is_integer);
+    term min = term_get_tuple_element(time_tuple, 1);
+    VALIDATE_VALUE(min, term_is_integer);
+    term sec = term_get_tuple_element(time_tuple, 2);
+    VALIDATE_VALUE(sec, term_is_integer);
+
+    datetime_t pico_datetime;
+    pico_datetime.year = term_to_int(year);
+    pico_datetime.month = term_to_int(month);
+    pico_datetime.day = term_to_int(day);
+    pico_datetime.hour = term_to_int(hour);
+    pico_datetime.min = term_to_int(min);
+    pico_datetime.sec = term_to_int(sec);
+
+    if (UNLIKELY(!rtc_set_datetime(&pico_datetime))) {
+        argv[0] = ERROR_ATOM;
+        argv[1] = BADARG_ATOM;
+        return term_invalid_term();
+    }
+
+    return OK_ATOM;
+}
+
+static const struct Nif atomvm_platform_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_atomvm_platform
+};
+static const struct Nif pico_rtc_set_datetime_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_pico_rtc_set_datetime
+};
+
+const struct Nif *platform_nifs_get_nif(const char *nifname)
+{
+    if (strcmp("atomvm:platform/0", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &atomvm_platform_nif;
+    }
+    if (strcmp("pico:rtc_set_datetime/1", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &pico_rtc_set_datetime_nif;
+    }
+    return NULL;
+}

--- a/src/platforms/rp2040/src/lib/platform_smp.h
+++ b/src/platforms/rp2040/src/lib/platform_smp.h
@@ -1,0 +1,139 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _PLATFORM_SMP_H
+#define _PLATFORM_SMP_H
+
+#include <limits.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+#include <pico/critical_section.h>
+#include <pico/mutex.h>
+
+#pragma GCC diagnostic pop
+
+#define SMP_PLATFORM_SPINLOCK
+#define ATOMIC
+
+#define ATOMIC_COMPARE_EXCHANGE_WEAK(object, expected, desired) \
+    smp_atomic_compare_exchange_weak(object, expected, desired, sizeof(desired))
+
+#ifndef TYPEDEF_SPINLOCK
+#define TYPEDEF_SPINLOCK
+typedef struct SpinLock SpinLock;
+#endif
+
+struct SpinLock
+{
+    mutex_t mutex;
+};
+
+// What AtomVM calls spinlocks are lightweight busy locks based on atomics.
+// This really is what Pico SDK provides as mutexes.
+
+/**
+ * @brief Initialize a spinlock based on atomics.
+ * @param lock the spin lock to initialize
+ */
+static inline void smp_spinlock_init(SpinLock *lock)
+{
+    mutex_init(&lock->mutex);
+}
+
+/**
+ * @brief Lock a spinlock.
+ * @param lock the spin lock to lock
+ */
+static inline void smp_spinlock_lock(SpinLock *lock)
+{
+    mutex_enter_blocking(&lock->mutex);
+}
+
+/**
+ * @brief Unlock a spinlock.
+ * @param lock the spin lock to unlock
+ */
+static inline void smp_spinlock_unlock(SpinLock *lock)
+{
+    mutex_exit(&lock->mutex);
+}
+
+static inline bool smp_atomic_compare_exchange_weak(void *object, void *expected, uint64_t desired, size_t desired_len)
+{
+    critical_section_t crit_sec;
+    critical_section_init(&crit_sec);
+    critical_section_enter_blocking(&crit_sec);
+
+    bool result;
+    switch (desired_len) {
+        case sizeof(uint64_t): {
+            uint64_t *object_ptr = (uint64_t *) object;
+            uint64_t *expected_ptr = (uint64_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+        case sizeof(uint32_t): {
+            uint32_t *object_ptr = (uint32_t *) object;
+            uint32_t *expected_ptr = (uint32_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+        case sizeof(uint16_t): {
+            uint16_t *object_ptr = (uint16_t *) object;
+            uint16_t *expected_ptr = (uint16_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+        case sizeof(uint8_t): {
+            uint8_t *object_ptr = (uint8_t *) object;
+            uint8_t *expected_ptr = (uint8_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+    }
+
+    critical_section_exit(&crit_sec);
+    critical_section_deinit(&crit_sec);
+    return result;
+}
+
+#endif

--- a/src/platforms/rp2040/src/lib/rp2040_sys.h
+++ b/src/platforms/rp2040/src/lib/rp2040_sys.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _RP2040_SYS_H_
+#define _RP2040_SYS_H_
+
+#include <pico/sync.h>
+
+struct RP2040PlatformData
+{
+    mutex_t event_poll_mutex;
+    cond_t event_poll_cond;
+};
+
+#endif

--- a/src/platforms/rp2040/src/lib/smp.c
+++ b/src/platforms/rp2040/src/lib/smp.c
@@ -1,0 +1,165 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include "smp.h"
+
+#ifndef AVM_NO_SMP
+
+#include <stdlib.h>
+
+// Pico SDK
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+#include <pico/cond.h>
+#include <pico/multicore.h>
+#include <pico/platform.h>
+#include <pico/sync.h>
+
+#pragma GCC diagnostic pop
+
+#include <utils.h>
+
+struct Mutex
+{
+    mutex_t mutex;
+};
+
+struct CondVar
+{
+    cond_t condvar;
+};
+
+struct RWLock
+{
+    mutex_t lock;
+};
+
+static void scheduler_core1_entry_point(void)
+{
+    _Static_assert(sizeof(uintptr_t) == sizeof(uint32_t), "Expected pointers to be 32 bits");
+    uint32_t ctx_int = multicore_fifo_pop_blocking();
+    return scheduler_entry_point((GlobalContext *) ctx_int);
+}
+
+void smp_scheduler_start(GlobalContext *ctx)
+{
+    multicore_launch_core1(scheduler_core1_entry_point);
+    multicore_fifo_push_blocking((uint32_t) ctx);
+}
+
+bool smp_is_main_thread(GlobalContext *glb)
+{
+    UNUSED(glb);
+    return get_core_num() == 0;
+}
+
+Mutex *smp_mutex_create()
+{
+    Mutex *result = malloc(sizeof(Mutex));
+    if (UNLIKELY(result == NULL && sizeof(Mutex) > 0)) {
+        AVM_ABORT();
+    }
+    mutex_init(&result->mutex);
+    return result;
+}
+
+void smp_mutex_destroy(Mutex *mtx)
+{
+    free(mtx);
+}
+
+void smp_mutex_lock(Mutex *mtx)
+{
+    mutex_enter_blocking(&mtx->mutex);
+}
+
+bool smp_mutex_trylock(Mutex *mtx)
+{
+    uint32_t owner;
+    return mutex_try_enter(&mtx->mutex, &owner);
+}
+
+void smp_mutex_unlock(Mutex *mtx)
+{
+    mutex_exit(&mtx->mutex);
+}
+
+CondVar *smp_condvar_create()
+{
+    CondVar *result = malloc(sizeof(CondVar));
+    if (UNLIKELY(result == NULL && sizeof(CondVar) > 0)) {
+        AVM_ABORT();
+    }
+    cond_init(&result->condvar);
+    return result;
+}
+
+void smp_condvar_destroy(CondVar *cv)
+{
+    free(cv);
+}
+
+void smp_condvar_wait(CondVar *cv, Mutex *mtx)
+{
+    cond_wait(&cv->condvar, &mtx->mutex);
+}
+
+void smp_condvar_signal(CondVar *cv)
+{
+    cond_signal(&cv->condvar);
+}
+
+RWLock *smp_rwlock_create()
+{
+    RWLock *result = malloc(sizeof(RWLock));
+    if (UNLIKELY(result == NULL && sizeof(RWLock) > 0)) {
+        AVM_ABORT();
+    }
+    mutex_init(&result->lock);
+    return result;
+}
+
+void smp_rwlock_destroy(RWLock *lock)
+{
+    free(lock);
+}
+
+void smp_rwlock_rdlock(RWLock *lock)
+{
+    mutex_enter_blocking(&lock->lock);
+}
+
+void smp_rwlock_wrlock(RWLock *lock)
+{
+    mutex_enter_blocking(&lock->lock);
+}
+
+void smp_rwlock_unlock(RWLock *lock)
+{
+    mutex_exit(&lock->lock);
+}
+
+int smp_get_online_processors()
+{
+    return 2;
+}
+
+#endif

--- a/src/platforms/rp2040/src/lib/sys.c
+++ b/src/platforms/rp2040/src/lib/sys.c
@@ -1,0 +1,180 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include <sys.h>
+
+// C11
+#include <time.h>
+
+// Pico SDK
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+#include <hardware/rtc.h>
+#include <pico/multicore.h>
+#include <pico/time.h>
+
+#pragma GCC diagnostic pop
+
+// libAtomVM
+#include <avmpack.h>
+#include <defaultatoms.h>
+#include <utils.h>
+
+#include "rp2040_sys.h"
+
+void sys_init_platform(GlobalContext *glb)
+{
+    struct RP2040PlatformData *platform = malloc(sizeof(struct RP2040PlatformData));
+    glb->platform_data = platform;
+    mutex_init(&platform->event_poll_mutex);
+    cond_init(&platform->event_poll_cond);
+}
+
+void sys_free_platform(GlobalContext *glb)
+{
+    struct RP2040PlatformData *platform = glb->platform_data;
+    free(platform);
+}
+
+#ifndef AVM_NO_SMP
+void sys_poll_events(GlobalContext *glb, int timeout_ms)
+{
+    if (timeout_ms > 0) {
+        struct RP2040PlatformData *platform = glb->platform_data;
+        mutex_enter_blocking(&platform->event_poll_mutex);
+        cond_wait_timeout_ms(&platform->event_poll_cond, &platform->event_poll_mutex, timeout_ms);
+        mutex_exit(&platform->event_poll_mutex);
+    }
+}
+
+void sys_signal(GlobalContext *glb)
+{
+    struct RP2040PlatformData *platform = glb->platform_data;
+    cond_signal(&platform->event_poll_cond);
+}
+#else
+void sys_poll_events(GlobalContext *glb, int timeout_ms)
+{
+    UNUSED(glb);
+    UNUSED(timeout_ms);
+}
+#endif
+
+void sys_listener_destroy(struct ListHead *item)
+{
+    UNUSED(item);
+}
+
+void sys_time(struct timespec *t)
+{
+    if (!rtc_running()) {
+        rtc_init();
+        sleep_us(64);
+    }
+    datetime_t pico_datetime;
+    rtc_get_datetime(&pico_datetime);
+    struct tm c11_time;
+    memset(&c11_time, 0, sizeof(c11_time));
+    c11_time.tm_sec = pico_datetime.sec;
+    c11_time.tm_min = pico_datetime.min;
+    c11_time.tm_hour = pico_datetime.hour;
+    c11_time.tm_mday = pico_datetime.day;
+    c11_time.tm_mon = pico_datetime.month - 1;
+    c11_time.tm_year = pico_datetime.year - 1900;
+    c11_time.tm_wday = pico_datetime.dotw;
+    t->tv_sec = mktime(&c11_time);
+
+    absolute_time_t now = get_absolute_time();
+    uint64_t usec = to_us_since_boot(now);
+    t->tv_nsec = (usec % 1000000) * 1000;
+}
+
+void sys_monotonic_time(struct timespec *t)
+{
+    sys_time(t);
+}
+
+uint64_t sys_millis(GlobalContext *glb)
+{
+    UNUSED(glb);
+    absolute_time_t now = get_absolute_time();
+    uint64_t usec = to_us_since_boot(now);
+    return usec / 1000;
+}
+
+struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *path)
+{
+    UNUSED(global);
+    UNUSED(path);
+
+    // No file support on pico.
+    return NULL;
+}
+
+Module *sys_load_module_from_file(GlobalContext *global, const char *path)
+{
+    UNUSED(global);
+    UNUSED(path);
+
+    // No file support on pico.
+    return NULL;
+}
+
+Module *sys_load_module(GlobalContext *global, const char *module_name)
+{
+    const void *beam_module = NULL;
+    uint32_t beam_module_size = 0;
+
+    struct ListHead *item;
+    struct ListHead *avmpack_data = synclist_rdlock(&global->avmpack_data);
+    LIST_FOR_EACH (item, avmpack_data) {
+        struct AVMPackData *avmpack_data = (struct AVMPackData *) item;
+        if (avmpack_find_section_by_name(avmpack_data->data, module_name, &beam_module, &beam_module_size)) {
+            break;
+        }
+    }
+    synclist_unlock(&global->avmpack_data);
+
+    if (IS_NULL_PTR(beam_module)) {
+        fprintf(stderr, "Failed to open module: %s\n", module_name);
+        return NULL;
+    }
+
+    Module *new_module = module_new_from_iff_binary(global, beam_module, beam_module_size);
+    new_module->module_platform_data = NULL;
+
+    return new_module;
+}
+
+Context *sys_create_port(GlobalContext *glb, const char *driver_name, term opts)
+{
+    UNUSED(glb);
+    UNUSED(driver_name);
+    UNUSED(opts);
+    return NULL;
+}
+
+term sys_get_info(Context *ctx, term key)
+{
+    UNUSED(ctx);
+    UNUSED(key);
+    return UNDEFINED_ATOM;
+}

--- a/src/platforms/rp2040/src/main.c
+++ b/src/platforms/rp2040/src/main.c
@@ -1,0 +1,187 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include <signal.h>
+#include <stdio.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+#include <hardware/regs/addressmap.h>
+#include <hardware/watchdog.h>
+#include <pico/binary_info.h>
+#include <pico/stdlib.h>
+
+#pragma GCC diagnostic pop
+
+#include <avmpack.h>
+#include <context.h>
+#include <defaultatoms.h>
+#include <globalcontext.h>
+#include <iff.h>
+#include <module.h>
+#include <version.h>
+
+extern char __flash_binary_end;
+
+#define LIB_AVM ((void *) 0x10080000)
+#define MAIN_AVM ((void *) 0x100A0000)
+
+#define ATOMVM_BANNER                                                   \
+    "\n"                                                                \
+    "    ###########################################################\n" \
+    "\n"                                                                \
+    "       ###    ########  #######  ##     ## ##     ## ##     ## \n" \
+    "      ## ##      ##    ##     ## ###   ### ##     ## ###   ### \n" \
+    "     ##   ##     ##    ##     ## #### #### ##     ## #### #### \n" \
+    "    ##     ##    ##    ##     ## ## ### ## ##     ## ## ### ## \n" \
+    "    #########    ##    ##     ## ##     ##  ##   ##  ##     ## \n" \
+    "    ##     ##    ##    ##     ## ##     ##   ## ##   ##     ## \n" \
+    "    ##     ##    ##     #######  ##     ##    ###    ##     ## \n" \
+    "\n"                                                                \
+    "    ###########################################################\n" \
+    "\n"
+
+static int app_main()
+{
+    bi_decl(bi_program_description("Atom VM"));
+
+    stdio_init_all();
+
+    fprintf(stderr, "%s", ATOMVM_BANNER);
+    fprintf(stderr, "Starting AtomVM revision " ATOMVM_VERSION "\n");
+
+    if ((uintptr_t) &__flash_binary_end >= (uintptr_t) LIB_AVM) {
+        sleep_ms(5000);
+        fprintf(stderr, "This VM is too large (end %p >= LIB_AVM %p), please update LIB_AVM\n", &__flash_binary_end, LIB_AVM);
+        AVM_ABORT();
+    }
+
+    GlobalContext *glb = globalcontext_new();
+
+    uint32_t startup_beam_size;
+    const void *startup_beam;
+    const char *startup_module_name;
+
+    if (!avmpack_is_valid(MAIN_AVM, XIP_SRAM_BASE - (uintptr_t) MAIN_AVM)) {
+        sleep_ms(5000);
+        fprintf(stderr, "Fatal error: invalid main.avm packbeam\n");
+        AVM_ABORT();
+    }
+    if (!avmpack_find_section_by_flag(MAIN_AVM, BEAM_START_FLAG, &startup_beam, &startup_beam_size, &startup_module_name)) {
+        sleep_ms(5000);
+        fprintf(stderr, "Fatal error: Failed to locate start module in main.avm packbeam.  (Did you flash a library by mistake?)");
+        AVM_ABORT();
+    }
+    fprintf(stderr, "Found startup beam %s\n", startup_module_name);
+    struct ConstAVMPack *avmpack_data = malloc(sizeof(struct ConstAVMPack));
+    if (IS_NULL_PTR(avmpack_data)) {
+        sleep_ms(5000);
+        fprintf(stderr, "Fatal memory error: Cannot allocate AVMPackData for main.avm.");
+        AVM_ABORT();
+    }
+
+    avmpack_data->base.data = MAIN_AVM;
+    avmpack_data->base.in_use = true;
+    synclist_append(&glb->avmpack_data, (struct ListHead *) avmpack_data);
+
+    if (avmpack_is_valid(LIB_AVM, (uintptr_t) MAIN_AVM - (uintptr_t) LIB_AVM)) {
+        avmpack_data = malloc(sizeof(struct AVMPackData));
+        if (IS_NULL_PTR(avmpack_data)) {
+            sleep_ms(5000);
+            fprintf(stderr, "Memory error: Cannot allocate AVMPackData for lib.avm.");
+            AVM_ABORT();
+        }
+        avmpack_data->base.data = LIB_AVM;
+        avmpack_data->base.in_use = true;
+        synclist_append(&glb->avmpack_data, (struct ListHead *) avmpack_data);
+    } else {
+        fprintf(stderr, "Warning: invalid lib.avm packbeam\n");
+    }
+
+    Module *mod = module_new_from_iff_binary(glb, startup_beam, startup_beam_size);
+    if (IS_NULL_PTR(mod)) {
+        sleep_ms(5000);
+        fprintf(stderr, "Fatal error: unable to load startup module %s", startup_module_name);
+        AVM_ABORT();
+    }
+
+    globalcontext_insert_module(glb, mod);
+    mod->module_platform_data = NULL;
+    Context *ctx = context_new(glb);
+    ctx->leader = 1;
+
+    fprintf(stderr, "Starting %s...", startup_module_name);
+    fprintf(stdout, "---\n");
+
+    context_execute_loop(ctx, mod, "start", 0);
+    term ret_value = ctx->x[0];
+
+    fprintf(stdout, "AtomVM finished with return value: ");
+    term_display(stdout, ret_value, ctx);
+    fprintf(stdout, "\n");
+    int result = ret_value != OK_ATOM;
+
+    context_destroy(ctx);
+
+    globalcontext_destroy(glb);
+
+    return result;
+}
+
+static void exit_handler(bool reboot)
+{
+#if defined(CONFIG_REBOOT_ON_NOT_OK)
+    reboot = reboot && (CONFIG_REBOOT_ON_NOT_OK ? true : false);
+#else
+    reboot = false;
+#endif
+    if (reboot) {
+        fprintf(stderr, "AtomVM application terminated with non-ok return value.  Rebooting ...\n");
+        watchdog_reboot(0, 0, 200);
+    } else {
+        fprintf(stderr, "AtomVM application terminated.  Going to sleep forever ...\n");
+    }
+}
+
+/* newlib stubs to get AVM_ABORT to work */
+pid_t _getpid()
+{
+    return 1; /* init :-) */
+}
+
+int _kill(pid_t pid, int sig)
+{
+    UNUSED(pid);
+    if (sig == SIGABRT) {
+        fprintf(stderr, "Aborted\n");
+    } else {
+        fprintf(stderr, "Unknown signal %d\n", sig);
+    }
+    exit_handler(true);
+    return 0;
+}
+
+int main()
+{
+    int reboot = app_main();
+    exit_handler(reboot);
+    return 0;
+}

--- a/tools/uf2tool/CMakeLists.txt
+++ b/tools/uf2tool/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # This file is part of AtomVM.
 #
-# Copyright 2018-2021 Fred Dushin <fred@dushin.net>
+# Copyright 2022 Paul Guyot <pguyot@kallisys.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,28 +18,19 @@
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-project(eavmlib)
+cmake_minimum_required (VERSION 3.13)
+project (UF2Tool)
 
-include(BuildErlang)
+include(${CMAKE_SOURCE_DIR}/CMakeModules/GetVersion.cmake)
 
-set(ERLANG_MODULES
-    atomvm
-    console
-    esp
-    gpio
-    i2c
-    http_server
-    json_encoder
-    ledc
-    logger
-    network
-    network_fsm
-    pico
-    port
-    spi
-    timer_manager
-    timestamp_util
-    uart
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/uf2tool.erl ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/uf2tool @ONLY)
+file(COPY ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/uf2tool
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 )
 
-pack_archive(eavmlib ${ERLANG_MODULES})
+add_custom_target(
+    uf2tool ALL
+    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/uf2tool
+    VERBATIM
+)

--- a/tools/uf2tool/uf2tool.erl
+++ b/tools/uf2tool/uf2tool.erl
@@ -1,0 +1,164 @@
+#!/usr/bin/env escript
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(uf2tool).
+
+-export([main/1]).
+-mode(compile).
+
+main([]) ->
+    io:format("UF2 tool for AtomVM usage on Pico\n");
+main(["-h"]) ->
+    usage();
+main(["help"]) ->
+    usage();
+main(["join", "-o", Output | Sources]) when length(Sources) > 1 ->
+    uf2join(Output, Sources);
+main(["create", "-o", Output, "-s", StartAddrStr, Image]) ->
+    StartAddr = parse_addr(StartAddrStr),
+    uf2create(Output, StartAddr, Image);
+main(_) ->
+    io:format("Syntax error\n"),
+    usage(),
+    erlang:halt(2).
+
+usage() ->
+    io:format("UF2 Tool, AtomVM version @ATOMVM_VERSION@\n\n"),
+    io:format("Usage:\n"),
+    io:format("  uf2tool help | -h\n"),
+    io:format("    Display this message\n\n"),
+    io:format("  uf2tool join -o combined.uf2 first.uf2 second.uf2...\n"),
+    io:format("    Join two or more UF2 binaries\n\n"),
+    io:format("  uf2tool create -o new.uf2 -s start_addr image.avm\n"),
+    io:format("    Create a UF2 image from a binary file (image.avm), suitable for the Pico\n"),
+    ok.
+
+parse_addr("0x" ++ AddrHex) ->
+    list_to_integer(AddrHex, 16);
+parse_addr("16#" ++ AddrHex) ->
+    list_to_integer(AddrHex, 16);
+parse_addr(AddrDec) ->
+    list_to_integer(AddrDec).
+
+%%% UF2 defines
+-define(UF2_MAGIC_START0, 16#0A324655).
+-define(UF2_MAGIC_START1, 16#9E5D5157).
+-define(UF2_MAGIC_END, 16#0AB16F30).
+
+-define(UF2_FLAG_FAMILY_ID_PRESENT, 16#00002000).
+
+%%% Pico defines
+-define(UF2_PICO_FLAGS, ?UF2_FLAG_FAMILY_ID_PRESENT).
+-define(UF2_PICO_PAGE_SIZE, 256).
+-define(UF2_PICO_FAMILY_ID, 16#E48BFF56).
+
+%%%
+
+uf2join(OutputPath, Sources) ->
+    SourceBins = [Bin || {ok, Bin} <- [file:read_file(Source) || Source <- Sources]],
+    BlocksCount = lists:sum([byte_size(SourceBin) || SourceBin <- SourceBins]) div 512,
+    {BlocksCount, OutputBinsLR} = lists:foldl(
+        fun(SourceBin, {StartBlock, Acc}) ->
+            {NewBlockStart, RewrittenBin} = rewrite_block_indices(
+                StartBlock, BlocksCount, SourceBin
+            ),
+            {NewBlockStart, [RewrittenBin | Acc]}
+        end,
+        {0, []},
+        SourceBins
+    ),
+    ok = file:write_file(OutputPath, lists:reverse(OutputBinsLR)).
+
+rewrite_block_indices(BlockIndex, BlocksCount, Bin) ->
+    rewrite_block_indices0(BlockIndex, BlocksCount, Bin, []).
+
+rewrite_block_indices0(LastBlock, _BlocksCount, <<>>, Acc) ->
+    {LastBlock, lists:reverse(Acc)};
+rewrite_block_indices0(BlockIndex, BlocksCount, <<Page:512/binary, Tail/binary>>, Acc) ->
+    <<
+        ?UF2_MAGIC_START0:32/little,
+        ?UF2_MAGIC_START1:32/little,
+        Flags:32/little,
+        TargetAddr:32/little,
+        PageSize:32/little,
+        _BlockNo:32/little,
+        _NumBlocks:32/little,
+        FamilyIdOrFileSize:32/little,
+        Data:476/binary,
+        ?UF2_MAGIC_END:32/little
+    >> = Page,
+    Rewritten = <<
+        ?UF2_MAGIC_START0:32/little,
+        ?UF2_MAGIC_START1:32/little,
+        Flags:32/little,
+        TargetAddr:32/little,
+        PageSize:32/little,
+        BlockIndex:32/little,
+        BlocksCount:32/little,
+        FamilyIdOrFileSize:32/little,
+        Data:476/binary,
+        ?UF2_MAGIC_END:32/little
+    >>,
+    rewrite_block_indices0(BlockIndex + 1, BlocksCount, Tail, [Rewritten | Acc]).
+
+uf2create(OutputPath, StartAddr, ImagePath) ->
+    {ok, ImageBin} = file:read_file(ImagePath),
+    BlocksCount0 = byte_size(ImageBin) div ?UF2_PICO_PAGE_SIZE,
+    BlocksCount =
+        BlocksCount0 +
+            if
+                byte_size(ImageBin) rem ?UF2_PICO_PAGE_SIZE =:= 0 -> 0;
+                true -> 1
+            end,
+    OutputBin = uf2create0(0, BlocksCount, StartAddr, ImageBin, []),
+    ok = file:write_file(OutputPath, OutputBin).
+
+uf2create0(_BlockIndex, _BlocksCount, _BaseAddr, <<>>, Acc) ->
+    lists:reverse(Acc);
+uf2create0(BlockIndex, BlocksCount, BaseAddr, ImageBin, Acc) ->
+    {PageBin, Tail} =
+        if
+            byte_size(ImageBin) >= ?UF2_PICO_PAGE_SIZE ->
+                split_binary(ImageBin, ?UF2_PICO_PAGE_SIZE);
+            true ->
+                {ImageBin, <<>>}
+        end,
+    PaddedData = pad_binary(PageBin, 476),
+    Block = [
+        <<
+            ?UF2_MAGIC_START0:32/little,
+            ?UF2_MAGIC_START1:32/little,
+            ?UF2_PICO_FLAGS:32/little,
+            BaseAddr:32/little,
+            ?UF2_PICO_PAGE_SIZE:32/little,
+            BlockIndex:32/little,
+            BlocksCount:32/little,
+            ?UF2_PICO_FAMILY_ID:32/little
+        >>,
+        PaddedData,
+        <<?UF2_MAGIC_END:32/little>>
+    ],
+    uf2create0(BlockIndex + 1, BlocksCount, BaseAddr + ?UF2_PICO_PAGE_SIZE, Tail, [Block | Acc]).
+
+pad_binary(Bin, Len) ->
+    PadCount = Len - byte_size(Bin),
+    Pad = binary:copy(<<0>>, PadCount),
+    [Bin, Pad].


### PR DESCRIPTION
This PR provides minimal support for Raspberry Pi Pico.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
