### PR TITLE
Fix binary_to_list/1: values should be unsigned, in 0..255 range

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1685,7 +1685,7 @@ static term nif_erlang_binary_to_list_1(Context *ctx, int argc, term argv[])
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
-    const char *bin_data = term_binary_data(argv[0]);
+    const uint8_t *bin_data = (const uint8_t *) term_binary_data(argv[0]);
 
     term prev = term_nil();
     for (int i = bin_size - 1; i >= 0; i--) {

--- a/tests/erlang_tests/test_binary_to_list.erl
+++ b/tests/erlang_tests/test_binary_to_list.erl
@@ -20,32 +20,35 @@
 
 -module(test_binary_to_list).
 
--export([start/0, id/1, concat_bin/2, safelen/1, compare_list/2]).
+-export([start/0, id/1, concat_bin/2]).
 
 start() ->
     L1 = concat_bin(<<"This">>, <<" is">>),
     L2 = concat_bin(<<" a ">>, <<"list">>),
     L3 = concat_bin(<<".">>, <<"">>),
     TheList = L1 ++ L2 ++ L3,
-    compare_list("This is a list.", TheList) + safelen({1, 2, 3}).
+    true = "This is a list." =:= TheList,
+    ok = test_badarg(),
+    ok = test_sign(),
+    0.
 
-safelen(Bin) ->
-    try binary_to_list(id(Bin)) of
-        L -> length(L) + 1
+test_badarg() ->
+    Bin = id({1, 2, 3}),
+    try
+        _ = binary_to_list(Bin),
+        fail_no_ex
     catch
-        error:badarg -> 0;
-        _:_ -> -1
+        error:badarg -> ok;
+        _:_ -> fail_other_ex
     end.
 
 concat_bin(Bin1, Bin2) ->
     binary_to_list(Bin1) ++ binary_to_list(Bin2).
 
-compare_list([], []) ->
-    1;
-compare_list([H_A | T_A], [H_B | T_B]) when H_A == H_B ->
-    compare_list(T_A, T_B);
-compare_list(_A, _B) ->
-    0.
-
 id(X) ->
     X.
+
+test_sign() ->
+    B = id(<<255>>),
+    [255] = binary_to_list(B),
+    ok.

--- a/tests/test.c
+++ b/tests/test.c
@@ -270,7 +270,7 @@ struct Test tests[] = {
 
     TEST_CASE_EXPECTED(test_integer_to_binary, 2),
     TEST_CASE_EXPECTED(test_list_to_binary, 1),
-    TEST_CASE_EXPECTED(test_binary_to_list, 1),
+    TEST_CASE_EXPECTED(test_binary_to_list, 0),
     TEST_CASE_EXPECTED(test_atom_to_binary, 1),
 
     TEST_CASE_EXPECTED(test_binary_part, 12),


### PR DESCRIPTION
Signed-off-by: Paul Guyot <pguyot@kallisys.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
