### PR TITLE
Fix unused var warning

### DIFF
--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -1108,7 +1108,6 @@ static NativeHandlerResult socket_consume_mailbox(Context *ctx)
         TRACE("close\n");
         port_send_reply(ctx, pid, ref, OK_ATOM);
         SocketDriverData *socket_data = (SocketDriverData *) ctx->platform_data;
-        struct GenericUnixPlatformData *platform = ctx->global->platform_data;
         if (socket_data->active_listener) {
             sys_unregister_listener(glb, &socket_data->active_listener->base);
             free(socket_data->active_listener);


### PR DESCRIPTION
Remove unsued var from generic_unix/lib/socket_driver.c.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
