### PR TITLE
Remove Ubuntu 18.04 and add Ubuntu 22.04 to GH workflows

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -12,27 +12,36 @@ jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
+
+      fail-fast: false
+
       matrix:
-        os: ["ubuntu-18.04", "ubuntu-20.04"]
-        cc: ["gcc-4.8", "gcc-5", "gcc-6", "gcc-7", "gcc-8", "gcc-9", "gcc-10", "clang-3.9",
-        "clang-10"]
+        os: ["ubuntu-20.04", "ubuntu-22.04"]
+        cc: ["gcc-5", "gcc-6", "gcc-7", "gcc-8", "gcc-9", "gcc-10", "clang-3.9", "clang-10"]
         cflags: ["-Os", "-O2", "-O3"]
         otp: ["21", "22", "23", "24", "25", "master"]
 
         exclude:
-        - os: "ubuntu-18.04"
-          cc: "gcc-7"
-        - os: "ubuntu-18.04"
-          cc: "gcc-8"
-        - os: "ubuntu-18.04"
-          cc: "gcc-9"
-        - os: "ubuntu-18.04"
-          cc: "clang-10"
-        - os: "ubuntu-18.04"
-          cc: "gcc-10"
+        - os: "ubuntu-22.04"
+          otp: "21"
+        - os: "ubuntu-22.04"
+          otp: "22"
+        - os: "ubuntu-22.04"
+          otp: "23"
 
-        - os: "ubuntu-20.04"
-          cc: "gcc-4.8"
+        - os: "ubuntu-22.04"
+          cc: "clang-3.9"
+        - os: "ubuntu-22.04"
+          cc: "clang-10"
+        - os: "ubuntu-22.04"
+          cc: "gcc-5"
+        - os: "ubuntu-22.04"
+          cc: "gcc-6"
+        - os: "ubuntu-22.04"
+          cc: "gcc-7"
+        - os: "ubuntu-22.04"
+          cc: "gcc-8"
+
         - os: "ubuntu-20.04"
           cc: "gcc-5"
         - os: "ubuntu-20.04"
@@ -63,9 +72,6 @@ jobs:
           cflags: "-O3"
 
         include:
-        - cc: "gcc-4.8"
-          cxx: "g++-4.8"
-          compiler_pkgs: "gcc-4.8 g++-4.8"
         - cc: "gcc-5"
           cxx: "g++-5"
           compiler_pkgs: "gcc-5 g++-5"
@@ -102,17 +108,6 @@ jobs:
 
         - otp: "24"
           elixir_version: "1.14"
-
-        - os: "ubuntu-18.04"
-          cc: "gcc-4.8"
-          cxx: "g++-4.8"
-          cflags: "-m32 -O2"
-          otp: "21"
-          elixir_version: "1.7"
-          cmake_opts: "-DOPENSSL_CRYPTO_LIBRARY=/usr/lib/i386-linux-gnu/libcrypto.so"
-          arch: "i386"
-          compiler_pkgs: "gcc-4.8 g++-4.8 gcc-4.8-multilib g++-4.8-multilib libc6-dev-i386
-          libc6-dbg:i386 zlib1g-dev:i386 libssl-dev:i386"
 
         - os: "ubuntu-20.04"
           cc: "gcc-10"


### PR DESCRIPTION
Ubuntu 18.04 stopped working, also add Ubuntu 22.04 to build and test.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
