### PR TITLE
Actual support for exact equal (=:= and =/=)

### DIFF
--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -1331,7 +1331,7 @@ term bif_erlang_xor_2(Context *ctx, term arg1, term arg2)
 
 term bif_erlang_equal_to_2(Context *ctx, term arg1, term arg2)
 {
-    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+    TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result == TermEquals) {
         return TRUE_ATOM;
     } else if (result & (TermLessThan | TermGreaterThan)) {
@@ -1343,9 +1343,7 @@ term bif_erlang_equal_to_2(Context *ctx, term arg1, term arg2)
 
 term bif_erlang_not_equal_to_2(Context *ctx, term arg1, term arg2)
 {
-    //TODO: fix this implementation
-    //it should compare any kind of type, and 5.0 != 5 is false
-    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+    TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result & (TermLessThan | TermGreaterThan)) {
         return TRUE_ATOM;
     } else if (result == TermEquals) {
@@ -1358,7 +1356,7 @@ term bif_erlang_not_equal_to_2(Context *ctx, term arg1, term arg2)
 term bif_erlang_exactly_equal_to_2(Context *ctx, term arg1, term arg2)
 {
     //TODO: 5.0 != 5
-    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+    TermCompareResult result = term_compare(arg1, arg2, TermCompareExact, ctx->global);
     if (result == TermEquals) {
         return TRUE_ATOM;
     } else if (result & (TermLessThan | TermGreaterThan)) {
@@ -1370,8 +1368,7 @@ term bif_erlang_exactly_equal_to_2(Context *ctx, term arg1, term arg2)
 
 term bif_erlang_exactly_not_equal_to_2(Context *ctx, term arg1, term arg2)
 {
-    //TODO: 5.0 != 5
-    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+    TermCompareResult result = term_compare(arg1, arg2, TermCompareExact, ctx->global);
     if (result & (TermLessThan | TermGreaterThan)) {
         return TRUE_ATOM;
     } else if (result == TermEquals) {
@@ -1383,7 +1380,7 @@ term bif_erlang_exactly_not_equal_to_2(Context *ctx, term arg1, term arg2)
 
 term bif_erlang_greater_than_2(Context *ctx, term arg1, term arg2)
 {
-    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+    TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result == TermGreaterThan) {
         return TRUE_ATOM;
     } else if (result & (TermEquals | TermLessThan)) {
@@ -1395,7 +1392,7 @@ term bif_erlang_greater_than_2(Context *ctx, term arg1, term arg2)
 
 term bif_erlang_less_than_2(Context *ctx, term arg1, term arg2)
 {
-    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+    TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result == TermLessThan) {
         return TRUE_ATOM;
     } else if (result & (TermEquals | TermGreaterThan)) {
@@ -1407,7 +1404,7 @@ term bif_erlang_less_than_2(Context *ctx, term arg1, term arg2)
 
 term bif_erlang_less_than_or_equal_2(Context *ctx, term arg1, term arg2)
 {
-    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+    TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result & (TermLessThan | TermEquals)) {
         return TRUE_ATOM;
     } else if (result == TermGreaterThan) {
@@ -1419,7 +1416,7 @@ term bif_erlang_less_than_or_equal_2(Context *ctx, term arg1, term arg2)
 
 term bif_erlang_greater_than_or_equal_2(Context *ctx, term arg1, term arg2)
 {
-    TermCompareResult result = term_compare(arg1, arg2, ctx->global);
+    TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result & (TermGreaterThan | TermEquals)) {
         return TRUE_ATOM;
     } else if (result & TermLessThan) {

--- a/src/libAtomVM/dictionary.c
+++ b/src/libAtomVM/dictionary.c
@@ -32,7 +32,7 @@ static DictionaryFunctionResult dictionary_find(
     struct ListHead *item;
     LIST_FOR_EACH (item, dictionary) {
         struct DictEntry *entry = GET_LIST_ENTRY(item, struct DictEntry, head);
-        TermCompareResult result = term_compare(entry->key, key, global);
+        TermCompareResult result = term_compare(entry->key, key, TermCompareExact, global);
         if (result == TermEquals) {
             *found = entry;
             return DictionaryOk;

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -427,6 +427,8 @@ compile_erlang(bs_append_extra_words)
 
 compile_erlang(test_monotonic_time)
 
+compile_erlang(exactly_eq)
+
 compile_erlang(spawn_opt_monitor_normal)
 compile_erlang(spawn_opt_monitor_throw)
 compile_erlang(spawn_opt_demonitor_normal)
@@ -841,6 +843,8 @@ add_custom_target(erlang_test_modules DEPENDS
     bs_append_extra_words.beam
 
     test_monotonic_time.beam
+
+    exactly_eq.beam
 
     spawn_opt_monitor_normal.beam
     spawn_opt_monitor_throw.beam

--- a/tests/erlang_tests/exactly_eq.erl
+++ b/tests/erlang_tests/exactly_eq.erl
@@ -1,0 +1,40 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(exactly_eq).
+
+-export([start/0, fact/3]).
+
+start() ->
+    A = fact(4, 1, 1),
+    B = fact(4, 1.0, 1.0),
+    test(not (A =:= B)) +
+        test(A =/= B) * 2 +
+        test(A == B) * 4.
+
+test(true) ->
+    1;
+test(false) ->
+    0.
+
+fact(N, _D, Acc) when N < 1 ->
+    Acc;
+fact(N, D, Acc) ->
+    fact(N - D, D, Acc * N).

--- a/tests/test.c
+++ b/tests/test.c
@@ -454,6 +454,8 @@ struct Test tests[] = {
 
     TEST_CASE_EXPECTED(test_monotonic_time, 1),
 
+    TEST_CASE_EXPECTED(exactly_eq, 7),
+
     // Tests relying on echo driver
     TEST_CASE_ATOMVM_ONLY(pingpong, 1),
 


### PR DESCRIPTION
This PR adds an additional parameter that allows to perform an exact comparison (=:=) instead of a numeric comparison (regular ==).

Maps comparison semantic still needs to be fixed and there might be some other minor quirks that need to be handled.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
