### PR TITLE
Propagate temp_stack errors

### DIFF
--- a/src/libAtomVM/dictionary.c
+++ b/src/libAtomVM/dictionary.c
@@ -26,55 +26,85 @@
 
 #include <stdlib.h>
 
-static struct DictEntry *dictionary_find(struct ListHead *dictionary, Context *ctx, term key)
+static DictionaryFunctionResult dictionary_find(
+    struct ListHead *dictionary, term key, struct DictEntry **found, GlobalContext *global)
 {
     struct ListHead *item;
     LIST_FOR_EACH (item, dictionary) {
         struct DictEntry *entry = GET_LIST_ENTRY(item, struct DictEntry, head);
-        if (term_compare(entry->key, key, ctx) == 0) {
-            return entry;
+        TermCompareResult result = term_compare(entry->key, key, global);
+        if (result == TermEquals) {
+            *found = entry;
+            return DictionaryOk;
+        } else if (UNLIKELY(result == TermCompareMemoryAllocFail)) {
+            return DictionaryMemoryAllocFail;
         }
     }
 
-    return NULL;
+    *found = NULL;
+    return DictionaryOk;
 }
 
-term dictionary_put(struct ListHead *dict, Context *ctx, term key, term value)
+DictionaryFunctionResult dictionary_put(
+    struct ListHead *dict, term key, term value, term *old, GlobalContext *global)
 {
-    struct DictEntry *entry = dictionary_find(dict, ctx, key);
+    struct DictEntry *entry;
+    DictionaryFunctionResult result = dictionary_find(dict, key, &entry, global);
+    if (UNLIKELY(result != DictionaryOk)) {
+        return result;
+    }
+
     if (entry) {
-        term old = entry->value;
+        *old = entry->value;
         entry->value = value;
 
-        return old;
     } else {
         entry = malloc(sizeof(struct DictEntry));
+        if (IS_NULL_PTR(entry)) {
+            return DictionaryMemoryAllocFail;
+        }
         entry->key = key;
         entry->value = value;
         list_prepend(dict, &entry->head);
 
-        return UNDEFINED_ATOM;
+        *old = UNDEFINED_ATOM;
     }
+
+    return DictionaryOk;
 }
 
-term dictionary_get(struct ListHead *dict, Context *ctx, term key)
+DictionaryFunctionResult dictionary_get(
+    struct ListHead *dict, term key, term *old, GlobalContext *global)
 {
-    struct DictEntry *entry = dictionary_find(dict, ctx, key);
-    return entry ? entry->value : UNDEFINED_ATOM;
+    struct DictEntry *entry;
+    DictionaryFunctionResult result = dictionary_find(dict, key, &entry, global);
+    if (UNLIKELY(result != DictionaryOk)) {
+        return result;
+    }
+
+    *old = entry ? entry->value : UNDEFINED_ATOM;
+    return DictionaryOk;
 }
 
-term dictionary_erase(struct ListHead *dict, Context *ctx, term key)
+DictionaryFunctionResult dictionary_erase(
+    struct ListHead *dict, term key, term *old, GlobalContext *global)
 {
-    struct DictEntry *entry = dictionary_find(dict, ctx, key);
+    struct DictEntry *entry;
+    DictionaryFunctionResult result = dictionary_find(dict, key, &entry, global);
+    if (UNLIKELY(result != DictionaryOk)) {
+        return result;
+    }
+
     if (!entry) {
-        return UNDEFINED_ATOM;
+        *old = UNDEFINED_ATOM;
+        return DictionaryOk;
     }
-    term old = entry->value;
+    *old = entry->value;
 
     list_remove(&entry->head);
     free(entry);
 
-    return old;
+    return DictionaryOk;
 }
 
 void dictionary_destroy(struct ListHead *dict)

--- a/src/libAtomVM/dictionary.h
+++ b/src/libAtomVM/dictionary.h
@@ -28,6 +28,12 @@ extern "C" {
 #include "list.h"
 #include "term.h"
 
+typedef enum
+{
+    DictionaryOk,
+    DictionaryMemoryAllocFail
+} DictionaryFunctionResult;
+
 struct DictEntry
 {
     struct ListHead head;
@@ -35,9 +41,12 @@ struct DictEntry
     term value;
 };
 
-term dictionary_put(struct ListHead *dict, Context *ctx, term key, term value);
-term dictionary_get(struct ListHead *dict, Context *ctx, term key);
-term dictionary_erase(struct ListHead *dict, Context *ctx, term key);
+DictionaryFunctionResult dictionary_put(
+    struct ListHead *dict, term key, term value, term *old, GlobalContext *ctx);
+DictionaryFunctionResult dictionary_get(
+    struct ListHead *dict, term key, term *old, GlobalContext *ctx);
+DictionaryFunctionResult dictionary_erase(
+    struct ListHead *dict, term key, term *old, GlobalContext *ctx);
 void dictionary_destroy(struct ListHead *dict);
 
 #ifdef __cplusplus

--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -249,9 +249,12 @@ term interop_map_get_value(Context *ctx, term map, term key)
 
 term interop_map_get_value_default(Context *ctx, term map, term key, term default_value)
 {
-    int pos = term_find_map_pos(ctx, map, key);
-    if (pos == -1) {
+    int pos = term_find_map_pos(map, key, ctx->global);
+    if (pos == TERM_MAP_NOT_FOUND) {
         return default_value;
+    } else if (UNLIKELY(pos == TERM_MAP_MEMORY_ALLOC_FAIL)) {
+        // TODO: do not crash, handle out of memory
+        AVM_ABORT();
     } else {
         return term_get_map_value(map, pos);
     }

--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -153,9 +153,18 @@ int interop_iolist_size(term t, int *ok)
     unsigned long acc = 0;
 
     struct TempStack temp_stack;
-    temp_stack_init(&temp_stack);
+    if (UNLIKELY(temp_stack_init(&temp_stack) != TempStackOk)) {
+        // TODO: return a better error code
+        *ok = 0;
+        return 0;
+    }
 
-    temp_stack_push(&temp_stack, t);
+    if (UNLIKELY(temp_stack_push(&temp_stack, t) != TempStackOk)) {
+        temp_stack_destory(&temp_stack);
+        // TODO: return a better error code
+        *ok = 0;
+        return 0;
+    }
 
     while (!temp_stack_is_empty(&temp_stack)) {
         if (term_is_integer(t)) {
@@ -166,7 +175,12 @@ int interop_iolist_size(term t, int *ok)
             t = temp_stack_pop(&temp_stack);
 
         } else if (term_is_nonempty_list(t)) {
-            temp_stack_push(&temp_stack, term_get_list_tail(t));
+            if (UNLIKELY(temp_stack_push(&temp_stack, term_get_list_tail(t)) != TempStackOk)) {
+                temp_stack_destory(&temp_stack);
+                // TODO: return a better error code
+                *ok = 0;
+                return 0;
+            }
             t = term_get_list_head(t);
 
         } else if (term_is_binary(t)) {
@@ -195,9 +209,16 @@ int interop_write_iolist(term t, char *p)
     }
 
     struct TempStack temp_stack;
-    temp_stack_init(&temp_stack);
+    if (UNLIKELY(temp_stack_init(&temp_stack) != TempStackOk)) {
+        // TODO: return a better error code
+        return 0;
+    }
 
-    temp_stack_push(&temp_stack, t);
+    if (UNLIKELY(temp_stack_push(&temp_stack, t) != TempStackOk)) {
+        temp_stack_destory(&temp_stack);
+        // TODO: return a better error code
+        return 0;
+    }
 
     while (!temp_stack_is_empty(&temp_stack)) {
         if (term_is_integer(t)) {
@@ -209,7 +230,11 @@ int interop_write_iolist(term t, char *p)
             t = temp_stack_pop(&temp_stack);
 
         } else if (term_is_nonempty_list(t)) {
-            temp_stack_push(&temp_stack, term_get_list_tail(t));
+            if (UNLIKELY(temp_stack_push(&temp_stack, term_get_list_tail(t)) != TempStackOk)) {
+                temp_stack_destory(&temp_stack);
+                // TODO: return a better error code
+                return 0;
+            }
             t = term_get_list_head(t);
 
         } else if (term_is_binary(t)) {

--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -28,6 +28,13 @@ extern "C" {
 #include "context.h"
 #include "term.h"
 
+typedef enum
+{
+    InteropOk,
+    InteropMemoryAllocFail,
+    InteropBadArg
+} InteropFunctionResult;
+
 /**
  * An idiomatic macro for marking an AtomStringIntPair table entry as a
  * interop_atom_term_select_int default.
@@ -55,8 +62,8 @@ term interop_proplist_get_value_default(term list, term key, term default_value)
 term interop_map_get_value(Context *ctx, term map, term key);
 term interop_map_get_value_default(Context *ctx, term map, term key, term default_value);
 
-int interop_iolist_size(term t, int *ok);
-int interop_write_iolist(term t, char *p);
+NO_DISCARD InteropFunctionResult interop_iolist_size(term t, size_t *size);
+NO_DISCARD InteropFunctionResult interop_write_iolist(term t, char *p);
 
 /**
  * @brief Finds on a table the first matching atom string.

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -224,9 +224,15 @@ unsigned long memory_estimate_usage(term t)
     unsigned long acc = 0;
 
     struct TempStack temp_stack;
-    temp_stack_init(&temp_stack);
+    if (UNLIKELY(temp_stack_init(&temp_stack) != TempStackOk)) {
+        // TODO: handle failed malloc
+        AVM_ABORT();
+    }
 
-    temp_stack_push(&temp_stack, t);
+    if (UNLIKELY(temp_stack_push(&temp_stack, t) != TempStackOk)) {
+        // TODO: handle failed malloc
+        AVM_ABORT();
+    }
 
     while (!temp_stack_is_empty(&temp_stack)) {
         if (term_is_atom(t)) {
@@ -243,7 +249,10 @@ unsigned long memory_estimate_usage(term t)
 
         } else if (term_is_nonempty_list(t)) {
             acc += 2;
-            temp_stack_push(&temp_stack, term_get_list_tail(t));
+            if (UNLIKELY(temp_stack_push(&temp_stack, term_get_list_tail(t)) != TempStackOk)) {
+                // TODO: handle failed malloc
+                AVM_ABORT();
+            }
             t = term_get_list_head(t);
 
         } else if (term_is_tuple(t)) {
@@ -252,7 +261,10 @@ unsigned long memory_estimate_usage(term t)
 
             if (tuple_size > 0) {
                 for (int i = 1; i < tuple_size; i++) {
-                    temp_stack_push(&temp_stack, term_get_tuple_element(t, i));
+                    if (UNLIKELY(temp_stack_push(&temp_stack, term_get_tuple_element(t, i)) != TempStackOk)) {
+                        // TODO: handle failed malloc
+                        AVM_ABORT();
+                    }
                 }
                 t = term_get_tuple_element(t, 0);
 
@@ -265,10 +277,19 @@ unsigned long memory_estimate_usage(term t)
             acc += term_map_size_in_terms(map_size);
             if (map_size > 0) {
                 for (int i = 1; i < map_size; i++) {
-                    temp_stack_push(&temp_stack, term_get_map_key(t, i));
-                    temp_stack_push(&temp_stack, term_get_map_value(t, i));
+                    if (UNLIKELY(temp_stack_push(&temp_stack, term_get_map_key(t, i)) != TempStackOk)) {
+                        // TODO: handle failed malloc
+                        AVM_ABORT();
+                    }
+                    if (UNLIKELY(temp_stack_push(&temp_stack, term_get_map_value(t, i)) != TempStackOk)) {
+                        // TODO: handle failed malloc
+                        AVM_ABORT();
+                    }
                 }
-                temp_stack_push(&temp_stack, term_get_map_value(t, 0));
+                if (UNLIKELY(temp_stack_push(&temp_stack, term_get_map_value(t, 0)) != TempStackOk)) {
+                    // TODO: handle failed malloc
+                    AVM_ABORT();
+                }
                 t = term_get_map_key(t, 0);
 
             } else {

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2490,7 +2490,8 @@ static term nif_erlang_binary_to_term(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
     uint8_t return_used = 0;
-    if (argc == 2 && term_list_member(argv[1], USED_ATOM, ctx)) {
+    if (argc == 2
+        && interop_proplist_get_value_default(argv[1], USED_ATOM, FALSE_ATOM) == TRUE_ATOM) {
         return_used = 1;
     }
     term dst = term_invalid_term();
@@ -2903,14 +2904,26 @@ static term nif_erlang_put_2(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);
 
-    return dictionary_put(&ctx->dictionary, ctx, argv[0], argv[1]);
+    term old;
+    DictionaryFunctionResult result = dictionary_put(&ctx->dictionary, argv[0], argv[1], &old, ctx->global);
+    if (UNLIKELY(result != DictionaryOk)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    return old;
 }
 
 static term nif_erlang_erase_1(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);
 
-    return dictionary_erase(&ctx->dictionary, ctx, argv[0]);
+    term old;
+    DictionaryFunctionResult result = dictionary_erase(&ctx->dictionary, argv[0], &old, ctx->global);
+    if (UNLIKELY(result != DictionaryOk)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    return old;
 }
 
 static term nif_erlang_monitor(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -852,7 +852,7 @@ struct kv_pair
     term value;
 };
 
-static void sort_kv_pairs(Context *ctx, struct kv_pair *kv, int size)
+static bool sort_kv_pairs(struct kv_pair *kv, int size, GlobalContext *global)
 {
     int k = size;
     while (1 < k) {
@@ -860,9 +860,11 @@ static void sort_kv_pairs(Context *ctx, struct kv_pair *kv, int size)
         for (int i = 1; i < k; i++) {
             term t_max = kv[max_pos].key;
             term t = kv[i].key;
-            int c = term_compare(t, t_max, ctx);
-            if (0 < c) {
+            TermCompareResult result = term_compare(t, t_max, global);
+            if (result == TermGreaterThan) {
                 max_pos = i;
+            } else if (UNLIKELY(result == TermCompareMemoryAllocFail)) {
+                return false;
             }
         }
         if (max_pos != k - 1) {
@@ -871,6 +873,8 @@ static void sort_kv_pairs(Context *ctx, struct kv_pair *kv, int size)
         k--;
         // kv[k..size] sorted
     }
+
+    return true;
 }
 
 static int get_catch_label_and_change_module(Context *ctx, Module **mod)
@@ -2178,10 +2182,13 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("is_lt/2, label=%i, arg1=%lx, arg2=%lx\n", label, arg1, arg2);
 
-                    if (term_compare(arg1, arg2, ctx) < 0) {
+                    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+                    if (result == TermLessThan) {
                         NEXT_INSTRUCTION(next_off);
-                    } else {
+                    } else if (result & (TermGreaterThan | TermEquals)) {
                         i = POINTER_TO_II(mod->labels[label]);
+                    } else {
+                        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                 #endif
 
@@ -2207,10 +2214,13 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("is_ge/2, label=%i, arg1=%lx, arg2=%lx\n", label, arg1, arg2);
 
-                    if (term_compare(arg1, arg2, ctx) >= 0) {
+                    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+                    if (result & (TermGreaterThan | TermEquals)) {
                         NEXT_INSTRUCTION(next_off);
-                    } else {
+                    } else if (result == TermLessThan) {
                         i = POINTER_TO_II(mod->labels[label]);
+                    } else {
+                        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                 #endif
 
@@ -2237,10 +2247,13 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     TRACE("is_equal/2, label=%i, arg1=%lx, arg2=%lx\n", label, arg1, arg2);
 
                     //TODO: implement this
-                    if (term_equals(arg1, arg2, ctx)) {
+                    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+                    if (result == TermEquals) {
                         NEXT_INSTRUCTION(next_off);
-                    } else {
+                    } else if (result & (TermLessThan | TermGreaterThan)) {
                         i = POINTER_TO_II(mod->labels[label]);
+                    } else {
+                        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                 #endif
 
@@ -2266,10 +2279,13 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("is_not_equal/2, label=%i, arg1=%lx, arg2=%lx\n", label, arg1, arg2);
 
-                    if (!term_equals(arg1, arg2, ctx)) {
+                    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+                    if (result & (TermLessThan | TermGreaterThan)) {
                         NEXT_INSTRUCTION(next_off);
-                    } else {
+                    } else if (result == TermEquals) {
                         i = POINTER_TO_II(mod->labels[label]);
+                    } else {
+                        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                 #endif
 
@@ -2295,8 +2311,9 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("is_eq_exact/2, label=%i, arg1=%lx, arg2=%lx\n", label, arg1, arg2);
 
+                    // handle error
                     //TODO: implement this
-                    if (term_exactly_equals(arg1, arg2, ctx)) {
+                    if (term_exactly_equals(arg1, arg2, ctx->global)) {
                         NEXT_INSTRUCTION(next_off);
                     } else {
                         i = POINTER_TO_II(mod->labels[label]);
@@ -2325,8 +2342,9 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("is_not_eq_exact/2, label=%i, arg1=%lx, arg2=%lx\n", label, arg1, arg2);
 
+                    // handle error
                     //TODO: implement this
-                    if (!term_exactly_equals(arg1, arg2, ctx)) {
+                    if (!term_exactly_equals(arg1, arg2, ctx->global)) {
                         NEXT_INSTRUCTION(next_off);
                     } else {
                         i = POINTER_TO_II(mod->labels[label]);
@@ -5075,8 +5093,11 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     DECODE_COMPACT_TERM(value, code, i, next_off);
 
                     #ifdef IMPL_EXECUTE_LOOP
-                        if (term_find_map_pos(ctx, src, key) == -1) {
+                        int map_pos = term_find_map_pos(src, key, ctx->global);
+                        if (map_pos == TERM_MAP_NOT_FOUND) {
                             new_entries++;
+                        } else if (UNLIKELY(map_pos == TERM_MAP_MEMORY_ALLOC_FAIL)) {
+                            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         }
                     #endif
                 }
@@ -5107,7 +5128,9 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         kv[j].key = key;
                         kv[j].value = value;
                     }
-                    sort_kv_pairs(ctx, kv, num_elements);
+                    if (UNLIKELY(!sort_kv_pairs(kv, num_elements, ctx->global))) {
+                        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+                    }
                     //
                     // Create a new map of the requested size and stitch src
                     // and kv together into new map.  Both src and kv are sorted.
@@ -5129,20 +5152,32 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         } else {
                             term src_key = term_get_map_key(src, src_pos);
                             term new_key = kv[kv_pos].key;
-                            int c = term_compare(src_key, new_key, ctx);
-                            if (c < 0) {
-                                term src_value = term_get_map_value(src, src_pos);
-                                term_set_map_assoc(map, j, src_key, src_value);
-                                src_pos++;
-                            } else if (0 < c) {
-                                term new_value = kv[kv_pos].value;
-                                term_set_map_assoc(map, j, new_key, new_value);
-                                kv_pos++;
-                            } else { // keys are the same
-                                term new_value = kv[kv_pos].value;
-                                term_set_map_assoc(map, j, src_key, new_value);
-                                src_pos++;
-                                kv_pos++;
+                            switch (term_compare(src_key, new_key, ctx->global)) {
+                                case TermLessThan: {
+                                    term src_value = term_get_map_value(src, src_pos);
+                                    term_set_map_assoc(map, j, src_key, src_value);
+                                    src_pos++;
+                                    break;
+                                }
+
+                                case TermGreaterThan: {
+                                    term new_value = kv[kv_pos].value;
+                                    term_set_map_assoc(map, j, new_key, new_value);
+                                    kv_pos++;
+                                    break;
+                                }
+
+                                case TermEquals: {
+                                    term new_value = kv[kv_pos].value;
+                                    term_set_map_assoc(map, j, src_key, new_value);
+                                    src_pos++;
+                                    kv_pos++;
+                                    break;
+                                }
+
+                                case TermCompareMemoryAllocFail: {
+                                    RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+                                }
                             }
                         }
                     }
@@ -5188,8 +5223,11 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     DECODE_COMPACT_TERM(value, code, i, next_off);
 
                     #ifdef IMPL_EXECUTE_LOOP
-                        if (term_find_map_pos(ctx, src, key) == -1) {
+                        int map_pos = term_find_map_pos(src, key, ctx->global);
+                        if (map_pos == TERM_MAP_NOT_FOUND) {
                             RAISE_ERROR(BADARG_ATOM);
+                        } else if (map_pos == TERM_MAP_MEMORY_ALLOC_FAIL) {
+                            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         }
                     #endif
                 }
@@ -5217,7 +5255,10 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         term key, value;
                         DECODE_COMPACT_TERM(key, code, i, list_off);
                         DECODE_COMPACT_TERM(value, code, i, list_off);
-                        int pos = term_find_map_pos(ctx, src, key);
+                        int pos = term_find_map_pos(src, key, ctx->global);
+                        if (UNLIKELY(pos == TERM_MAP_MEMORY_ALLOC_FAIL)) {
+                            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+                        }
                         term_set_map_assoc(map, pos, key, value);
                     }
                     WRITE_REGISTER(dreg_type, dreg, map);
@@ -5273,10 +5314,12 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     DECODE_COMPACT_TERM(key, code, i, next_off);
 
                     #ifdef IMPL_EXECUTE_LOOP
-                        int pos = term_find_map_pos(ctx, src, key);
-                        if (pos == -1) {
+                        int pos = term_find_map_pos(src, key, ctx->global);
+                        if (pos == TERM_MAP_NOT_FOUND) {
                             i = POINTER_TO_II(mod->labels[label]);
                             fail = 1;
+                        } else if (pos == TERM_MAP_MEMORY_ALLOC_FAIL) {
+                            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         }
                     #endif
                 }
@@ -5307,10 +5350,12 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     DECODE_DEST_REGISTER(dreg, dreg_type, code, i, next_off);
 
                     #ifdef IMPL_EXECUTE_LOOP
-                        int pos = term_find_map_pos(ctx, src, key);
-                        if (pos == -1) {
+                        int pos = term_find_map_pos(src, key, ctx->global);
+                        if (pos == TERM_MAP_NOT_FOUND) {
                             i = POINTER_TO_II(mod->labels[label]);
                             fail = 1;
+                        } else if (UNLIKELY(pos == TERM_MAP_MEMORY_ALLOC_FAIL)) {
+                            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         } else {
                             term value = term_get_map_value(src, pos);
                             WRITE_REGISTER(dreg_type, dreg, value);
@@ -6266,7 +6311,8 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     DECODE_COMPACT_TERM(update_value, code, i, next_off);
                     #ifdef IMPL_EXECUTE_LOOP
                         if (reuse) {
-                            if (term_exactly_equals(update_value, term_get_tuple_element(dst, update_ix - 1), ctx)) {
+                            // handle error
+                            if (term_exactly_equals(update_value, term_get_tuple_element(dst, update_ix - 1), ctx->global)) {
                                 continue;
                             }
                             reuse = false;

--- a/src/libAtomVM/tempstack.h
+++ b/src/libAtomVM/tempstack.h
@@ -21,6 +21,7 @@
 #ifndef _TEMPSTACK_H_
 #define _TEMPSTACK_H_
 
+#include "term_typedef.h"
 #include "utils.h"
 
 typedef enum

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -106,6 +106,17 @@ enum RefcBinaryFlags
     RefcBinaryIsConst
 };
 
+typedef enum
+{
+    TermCompareMemoryAllocFail = 0,
+    TermEquals = 1,
+    TermLessThan = 2,
+    TermGreaterThan = 4
+} TermCompareResult;
+
+#define TERM_MAP_NOT_FOUND -1
+#define TERM_MAP_MEMORY_ALLOC_FAIL -2
+
 /**
  * @brief All empty tuples will reference this
  */
@@ -117,9 +128,10 @@ extern const term empty_tuple;
  * @details Tells if first term is >, < or == to the second term.
  * @param t the first term
  * @param other the second term
- * @return 0 when given terms are equals, otherwise -1 when t < other, or 1 when t > other.
+ * @param global the global context
+ * @return any of TermEquals, TermLessThan, TermGreaterThan or TermCompareMemoryAllocFail error.
  */
-int term_compare(term t, term other, Context *ctx);
+TermCompareResult term_compare(term t, term other, GlobalContext *global);
 
 /**
  * @brief Create a reference-counted binary on the heap
@@ -1334,30 +1346,19 @@ static inline int term_list_length(term t, int *proper)
  * @param b second term
  * @return 1 if they are the same, 0 otherwise.
  */
-static inline int term_exactly_equals(term a, term b, Context *ctx)
+static inline int term_exactly_equals(term a, term b, GlobalContext *global)
 {
     if (a == b) {
         return 1;
     } else {
-        return term_compare(a, b, ctx) == 0;
-    }
-}
-
-/**
- * @brief Returns 1 if given terms are equal.
- *
- * @details Compares 2 given terms and returns 1 if they are the same or they have same numeric value.
- * @param a first term
- * @param b second term
- * @return 1 if they are the same, 0 otherwise.
- */
-static inline int term_equals(term a, term b, Context *ctx)
-{
-    if (a == b) {
-        return 1;
-    } else {
-        //TODO: add parameter for exactly equals.
-        return term_compare(a, b, ctx) == 0;
+        TermCompareResult result = term_compare(a, b, global);
+        if (result == TermEquals) {
+            return 1;
+        } else if (UNLIKELY(result == TermCompareMemoryAllocFail)) {
+            AVM_ABORT();
+        } else {
+            return 0;
+        }
     }
 }
 
@@ -1465,27 +1466,6 @@ static inline int term_is_string(term t)
         t = term_get_list_tail(t);
     }
     return term_is_nil(t);
-}
-
-/**
- * @brief Checks to see if e is a member of list
- *
- * @details returns 1 if e is equal to an element of list; 0, otherwise
- * @param   list list term
- * @param   e element term
- * @return  1 if e is equal to a member of list; 0, otherwise
- */
-static inline int term_list_member(term list, term e, Context *ctx)
-{
-    term t = list;
-    while (term_is_nonempty_list(t)) {
-        term head = term_get_list_head(t);
-        if (term_equals(head, e, ctx)) {
-            return 1;
-        }
-        t = term_get_list_tail(t);
-    }
-    return 0;
 }
 
 static inline term term_make_function_reference(term m, term f, term a, Context *ctx)
@@ -1670,18 +1650,21 @@ static inline term term_get_map_value(term map, avm_uint_t pos)
     return boxed_value[term_get_map_value_offset() + pos];
 }
 
-static inline int term_find_map_pos(Context *ctx, term map, term key)
+static inline int term_find_map_pos(term map, term key, GlobalContext *global)
 {
     term keys = term_get_map_keys(map);
     int arity = term_get_tuple_arity(keys);
     for (int i = 0; i < arity; ++i) {
         term k = term_get_tuple_element(keys, i);
-        if (term_equals(key, k, ctx)) {
+        TermCompareResult result = term_compare(key, k, global);
+        if (result == TermEquals) {
             return i;
+        } else if (UNLIKELY(result == TermCompareMemoryAllocFail)) {
+            return TERM_MAP_MEMORY_ALLOC_FAIL;
         }
     }
-    // TODO define a mnemonic (MAP_NOT_FOUND) in place of -1
-    return -1;
+
+    return TERM_MAP_NOT_FOUND;
 }
 
 term term_get_map_assoc(Context *ctx, term map, term key);

--- a/src/libAtomVM/utils.h
+++ b/src/libAtomVM/utils.h
@@ -194,4 +194,11 @@ static inline void *rand_fail_calloc(int n, unsigned long alloc_size)
     #define PRINTF_FORMAT_ARGS(...)
 #endif
 
+#ifdef __GNUC__
+    #define NO_DISCARD \
+        __attribute__ ((warn_unused_result))
+#else
+    #define NO_DISCARD(...)
+#endif
+
 #endif

--- a/src/platforms/esp32/components/avm_builtins/i2c_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/i2c_driver.c
@@ -458,16 +458,26 @@ static void i2cdriver_consume_mailbox(Context *ctx)
             ret = ERROR_ATOM;
     }
 
-    dictionary_put(&ctx->dictionary, ctx, i2c_driver, ret);
+    term old;
+    if (UNLIKELY(dictionary_put(&ctx->dictionary, i2c_driver, ret, &old, ctx->global) != DictionaryOk)) {
+        // TODO: handle alloc error
+        AVM_ABORT();
+    }
     term ret_msg;
     if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
         ret_msg = OUT_OF_MEMORY_ATOM;
     } else {
-        ret = dictionary_get(&ctx->dictionary, ctx, i2c_driver);
+        if (UNLIKELY(dictionary_get(&ctx->dictionary, i2c_driver, &ret, ctx->global) != DictionaryOk)) {
+            // TODO: handle alloc error
+            AVM_ABORT();
+        }
         term ref = term_get_tuple_element(msg, 1);
         ret_msg = create_pair(ctx, ref, ret);
     }
-    dictionary_erase(&ctx->dictionary, ctx, i2c_driver);
+    if (UNLIKELY(dictionary_erase(&ctx->dictionary, i2c_driver, &old, ctx->global) != DictionaryOk)) {
+        // TODO: handle alloc error
+        AVM_ABORT();
+    }
 
     mailbox_send(target, ret_msg);
     mailbox_destroy_message(message);

--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -558,15 +558,24 @@ term socket_driver_do_send(Context *ctx, term buffer)
         buf = (char *) term_binary_data(buffer);
         len = term_binary_size(buffer);
     } else if (term_is_list(buffer)) {
-        int ok;
-        len = interop_iolist_size(buffer, &ok);
-        if (UNLIKELY(!ok)) {
-            return port_create_error_tuple(ctx, BADARG_ATOM);
+        switch (interop_iolist_size(buffer, &len)) {
+            case InteropOk:
+                break;
+            case InteropMemoryAllocFail:
+                return port_create_error_tuple(ctx, OUT_OF_MEMORY_ATOM);
+            case InteropBadArg:
+                return port_create_error_tuple(ctx, BADARG_ATOM);
         }
         buf = malloc(len);
-        if (UNLIKELY(!interop_write_iolist(buffer, buf))) {
-            free(buf);
-            return port_create_error_tuple(ctx, BADARG_ATOM);
+        switch (interop_write_iolist(buffer, buf)) {
+            case InteropOk:
+                break;
+            case InteropMemoryAllocFail:
+                free(buf);
+                return port_create_error_tuple(ctx, OUT_OF_MEMORY_ATOM);
+            case InteropBadArg:
+                free(buf);
+                return port_create_error_tuple(ctx, BADARG_ATOM);
         }
     } else {
         return port_create_error_tuple(ctx, BADARG_ATOM);
@@ -600,15 +609,24 @@ term socket_driver_do_sendto(Context *ctx, term dest_address, term dest_port, te
         buf = (char *) term_binary_data(buffer);
         len = term_binary_size(buffer);
     } else if (term_is_list(buffer)) {
-        int ok;
-        len = interop_iolist_size(buffer, &ok);
-        if (UNLIKELY(!ok)) {
-            return port_create_error_tuple(ctx, BADARG_ATOM);
+        switch (interop_iolist_size(buffer, &len)) {
+            case InteropOk:
+                break;
+            case InteropMemoryAllocFail:
+                return port_create_error_tuple(ctx, OUT_OF_MEMORY_ATOM);
+            case InteropBadArg:
+                return port_create_error_tuple(ctx, BADARG_ATOM);
         }
         buf = malloc(len);
-        if (UNLIKELY(!interop_write_iolist(buffer, buf))) {
-            free(buf);
-            return port_create_error_tuple(ctx, BADARG_ATOM);
+        switch (interop_write_iolist(buffer, buf)) {
+            case InteropOk:
+                break;
+            case InteropMemoryAllocFail:
+                free(buf);
+                return port_create_error_tuple(ctx, OUT_OF_MEMORY_ATOM);
+            case InteropBadArg:
+                free(buf);
+                return port_create_error_tuple(ctx, BADARG_ATOM);
         }
     } else {
         return port_create_error_tuple(ctx, BADARG_ATOM);


### PR DESCRIPTION
Some temp_stack functions (such as init and push) were using malloc, that might fail under low memory conditions.
Rather than ignoring it, or using abort, try to propagate the error to the caller.
A lot of API changes have been made, since those functions were used quite everywhere.

Last but not least, remove dependency on Context and use GlobalContext while changing the API.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
