### PR TITLE
Fix race condition bug in timer_manager (fix #432)

### DIFF
--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -133,6 +133,7 @@ compile_erlang(test_bif_badargument3)
 compile_erlang(test_tuple_nifs_badargs)
 compile_erlang(test_apply)
 compile_erlang(test_apply_last)
+compile_erlang(test_monitor)
 compile_erlang(test_set_tuple_element)
 compile_erlang(test_timestamp)
 compile_erlang(long_atoms)
@@ -535,6 +536,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_tuple_nifs_badargs.beam
     test_apply.beam
     test_apply_last.beam
+    test_monitor.beam
     test_set_tuple_element.beam
     test_timestamp.beam
     long_atoms.beam

--- a/tests/erlang_tests/test_monitor.erl
+++ b/tests/erlang_tests/test_monitor.erl
@@ -1,0 +1,84 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_monitor).
+
+-export([start/0]).
+
+start() ->
+    ok = test_monitor_normal(),
+    ok = test_monitor_demonitor(),
+    ok = test_monitor_noproc(),
+    0.
+
+test_monitor_normal() ->
+    Pid = spawn(fun() -> normal_loop() end),
+    Ref = monitor(process, Pid),
+    Pid ! {self(), quit},
+    ok =
+        receive
+            {Pid, finished} -> ok;
+            Other1 -> {unexpected, Other1}
+        after 5000 -> timeout
+        end,
+    ok =
+        receive
+            {'DOWN', Ref, process, Pid, normal} -> ok;
+            Other2 -> {unexpected, Other2}
+        after 5000 -> timeout
+        end,
+    ok.
+
+test_monitor_demonitor() ->
+    Pid = spawn(fun() -> normal_loop() end),
+    Ref = monitor(process, Pid),
+    demonitor(Ref),
+    Pid ! {self(), quit},
+    ok =
+        receive
+            {Pid, finished} -> ok;
+            Other1 -> {unexpected, Other1}
+        after 5000 -> timeout
+        end,
+    ok =
+        receive
+            Other2 -> {unexpected, Other2}
+        after 200 -> ok
+        end,
+    ok.
+
+test_monitor_noproc() ->
+    Pid = spawn(fun() -> ok end),
+    receive
+    after 100 -> ok
+    end,
+    Ref = monitor(process, Pid),
+    ok =
+        receive
+            {'DOWN', Ref, process, Pid, noproc} -> ok;
+            Other -> {unexpected, Other}
+        after 5000 -> timeout
+        end,
+    ok.
+
+normal_loop() ->
+    receive
+        {Caller, quit} -> Caller ! {self(), finished}
+    end.

--- a/tests/libs/eavmlib/test_timer_manager.erl
+++ b/tests/libs/eavmlib/test_timer_manager.erl
@@ -39,10 +39,12 @@ test_cancel_timer() ->
     ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
     TimerRef = timer_manager:start_timer(60000, self(), test_cancel_timer),
     ?ASSERT_MATCH(timer_manager:get_timer_refs(), [TimerRef]),
-    %% TODO check return value
-    timer_manager:cancel_timer(TimerRef),
-    %?TIMER:sleep(100),
+    R = timer_manager:cancel_timer(TimerRef),
+    ?ASSERT_TRUE(is_integer(R)),
+    ?ASSERT_TRUE(R > 0),
     ?ASSERT_MATCH(timer_manager:get_timer_refs(), []),
+    R2 = timer_manager:cancel_timer(TimerRef),
+    ?ASSERT_EQUALS(false, R2),
     ok.
 
 test_send_after() ->

--- a/tests/libs/estdlib/test_gen_statem.erl
+++ b/tests/libs/estdlib/test_gen_statem.erl
@@ -31,25 +31,9 @@
 
 test() ->
     ok = test_call(),
-    receive
-        X1 -> io:format("test_call, got ~p\n", [X1])
-    after 0 -> ok
-    end,
     ok = test_cast(),
-    receive
-        X2 -> io:format("test_cast, got ~p\n", [X2])
-    after 0 -> ok
-    end,
     ok = test_info(),
-    receive
-        X3 -> io:format("test_info, got ~p\n", [X3])
-    after 0 -> ok
-    end,
     ok = test_timeout(),
-    receive
-        X4 -> io:format("test_timeout, got ~p\n", [X4])
-    after 0 -> ok
-    end,
     ok.
 
 test_call() ->
@@ -90,14 +74,14 @@ test_timeout() ->
     {ok, Pid} = gen_statem:start(?MODULE, [], []),
     ok = gen_statem:call(Pid, {go_to_jail, 250}),
     no = gen_statem:call(Pid, are_you_free),
-    timer:sleep(251),
+    timer:sleep(500),
     yes = gen_statem:call(Pid, are_you_free),
 
     ok = gen_statem:call(Pid, {go_to_jail, 250}),
     no = gen_statem:call(Pid, are_you_free),
     ok = gen_statem:cast(Pid, escape),
     yes = gen_statem:call(Pid, are_you_free),
-    timer:sleep(251),
+    timer:sleep(500),
     0 = gen_statem:call(Pid, get_num_spurious_timeouts),
 
     gen_statem:stop(Pid),

--- a/tests/test.c
+++ b/tests/test.c
@@ -256,6 +256,7 @@ struct Test tests[] = {
 
     TEST_CASE_EXPECTED(test_apply, 17),
     TEST_CASE_EXPECTED(test_apply_last, 17),
+    TEST_CASE(test_monitor),
     TEST_CASE_EXPECTED(test_timestamp, 1),
     TEST_CASE(test_set_tuple_element),
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
