### PR TITLE
mailbox: add port driver friendly functions

### DIFF
--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -239,7 +239,42 @@ static inline bool mailbox_has_next(Mailbox *mbox)
  * @param out the allocated term.
  * @returns true if a term was available
  */
+// TODO: this function might be renamed to `mailbox_peek_term`.
 bool mailbox_peek(Context *ctx, term *out);
+
+/**
+ * @brief Gets next \c Message from a mailbox (without removing it).
+ *
+ * @details Peek the mailbox and retrieve a Message that has been previously
+ * queued on a certain process or driver mailbox. To be called from the process
+ * only.
+ * @param mbox the mailbox.
+ * @param out the found message, if any.
+ * @returns true if a \c Message was available
+ */
+// TODO: this function might be renamed to `mailbox_peek`.
+bool mailbox_peek_message(Mailbox *mbox, Message **out);
+
+/**
+ * @brief Detaches a \c Message from mailbox.
+ *
+ * @details It takes a message out of the mailbox, so it can be handled safely from outside the
+ * context thread. To be called from the process only.
+ * @param mbox the mailbox.
+ * @param message the Message that will be removed from the mailbox.
+ * @returns true if a \c Message was available
+ */
+void mailbox_take_message(Mailbox *mbox, Message *message);
+
+/**
+ * @brief Remove given \c Message from mailbox.
+ *
+ * @details Discard a \c Message that has been previously queued on a certain process
+ * or driver mailbox. To be called from the process only.
+ * @param mbox the mailbox to remove message from.
+ * @param message the Message that will be removed and deleted.
+ */
+void mailbox_remove_message(Mailbox *mbox, Message *message);
 
 /**
  * @brief Remove next message from mailbox.

--- a/tests/test-mailbox.c
+++ b/tests/test-mailbox.c
@@ -128,6 +128,108 @@ void test_mailbox_next()
     globalcontext_destroy(glb);
 }
 
+void test_mailbox_api_for_port_drivers()
+{
+    GlobalContext *glb = globalcontext_new();
+    Context *ctx = context_new(glb);
+
+    mailbox_send(ctx, term_from_int(1));
+    mailbox_send(ctx, term_from_int(2));
+    mailbox_send(ctx, term_from_int(3));
+    mailbox_send(ctx, term_from_int(4));
+    mailbox_send(ctx, term_from_int(5));
+
+    assert(mailbox_process_outer_list(&ctx->mailbox) == NULL);
+    Message *msg1;
+    assert(mailbox_peek_message(&ctx->mailbox, &msg1));
+    assert(1 == term_to_int(msg1->message));
+
+    // mailbox_peek_message doesn't move next
+    Message *msg1b;
+    assert(mailbox_peek_message(&ctx->mailbox, &msg1b));
+    assert(1 == term_to_int(msg1b->message));
+
+    mailbox_remove_message(&ctx->mailbox, msg1);
+
+    Message *msg2;
+    assert(mailbox_peek_message(&ctx->mailbox, &msg2));
+    assert(2 == term_to_int(msg2->message));
+
+    mailbox_next(&ctx->mailbox);
+
+    Message *msg3;
+    assert(mailbox_peek_message(&ctx->mailbox, &msg3));
+    assert(3 == term_to_int(msg3->message));
+
+    mailbox_remove_message(&ctx->mailbox, msg3);
+
+    Message *msg4;
+    assert(mailbox_peek_message(&ctx->mailbox, &msg4));
+    assert(4 == term_to_int(msg4->message));
+
+    Message *msg2b = mailbox_first(&ctx->mailbox);
+    assert(msg2 == msg2b);
+
+    mailbox_remove(&ctx->mailbox);
+
+    Message *msg4b = mailbox_first(&ctx->mailbox);
+    assert(msg4 == msg4b);
+
+    mailbox_next(&ctx->mailbox);
+
+    Message *msg5;
+    assert(mailbox_peek_message(&ctx->mailbox, &msg5));
+    assert(5 == term_to_int(msg5->message));
+
+    mailbox_remove_message(&ctx->mailbox, msg5);
+
+    Message *no_next = msg5;
+    assert(mailbox_peek_message(&ctx->mailbox, &no_next) == false);
+    // if there is no next, the pointer must not be updated
+    assert(msg5 == no_next);
+
+    Message *msg2c = mailbox_first(&ctx->mailbox);
+    assert(msg2c != NULL);
+    assert(term_to_int(msg2c->message) == 4);
+
+    mailbox_remove_message(&ctx->mailbox, msg2c);
+
+    assert(mailbox_peek_message(&ctx->mailbox, &no_next) == false);
+    assert(mailbox_first(&ctx->mailbox) == NULL);
+    assert(mailbox_len(&ctx->mailbox) == 0);
+
+    mailbox_send(ctx, term_from_int(1));
+    mailbox_send(ctx, term_from_int(2));
+    mailbox_send(ctx, term_from_int(3));
+    mailbox_send(ctx, term_from_int(4));
+    mailbox_send(ctx, term_from_int(5));
+    assert(mailbox_process_outer_list(&ctx->mailbox) == NULL);
+
+    assert(mailbox_first(&ctx->mailbox) != NULL);
+    mailbox_next(&ctx->mailbox);
+
+    Message *msg2d;
+    assert(mailbox_peek_message(&ctx->mailbox, &msg2d));
+    assert(term_to_int(msg2d->message) == 2);
+
+    mailbox_next(&ctx->mailbox);
+
+    mailbox_remove_message(&ctx->mailbox, msg2d);
+
+    mailbox_remove(&ctx->mailbox);
+
+    mailbox_next(&ctx->mailbox);
+
+    Message *msg4c;
+    assert(mailbox_peek_message(&ctx->mailbox, &msg4c));
+    assert(term_to_int(msg4c->message) == 4);
+
+    assert(mailbox_len(&ctx->mailbox) == 3);
+
+    context_destroy(ctx);
+    globalcontext_destroy(glb);
+}
+
 int main(int argc, char **argv)
 {
     UNUSED(argc);
@@ -135,6 +237,7 @@ int main(int argc, char **argv)
 
     test_mailbox_send();
     test_mailbox_next();
+    test_mailbox_api_for_port_drivers();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR focus is adding few additional functions that make easier the development of advanced port drivers.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
