### PR TITLE
Fix PackBeam compilation for Release build type

### DIFF
--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -115,15 +115,38 @@ int main(int argc, char **argv)
     }
 }
 
+static void assert_fread(void *buffer, size_t size, FILE* file)
+{
+    size_t r = fread(buffer, sizeof(uint8_t), size, file);
+    if (r != size) {
+        fprintf(stderr, "Unable to read, wanted to read %zu bytes, read %zu bytes\n", size, r);
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void assert_fwrite(const void *buffer, size_t size, FILE* file)
+{
+    size_t r = fwrite(buffer, 1, size, file);
+    if (r != size) {
+        fprintf(stderr, "Unable to write, wanted to write %zu bytes, wrote %zu bytes\n", size, r);
+        exit(EXIT_FAILURE);
+    }
+}
 
 static void *pack_beam_fun(void *accum, const void *section_ptr, uint32_t section_size, const void *beam_ptr, uint32_t flags, const char *section_name)
 {
     UNUSED(beam_ptr);
     UNUSED(flags);
     UNUSED(section_name);
+    if (accum == NULL) {
+        return NULL;
+    }
 
     FILE *pack = (FILE *)accum;
-    assert(fwrite(section_ptr, sizeof(unsigned char), section_size, pack) == section_size);
+    size_t r = fwrite(section_ptr, sizeof(unsigned char), section_size, pack);
+    if (r != section_size) {
+        return NULL;
+    }
     return accum;
 }
 
@@ -137,7 +160,7 @@ FileData read_file_data(FILE *file)
         fprintf(stderr, "Unable to allocate %zu bytes\n", size);
         exit(EXIT_FAILURE);
     }
-    assert(fread(data, sizeof(uint8_t), size, file) == size);
+    assert_fread(data, size, file);
 
     FileData file_data = {
         .data = data,
@@ -211,7 +234,7 @@ static int do_pack(int argc, char **argv, int is_archive)
         0x74, 0x6f, 0x6d, 0x56,
         0x4d, 0x0a, 0x00, 0x00
     };
-    assert(fwrite(pack_header, sizeof(unsigned char), 24, pack) == 24);
+    assert_fwrite(pack_header, 24, pack);
 
     for (int i = 1; i < argc; i++) {
         FILE *file = fopen(argv[i], "r");
@@ -232,9 +255,12 @@ static int do_pack(int argc, char **argv, int is_archive)
             fprintf(stderr, "Unable to allocate %zu bytes\n", file_size);
             return EXIT_FAILURE;
         }
-        assert(fread(file_data, sizeof(uint8_t), file_size, file) == file_size);
+        assert_fread(file_data, file_size, file);
         if (avmpack_is_valid(file_data, file_size)) {
-            avmpack_fold(pack, file_data, pack_beam_fun);
+            void *result = avmpack_fold(pack, file_data, pack_beam_fun);
+            if (result == NULL) {
+                return EXIT_FAILURE;
+            }
         } else {
             char *filename = basename(argv[i]);
             pack_beam_file(pack, file_data, file_size, filename, !is_archive && i == 1);
@@ -264,53 +290,52 @@ static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const c
         0x00, 0x00, 0x00, 0x00,
         0x42, 0x45, 0x41, 0x4d
     };
-    assert(fwrite(beam_header, 1, 12, pack) == 12);
-
+    assert_fwrite(beam_header, 12, pack);
 
     unsigned long offsets[MAX_OFFS];
     unsigned long sizes[MAX_SIZES];
     scan_iff(data, size, offsets, sizes);
 
     if (offsets[AT8U]) {
-        assert(fwrite(data + offsets[AT8U], sizeof(uint8_t), sizes[AT8U] + IFF_SECTION_HEADER_SIZE, pack) == sizes[AT8U] + IFF_SECTION_HEADER_SIZE);
+        assert_fwrite(data + offsets[AT8U], sizes[AT8U] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);
     }
     if (offsets[CODE]) {
-        fwrite(data + offsets[CODE], sizeof(uint8_t), sizes[CODE] + IFF_SECTION_HEADER_SIZE, pack);
+        assert_fwrite(data + offsets[CODE], sizes[CODE] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);
     }
     if (offsets[EXPT]) {
-        fwrite(data + offsets[EXPT], sizeof(uint8_t), sizes[EXPT] + IFF_SECTION_HEADER_SIZE, pack);
+        assert_fwrite(data + offsets[EXPT], sizes[EXPT] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);
     }
     if (offsets[LOCT]) {
-        fwrite(data + offsets[LOCT], sizeof(uint8_t), sizes[LOCT] + IFF_SECTION_HEADER_SIZE, pack);
+        assert_fwrite(data + offsets[LOCT], sizes[LOCT] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);
     }
     if (offsets[IMPT]) {
-        fwrite(data + offsets[IMPT], sizeof(uint8_t), sizes[IMPT] + IFF_SECTION_HEADER_SIZE, pack);
+        assert_fwrite(data + offsets[IMPT], sizes[IMPT] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);
     }
     if (offsets[LITU]) {
-        fwrite(data + offsets[LITU], sizeof(uint8_t), sizes[LITU] + IFF_SECTION_HEADER_SIZE, pack);
+        assert_fwrite(data + offsets[LITU], sizes[LITU] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);
     }
     if (offsets[FUNT]) {
-        fwrite(data + offsets[FUNT], sizeof(uint8_t), sizes[FUNT] + IFF_SECTION_HEADER_SIZE, pack);
+        assert_fwrite(data + offsets[FUNT], sizes[FUNT] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);
     }
     if (offsets[STRT]) {
-        fwrite(data + offsets[STRT], sizeof(uint8_t), sizes[STRT] + IFF_SECTION_HEADER_SIZE, pack);
+        assert_fwrite(data + offsets[STRT], sizes[STRT] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);
     }
 
     if (offsets[LITT]) {
         size_t u_size;
         void *deflated = uncompress_literals(data + offsets[LITT], sizes[LITT], &u_size);
-        assert(fwrite("LitU", sizeof(uint8_t), 4, pack) == 4);
+        assert_fwrite("LitU", 4, pack);
         uint32_t size_field = ENDIAN_SWAP_32(u_size);
-        assert(fwrite(&size_field, sizeof(size_field), 1, pack) == 1);
-        assert(fwrite(deflated, sizeof(uint8_t), u_size, pack) == u_size);
+        assert_fwrite(&size_field, sizeof(size_field), pack);
+        assert_fwrite(deflated, u_size, pack);
         free(deflated);
     }
 
@@ -321,13 +346,13 @@ static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const c
     size_t rsize = end_of_module_pos - zero_pos;
     uint32_t size_field = ENDIAN_SWAP_32(rsize);
     fseek(pack, zero_pos, SEEK_SET);
-    assert(fwrite(&size_field, sizeof(uint32_t), 1, pack) == 1);
+    assert_fwrite(&size_field, sizeof(uint32_t), pack);
     fseek(pack, end_of_module_pos, SEEK_SET);
 
     int beam_written_size = end_of_module_pos - written_beam_header_pos;
     uint32_t beam_written_size_field = ENDIAN_SWAP_32(beam_written_size);
     fseek(pack, written_beam_header_pos + 4, SEEK_SET);
-    assert(fwrite(&beam_written_size_field , sizeof(uint32_t), 1, pack) == 1);
+    assert_fwrite(&beam_written_size_field , sizeof(uint32_t), pack);
     fseek(pack, end_of_module_pos, SEEK_SET);
 }
 
@@ -432,9 +457,9 @@ static void add_module_header(FILE *f, const char *module_name, uint32_t flags)
     uint32_t flags_field = ENDIAN_SWAP_32(flags);
     uint32_t reserved = 0;
 
-    assert(fwrite(&size_field, sizeof(uint32_t), 1, f) == 1);
-    assert(fwrite(&flags_field, sizeof(uint32_t), 1, f) == 1);
-    assert(fwrite(&reserved, sizeof(uint32_t), 1, f) == 1);
-    assert(fwrite(module_name, sizeof(char), strlen(module_name) + 1, f) == strlen(module_name) + 1);
+    assert_fwrite(&size_field, sizeof(uint32_t), f);
+    assert_fwrite(&flags_field, sizeof(uint32_t), f);
+    assert_fwrite(&reserved, sizeof(uint32_t), f);
+    assert_fwrite(module_name, strlen(module_name) + 1, f);
     pad_and_align(f);
 }


### PR DESCRIPTION
Replace assert calls that have side effects

Signed-off-by: Paul Guyot <pguyot@kallisys.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
