### PR TITLE
Update stm32 gpio driver

### DIFF
--- a/libs/eavmlib/src/gpio.erl
+++ b/libs/eavmlib/src/gpio.erl
@@ -43,6 +43,9 @@
 %%
 %% This module provides functions for interacting with micro-controller GPIO
 %% (General Purpose Input and Output) pins.
+%%
+%% Note: `-type pin()' used in this driver refers to a pin number on Espressif
+%% chips, or a tuple {GPIO_GROUP, PIN} for stm32 chips.
 %% @end
 %%-----------------------------------------------------------------------------
 -module(gpio).
@@ -62,7 +65,7 @@
 ]).
 
 -type gpio() :: pid().
--type pin() :: non_neg_integer().
+-type pin() :: non_neg_integer() | {atom(), non_neg_integer()}.
 -type direction() :: input | output | output_od.
 -type pull() :: up | down | up_down | floating.
 -type low_level() :: low | 0.

--- a/libs/exavmlib/lib/GPIO.ex
+++ b/libs/exavmlib/lib/GPIO.ex
@@ -28,8 +28,10 @@ defmodule GPIO do
   Valid GPIO pin number.
 
   The actual number of pins that are broken out vary by board and module.
+  For espressif chips this a the pin number marked on the board or data sheet.
+  For stm32 chips this is a tuple {GPIO_GROUP, PIN_NUMBER}.
   """
-  @type gpio_pin() :: non_neg_integer()
+  @type gpio_pin() :: non_neg_integer() | {atom(), non_neg_integer()}
 
   @typedoc """
   Event type describing the voltage that will trigger an interrupt.


### PR DESCRIPTION
Restores functionality to the stm32 gpio driver by updating mailbox message parsing to match updates to the the erlang and elixir drivers. Modifies the `pin() type` in both versions of the gpio driver to accommodate tuples used in the stm32 port.

Signed-off-by: Winford <winford@object.stream>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
