### PR TITLE
Fix ESP32 build

### DIFF
--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -292,6 +292,7 @@ static term nif_esp_sleep_get_wakeup_cause(Context *ctx, int argc, term argv[])
             return globalcontext_make_atom(ctx->global, sleep_wakeup_ext0_atom);
         case ESP_SLEEP_WAKEUP_EXT1:
             return globalcontext_make_atom(ctx->global, sleep_wakeup_ext1_atom);
+#endif
         case ESP_SLEEP_WAKEUP_TIMER:
             return globalcontext_make_atom(ctx->global, sleep_wakeup_timer_atom);
         case ESP_SLEEP_WAKEUP_TOUCHPAD:


### PR DESCRIPTION
Fix missing #endif.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
