### PR TITLE
ESP32 sys: add missing unlock in receive_events

### DIFF
--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -150,6 +150,8 @@ static void receive_events(GlobalContext *glb, TickType_t wait_ticks)
         if (item == listeners_list) {
             TRACE("sys: handler not found for: %p\n", (void *) sender);
         }
+
+        synclist_unlock(&platform->listeners);
     }
 }
 


### PR DESCRIPTION
Fix deadlock

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
