### PR TITLE
Add support for erlang:integer_to_list/2 with bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Elixir I2C driver and example
 - Added the ability to specify the I2C port
 - Added support for the OTP `math` module
+- Added support for `erlang:integer_to_list/2` and `erlang:integer_to_binary/2`
+
+### Fixed
+- Fixed issue with formatting integers with io:format() on STM32 platform
 
 ### Breaking Changes
 

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -57,7 +57,9 @@ erlang:insert_element/3, &insert_element_nif
 erlang:list_to_atom/1, &list_to_atom_nif
 erlang:list_to_existing_atom/1, &list_to_existing_atom_nif
 erlang:integer_to_binary/1, &integer_to_binary_nif
+erlang:integer_to_binary/2, &integer_to_binary_nif
 erlang:integer_to_list/1, &integer_to_list_nif
+erlang:integer_to_list/2, &integer_to_list_nif
 erlang:link/1, &link_nif
 erlang:list_to_binary/1, &list_to_binary_nif
 erlang:list_to_integer/1, &list_to_integer_nif

--- a/tests/erlang_tests/test_integer_to_binary.erl
+++ b/tests/erlang_tests/test_integer_to_binary.erl
@@ -20,13 +20,20 @@
 
 -module(test_integer_to_binary).
 
--export([start/0, some_calculation/2, compare_bin/3]).
+-export([start/0, some_calculation/2, compare_bin/3, id/1]).
 
 start() ->
+    ok = test_decimal(),
+    ok = test_bases(),
+    0.
+
+test_decimal() ->
     NewBin1 = integer_to_binary(some_calculation(20, -2)),
     NewBin2 = integer_to_binary(some_calculation(1780, 0)),
-    compare_bin(NewBin1, <<"-1">>) + compare_bin(NewBin2, <<"89">>) -
-        compare_bin(NewBin1, <<"+1">>) * 10 - compare_bin(NewBin2, <<"88">>) * 100.
+    2 =
+        compare_bin(NewBin1, <<"-1">>) + compare_bin(NewBin2, <<"89">>) -
+            compare_bin(NewBin1, <<"+1">>) * 10 - compare_bin(NewBin2, <<"88">>) * 100,
+    ok.
 
 some_calculation(N, A) when is_integer(N) and is_integer(A) ->
     N div 20 + A;
@@ -46,3 +53,31 @@ compare_bin(Bin1, Bin2, Index) ->
         _Any ->
             0
     end.
