### PR TITLE
Add Elixir I2C driver and example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `uart:close/1`
 - Added Bitwise support for Elixir
 - Added support for esp32-s2, esp32-s3, and esp32-c3 chips.
+- Added Elixir I2C driver and example
 
 ### Breaking Changes
 

--- a/examples/elixir/esp32/CMakeLists.txt
+++ b/examples/elixir/esp32/CMakeLists.txt
@@ -24,3 +24,6 @@ include(BuildElixir)
 
 pack_runnable(Blink Blink estdlib eavmlib exavmlib)
 pack_runnable(Ledc_x4 Ledc_x4 estdlib eavmlib exavmlib)
+if(NOT (AVM_DISABLE_FP))
+    pack_runnable(SHT31 SHT31 estdlib eavmlib exavmlib)
+endif()

--- a/examples/elixir/esp32/SHT31.ex
+++ b/examples/elixir/esp32/SHT31.ex
@@ -1,0 +1,77 @@
+#
+#  This file is part of AtomVM.
+#
+#  Copyright 2019-2020 Davide Bettio <davide@uninstall.it>
+#  Copyright 2022 Winford (Uncle Grumpy) <dwinford@proton.me>
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+defmodule SHT31 do
+  # suppress warnings when compiling the VM
+  # not needed or recommended for user apps.
+  @compile {:no_warn_undefined, [I2C]}
+
+  use Bitwise
+
+  @sht31_base_addr 0x44
+  @sht31_meas_high_rep 0x2400
+
+  def start do
+    i2c = I2C.open([{:scl_io_num, 15}, {:sda_io_num, 4}, {:i2c_clock_hz, 1000000}])
+    loop(i2c)
+  end
+
+  defp loop(i2c) do
+    val = read(i2c)
+    :erlang.display(val)
+    Process.sleep(10000)
+    loop(i2c)
+  end
+
+  defp read(i2c) do
+    bin = read_sensor(i2c)
+    parse_bin(bin)
+  end
+
+  defp parse_bin(bin) do
+    int_temp = (:binary.at(bin, 0) <<< 8) ||| :binary.at(bin, 1)
+    temp = float_temp(int_temp, 0.01)
+    int_hum = (:binary.at(bin, 3) <<< 8) ||| :binary.at(bin, 4)
+    hum = float_hum(int_hum, 0.01)
+    {:ok, temp, hum}
+  end
+
+  defp float_temp(int_temp, s) do
+    (((4375 * int_temp) >>> 14) - 4500) * s
+  end
+
+  defp float_hum(int_hum, s) do
+    ((625 * int_hum) >>> 12) * s
+  end
+
+  defp read_sensor(i2c) do
+    send_command(i2c, @sht31_meas_high_rep)
+    Process.sleep(20)
+    I2C.read_bytes(i2c, @sht31_base_addr, 6)
+  end
+
+  defp send_command(i2c, command) do
+    I2C.begin_transmission(i2c, @sht31_base_addr)
+    I2C.write_byte(i2c, (command >>> 8) &&& 0xFF)
+    I2C.write_byte(i2c, command &&& 0xFF)
+    I2C.end_transmission(i2c)
+  end
+end

