### PR TITLE
Add support for term_to_binary(Float)

### DIFF
--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -219,6 +219,19 @@ static int serialize_term(Context *ctx, uint8_t *buf, term t)
         }
         return 5;
 
+    } else if (term_is_float(t)) {
+        if (!IS_NULL_PTR(buf)) {
+            avm_float_t val = term_to_float(t);
+            buf[0] = NEW_FLOAT_EXT;
+            union {
+                uint64_t intvalue;
+                double doublevalue;
+            } v;
+            v.doublevalue = val;
+            WRITE_64_UNALIGNED(buf + 1, v.intvalue);
+        }
+        return NEW_FLOAT_EXT_SIZE;
+
     } else if (term_is_atom(t)) {
         AtomString atom_string = globalcontext_atomstring_from_term(ctx->global, t);
         size_t atom_len = atom_string_len(atom_string);
@@ -338,7 +351,7 @@ static term parse_external_terms(const uint8_t *external_term_buf, int *eterm_si
             } v;
             v.intvalue = READ_64_UNALIGNED(external_term_buf + 1);
 
-            *eterm_size = 9;
+            *eterm_size = NEW_FLOAT_EXT_SIZE;
             return term_from_float(v.doublevalue, ctx);
         }
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -348,6 +348,7 @@ compile_erlang(floatneg)
 compile_erlang(floatabs)
 compile_erlang(floatdiv)
 compile_erlang(floatmath)
+compile_erlang(floatext)
 
 compile_erlang(boxed_is_not_float)
 compile_erlang(float_is_float)
@@ -760,6 +761,7 @@ add_custom_target(erlang_test_modules DEPENDS
     floatabs.beam
     floatdiv.beam
     floatmath.beam
+    floatext.beam
 
     boxed_is_not_float.beam
     float_is_float.beam

--- a/tests/erlang_tests/floatext.erl
+++ b/tests/erlang_tests/floatext.erl
@@ -1,0 +1,40 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2022 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(floatext).
+
+-export([start/0]).
+
+start() ->
+    true = test_reverse(3.14159265, <<131, 70, 64, 9, 33, 251, 83, 200, 212, 241>>),
+    true = test_reverse(0.0, <<131, 70, 0, 0, 0, 0, 0, 0, 0, 0>>),
+    true = test_reverse(negate(0.0), <<131, 70, 128, 0, 0, 0, 0, 0, 0, 0>>),
+    true = test_reverse(negate(3.14159265), <<131, 70, 192, 9, 33, 251, 83, 200, 212, 241>>),
+    0.
+
+test_reverse(T, Interop) ->
+    Bin = erlang:term_to_binary(T),
+    Bin = Interop,
+    {X, Used} = erlang:binary_to_term(Bin, [used]),
+    Used = erlang:byte_size(Bin),
+    X =:= T.
+
+negate(X) ->
+    -1 * X.

--- a/tests/test.c
+++ b/tests/test.c
@@ -397,6 +397,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(bin2float, 511),
     TEST_CASE_EXPECTED(list2float, 511),
     TEST_CASE(floatmath),
+    TEST_CASE(floatext),
 
     TEST_CASE(test_fp_allocate_heap_zero),
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
