### PR TITLE
Fix order of supervisor child initialization

### DIFF
--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -34,6 +34,7 @@ set(ERLANG_MODULES
     test_proplists
     test_timer
     test_supervisor
+    notify_init_server
     ping_pong_server
 )
 

--- a/tests/libs/estdlib/notify_init_server.erl
+++ b/tests/libs/estdlib/notify_init_server.erl
@@ -1,0 +1,44 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2021 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(notify_init_server).
+
+-behavior(gen_server).
+
+-export([start_link/1, init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+start_link({Parent, ReadyMsg}) ->
+    gen_server:start_link(?MODULE, {Parent, ReadyMsg}, []).
+
+init({Parent, ReadyMsg}) ->
+    Parent ! ReadyMsg,
+    {ok, nil}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_call(_Request, _From, State) ->
+    {reply, unimplemented, State}.
+
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.


### PR DESCRIPTION
This PR corrects the order of initialization of children under the supervision of a supervisor, to ensure that they are started in the order specified in the OTP supervisor behavior.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
