### PR TITLE
Add missing memory_ensure_free in `nif_openssl_random`

### DIFF
--- a/src/platforms/generic_unix/lib/platform_nifs.c
+++ b/src/platforms/generic_unix/lib/platform_nifs.c
@@ -100,7 +100,11 @@ static term nif_openssl_random(Context *ctx, int argc, term argv[])
         return t;
     }
     uint32_t *r = (uint32_t *) term_binary_data(t);
-    return term_make_boxed_int(*r, ctx);
+    avm_int_t value = *r;
+    if (UNLIKELY(memory_ensure_free(ctx, BOXED_INT_SIZE) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    return term_make_boxed_int(value, ctx);
 }
 
 static const struct Nif openssl_md5_nif =


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
