### PR TITLE
Fix allocation bug in `nif_binary_split_2`

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2648,8 +2648,8 @@ static term nif_binary_split_2(Context *ctx, int argc, term argv[])
         int rest_size = bin_size - offset - pattern_size;
         size_t rest_size_in_terms = term_sub_binary_heap_size(bin_term, rest_size);
 
-        // + 2 which is the result cons
-        if (UNLIKELY(memory_ensure_free(ctx, tok_size_in_terms + rest_size_in_terms + 2) != MEMORY_GC_OK)) {
+        // + 4 which is the result cons
+        if (UNLIKELY(memory_ensure_free(ctx, tok_size_in_terms + rest_size_in_terms + 4) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
 


### PR DESCRIPTION
This bug did not yield any crash because `MIN_FREE_SPACE_SIZE` is not 0 and allocated memory is more than was is requested.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
