### PR TITLE
Fix link to creator's GH account

### DIFF
--- a/README.Md
+++ b/README.Md
@@ -103,7 +103,7 @@ All of these limitations are going to be fixed in a reasonable amount of time.
 
 About This Project
 ==================
-This project has been created by [Davide Bettio](https://github.com/atomvm/), and now is developed
+This project has been created by [Davide Bettio](https://github.com/bettio/), and now is developed
 from a growing number of contributors.
 
 How to Contribute


### PR DESCRIPTION
This fix changes the link in

> This project has been created by Davide Bettio, and now is developed from a growing number of contributors.

redirecting to Davide Bettio's GH account.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
