### PR TITLE
Fix potential GC crash related to `OP_RECV_MARKER_RESERVE`

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -6195,6 +6195,10 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 dreg_type_t reg_a_type;
                 DECODE_DEST_REGISTER(reg_a, reg_a_type, code, i, next_off);
                 TRACE("recv_marker_reserve/1: reg1=%c%i\n", T_DEST_REG(reg_a_type, reg_a));
+#ifdef IMPL_EXECUTE_LOOP
+                // Clear register to avoid any issue with GC
+                WRITE_REGISTER(reg_a_type, reg_a, term_nil());
+#endif
                 NEXT_INSTRUCTION(next_off);
                 break;
             }


### PR DESCRIPTION
This bug could potentially yield a crash with current GC/memory implementation, however it was not observed.

The crash can be observed with heap fragments, though.
The compiler puts allocate to allocate three y registers, registers 1 and 2 are filled with move opcode, register 0 is supposed to be filled by the recv_marker_reserve, and then GC is called and can find garbage (here 2B) and then crash.

<img width="735" alt="image" src="https://user-images.githubusercontent.com/168407/233457776-0402d466-4231-4418-b9af-22f39efc742b.png">


These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
