### PR TITLE
Fix stm32 warnings

### DIFF
--- a/src/platforms/stm32/src/CMakeLists.txt
+++ b/src/platforms/stm32/src/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(${PROJECT_EXECUTABLE} main.c)
 
 target_compile_features(${PROJECT_EXECUTABLE} PUBLIC c_std_11)
 if(CMAKE_COMPILER_IS_GNUCC)
-    target_compile_options(${PROJECT_EXECUTABLE} PUBLIC -Wall -pedantic -Wextra -ggdb)
+    target_compile_options(${PROJECT_EXECUTABLE} PUBLIC -Wall -pedantic -Wextra -ggdb -std=gnu11)
 endif()
 
 add_subdirectory(lib)

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -26,6 +26,9 @@
 
 #include "gpiodriver.h"
 
+void sys_tick_handler();
+void sys_set_timestamp_from_relative_to_abs(struct timespec *t, int32_t millis);
+
 // Monotonically increasing number of milliseconds from reset
 // Overflows every 49 days
 // TODO: use 64 bit (remember to take into account atomicity)

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -51,13 +51,13 @@ static void msleep(uint32_t delay)
 
 static inline void sys_clock_gettime(struct timespec *t)
 {
-    t->tv_sec = system_millis / 1000;
-    t->tv_nsec = (system_millis % 1000) * 1000000;
+    t->tv_sec = (time_t) system_millis / 1000;
+    t->tv_nsec = ((int32_t) system_millis % 1000) * 1000000;
 }
 
 static int32_t timespec_diff_to_ms(struct timespec *timespec1, struct timespec *timespec2)
 {
-    return (timespec1->tv_sec - timespec2->tv_sec) * 1000 + (timespec1->tv_nsec - timespec2->tv_nsec) / 1000000;
+    return (int32_t) ((timespec1->tv_sec - timespec2->tv_sec) * 1000 + (timespec1->tv_nsec - timespec2->tv_nsec) / 1000000);
 }
 
 void sys_init_platform(GlobalContext *glb)


### PR DESCRIPTION
This fixes the compiler warnings specific to the stm32 port. The remainder of the warnings when compiling for stm32 are from libAtomVM and related to the API type mismatches.

This is part of meta issue #255.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