+
+test_bases() ->
+    <<"0">> = integer_to_binary(?MODULE:id(0)),
+    <<"0">> = integer_to_binary(?MODULE:id(0), 10),
+    <<"-1">> = integer_to_binary(?MODULE:id(-1)),
+    <<"-1010">> = integer_to_binary(?MODULE:id(-10), 2),
+    <<"1010">> = integer_to_binary(?MODULE:id(10), 2),
+    <<"A">> = integer_to_binary(?MODULE:id(10), 16),
+    <<"123456789ABCDEF0">> = integer_to_binary(?MODULE:id(16#123456789ABCDEF0), 16),
+    <<"7FFFFFFFFFFFFFFF">> = integer_to_binary(?MODULE:id(16#7FFFFFFFFFFFFFFF), 16),
+    <<"-8000000000000000">> = integer_to_binary(?MODULE:id(-16#8000000000000000), 16),
+    <<"A">> = integer_to_binary(?MODULE:id(10), 36),
+    assert_badarg(fun() -> integer_to_binary(?MODULE:id(10), 1) end),
+    assert_badarg(fun() -> integer_to_binary(?MODULE:id(10), 0) end),
+    assert_badarg(fun() -> integer_to_binary(?MODULE:id(10), -1) end),
+    assert_badarg(fun() -> integer_to_binary(?MODULE:id(10), 37) end),
+    ok.
+
+assert_badarg(F) ->
+    ok =
+        try
+            F(),
+            fail_no_ex
+        catch
+            error:badarg -> ok
+        end.
+
+id(I) -> I.

--- a/tests/erlang_tests/test_integer_to_list.erl
+++ b/tests/erlang_tests/test_integer_to_list.erl
@@ -20,13 +20,19 @@
 
 -module(test_integer_to_list).
 
--export([start/0, some_calculation/2, concat_integers/2, compare_list/2]).
+-export([start/0, some_calculation/2, concat_integers/2, compare_list/2, id/1]).
 
 start() ->
+    ok = test_decimal(),
+    ok = test_bases(),
+    0.
+
+test_decimal() ->
     NewList =
         concat_integers(some_calculation(100, 1), some_calculation(100, hello)) ++
             concat_integers(a, []),
-    compare_list(NewList, "6,-1").
+    1 = compare_list(NewList, "6,-1"),
+    ok.
 
 some_calculation(N, A) when is_integer(N) and is_integer(A) ->
     N div 20 + A;
@@ -56,3 +62,66 @@ compare_list([H_A | T_A], [H_B | T_B]) when H_A == H_B ->
     compare_list(T_A, T_B);
 compare_list(_A, _B) ->
     0.
+
+test_bases() ->
+    "0" = integer_to_list(?MODULE:id(0)),
+    "0" = integer_to_list(?MODULE:id(0), 10),
+    "-1" = integer_to_list(?MODULE:id(-1)),
+    "-1010" = integer_to_list(?MODULE:id(-10), 2),
+    "1010" = integer_to_list(?MODULE:id(10), 2),
+    "A" = integer_to_list(?MODULE:id(10), 16),
+    "123456789ABCDEF0" = integer_to_list(?MODULE:id(16#123456789ABCDEF0), 16),
+    "7FFFFFFFFFFFFFFF" = integer_to_list(?MODULE:id(16#7FFFFFFFFFFFFFFF), 16),
+    "-8000000000000000" = integer_to_list(?MODULE:id(-16#8000000000000000), 16),
+    "A" = integer_to_list(?MODULE:id(10), 36),
+    assert_badarg(fun() -> integer_to_list(?MODULE:id(10), 1) end),
+    assert_badarg(fun() -> integer_to_list(?MODULE:id(10), 0) end),
+    assert_badarg(fun() -> integer_to_list(?MODULE:id(10), -1) end),
+    assert_badarg(fun() -> integer_to_list(?MODULE:id(10), 37) end),
+    "100111000000110010111011010010" = integer_to_list(?MODULE:id(654520018), 2),
+    "1200121121001200011" = integer_to_list(?MODULE:id(654520018), 3),
+    "213000302323102" = integer_to_list(?MODULE:id(654520018), 4),
+    "2320024120033" = integer_to_list(?MODULE:id(654520018), 5),
+    "144540345134" = integer_to_list(?MODULE:id(654520018), 6),
+    "22135220425" = integer_to_list(?MODULE:id(654520018), 7),
+    "4700627322" = integer_to_list(?MODULE:id(654520018), 8),
+    "1617531604" = integer_to_list(?MODULE:id(654520018), 9),
+    "654520018" = integer_to_list(?MODULE:id(654520018), 10),
+    "306506639" = integer_to_list(?MODULE:id(654520018), 11),
+    "1632451AA" = integer_to_list(?MODULE:id(654520018), 12),
+    "A57A7469" = integer_to_list(?MODULE:id(654520018), 13),
+    "62CD99BC" = integer_to_list(?MODULE:id(654520018), 14),
+    "3C6DBCCD" = integer_to_list(?MODULE:id(654520018), 15),
+    "27032ED2" = integer_to_list(?MODULE:id(654520018), 16),
+    "1A1GA129" = integer_to_list(?MODULE:id(654520018), 17),
+    "1146H194" = integer_to_list(?MODULE:id(654520018), 18),
+    "DH66IG0" = integer_to_list(?MODULE:id(654520018), 19),
+    "A4AF00I" = integer_to_list(?MODULE:id(654520018), 20),
+    "7D59I7J" = integer_to_list(?MODULE:id(654520018), 21),
+    "5H00I1K" = integer_to_list(?MODULE:id(654520018), 22),
+    "49FKFL2" = integer_to_list(?MODULE:id(654520018), 23),
+    "3A4IFBA" = integer_to_list(?MODULE:id(654520018), 24),
+    "2H0E70I" = integer_to_list(?MODULE:id(654520018), 25),
+    "2327AMM" = integer_to_list(?MODULE:id(654520018), 26),
+    "1IGG1I4" = integer_to_list(?MODULE:id(654520018), 27),
+    "1A0NQQQ" = integer_to_list(?MODULE:id(654520018), 28),
+    "12QBJSN" = integer_to_list(?MODULE:id(654520018), 29),
+    "QS1EDS" = integer_to_list(?MODULE:id(654520018), 30),
+    "MQMC6U" = integer_to_list(?MODULE:id(654520018), 31),
+    "JG6BMI" = integer_to_list(?MODULE:id(654520018), 32),
+    "GNTWFV" = integer_to_list(?MODULE:id(654520018), 33),
+    "EDQPQQ" = integer_to_list(?MODULE:id(654520018), 34),
+    "CG5R1X" = integer_to_list(?MODULE:id(654520018), 35),
+    "ATOMVM" = integer_to_list(?MODULE:id(654520018), 36),
+    ok.
+
+assert_badarg(F) ->
+    ok =
+        try
+            F(),
+            fail_no_ex
+        catch
+            error:badarg -> ok
+        end.
+
+id(I) -> I.

--- a/tests/test.c
+++ b/tests/test.c
@@ -152,7 +152,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(test_binary_to_existing_atom, 9),
     TEST_CASE_EXPECTED(test_atom_to_list, 1),
     TEST_CASE(test_display),
-    TEST_CASE_EXPECTED(test_integer_to_list, 1),
+    TEST_CASE(test_integer_to_list),
     TEST_CASE_EXPECTED(test_list_to_integer, 99),
     TEST_CASE_EXPECTED(test_abs, 5),
     TEST_CASE_EXPECTED(test_is_process_alive, 121),
@@ -268,7 +268,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(binary_first_test, 82),
     TEST_CASE_EXPECTED(binary_last_test, 110),
 
-    TEST_CASE_EXPECTED(test_integer_to_binary, 2),
+    TEST_CASE(test_integer_to_binary),
     TEST_CASE_EXPECTED(test_list_to_binary, 1),
     TEST_CASE_EXPECTED(test_binary_to_list, 1),
     TEST_CASE_EXPECTED(test_atom_to_binary, 1),


### PR DESCRIPTION
Also for erlang:integer_to_binary/2
This should fix an issue with io:format on STM32.

Signed-off-by: Paul Guyot <pguyot@kallisys.net>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
