### PR TITLE
Check tuple allocation

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -2980,6 +2980,9 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 DECODE_DEST_REGISTER(dreg, dreg_type, code, i, next_off);
 
 #ifdef IMPL_EXECUTE_LOOP
+                if (memory_ensure_free(ctx, 2) != MEMORY_GC_OK) {
+                        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+                }
                 term *list_elem = term_list_alloc(ctx);
 #endif
 
@@ -3011,7 +3014,12 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 USED_BY_TRACE(dreg);
 
                 #ifdef IMPL_EXECUTE_LOOP
+                    if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(size)) != MEMORY_GC_OK)) {
+                      RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+                    }
+
                     term t = term_alloc_tuple(size, ctx);
+
                     WRITE_REGISTER(dreg_type, dreg, t);
                 #endif
 
@@ -3056,9 +3064,12 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("badmatch/1, v=0x%lx\n", arg1);
+                    if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
+                      RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+                    }
 
                     term new_error_tuple = term_alloc_tuple(2, ctx);
-                    //TODO: check alloc
+
                     term_put_tuple_element(new_error_tuple, 0, BADMATCH_ATOM);
                     term_put_tuple_element(new_error_tuple, 1, arg1);
 
@@ -3107,9 +3118,12 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("case_end/1, v=0x%lx\n", arg1);
+                    if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
+                      RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+                    }
 
                     term new_error_tuple = term_alloc_tuple(2, ctx);
-                    //TODO: reserve memory before
+
                     term_put_tuple_element(new_error_tuple, 0, CASE_CLAUSE_ATOM);
                     term_put_tuple_element(new_error_tuple, 1, arg1);
 
@@ -3345,6 +3359,9 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("try_case_end/1, val=%lx\n", arg1);
+                    if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
+                      RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+                    }
 
                     term new_error_tuple = term_alloc_tuple(2, ctx);
                     //TODO: ensure memory before
@@ -3421,7 +3438,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         case ERROR_ATOM_INDEX: {
                             ctx->x[2] = stacktrace_build(ctx, &ctx->x[2]);
 
-                            if (UNLIKELY(memory_ensure_free(ctx, 6) != MEMORY_GC_OK)) {
+                            if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2) + TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
                                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                             }
                             term reason_tuple = term_alloc_tuple(2, ctx);
@@ -3435,7 +3452,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                             break;
                         }
                         case LOWERCASE_EXIT_ATOM_INDEX: {
-                            if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
+                            if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
                                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                             }
                             term exit_tuple = term_alloc_tuple(2, ctx);
@@ -6014,6 +6031,10 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 #endif
 
                 #ifdef IMPL_EXECUTE_LOOP
+                    if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(size)) != MEMORY_GC_OK)) {
+                            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+                    }
+
                     term t = term_alloc_tuple(size, ctx);
                 #endif
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -42,6 +42,7 @@ compile_erlang(send_to_dead_process)
 compile_erlang(selval)
 compile_erlang(byte_size_test)
 compile_erlang(tuple)
+compile_erlang(tuple_list_alloc)
 compile_erlang(count_char)
 compile_erlang(len_test)
 compile_erlang(makelist_test)
@@ -456,6 +457,7 @@ add_custom_target(erlang_test_modules DEPENDS
     selval.beam
     byte_size_test.beam
     tuple.beam
+    tuple_list_alloc.beam
     count_char.beam
     len_test.beam
     makelist_test.beam

--- a/tests/erlang_tests/tuple_list_alloc.erl
+++ b/tests/erlang_tests/tuple_list_alloc.erl
@@ -1,0 +1,43 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Illya Petrov <ilya.muromec@gmail.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(tuple_list_alloc).
+
+-export([start/0]).
+
+start() -> 
+  erlang:garbage_collect(self()),
+  Config = make_config(1, 2, 3),
+  tuple_size(Config).
+
+make_config(A, B, C) -> 
+  erlang:garbage_collect(self()),
+
+  X = [
+    {
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
+      1, 2, 3, 4, 5, 5, 7,
+      fun() -> 0 end
+    }
+  ],
+  maketuple(A, B, C, X).
+
+maketuple(A, B, C, D) -> {A, B, C, D}.

--- a/tests/test.c
+++ b/tests/test.c
@@ -81,6 +81,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(send_to_dead_process, 20),
     TEST_CASE_EXPECTED(byte_size_test, 10),
     TEST_CASE_EXPECTED(tuple, 6),
+    TEST_CASE_ATOMVM_ONLY(tuple_list_alloc, 4),
     TEST_CASE_EXPECTED(len_test, 5),
     TEST_CASE_EXPECTED(count_char, 2),
     TEST_CASE_EXPECTED(makelist_test, 532),


### PR DESCRIPTION
Ensure enough memory is available in heap when allocating tuples and lists, abort otherwise.
Allocation of lists, tuple and funcs are preceeded by either test_heap/2 or allocate/2
to ensure there is enough memory for subsequent make_fun3, put_tuple and put_list calls.

Sometimes however test_heap underestimates amount of resources needed as demonstrated by
included test case (best run with tracing enabled in opcodeswitch.h).

Currently make_fun3 includes a check before allocation, so this commit mirrors the same
behavior for lists and tuples

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
