### PR TITLE
opcodesswitch.h: fix build after #442

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -2204,9 +2204,9 @@ wait_timeout_trap_handler:
                 // Redo the offset computation and refetch the label
                 int next_off = 1;
                 int label;
-                DECODE_LABEL(label, code, i, next_off, next_off)
+                DECODE_LABEL(label, code, i, next_off)
                 int timeout;
-                DECODE_COMPACT_TERM(timeout, code, i, next_off, next_off)
+                DECODE_COMPACT_TERM(timeout, code, i, next_off)
                 TRACE("wait_timeout_trap_handler, label: %i\n", label);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"


### PR DESCRIPTION
DECODE_LABEL and DECODE_COMPACT_TERM have been changed in order to remove redundant offset parameter.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
