### PR TITLE
Add chip name to constucted esp32 images

### DIFF
--- a/src/platforms/esp32/tools/CMakeLists.txt
+++ b/src/platforms/esp32/tools/CMakeLists.txt
@@ -26,7 +26,7 @@ project (ReleaseEsp32)
 ## the code here .../GetVersion.cmake and AtomVM/version.cmake should be reworked so they can be used
 ## here as well as for the "generic_unix" port.
 
-include(${CMAKE_SOURCE_DIR}/../../../version.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../../version.cmake)
 
 if (ATOMVM_DEV)
     set(ATOMVM_GIT_REVISION "<unknown>")

--- a/src/platforms/esp32/tools/flashimage.sh.in
+++ b/src/platforms/esp32/tools/flashimage.sh.in
@@ -22,4 +22,4 @@
 THIS_DIR="$(cd $(dirname $0) && pwd)"
 ROOT_DIR="$(cd "${THIS_DIR}/../../../.." && pwd)"
 
-FLASH_OFFSET="@BOOTLOADER_OFFSET@" ${ROOT_DIR}/src/platforms/esp32/build/flash.sh "${ROOT_DIR}/src/platforms/esp32/build/atomvm-esp32-@ATOMVM_VERSION@.img"
+FLASH_OFFSET="@BOOTLOADER_OFFSET@" ${ROOT_DIR}/src/platforms/esp32/build/flash.sh "${ROOT_DIR}/src/platforms/esp32/build/atomvm-@CONFIG_IDF_TARGET@-@ATOMVM_VERSION@.img"

--- a/src/platforms/esp32/tools/mkimage.sh.in
+++ b/src/platforms/esp32/tools/mkimage.sh.in
@@ -20,13 +20,13 @@
 #
 
 escript "@CMAKE_BINARY_DIR@/mkimage.erl" \
-    --root_dir "@CMAKE_BINARY_DIR@/../../.." \
+    --root_dir "@CMAKE_BINARY_DIR@/../../../.." \
     --config "@CMAKE_BINARY_DIR@/mkimage.config" \
-    --out "@CMAKE_BINARY_DIR@/atomvm-esp32-@ATOMVM_VERSION@.img" \
+    --out "@CMAKE_BINARY_DIR@/atomvm-@CONFIG_IDF_TARGET@-@ATOMVM_VERSION@.img" \
     "$@"
 
 echo "============================================="
 
 echo ""
-echo "AtomVM ESP32 version @ATOMVM_VERSION@ image written to:"
-echo "@CMAKE_BINARY_DIR@/atomvm-esp32-@ATOMVM_VERSION@.img"
+echo "AtomVM @CONFIG_IDF_TARGET@ version @ATOMVM_VERSION@ image written to:"
+echo "@CMAKE_BINARY_DIR@/atomvm-@CONFIG_IDF_TARGET@-@ATOMVM_VERSION@.img"


### PR DESCRIPTION
Modifies the esp32 tools to add the target chip name to images created with the `AtomVM/src/platforms/esp32/build/mkimage.sh` tool.

Signed-off-by: Winford <dwinford@pm.me>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
