### PR TITLE
Embed instead of alloc

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -124,7 +124,7 @@ GlobalContext *globalcontext_new()
     sys_init_platform(glb);
 
 #ifndef AVM_NO_SMP
-    glb->schedulers_mutex = smp_mutex_create();
+    smp_mutex_init(&glb->schedulers_mutex);
     if (IS_NULL_PTR(glb->schedulers_mutex)) {
         smp_rwlock_destroy(glb->modules_lock);
         free(glb->modules_table);
@@ -135,7 +135,7 @@ GlobalContext *globalcontext_new()
     }
     glb->schedulers_cv = smp_condvar_create();
     if (IS_NULL_PTR(glb->schedulers_cv)) {
-        smp_mutex_destroy(glb->schedulers_mutex);
+        smp_mutex_deinit(&glb->schedulers_mutex);
         smp_rwlock_destroy(glb->modules_lock);
         free(glb->modules_table);
         free(glb->atoms_ids_table);
@@ -158,7 +158,7 @@ COLD_FUNC void globalcontext_destroy(GlobalContext *glb)
 
 #ifndef AVM_NO_SMP
     smp_condvar_destroy(glb->schedulers_cv);
-    smp_mutex_destroy(glb->schedulers_mutex);
+    smp_mutex_deinit(&glb->schedulers_mutex);
     smp_rwlock_destroy(glb->modules_lock);
 #endif
     synclist_destroy(&glb->registered_processes);

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -183,7 +183,7 @@ Module *module_new_from_iff_binary(GlobalContext *global, const void *iff_binary
     mod->global = global;
 
 #ifndef AVM_NO_SMP
-    mod->mutex = smp_mutex_create();
+    smp_mutex_init(&mod->mutex);
 #endif
 
     if (UNLIKELY(module_populate_atoms_table(mod, beam_file + offsets[AT8U]) != MODULE_LOAD_OK)) {
@@ -255,7 +255,7 @@ COLD_FUNC void module_destroy(Module *module)
         free(module->literals_data);
     }
 #ifndef AVM_NO_SMP
-    smp_mutex_destroy(module->mutex);
+    smp_mutex_deinit(&module->mutex);
 #endif
     free(module);
 }

--- a/src/libAtomVM/smp.h
+++ b/src/libAtomVM/smp.h
@@ -96,13 +96,13 @@ struct SpinLock
  * @brief Create a new mutex.
  * @return a pointer to a mutex.
  */
-Mutex *smp_mutex_create();
+void smp_mutex_init(Mutex *mtx);
 
 /**
  * @brief Destroy a mutex.
  * @param mtx the mutex to destroy
  */
-void smp_mutex_destroy(Mutex *mtx);
+void smp_mutex_deinit(Mutex *mtx);
 
 /**
  * @brief Lock a mutex.

--- a/src/platforms/generic_unix/lib/smp.c
+++ b/src/platforms/generic_unix/lib/smp.c
@@ -96,24 +96,18 @@ bool smp_is_main_thread(GlobalContext *glb)
 #endif
 }
 
-Mutex *smp_mutex_create()
+void smp_mutex_init(Mutex *mtx)
 {
-    Mutex *result = malloc(sizeof(Mutex));
-    if (UNLIKELY(result == NULL && sizeof(Mutex) > 0)) {
-        AVM_ABORT();
-    }
     if (UNLIKELY(pthread_mutex_init(&result->mutex, NULL))) {
         AVM_ABORT();
     }
-    return result;
 }
 
-void smp_mutex_destroy(Mutex *mtx)
+void smp_mutex_deinit(Mutex *mtx)
 {
     if (UNLIKELY(pthread_mutex_destroy(&mtx->mutex))) {
         AVM_ABORT();
     }
-    free(mtx);
 }
 
 void smp_mutex_lock(Mutex *mtx)

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -415,7 +415,7 @@ void sys_init_platform(GlobalContext *global)
     }
     list_init(&platform->listeners);
 #ifndef AVM_NO_SMP
-    platform->listeners_mutex = smp_mutex_create();
+    smp_mutex_create(&platform->listeners_mutex);
 #endif
 #ifdef HAVE_KQUEUE
     platform->kqueue_fd = kqueue();
@@ -462,7 +462,7 @@ void sys_free_platform(GlobalContext *global)
 {
     struct GenericUnixPlatformData *platform = global->platform_data;
 #ifndef AVM_NO_SMP
-    smp_mutex_destroy(platform->listeners_mutex);
+    smp_mutex_deinit(&platform->listeners_mutex);
 #endif
 
 #ifdef HAVE_KQUEUE


### PR DESCRIPTION
Right now Mutex and the other synchronization objects are inside structs that are malloc-ated on the heap.
This introduces both some overhead, since each allocated object has a memory cost, and more complex error handling since malloc might fail.

This PR aims to directly embed the synchronization objects inside of existing structs, and to make the `smp_`* functions thin wrappers around `pthread_mutex_`* or other primitives.

So following changes have been made:
`MyObj *smp_myobj_create()` -> `void smp_myobj_init(MyObj *obj)`
`void smp_myobj_destroy(MyObj *obj)` -> `void smp_myobj_deinit(MyObj *obj)`

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
