### PR TITLE
Improvements to stm32 build artifacts

### DIFF
--- a/src/platforms/stm32/CMakeLists.txt
+++ b/src/platforms/stm32/CMakeLists.txt
@@ -20,6 +20,8 @@
 
 cmake_minimum_required (VERSION 3.13)
 project(AtomVM)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
 
 # Options that make sense for this platform
 option(AVM_DISABLE_FP "Disable floating point support." OFF)

--- a/src/platforms/stm32/cmake/compile-flags.cmake
+++ b/src/platforms/stm32/cmake/compile-flags.cmake
@@ -39,12 +39,15 @@ set(C_WARN_FLAGS "${COMMON_WARN_FLAGS} -Wbad-function-cast -Wmissing-prototypes 
 set(CXX_WARN_FLAGS "${COMMON_WARN_FLAGS} -Wctor-dtor-privacy -Wnoexcept -Wold-style-cast -Woverloaded-virtual \
 -Wsign-promo -Wstrict-null-sentinel -Wuseless-cast -Wzero-as-null-pointer-constant")
 
+# Use C and C++ compiler optimizatons for size and speed.
+set(OPTIMIZE_FLAG "-O2")
+
 # Pass them back to the CMake variable
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_WARN_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_WARN_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_WARN_FLAGS} ${OPTIMIZE_FLAG}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_WARN_FLAGS} ${OPTIMIZE_FLAG}")
 
 if (LOG_VERBOSE)
-    message("-------------Warning Flags--------------")
-    message(STATUS "C   : ${C_WARN_FLAGS}")
-    message(STATUS "CXX : ${CXX_WARN_FLAGS}")
+    message("--------------Build Flags---------------")
+    message(STATUS "C   : ${CMAKE_C_FLAGS}")
+    message(STATUS "CXX : ${CMAKE_CXX_FLAGS}")
 endif ()

--- a/src/platforms/stm32/cmake/libopencm3.cmake
+++ b/src/platforms/stm32/cmake/libopencm3.cmake
@@ -137,15 +137,15 @@ string(REPLACE " " ";" ARCH_FLAGS ${ARCH_FLAGS})
 # ------------------
 execute_process(
     COMMAND ${ARM_CXX} ${ARCH_FLAGS} ${GENLINK_DEFS} "-P" "-E" "${LIBOPENCM3_DIR}/ld/linker.ld.S"
-    OUTPUT_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_SCRIPT}"
+    OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/${LINKER_SCRIPT}"
 )
 message("-----------Target Specific Info---------")
-message(STATUS "Generated Linker File   : .../${LINKER_SCRIPT}")
+message(STATUS "Generated Linker File   : ${CMAKE_CURRENT_BINARY_DIR}/${LINKER_SCRIPT}")
 
 # ARCH_FLAGS has to be passed as a string here
 JOIN("${ARCH_FLAGS}" " " ARCH_FLAGS)
 # Set linker flags
-set(LINKER_FLAGS "${LINKER_FLAGS} -specs=nosys.specs -specs=nano.specs -nostartfiles -T${CMAKE_CURRENT_SOURCE_DIR}/${LINKER_SCRIPT} ${ARCH_FLAGS}")
+set(LINKER_FLAGS "${LINKER_FLAGS} -specs=nosys.specs -specs=nano.specs -nostartfiles -T${CMAKE_CURRENT_BINARY_DIR}/${LINKER_SCRIPT} ${ARCH_FLAGS}")
 message(STATUS "Linker Flags            : ${LINKER_FLAGS}")
 
 # Compiler flags
@@ -166,25 +166,25 @@ macro(add_executable _name)
     if (TARGET ${_name} AND NOT ${_name} MATCHES ".*Doxygen.*")
         # Set target properties
         set_target_properties(${_name} PROPERTIES LINK_FLAGS ${LINKER_FLAGS})
-        set_target_properties(${_name} PROPERTIES OUTPUT_NAME "${PROJECT_NAME}.elf")
+        set_target_properties(${_name} PROPERTIES OUTPUT_NAME "${PROJECT_EXECUTABLE}")
 
         # Set output file locations
         string(REGEX MATCH "^(.*)\\.[^.]*$" dummy "${_name}")
         set(bin ${CMAKE_MATCH_1}.bin)
         set(elf ${_name})
         set(bin_out ${CMAKE_MATCH_1}.bin)
-        get_target_property(elf_in ${PROJECT_NAME}.elf OUTPUT_NAME)
+        get_target_property(elf_in ${PROJECT_EXECUTABLE} OUTPUT_NAME)
 
         # Add target
         add_custom_target(
             ${bin} ALL
             COMMAND ${ARM_OBJCOPY} -Obinary ${elf_in} ${bin_out}
-            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             DEPENDS ${elf}
         )
 
         message("------------Output Locations------------")
-        message(STATUS "BIN: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${bin_out}")
-        message(STATUS "ELF: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${elf_in}")
+        message(STATUS "BIN: ${CMAKE_BINARY_DIR}/${bin_out}")
+        message(STATUS "ELF: ${CMAKE_BINARY_DIR}/${elf_in}")
     endif ()
 endmacro()

--- a/src/platforms/stm32/src/CMakeLists.txt
+++ b/src/platforms/stm32/src/CMakeLists.txt
@@ -21,7 +21,7 @@
 cmake_minimum_required (VERSION 3.13)
 
 # Specify output executable
-set(PROJECT_EXECUTABLE ${PROJECT_NAME}.elf)
+set(PROJECT_EXECUTABLE ${PROJECT_NAME}-${DEVICE}.elf)
 add_executable(${PROJECT_EXECUTABLE} main.c)
 
 target_compile_features(${PROJECT_EXECUTABLE} PUBLIC c_std_11)
@@ -45,6 +45,6 @@ target_link_libraries(${PROJECT_EXECUTABLE} PRIVATE libAtomVM${PLATFORM_LIB_SUFF
 add_custom_command(
     TARGET ${PROJECT_EXECUTABLE}
     POST_BUILD
-    COMMAND ${ARM_SIZE} ${PROJECT_NAME}.elf
+    COMMAND ${ARM_SIZE} ${PROJECT_EXECUTABLE}
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 )


### PR DESCRIPTION
This changes the location of the generated linker script to the `build` directory, from the stm32 root directory. The `${DEVICE}` name is added to the binary files. Binaries are in the root of the `build` directory, rather than in `build/src`. Adds `-O2` compiler flag to reduce the size of the final binary and speed up execution.

Signed-off-by: Winford <winford@object.stream>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
