### PR TITLE
Do not cast, always use LIST_FOR_EACH

### DIFF
--- a/src/libAtomVM/dictionary.c
+++ b/src/libAtomVM/dictionary.c
@@ -79,9 +79,10 @@ term dictionary_erase(struct ListHead *dict, Context *ctx, term key)
 
 void dictionary_destroy(struct ListHead *dict)
 {
-    struct ListHead *entry;
+    struct ListHead *item;
     struct ListHead *tmp;
-    MUTABLE_LIST_FOR_EACH (entry, tmp, dict) {
+    MUTABLE_LIST_FOR_EACH (item, tmp, dict) {
+        struct DictEntry *entry = GET_LIST_ENTRY(item, struct DictEntry, head);
         free(entry);
     }
 }

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -169,6 +169,7 @@ enum MemoryGCResult memory_gc(Context *ctx, int new_size)
     struct ListHead *fragment;
     struct ListHead *tmp;
     MUTABLE_LIST_FOR_EACH (fragment, tmp, &ctx->heap_fragments) {
+        // no need to get list entry, since it is guaranteed to be at offset 0
         free(fragment);
     }
     list_init(&ctx->heap_fragments);

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -239,7 +239,7 @@ Context *spi_driver_create_port(GlobalContext *global, term opts)
             // TODO handle out of memory errors
             spi_device->device_name = device_name;
             spi_device->handle = handle;
-            list_append(&spi_data->devices, (struct ListHead *) spi_device);
+            list_append(&spi_data->devices, &spi_device->list_head);
             char *str = interop_atom_to_string(ctx, device_name);
             ESP_LOGI(TAG, "SPI device %s added.", str);
             free(str);


### PR DESCRIPTION
Always use LIST_FOR_EACH for getting the struct containing the list head, since the struct layout might change causing hard to find bugs.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
