### PR TITLE
Fix allocation issue in refc_binary_info

### DIFF
--- a/src/libAtomVM/refc_binary.c
+++ b/src/libAtomVM/refc_binary.c
@@ -76,7 +76,7 @@ term refc_binary_create_binary_info(Context *ctx)
     if (len == 0) {
         return term_nil();
     }
-    if (memory_ensure_free(ctx, len * TUPLE_SIZE(2)) != MEMORY_GC_OK) {
+    if (memory_ensure_free(ctx, len * (2 + TUPLE_SIZE(2))) != MEMORY_GC_OK) {
         return term_invalid_term();
     }
     term ret = term_nil();


### PR DESCRIPTION
Also add new test based on refc_binary_info authored by @fadushin

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
