### PR TITLE
Temporarily disable flappy timer test

### DIFF
--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -32,6 +32,7 @@ start() ->
         test_io_lib,
         test_maps,
         test_proplists,
-        test_timer,
+        %% TODO investigate flappy test
+        % test_timer,
         test_supervisor
     ]).


### PR DESCRIPTION
The timer test in the estdlib tests is failing some percentage of the time in CI.  This disables the test temporarily while we investigate the cause.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
