### PR TITLE
Math tests also pass with valgrind

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -203,7 +203,7 @@ jobs:
       working-directory: build
       run: |
         ./tests/test-erlang
-        valgrind ./tests/test-erlang -s floatmath
+        valgrind ./tests/test-erlang
 
     - name: "Test: test-structs"
       timeout-minutes: 10


### PR DESCRIPTION
Signed-off-by: Paul Guyot <pguyot@kallisys.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