--- a/libs/exavmlib/lib/CMakeLists.txt
+++ b/libs/exavmlib/lib/CMakeLists.txt
@@ -28,6 +28,7 @@ set(ELIXIR_MODULES
     Code
     Console
     GPIO
+    I2C
     LEDC
     Access
     Enum

--- a/libs/exavmlib/lib/I2C.ex
+++ b/libs/exavmlib/lib/I2C.ex
@@ -1,0 +1,219 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2018-2022 Davide Bettio <davide@uninstall.it>
+# Copyright 2022 Winford (Uncle Grumpy) <dwinford@proton.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+defmodule I2C do
+  @compile {:no_warn_undefined, [AVMPort]}
+  @moduledoc """
+  Functions for interacting with the i2c buss.
+  """
+
+  @typedoc """
+  Valid GPIO pin number.
+
+  The actual number of pins that are broken out vary by board and module.
+  """
+  @type gpio_pin() :: 0..48
+
+  @typedoc """
+  Clock speed of the i2c buss.
+  """
+  @type freq_hz() :: non_neg_integer()
+
+  @typedoc """
+  Valid parameters.
+
+  Used to set the SCL pin, SDA pin, and clock speed.
+  """
+  @type param() ::
+          {:scl_io_num, gpio_pin()}
+          | {:sda_io_num, gpio_pin()}
+          | {:i2c_clock_hz, freq_hz()}
+
+  @type params() :: [param()]
+
+  @typedoc """
+  I2C device address.
+
+  Devices are addressed in the range of 0-127.
+  """
+  @type address() :: 0..127
+
+  @typedoc """
+  The register address in the device from which to read data
+  """
+  @type register() :: non_neg_integer()
+
+  @doc """
+  Open a connection to the I2C driver.
+
+  Start the driver with a list of initialization parameters,
+  see type param(). Returns the process id of the driver.
+
+  ## Example:
+
+  `I2C.open([{:scl_io_num, 15}, {:sda_io_num, 4}, {:i2c_clock_hz, 1000000}])`
+  """
+  @spec open(params()) :: pid()
+  def open(configuration) do
+    AVMPort.open({:spawn, "i2c"}, configuration)
+  end
+
+  @doc """
+  Begin a transmission of I2C commands.
+
+  ## Parameters
+    - driver:   pid returned by I2C.open()
+    - device:   device address to communicate with
+
+  This command is typically followed by one or more calls to
+  write_byte/2 and then a call to end_transmission/1.
+  """
+  @spec begin_transmission(pid(), address()) :: :ok | :error
+  def begin_transmission(driver, device) do
+    AVMPort.call(driver, {:begin_transmission, device})
+  end
+
+  @doc """
+  Write a byte to the device.
+
+  ## Parameters
+    - driver:   pid returned by I2C.open()
+    - data:     byte to be written
+
+  This command must be wrapped in a begin_transmission/2
+  and end_transmission/1 call.
+  """
+  @spec write_byte(pid(), byte()) :: :ok | :error
+  def write_byte(driver, data) do
+    AVMPort.call(driver, {:write_byte, data})
+  end
+
+  @doc """
+  Write a sequence of bytes to the device.
+
+  ## Parameters
+    - driver:   pid returned by I2C.open()
+    - data:     binary data to be written
+
+  This command must be wrapped in a begin_transmission/2
+  and end_transmission/1 call.
+  """
+  @spec write_bytes(pid(), binary()) :: :ok | :error
+  def write_bytes(driver, data) do
+    AVMPort.call(driver, {:write_bytes, data})
+  end
+
+  @doc """
+  End a transmission of I2C commands
+
+  ## Parameters
+    - driver:   pid returned by I2C.open()
+
+  This command is typically preceded by a call to begin_transmission/2
+  and one or more calls to write_byte/2 or write_bytes/2.
+  """
+  @spec end_transmission(pid()) :: :ok | :error
+  def end_transmission(driver) do
+    AVMPort.call(driver, {:end_transmission})
+  end
+
+  @doc """
+  Read a block of bytes from the I2C device.
+
+  ## Parameters
+    - driver:   pid returned by I2C.open()
+    - device:   device address to communicate with
+    - count:    number of byte to read
+
+  This command is not wrapped in a begin_transmission/2
+  and end_transmission/1 call.
+  """
+  @spec read_bytes(pid(), address(), non_neg_integer()) :: :error | binary()
+  def read_bytes(driver, addr, count) do
+    AVMPort.call(driver, {:read_bytes, addr, count})
+  end
+
+  @doc """
+  Read a block of bytes from the I2C device starting at a specified
+  register address.
+
+  ## Parameters
+    - driver:   pid returned by I2C.open()
+    - device:   device address to communicate with
+    - reg:      register address of the device to read from
+    - count:    number of byte to read
+
+  This command is not wrapped in a begin_transmission/2
+  and end_transmission/1 call.
+  """
+  @spec read_bytes(pid(), address(), register(), non_neg_integer()) :: :error | binary()
+  def read_bytes(device, addr, reg, count) do
+    AVMPort.call(device, {:read_bytes, addr, count, reg})
+  end
+
+  @doc """
+  Write a block of bytes to the I2C device.
+
+  ## Parameters
+    - driver:   pid returned by I2C.open()
+    - device:   device address to communicate with
+    - data:     binary or byte value to be written
+
+  This command is not wrapped in a begin_transmission/2
+  and end_transmission/1 call.
+  """
+  @spec write_bytes(pid(), address(), binary() | byte()) :: :ok | :error
+  def write_bytes(driver, addr, data) do
+    AVMPort.call(driver, {:write_bytes, addr, data})
+  end
+
+  @doc """
+  Write a block of bytes to the I2C device starting at a specified
+  register address.
+
+  ## Parameters
+    - driver:   pid returned by I2C.open()
+    - device:   device address to communicate with
+    - reg:      register address of the device to write to
+    - data:     binary or byte value to be written
+
+  This command is not wrapped in a begin_transmission/2
+  and end_transmission/1 call.
+  """
+  @spec write_bytes(pid(), address(), register(), binary() | integer()) :: :ok | :error
+  def write_bytes(driver, addr, reg, data) do
+    AVMPort.call(driver, {:write_bytes, addr, data, reg})
+  end
+
+  @doc """
+  Close the connection to the I2C driver
+
+  ## Parameters
+    - driver:   pid returned by I2C.open()
+
+  This function will close the connection to the I2C driver and
+  free any resources in use by it.
+  """
+  @spec close(pid()) :: :ok | :error
+  def close(driver) do
+    AVMPort.call(driver, {:close})
+  end
+end


### PR DESCRIPTION
Adds an Elixir interface to the I2C driver and an example for the SHT31 that will only be compile along with the generic_unix port if floating point is enabled.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
