### PR TITLE
Add image creation workflow for esp32 family

### DIFF
--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -1,0 +1,114 @@
+#
+#  Copyright 2022 Fred Dushin <fred@dushin.net>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+name: esp32-mkimage
+
+on:
+  workflow_run:
+    workflows: ["ESP32 Builds"]
+    types: ["completed"]
+
+
+jobs:
+  esp32-release:
+    runs-on: ubuntu-latest
+    container: espressif/idf:v${{ matrix.idf-version }}
+
+    strategy:
+      matrix:
+        idf-version: ["4.4.3"]
+        cc: ["clang-10"]
+        cxx: ["clang++-10"]
+        cflags: ["-O3"]
+        otp: ["24"]
+        elixir_version: ["1.11"]
+        compiler_pkgs: ["clang-10"]
+        soc: ["esp32", "esp32c3", "esp32s2", "esp32s3"]
+
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+      CFLAGS: ${{ matrix.cflags }}
+      CXXFLAGS: ${{ matrix.cflags }}
+      ImageOS: "ubuntu20"
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ matrix.otp }}
+        elixir-version: ${{ matrix.elixir_version }}
+
+    - name: "APT update"
+      run: apt update -y
+
+    - name: "Install deps"
+      run: DEBIAN_FRONTEND=noninteractive apt install -y ${{ matrix.compiler_pkgs}} git cmake gperf zlib1g-dev
+
+    # needed for generating AtomVM version when running in a docker container
+    - name: "Configure Git"
+      run: |
+        git config --global --add safe.directory /__w/AtomVM/AtomVM
+        echo -n "git rev-parse: "
+        git rev-parse --short HEAD
+
+    # Builder info
+    - name: "System info"
+      run: |
+        echo "**uname:**"
+        uname -a
+        echo "**libc version:**"
+        ldd --version
+        echo "**C Compiler version:**"
+        $CC --version
+        $CXX --version
+        echo "**Linker version:**"
+        ld --version
+        echo "**CMake version:**"
+        cmake --version
+        echo "**OTP version:**"
+        cat $(dirname $(which erlc))/../releases/RELEASES || true
+
+    - name: "Build: create build dir"
+      run: mkdir build
+
+    - name: "Build: run cmake"
+      working-directory: build
+      run: |
+        cmake ..
+        # git clone will use more recent timestamps than cached beam files
+        # touch them so we can benefit from the cache and avoid costly beam file rebuild.
+        find . -name '*.beam' -exec touch {} \;
+
+    - name: "Build erlang and Elixir libs"
+      working-directory: build/libs
+      run: |
+        make
+
+    - name: "Build ${{ matrix.soc }} with idf.py"
+      shell: bash
+      working-directory: ./src/platforms/esp32/
+      run: |
+        rm -rf build
+        . $IDF_PATH/export.sh
+        idf.py set-target ${{ matrix.soc }}
+        idf.py reconfigure
+        idf.py build
+
+    - name: "Create a ${{ matrix.soc }} image"
+      working-directory: ./src/platforms/esp32/build
+      run: |
+        ./mkimage.sh
+        ls -l *.img
+
+    - name: "Upload ${{ matrix.soc }} artifacts"
+      uses: actions/upload-artifact@v3
+      with:
+        name: atomvm-${{ matrix.soc }}-image
+        path: ./src/platforms/esp32/build/atomvm-${{ matrix.soc }}-*.img
+        if-no-files-found: error

--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -255,8 +255,10 @@ static term nif_esp_deep_sleep(Context *ctx, int argc, term argv[])
     // technically, this function does not return
     return OK_ATOM;
 }
+#if SOC_PM_SUPPORT_EXT_WAKEUP
 static const char *const sleep_wakeup_ext0_atom = "\x11" "sleep_wakeup_ext0";
 static const char *const sleep_wakeup_ext1_atom = "\x11" "sleep_wakeup_ext1";
+#endif
 static const char *const sleep_wakeup_timer_atom = "\x12" "sleep_wakeup_timer";
 static const char *const sleep_wakeup_touchpad_atom = "\x15" "sleep_wakeup_touchpad";
 static const char *const sleep_wakeup_ulp_atom = "\x10" "sleep_wakeup_ulp";
@@ -285,10 +287,12 @@ static term nif_esp_sleep_get_wakeup_cause(Context *ctx, int argc, term argv[])
     switch (cause) {
         case ESP_SLEEP_WAKEUP_UNDEFINED:
             return UNDEFINED_ATOM;
+#if SOC_PM_SUPPORT_EXT_WAKEUP
         case ESP_SLEEP_WAKEUP_EXT0:
             return context_make_atom(ctx, sleep_wakeup_ext0_atom);
         case ESP_SLEEP_WAKEUP_EXT1:
             return context_make_atom(ctx, sleep_wakeup_ext1_atom);
+#endif
         case ESP_SLEEP_WAKEUP_TIMER:
             return context_make_atom(ctx, sleep_wakeup_timer_atom);
         case ESP_SLEEP_WAKEUP_TOUCHPAD:
@@ -319,6 +323,8 @@ static term nif_esp_sleep_get_wakeup_cause(Context *ctx, int argc, term argv[])
             return ERROR_ATOM;
     }
 }
+
+#if SOC_PM_SUPPORT_EXT_WAKEUP
 
 static term nif_esp_sleep_enable_ext0_wakeup(Context *ctx, int argc, term argv[])
 {
@@ -355,6 +361,8 @@ static term nif_esp_sleep_enable_ext1_wakeup(Context *ctx, int argc, term argv[]
     }
     return OK_ATOM;
 }
+
+#endif
 
 static term nif_rom_md5(Context *ctx, int argc, term argv[])
 {
@@ -434,6 +442,7 @@ static const struct Nif esp_sleep_get_wakeup_cause_nif =
     .base.type = NIFFunctionType,
     .nif_ptr = nif_esp_sleep_get_wakeup_cause
 };
+#if SOC_PM_SUPPORT_EXT_WAKEUP
 static const struct Nif esp_sleep_enable_ext0_wakeup_nif =
 {
     .base.type = NIFFunctionType,
@@ -444,6 +453,7 @@ static const struct Nif esp_sleep_enable_ext1_wakeup_nif =
     .base.type = NIFFunctionType,
     .nif_ptr = nif_esp_sleep_enable_ext1_wakeup
 };
+#endif
 static const struct Nif rom_md5_nif =
 {
     .base.type = NIFFunctionType,
@@ -497,6 +507,7 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &esp_sleep_get_wakeup_cause_nif;
     }
+#if SOC_PM_SUPPORT_EXT_WAKEUP
     if (strcmp("esp:sleep_enable_ext0_wakeup/2", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &esp_sleep_enable_ext0_wakeup_nif;
@@ -505,6 +516,7 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &esp_sleep_enable_ext1_wakeup_nif;
     }
+#endif
     if (strcmp("erlang:md5/1", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &rom_md5_nif;


### PR DESCRIPTION
This PR adds a GitHub workflow to build complete images for the ESP32 family of chipsets, including

* esp32
* esp32c3
* esp32s2
* esp32s3

Images are available as artifacts that can be downloaded after the build completes.

This workflow will be run after a successful run of the ESP32 Build workflow.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
