### PR TITLE
Prepare SMP code to support Pico

### DIFF
--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -126,8 +126,22 @@ if (AVM_DISABLE_SMP)
 else()
     include(CheckIncludeFile)
     CHECK_INCLUDE_FILE(stdatomic.h STDATOMIC_INCLUDE)
-    if(NOT STDATOMIC_INCLUDE)
-       message(FATAL_ERROR "stdatomic.h cannot be found, you need to disable SMP on this platform")
+    if(HAVE_PLATFORM_SMP_H)
+        target_compile_definitions(libAtomVM PUBLIC HAVE_PLATFORM_SMP_H)
+    endif()
+    include(CheckCSourceCompiles)
+    check_c_source_compiles("
+        #include <stdatomic.h>
+        int main() {
+            _Static_assert(ATOMIC_POINTER_LOCK_FREE == 2, \"Expected ATOMIC_POINTER_LOCK_FREE to be equal to 2\");
+        }
+    " ATOMIC_POINTER_LOCK_FREE_IS_TWO)
+    if (NOT ATOMIC_POINTER_LOCK_FREE_IS_TWO AND NOT HAVE_PLATFORM_SMP_H)
+        if (NOT STDATOMIC_INCLUDE)
+            message(FATAL_ERROR "stdatomic.h cannot be found, you need to disable SMP on this platform or provide platform_smp.h and define HAVE_PLATFORM_SMP_H")
+        else()
+            message(FATAL_ERROR "Platform doesn't support atomic pointers, you need to disable SMP or provide platform_smp.h and define HAVE_PLATFORM_SMP_H")
+        endif()
     endif()
 endif()
 

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -177,7 +177,7 @@ void context_update_flags(Context *ctx, int mask, int value) CLANG_THREAD_SANITI
     enum ContextFlags desired;
     do {
         desired = (expected & mask) | value;
-    } while (!atomic_compare_exchange_weak(&ctx->flags, &expected, desired));
+    } while (!ATOMIC_COMPARE_EXCHANGE_WEAK(&ctx->flags, &expected, desired));
 #else
     ctx->flags = (ctx->flags & mask) | value;
 #endif

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -35,15 +35,9 @@ extern "C" {
 #include "globalcontext.h"
 #include "linkedlist.h"
 #include "mailbox.h"
+#include "smp.h"
 #include "term.h"
 #include "timer_list.h"
-
-#if !defined(AVM_NO_SMP) && !defined(__cplusplus)
-#include <stdatomic.h>
-#define ATOMIC _Atomic
-#else
-#define ATOMIC
-#endif
 
 struct Module;
 

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -34,13 +34,6 @@ extern "C" {
 
 #include <stdint.h>
 
-#if !defined(AVM_NO_SMP) && !defined(__cplusplus)
-#include <stdatomic.h>
-#define ATOMIC _Atomic
-#else
-#define ATOMIC
-#endif
-
 #include "atom.h"
 #include "linkedlist.h"
 #include "smp.h"
@@ -102,7 +95,7 @@ struct GlobalContext
 #endif
 
 #if !defined(AVM_NO_SMP) && ATOMIC_LLONG_LOCK_FREE == 2
-    atomic_ullong ref_ticks;
+    unsigned long long ATOMIC ref_ticks;
 #else
     unsigned long long ref_ticks;
 #ifndef AVM_NO_SMP

--- a/src/libAtomVM/mailbox.c
+++ b/src/libAtomVM/mailbox.c
@@ -142,7 +142,7 @@ static void mailbox_post_message(Context *c, MailboxMessage *m)
     MailboxMessage *current_first = NULL;
     do {
         m->next = current_first;
-    } while (!atomic_compare_exchange_weak(&c->mailbox.outer_first, &current_first, m));
+    } while (!ATOMIC_COMPARE_EXCHANGE_WEAK(&c->mailbox.outer_first, &current_first, m));
 #else
     m->next = c->mailbox.outer_first;
     c->mailbox.outer_first = m;
@@ -242,7 +242,7 @@ MailboxMessage *mailbox_process_outer_list(Mailbox *mbox)
     // Empty outer list using CAS
     MailboxMessage *current = mbox->outer_first;
 #ifndef AVM_NO_SMP
-    while (!atomic_compare_exchange_weak(&mbox->outer_first, &current, NULL)) {
+    while (!ATOMIC_COMPARE_EXCHANGE_WEAK(&mbox->outer_first, &current, NULL)) {
     };
 #else
     mbox->outer_first = NULL;

--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -33,16 +33,10 @@
 extern "C" {
 #endif
 
-#if !defined(AVM_NO_SMP) && !defined(__cplusplus)
-#include <stdatomic.h>
-#define ATOMIC _Atomic
-#else
-#define ATOMIC
-#endif
-
 #include <stdbool.h>
 
 #include "list.h"
+#include "smp.h"
 #include "term_typedef.h"
 
 struct Context;

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -35,6 +35,7 @@
 #include "platform_nifs.h"
 #include "port.h"
 #include "scheduler.h"
+#include "smp.h"
 #include "sys.h"
 #include "term.h"
 #include "utils.h"
@@ -68,7 +69,10 @@
     ctx->x[1] = (b); \
     return term_invalid_term();
 
+#ifndef MAX
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
+#endif
+
 #define NOT_FOUND (0xFF)
 
 #ifdef ENABLE_ADVANCED_TRACE
@@ -2525,7 +2529,7 @@ static term nif_erlang_system_flag(Context *ctx, int argc, term argv[])
             argv[1] = BADARG_ATOM;
             return term_invalid_term();
         }
-        while (!atomic_compare_exchange_weak(&ctx->global->online_schedulers, &old_value, new_value)) {};
+        while (!ATOMIC_COMPARE_EXCHANGE_WEAK(&ctx->global->online_schedulers, &old_value, new_value)) {};
         return term_from_int32(old_value);
     }
 #else

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -902,7 +902,9 @@ typedef union
     }
 
 
+#ifndef MIN
 #define MIN(X, Y) ((X) < (Y) ? (X) : (Y))
+#endif
 
 #ifdef IMPL_EXECUTE_LOOP
 struct Int24

--- a/src/libAtomVM/refc_binary.h
+++ b/src/libAtomVM/refc_binary.h
@@ -25,16 +25,11 @@
 extern "C" {
 #endif
 
-#include "list.h"
 #include <stdbool.h>
 #include <stdlib.h>
 
-#if !defined(AVM_NO_SMP) && !defined(__cplusplus)
-#include <stdatomic.h>
-#define ATOMIC _Atomic
-#else
-#define ATOMIC
-#endif
+#include "list.h"
+#include "smp.h"
 
 struct RefcBinary
 {

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -52,14 +52,6 @@
 #endif
 
 #ifndef AVM_NO_SMP
-#include <stdatomic.h>
-#else
-#ifndef _Atomic
-#define _Atomic
-#endif
-#endif
-
-#ifndef AVM_NO_SMP
 #define SMP_MUTEX_LOCK(mtx) smp_mutex_lock(mtx)
 #define SMP_MUTEX_UNLOCK(mtx) smp_mutex_unlock(mtx)
 #else
@@ -86,7 +78,7 @@ struct GenericUnixPlatformData
 #else
     struct pollfd *fds;
 #endif
-    int _Atomic poll_count;
+    int ATOMIC poll_count;
 #ifndef AVM_NO_SMP
 #ifndef HAVE_KQUEUE
 #ifdef HAVE_EVENTFD


### PR DESCRIPTION
- Allow smp platforms to define their own spinlock structures
- Allow smp platforms to not provide stdatomic.h
- Allow platforms to define MIN and MAX macros

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
