### PR TITLE
Implement erlang:monotonic_time/1 and fix timer test

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -120,6 +120,7 @@ static term nif_erlang_list_to_integer_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_list_to_float_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_list_to_atom_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_list_to_existing_atom_1(Context *ctx, int argc, term argv[]);
+static term nif_erlang_monotonic_time_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_iolist_size_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_iolist_to_binary_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_open_port_2(Context *ctx, int argc, term argv[]);
@@ -450,6 +451,12 @@ static const struct Nif concat_nif =
 {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_erlang_concat_2
+};
+
+static const struct Nif monotonic_time_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_erlang_monotonic_time_1
 };
 
 static const struct Nif system_time_nif =
@@ -1272,6 +1279,28 @@ term nif_erlang_make_ref_0(Context *ctx, int argc, term argv[])
     uint64_t ref_ticks = globalcontext_get_ref_ticks(ctx->global);
 
     return term_from_ref_ticks(ref_ticks, ctx);
+}
+
+term nif_erlang_monotonic_time_1(Context *ctx, int argc, term argv[])
+{
+    UNUSED(ctx);
+    UNUSED(argc);
+
+    struct timespec ts;
+    sys_monotonic_time(&ts);
+
+    if (argv[0] == SECOND_ATOM) {
+        return make_maybe_boxed_int64(ctx, ts.tv_sec);
+
+    } else if (argv[0] == MILLISECOND_ATOM) {
+        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000 + ts.tv_nsec / 1000000);
+
+    } else if (argv[0] == MICROSECOND_ATOM) {
+        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000 + ts.tv_nsec / 1000);
+
+    } else {
+        RAISE_ERROR(BADARG_ATOM);
+    }
 }
 
 term nif_erlang_system_time_1(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -85,6 +85,7 @@ erlang:spawn_opt/4, &spawn_opt_nif
 erlang:system_info/1, &system_info_nif
 erlang:whereis/1, &whereis_nif
 erlang:++/2, &concat_nif
+erlang:monotonic_time/1, &monotonic_time_nif
 erlang:system_time/1, &system_time_nif
 erlang:tuple_to_list/1, &tuple_to_list_nif
 erlang:universaltime/0, &universaltime_nif

--- a/src/libAtomVM/sys.h
+++ b/src/libAtomVM/sys.h
@@ -56,6 +56,14 @@ void sys_consume_pending_events(GlobalContext *glb);
 void sys_time(struct timespec *t);
 
 /**
+ * @brief gets monotonic time
+ *
+ * @details gets monotonic time.
+ * @param t the timespec that will be updated.
+ */
+void sys_monotonic_time(struct timespec *t);
+
+/**
  * @brief Loads a BEAM module using platform dependent methods.
  *
  * @details Loads a BEAM module into memory using platform dependent methods and returns a pointer to a Module struct.

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -34,6 +34,7 @@
 #include "esp_heap_caps.h"
 #include "esp_idf_version.h"
 #include "esp_system.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include <limits.h>
 #include <stdint.h>
@@ -143,6 +144,14 @@ void sys_time(struct timespec *t)
 
     t->tv_sec = tv.tv_sec;
     t->tv_nsec = tv.tv_usec * 1000;
+}
+
+void sys_monotonic_time(struct timespec *t)
+{
+    int64_t us_since_boot = esp_timer_get_time();
+
+    t->tv_sec = us_since_boot / 1000000;
+    t->tv_nsec = us_since_boot * 1000;
 }
 
 void sys_init_platform(GlobalContext *glb)

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -141,6 +141,14 @@ void sys_time(struct timespec *t)
     }
 }
 
+void sys_monotonic_time(struct timespec *t)
+{
+    if (UNLIKELY(clock_gettime(CLOCK_MONOTONIC, t))) {
+        fprintf(stderr, "Failed clock_gettime.\n");
+        AVM_ABORT();
+    }
+}
+
 Module *sys_load_module(GlobalContext *global, const char *module_name)
 {
     TRACE("sys_load_module: Going to load: %s\n", module_name);

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -82,6 +82,11 @@ void sys_time(struct timespec *t)
     sys_clock_gettime(t);
 }
 
+void sys_monotonic_time(struct timespec *t)
+{
+    sys_clock_gettime(t);
+}
+
 uint32_t sys_millis()
 {
     return system_millis;

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -426,6 +426,8 @@ compile_erlang(test_refc_binaries)
 compile_erlang(test_sub_binaries)
 compile_erlang(bs_append_extra_words)
 
+compile_erlang(test_monotonic_time)
+
 compile_erlang(spawn_opt_monitor_normal)
 compile_erlang(spawn_opt_monitor_throw)
 compile_erlang(spawn_opt_demonitor_normal)
@@ -838,6 +840,8 @@ add_custom_target(erlang_test_modules DEPENDS
     bs_restore2_start_offset.beam
     bs_restore2_start_offset_no_fp.beam
     bs_append_extra_words.beam
+
+    test_monotonic_time.beam
 
     spawn_opt_monitor_normal.beam
     spawn_opt_monitor_throw.beam

--- a/tests/erlang_tests/test_monotonic_time.erl
+++ b/tests/erlang_tests/test_monotonic_time.erl
@@ -1,0 +1,36 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_monotonic_time).
+
+-export([start/0]).
+
+start() ->
+    T1 = erlang:monotonic_time(millisecond),
+    receive
+    after 1 -> ok
+    end,
+    T2 = erlang:monotonic_time(millisecond),
+    test_diff(T2 - T1).
+
+test_diff(X) when is_integer(X) andalso X >= 0 ->
+    1;
+test_diff(X) when X < 0 ->
+    0.

--- a/tests/libs/estdlib/test_timer.erl
+++ b/tests/libs/estdlib/test_timer.erl
@@ -32,9 +32,9 @@ test() ->
     ok.
 
 test_timer() ->
-    T0 = erlang:system_time(millisecond),
+    T0 = erlang:monotonic_time(millisecond),
     ok = timer:sleep(101),
-    T1 = erlang:system_time(millisecond),
+    T1 = erlang:monotonic_time(millisecond),
     ok = etest:assert_true((T1 - T0) >= 101),
     ok.
 
@@ -59,9 +59,9 @@ timer_loop(0) ->
             {error, SomethingElse}
     end;
 timer_loop(I) ->
-    T0 = erlang:system_time(millisecond),
+    T0 = erlang:monotonic_time(millisecond),
     ok = timer:sleep(101),
-    T1 = erlang:system_time(millisecond),
+    T1 = erlang:monotonic_time(millisecond),
     ok = etest:assert_true((T1 - T0) >= 101),
     timer_loop(I - 1).
 

--- a/tests/test.c
+++ b/tests/test.c
@@ -461,6 +461,8 @@ struct Test tests[] = {
     TEST_CASE_COND(bs_restore2_start_offset, 823, SKIP_NO_FP),
     TEST_CASE_COND(bs_restore2_start_offset_no_fp, 823, SKIP_FP),
 
+    TEST_CASE_EXPECTED(test_monotonic_time, 1),
+
     // Tests relying on echo driver
     TEST_CASE_ATOMVM_ONLY(pingpong, 1),
 


### PR DESCRIPTION
This PR supersedes #481 since we fixed the test using monotonic time.

Closes #481.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
