### PR TITLE
nifs.c: fix bogus may be used uninitialized

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3329,7 +3329,7 @@ static term base64_decode(Context *ctx, int argc, term argv[], bool return_binar
     if (UNLIKELY(memory_ensure_free(ctx, heap_free) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
-    term dst;
+    term dst = term_invalid_term();
     uint8_t *dst_pos, *dst_buf = NULL;
     if (return_binary) {
         dst = term_create_empty_binary(dst_size, ctx);


### PR DESCRIPTION
xtensa GCC 8.4.0 when using additional optimization level is reporting bogus: "error: 'dst' may be used uninitialized" in base64 function.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
