### PR TITLE
Clarify GC shrink strategy

### DIFF
--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -169,7 +169,7 @@ term bif_erlang_is_map_1(Context *ctx, term arg1)
 term bif_erlang_is_map_key_2(Context *ctx, term arg1, term arg2)
 {
     if (UNLIKELY(!term_is_map(arg2))) {
-        if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, ctx);
@@ -246,7 +246,7 @@ term bif_erlang_map_size_1(Context *ctx, int live, term arg1)
     UNUSED(live);
 
     if (!UNLIKELY(term_is_map(arg1))) {
-        if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, ctx);
@@ -263,7 +263,7 @@ term bif_erlang_map_size_1(Context *ctx, int live, term arg1)
 term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
 {
     if (!UNLIKELY(term_is_map(arg2))) {
-        if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, ctx);
@@ -276,7 +276,7 @@ term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
 
     int pos = term_find_map_pos(arg2, arg1, ctx->global);
     if (pos == TERM_MAP_NOT_FOUND) {
-        if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, ctx);
@@ -296,7 +296,7 @@ term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
 
 static inline term make_boxed_int(Context *ctx, avm_int_t value)
 {
-    if (UNLIKELY(memory_ensure_free(ctx, BOXED_INT_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -306,7 +306,7 @@ static inline term make_boxed_int(Context *ctx, avm_int_t value)
 #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
 static inline term make_boxed_int64(Context *ctx, avm_int64_t value)
 {
-    if (UNLIKELY(memory_ensure_free(ctx, BOXED_INT64_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT64_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -377,7 +377,7 @@ static term add_boxed_helper(Context *ctx, term arg1, term arg2)
             RAISE_ERROR(BADARITH_ATOM);
         }
 
-        if (UNLIKELY(memory_ensure_free(ctx, FLOAT_SIZE) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, ctx);
@@ -485,7 +485,7 @@ static term sub_boxed_helper(Context *ctx, term arg1, term arg2)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free(ctx, FLOAT_SIZE) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, ctx);
@@ -608,7 +608,7 @@ static term mul_boxed_helper(Context *ctx, term arg1, term arg2)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free(ctx, FLOAT_SIZE) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, ctx);
@@ -776,7 +776,7 @@ static term neg_boxed_helper(Context *ctx, term arg1)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free(ctx, FLOAT_SIZE) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, ctx);
@@ -863,7 +863,7 @@ static term abs_boxed_helper(Context *ctx, term arg1)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free(ctx, FLOAT_SIZE) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, ctx);

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -169,7 +169,7 @@ term bif_erlang_is_map_1(Context *ctx, term arg1)
 term bif_erlang_is_map_key_2(Context *ctx, term arg1, term arg2)
 {
     if (UNLIKELY(!term_is_map(arg2))) {
-        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, ctx);
@@ -246,7 +246,7 @@ term bif_erlang_map_size_1(Context *ctx, int live, term arg1)
     UNUSED(live);
 
     if (!UNLIKELY(term_is_map(arg1))) {
-        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, ctx);
@@ -263,7 +263,7 @@ term bif_erlang_map_size_1(Context *ctx, int live, term arg1)
 term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
 {
     if (!UNLIKELY(term_is_map(arg2))) {
-        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, ctx);
@@ -276,7 +276,7 @@ term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
 
     int pos = term_find_map_pos(arg2, arg1, ctx->global);
     if (pos == TERM_MAP_NOT_FOUND) {
-        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, ctx);
@@ -296,7 +296,7 @@ term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
 
 static inline term make_boxed_int(Context *ctx, avm_int_t value)
 {
-    if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -306,7 +306,7 @@ static inline term make_boxed_int(Context *ctx, avm_int_t value)
 #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
 static inline term make_boxed_int64(Context *ctx, avm_int64_t value)
 {
-    if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT64_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT64_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -377,7 +377,7 @@ static term add_boxed_helper(Context *ctx, term arg1, term arg2)
             RAISE_ERROR(BADARITH_ATOM);
         }
 
-        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, ctx);
@@ -485,7 +485,7 @@ static term sub_boxed_helper(Context *ctx, term arg1, term arg2)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, ctx);
@@ -608,7 +608,7 @@ static term mul_boxed_helper(Context *ctx, term arg1, term arg2)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, ctx);
@@ -776,7 +776,7 @@ static term neg_boxed_helper(Context *ctx, term arg1)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, ctx);
@@ -863,7 +863,7 @@ static term abs_boxed_helper(Context *ctx, term arg1)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, ctx);

--- a/src/libAtomVM/mailbox.c
+++ b/src/libAtomVM/mailbox.c
@@ -75,7 +75,7 @@ term mailbox_peek(Context *c)
     if (c->e - c->heap_ptr < m->msg_memory_size) {
         // ADDITIONAL_PROCESSING_MEMORY_SIZE: ensure some additional memory for message processing, so there is
         // no need to run GC again.
-        if (UNLIKELY(memory_gc(c, context_memory_size(c) + m->msg_memory_size + ADDITIONAL_PROCESSING_MEMORY_SIZE) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free(c, m->msg_memory_size + ADDITIONAL_PROCESSING_MEMORY_SIZE) != MEMORY_GC_OK)) {
             fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
         }
     }

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -37,6 +37,7 @@
 
 static void memory_scan_and_copy(term *mem_start, const term *mem_end, term **new_heap_pos, term *mso_list, int move);
 static term memory_shallow_copy_term(term t, term **new_heap, int move);
+static enum MemoryGCResult memory_gc(Context *ctx, int new_size, int num_roots, term *roots);
 
 HOT_FUNC term *memory_heap_alloc(Context *c, uint32_t size)
 {
@@ -57,38 +58,29 @@ MALLOC_LIKE term *memory_alloc_heap_fragment(Context *ctx, uint32_t fragment_siz
     return (term *) (heap_fragment + 1);
 }
 
-enum MemoryGCResult memory_ensure_free(Context *c, uint32_t size)
+enum MemoryGCResult memory_ensure_free_opt(Context *c, uint32_t size, enum MemoryShrinkMode shrink_mode, int num_roots, term *roots)
 {
     size_t free_space = context_avail_free_memory(c);
-    if (free_space < size + MIN_FREE_SPACE_SIZE) {
+    size_t maximum_free_space = 2 * (size + MIN_FREE_SPACE_SIZE);
+    if (free_space < size || (shrink_mode == MEMORY_FORCE_SHRINK) || ((shrink_mode == MEMORY_CAN_SHRINK) && free_space > maximum_free_space)) {
         size_t memory_size = context_memory_size(c);
-        if (UNLIKELY(memory_gc(c, memory_size + size + MIN_FREE_SPACE_SIZE) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_gc(c, memory_size + size + MIN_FREE_SPACE_SIZE, num_roots, roots) != MEMORY_GC_OK)) {
             //TODO: handle this more gracefully
             TRACE("Unable to allocate memory for GC.  memory_size=%zu size=%u\n", memory_size, size);
             return MEMORY_GC_ERROR_FAILED_ALLOCATION;
         }
-        size_t new_free_space = context_avail_free_memory(c);
-        size_t new_minimum_free_space = 2 * (size + MIN_FREE_SPACE_SIZE);
-        if (new_free_space > new_minimum_free_space) {
-            size_t new_memory_size = context_memory_size(c);
-            size_t new_requested_size = (new_memory_size - new_free_space) + new_minimum_free_space;
-            if (!c->has_min_heap_size || (c->min_heap_size < new_requested_size)) {
-                if (UNLIKELY(memory_gc(c, new_requested_size) != MEMORY_GC_OK)) {
-                    TRACE("Unable to allocate memory for GC shrink.  new_memory_size=%zu new_free_space=%zu new_minimum_free_space=%zu size=%u\n", new_memory_size, new_free_space, new_minimum_free_space, size);
-                    return MEMORY_GC_ERROR_FAILED_ALLOCATION;
+        if (shrink_mode != MEMORY_NO_SHRINK) {
+            size_t new_free_space = context_avail_free_memory(c);
+            if (new_free_space > maximum_free_space) {
+                size_t new_memory_size = context_memory_size(c);
+                size_t new_requested_size = (new_memory_size - new_free_space) + maximum_free_space;
+                if (!c->has_min_heap_size || (c->min_heap_size < new_requested_size)) {
+                    if (UNLIKELY(memory_gc(c, new_requested_size, num_roots, roots) != MEMORY_GC_OK)) {
+                        TRACE("Unable to allocate memory for GC shrink.  new_memory_size=%zu new_free_space=%zu new_minimum_free_space=%zu size=%u\n", new_memory_size, new_free_space, maximum_free_space, size);
+                        return MEMORY_GC_ERROR_FAILED_ALLOCATION;
+                    }
                 }
             }
-        }
-    }
-
-    return MEMORY_GC_OK;
-}
-
-enum MemoryGCResult memory_gc_and_shrink(Context *c)
-{
-    if (context_avail_free_memory(c) >= MIN_FREE_SPACE_SIZE * 2) {
-        if (UNLIKELY(memory_gc(c, context_memory_size(c) - context_avail_free_memory(c) / 2) != MEMORY_GC_OK)) {
-            fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
         }
     }
 
@@ -101,7 +93,7 @@ static inline void push_to_stack(term **stack, term value)
     **stack = value;
 }
 
-enum MemoryGCResult memory_gc(Context *ctx, int new_size)
+static enum MemoryGCResult memory_gc(Context *ctx, int new_size, int num_roots, term *roots)
 {
     TRACE("Going to perform gc on process %i\n", ctx->process_id);
     avm_int_t min_heap_size = ctx->has_min_heap_size ? ctx->min_heap_size : 0;
@@ -148,6 +140,11 @@ enum MemoryGCResult memory_gc(Context *ctx, int new_size)
 
     TRACE("- Running copy GC on exit reason\n");
     ctx->exit_reason = memory_shallow_copy_term(ctx->exit_reason, &heap_ptr, 1);
+
+    TRACE("- Running copy GC on provided roots\n");
+    for (int i = 0; i < num_roots; i++) {
+        roots[i] = memory_shallow_copy_term(roots[i], &heap_ptr, 1);
+    }
 
     term *temp_start = new_heap;
     term *temp_end = heap_ptr;

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -58,7 +58,7 @@ MALLOC_LIKE term *memory_alloc_heap_fragment(Context *ctx, uint32_t fragment_siz
     return (term *) (heap_fragment + 1);
 }
 
-enum MemoryGCResult memory_ensure_free_opt(Context *c, uint32_t size, enum MemoryShrinkMode shrink_mode, int num_roots, term *roots)
+enum MemoryGCResult memory_ensure_free_with_roots(Context *c, uint32_t size, int num_roots, term *roots, enum MemoryShrinkMode shrink_mode)
 {
     size_t free_space = context_avail_free_memory(c);
     size_t maximum_free_space = 2 * (size + MIN_FREE_SPACE_SIZE);

--- a/src/libAtomVM/memory.h
+++ b/src/libAtomVM/memory.h
@@ -45,6 +45,13 @@ enum MemoryGCResult
     MEMORY_GC_DENIED_ALLOCATION = 2
 };
 
+enum MemoryShrinkMode
+{
+    MEMORY_NO_SHRINK = 0,
+    MEMORY_CAN_SHRINK = 1,
+    MEMORY_FORCE_SHRINK = 2
+};
+
 /**
  * @brief allocates space for a certain amount of terms on the heap
  *
@@ -58,16 +65,6 @@ MALLOC_LIKE term *memory_heap_alloc(Context *ctx, uint32_t size);
 MALLOC_LIKE term *memory_alloc_heap_fragment(Context *ctx, uint32_t size);
 
 /**
- * @brief allocates a new memory block and executes garbage collection
- *
- * @details allocates a new memory block (that can have new size) and executes garbage collection, any existing term might be invalid after this call.
- * @param ctx the context that owns the memory block.
- * @param new_size the size of the new memory block in term units.
- * @returns MEMORY_GC_OK when successful.
- */
-enum MemoryGCResult memory_gc(Context *ctx, int new_size);
-
-/**
  * @brief copies a term to a destination heap
  *
  * @details deep copies a term to a destination heap, once finished old memory can be freed.
@@ -77,22 +74,33 @@ enum MemoryGCResult memory_gc(Context *ctx, int new_size);
 term memory_copy_term_tree(term **new_heap, term t, term *mso_list);
 
 /**
- * @brief meakes sure that the given context has given free memory
+ * @brief makes sure that the given context has given free memory.
+ *
+ * @details this function makes sure at least size terms are available. Optionally,
+ * it can shrink the heap to the specified size, depending on allocation strategy.
+ * The function can also be passed roots to update during any garbage collection.
+ * @param ctx the target context.
+ * @param size needed available memory.
+ * @param shrink if the heap can be shrunk
+ * @param num_roots number of roots
+ * @param roots roots to preserve
+ */
+enum MemoryGCResult memory_ensure_free_opt(Context *ctx, uint32_t size, enum MemoryShrinkMode shrink_mode, int num_roots, term *roots) MUST_CHECK;
+
+/**
+ * @brief makes sure that the given context has given free memory
  *
  * @details this function makes sure that at least size terms are available, when not available gc will be performed, any existing term might be invalid after this call.
-
+ * It does not shrink the heap, so if this function is called with a given value N and it is later called with a smaller value n, the actual amount of available free
+ * memory is N.
  * @param ctx the target context.
  * @param size needed available memory.
  */
-enum MemoryGCResult memory_ensure_free(Context *ctx, uint32_t size) MUST_CHECK;
-
-/**
- * @brief runs a garbage collection and shrinks used memory
- *
- * @details runs a garbage collection and shrinks used memory, a new heap will be allocated, any existing term might be invalid after this call.
- * @param ctx the context on which the garbage collection will be performed.
- */
-enum MemoryGCResult memory_gc_and_shrink(Context *ctx) MUST_CHECK;
+static inline enum MemoryGCResult memory_ensure_free(Context *ctx, uint32_t size)
+{
+    return memory_ensure_free_opt(ctx, size, MEMORY_NO_SHRINK, 0, NULL);
+}
+MUST_CHECK
 
 /**
  * @brief calculates term memory usage

--- a/src/libAtomVM/memory.h
+++ b/src/libAtomVM/memory.h
@@ -81,11 +81,25 @@ term memory_copy_term_tree(term **new_heap, term t, term *mso_list);
  * The function can also be passed roots to update during any garbage collection.
  * @param ctx the target context.
  * @param size needed available memory.
- * @param shrink if the heap can be shrunk
  * @param num_roots number of roots
  * @param roots roots to preserve
+ * @param shrink_mode whether the function can or should shrink
  */
-enum MemoryGCResult memory_ensure_free_opt(Context *ctx, uint32_t size, enum MemoryShrinkMode shrink_mode, int num_roots, term *roots) MUST_CHECK;
+enum MemoryGCResult memory_ensure_free_with_roots(Context *ctx, uint32_t size, int num_roots, term *roots, enum MemoryShrinkMode shrink_mode) MUST_CHECK;
+
+/**
+ * @brief makes sure that the given context has given free memory.
+ *
+ * @details this function makes sure at least size terms are available. Optionally,
+ * it can shrink the heap to the specified size, depending on allocation strategy.
+ * @param ctx the target context.
+ * @param size needed available memory.
+ * @param shrink_mode whether the function can or should shrink
+ */
+MUST_CHECK static inline enum MemoryGCResult memory_ensure_free_opt(Context *ctx, uint32_t size, enum MemoryShrinkMode shrink_mode)
+{
+    return memory_ensure_free_with_roots(ctx, size, 0, NULL, shrink_mode);
+}
 
 /**
  * @brief makes sure that the given context has given free memory
@@ -96,11 +110,10 @@ enum MemoryGCResult memory_ensure_free_opt(Context *ctx, uint32_t size, enum Mem
  * @param ctx the target context.
  * @param size needed available memory.
  */
-static inline enum MemoryGCResult memory_ensure_free(Context *ctx, uint32_t size)
+MUST_CHECK static inline enum MemoryGCResult memory_ensure_free(Context *ctx, uint32_t size)
 {
-    return memory_ensure_free_opt(ctx, size, MEMORY_NO_SHRINK, 0, NULL);
+    return memory_ensure_free_opt(ctx, size, MEMORY_NO_SHRINK);
 }
-MUST_CHECK
 
 /**
  * @brief calculates term memory usage

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -712,7 +712,7 @@ static inline term make_maybe_boxed_int64(Context *ctx, avm_int64_t value)
 {
     #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
         if ((value < AVM_INT_MIN) || (value > AVM_INT_MAX)) {
-            if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT64_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+            if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT64_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
             }
 
@@ -722,7 +722,7 @@ static inline term make_maybe_boxed_int64(Context *ctx, avm_int64_t value)
     #endif
 
     if ((value < MIN_NOT_BOXED_INT) || (value > MAX_NOT_BOXED_INT)) {
-        if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
 
@@ -786,7 +786,7 @@ static term nif_erlang_iolist_to_binary_1(Context *ctx, int argc, term argv[])
             RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(bin_size) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(bin_size) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         free(bin_buf);
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
@@ -1037,7 +1037,7 @@ static term nif_erlang_spawn_fun(Context *ctx, int argc, term argv[])
     for (uint32_t i = 0; i < n_freeze; i++) {
         size += memory_estimate_usage(boxed_value[i + 3]);
     }
-    if (UNLIKELY(memory_ensure_free_opt(new_ctx, size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(new_ctx, size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         //TODO: new process should be terminated, however a new pid is returned anyway
         fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
         AVM_ABORT();
@@ -1161,7 +1161,7 @@ static term nif_erlang_spawn(Context *ctx, int argc, term argv[])
     int reg_index = 0;
     term t = argv[2];
     avm_int_t size = MAX((unsigned long) term_to_int(min_heap_size_term), memory_estimate_usage(t));
-    if (UNLIKELY(memory_ensure_free_opt(new_ctx, size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(new_ctx, size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         //TODO: new process should be terminated, however a new pid is returned anyway
         fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
         AVM_ABORT();
@@ -1180,7 +1180,7 @@ static term nif_erlang_spawn(Context *ctx, int argc, term argv[])
 
     if (ref_ticks) {
         int res_size = REF_SIZE + TUPLE_SIZE(2);
-        if (UNLIKELY(memory_ensure_free_opt(ctx, res_size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, res_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             //TODO: new process should be terminated, however a new pid is returned anyway
             fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
             AVM_ABORT();
@@ -1243,7 +1243,7 @@ static term nif_erlang_concat_2(Context *ctx, int argc, term argv[])
     if (UNLIKELY(!proper)) {
         RAISE_ERROR(BADARG_ATOM);
     }
-    if (UNLIKELY(memory_ensure_free_opt(ctx, len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1285,7 +1285,7 @@ term nif_erlang_make_ref_0(Context *ctx, int argc, term argv[])
     UNUSED(argv);
 
     // a ref is 64 bits, hence 8 bytes
-    if (UNLIKELY(memory_ensure_free_opt(ctx, (8 / TERM_BYTES) + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, (8 / TERM_BYTES) + 1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1345,7 +1345,7 @@ term nif_erlang_universaltime_0(Context *ctx, int argc, term argv[])
     UNUSED(argv);
 
     // 4 = size of date/time tuple, 3 size of date time tuple
-    if (UNLIKELY(memory_ensure_free_opt(ctx, 3 + 4 + 4, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, 3 + 4 + 4, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term date_tuple = term_alloc_tuple(3, ctx);
@@ -1378,7 +1378,7 @@ term nif_erlang_timestamp_0(Context *ctx, int argc, term argv[])
     UNUSED(argc);
     UNUSED(argv);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, 4, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, 4, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term timestamp_tuple = term_alloc_tuple(3, ctx);
@@ -1405,7 +1405,7 @@ static term nif_erlang_make_tuple_2(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, count_elem + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, count_elem + 1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term new_tuple = term_alloc_tuple(count_elem, ctx);
@@ -1436,7 +1436,7 @@ static term nif_erlang_insert_element_3(Context *ctx, int argc, term argv[])
     }
 
     int new_tuple_size = old_tuple_size + 1;
-    if (UNLIKELY(memory_ensure_free_opt(ctx, new_tuple_size + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, new_tuple_size + 1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term new_tuple = term_alloc_tuple(new_tuple_size, ctx);
@@ -1474,7 +1474,7 @@ static term nif_erlang_delete_element_2(Context *ctx, int argc, term argv[])
     }
 
     int new_tuple_size = old_tuple_size - 1;
-    if (UNLIKELY(memory_ensure_free_opt(ctx, new_tuple_size + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, new_tuple_size + 1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term new_tuple = term_alloc_tuple(new_tuple_size, ctx);
@@ -1508,7 +1508,7 @@ static term nif_erlang_setelement_3(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, tuple_size + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, tuple_size + 1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term new_tuple = term_alloc_tuple(tuple_size, ctx);
@@ -1532,7 +1532,7 @@ static term nif_erlang_tuple_to_list_1(Context *ctx, int argc, term argv[])
 
     int tuple_size = term_get_tuple_arity(argv[0]);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, tuple_size * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, tuple_size * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1558,7 +1558,7 @@ static term nif_erlang_list_to_tuple_1(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(len), MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(len), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term tuple = term_alloc_tuple(len, ctx);
@@ -1656,7 +1656,7 @@ static term parse_float(Context *ctx, const char *buf, int len)
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     return term_from_float(fvalue, ctx);
@@ -1708,7 +1708,7 @@ static term nif_erlang_binary_to_list_1(Context *ctx, int argc, term argv[])
     VALIDATE_VALUE(value, term_is_binary);
 
     int bin_size = term_binary_size(value);
-    if (UNLIKELY(memory_ensure_free_opt(ctx, bin_size * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, bin_size * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1836,7 +1836,7 @@ static term nif_erlang_atom_to_binary_2(Context *ctx, int argc, term argv[])
 
     int atom_len = atom_string_len(atom_string);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(atom_len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(atom_len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1856,7 +1856,7 @@ static term nif_erlang_atom_to_list_1(Context *ctx, int argc, term argv[])
 
     int atom_len = atom_string_len(atom_string);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, atom_len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, atom_len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1919,7 +1919,7 @@ static term nif_erlang_integer_to_binary_2(Context *ctx, int argc, term argv[])
     avm_int64_t int_value = term_maybe_unbox_int64(value);
     size_t len = lltoa(int_value, base, NULL);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term result = term_create_empty_binary(len, ctx);
@@ -1945,7 +1945,7 @@ static term nif_erlang_integer_to_list_2(Context *ctx, int argc, term argv[])
     char integer_string[integer_string_len];
     lltoa(int_value, base, integer_string);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, integer_string_len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, integer_string_len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2070,7 +2070,7 @@ static term nif_erlang_float_to_binary(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2102,7 +2102,7 @@ static term nif_erlang_float_to_list(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2127,7 +2127,7 @@ static term nif_erlang_list_to_binary_1(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(BADARG_ATOM);
     }
 
@@ -2370,7 +2370,7 @@ static term nif_erlang_processes(Context *ctx, int argc, term argv[])
     UNUSED(argc);
 
     size_t num_processes = nif_num_processes(ctx->global);
-    if (memory_ensure_free_opt(ctx, 2 * num_processes, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
+    if (memory_ensure_free_opt(ctx, 2 * num_processes, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     return nif_list_processes(ctx);
@@ -2393,7 +2393,7 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
     int local_process_id = term_to_local_process_id(pid);
     Context *target = globalcontext_get_process(ctx->global, local_process_id);
 
-    if (memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
+    if (memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2447,7 +2447,7 @@ static term nif_erlang_system_info(Context *ctx, int argc, term argv[])
         return term_from_int32(TERM_BYTES);
     }
     if (key == MACHINE_ATOM) {
-        if (memory_ensure_free_opt(ctx, (sizeof("ATOM") - 1) * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
+        if (memory_ensure_free_opt(ctx, (sizeof("ATOM") - 1) * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_string((const uint8_t *) "ATOM", sizeof("ATOM") - 1, ctx);
@@ -2459,7 +2459,7 @@ static term nif_erlang_system_info(Context *ctx, int argc, term argv[])
         char buf[128];
         snprintf(buf, 128, "%s-%s-%s", SYSTEM_NAME, SYSTEM_VERSION, SYSTEM_ARCHITECTURE);
         size_t len = strnlen(buf, 128);
-        if (memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len), MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
+        if (memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len), MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_literal_binary((const uint8_t *) buf, len, ctx);
@@ -2511,7 +2511,7 @@ static term nif_erlang_binary_to_term(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM)
     }
     if (return_used) {
-        if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK, 1, &dst) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_with_roots(ctx, TUPLE_SIZE(2), 1, &dst, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term ret = term_alloc_tuple(2, ctx);
@@ -2614,7 +2614,7 @@ static term nif_binary_part_3(Context *ctx, int argc, term argv[])
     }
 
     size_t size = term_sub_binary_heap_size(bin_term, len);
-    if (UNLIKELY(memory_ensure_free_opt(ctx, size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     return term_maybe_create_sub_binary(argv[0], pos, len, ctx);
@@ -2652,7 +2652,7 @@ static term nif_binary_split_2(Context *ctx, int argc, term argv[])
         size_t rest_size_in_terms = term_sub_binary_heap_size(bin_term, rest_size);
 
         // + 4 which is the result cons
-        if (UNLIKELY(memory_ensure_free_opt(ctx, tok_size_in_terms + rest_size_in_terms + 4, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, tok_size_in_terms + rest_size_in_terms + 4, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
 
@@ -2666,7 +2666,7 @@ static term nif_binary_split_2(Context *ctx, int argc, term argv[])
         return result_list;
 
     } else {
-        if (UNLIKELY(memory_ensure_free_opt(ctx, 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
 
@@ -2721,7 +2721,7 @@ static term nif_erlang_pid_to_list(Context *ctx, int argc, term argv[])
 
     int str_len = strnlen(buf, 17);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2752,7 +2752,7 @@ static term nif_erlang_ref_to_list(Context *ctx, int argc, term argv[])
 
     int str_len = strnlen(buf, 33);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2787,7 +2787,7 @@ static term nif_erlang_fun_to_list(Context *ctx, int argc, term argv[])
 
     int str_len = strnlen(buf, 47);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2853,7 +2853,7 @@ static term nif_erlang_garbage_collect(Context *ctx, int argc, term argv[])
         }
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, 0, MEMORY_FORCE_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, 0, MEMORY_FORCE_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2935,7 +2935,7 @@ static term nif_erlang_monitor(Context *ctx, int argc, term argv[])
     Context *target = globalcontext_get_process(ctx->global, local_process_id);
     if (IS_NULL_PTR(target)) {
         int res_size = REF_SIZE + TUPLE_SIZE(5);
-        if (UNLIKELY(memory_ensure_free_opt(ctx, res_size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, res_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term ref = nif_erlang_make_ref_0(ctx, argc, argv);
@@ -2953,7 +2953,7 @@ static term nif_erlang_monitor(Context *ctx, int argc, term argv[])
 
     uint64_t ref_ticks = context_monitor(target, callee_pid, false);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, REF_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, REF_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -3101,7 +3101,7 @@ static term nif_atomvm_read_priv(Context *ctx, int argc, term argv[])
         if (avmpack_find_section_by_name(avmpack_data->data, complete_path, &bin_data, &size)) {
             uint32_t file_size = READ_32_ALIGNED((uint32_t *) bin_data);
             free(complete_path);
-            if (UNLIKELY(memory_ensure_free_opt(ctx, TERM_BOXED_REFC_BINARY_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+            if (UNLIKELY(memory_ensure_free_opt(ctx, TERM_BOXED_REFC_BINARY_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
             }
             return term_from_const_binary(((uint8_t *) bin_data) + sizeof(uint32_t), file_size, ctx);
@@ -3179,7 +3179,7 @@ static term base64_encode(Context *ctx, int argc, term argv[], bool return_binar
         }
         if (src_size == 0) {
             if (return_binary) {
-                if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                     RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                 }
                 return term_create_empty_binary(0, ctx);
@@ -3223,7 +3223,7 @@ static term base64_encode(Context *ctx, int argc, term argv[], bool return_binar
     size_t heap_free = return_binary ?
         term_binary_data_size_in_terms(dst_size_with_pad) + BINARY_HEADER_SIZE
         : 2*dst_size_with_pad;
-    if (UNLIKELY(memory_ensure_free_opt(ctx, heap_free, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, heap_free, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     if (term_is_binary(argv[0])) {
@@ -3326,7 +3326,7 @@ static term base64_decode(Context *ctx, int argc, term argv[], bool return_binar
         }
         if (src_size == 0) {
             if (return_binary) {
-                if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                     RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                 }
                 return term_create_empty_binary(0, ctx);
@@ -3370,7 +3370,7 @@ static term base64_decode(Context *ctx, int argc, term argv[], bool return_binar
     size_t heap_free = return_binary ?
         term_binary_data_size_in_terms(dst_size) + BINARY_HEADER_SIZE
         : 2*dst_size;
-    if (UNLIKELY(memory_ensure_free_opt(ctx, heap_free, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, heap_free, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term dst = term_invalid_term();
@@ -3470,7 +3470,7 @@ static term nif_maps_next(Context *ctx, int argc, term argv[])
         return NONE_ATOM;
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, 6, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, 6, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -3535,7 +3535,7 @@ static term math_unary_op(Context *ctx, term x_term, unary_math_f f)
         return exception;
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         return OUT_OF_MEMORY_ATOM;
     }
     return term_from_float(y, ctx);
@@ -3555,7 +3555,7 @@ static term math_binary_op(Context *ctx, term x_term, term y_term, binary_math_f
         return exception;
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         return OUT_OF_MEMORY_ATOM;
     }
     return term_from_float(z, ctx);

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -712,7 +712,7 @@ static inline term make_maybe_boxed_int64(Context *ctx, avm_int64_t value)
 {
     #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
         if ((value < AVM_INT_MIN) || (value > AVM_INT_MAX)) {
-            if (UNLIKELY(memory_ensure_free(ctx, BOXED_INT64_SIZE) != MEMORY_GC_OK)) {
+            if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT64_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
             }
 
@@ -722,7 +722,7 @@ static inline term make_maybe_boxed_int64(Context *ctx, avm_int64_t value)
     #endif
 
     if ((value < MIN_NOT_BOXED_INT) || (value > MAX_NOT_BOXED_INT)) {
-        if (UNLIKELY(memory_ensure_free(ctx, BOXED_INT_SIZE) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
 
@@ -786,7 +786,7 @@ static term nif_erlang_iolist_to_binary_1(Context *ctx, int argc, term argv[])
             RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(bin_size) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(bin_size) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         free(bin_buf);
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
@@ -1037,7 +1037,7 @@ static term nif_erlang_spawn_fun(Context *ctx, int argc, term argv[])
     for (uint32_t i = 0; i < n_freeze; i++) {
         size += memory_estimate_usage(boxed_value[i + 3]);
     }
-    if (UNLIKELY(memory_ensure_free(new_ctx, size) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(new_ctx, size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         //TODO: new process should be terminated, however a new pid is returned anyway
         fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
         AVM_ABORT();
@@ -1161,7 +1161,7 @@ static term nif_erlang_spawn(Context *ctx, int argc, term argv[])
     int reg_index = 0;
     term t = argv[2];
     avm_int_t size = MAX((unsigned long) term_to_int(min_heap_size_term), memory_estimate_usage(t));
-    if (UNLIKELY(memory_ensure_free(new_ctx, size) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(new_ctx, size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         //TODO: new process should be terminated, however a new pid is returned anyway
         fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
         AVM_ABORT();
@@ -1180,7 +1180,7 @@ static term nif_erlang_spawn(Context *ctx, int argc, term argv[])
 
     if (ref_ticks) {
         int res_size = REF_SIZE + TUPLE_SIZE(2);
-        if (UNLIKELY(memory_ensure_free(ctx, res_size) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, res_size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             //TODO: new process should be terminated, however a new pid is returned anyway
             fprintf(stderr, "Unable to allocate sufficient memory to spawn process.\n");
             AVM_ABORT();
@@ -1243,7 +1243,7 @@ static term nif_erlang_concat_2(Context *ctx, int argc, term argv[])
     if (UNLIKELY(!proper)) {
         RAISE_ERROR(BADARG_ATOM);
     }
-    if (UNLIKELY(memory_ensure_free(ctx, len * 2) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1285,7 +1285,7 @@ term nif_erlang_make_ref_0(Context *ctx, int argc, term argv[])
     UNUSED(argv);
 
     // a ref is 64 bits, hence 8 bytes
-    if (UNLIKELY(memory_ensure_free(ctx, (8 / TERM_BYTES) + 1) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, (8 / TERM_BYTES) + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1345,7 +1345,7 @@ term nif_erlang_universaltime_0(Context *ctx, int argc, term argv[])
     UNUSED(argv);
 
     // 4 = size of date/time tuple, 3 size of date time tuple
-    if (UNLIKELY(memory_ensure_free(ctx, 3 + 4 + 4) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, 3 + 4 + 4, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term date_tuple = term_alloc_tuple(3, ctx);
@@ -1378,7 +1378,7 @@ term nif_erlang_timestamp_0(Context *ctx, int argc, term argv[])
     UNUSED(argc);
     UNUSED(argv);
 
-    if (UNLIKELY(memory_ensure_free(ctx, 4) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, 4, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term timestamp_tuple = term_alloc_tuple(3, ctx);
@@ -1405,7 +1405,7 @@ static term nif_erlang_make_tuple_2(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, count_elem + 1) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, count_elem + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term new_tuple = term_alloc_tuple(count_elem, ctx);
@@ -1436,7 +1436,7 @@ static term nif_erlang_insert_element_3(Context *ctx, int argc, term argv[])
     }
 
     int new_tuple_size = old_tuple_size + 1;
-    if (UNLIKELY(memory_ensure_free(ctx, new_tuple_size + 1) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, new_tuple_size + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term new_tuple = term_alloc_tuple(new_tuple_size, ctx);
@@ -1474,7 +1474,7 @@ static term nif_erlang_delete_element_2(Context *ctx, int argc, term argv[])
     }
 
     int new_tuple_size = old_tuple_size - 1;
-    if (UNLIKELY(memory_ensure_free(ctx, new_tuple_size + 1) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, new_tuple_size + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term new_tuple = term_alloc_tuple(new_tuple_size, ctx);
@@ -1508,7 +1508,7 @@ static term nif_erlang_setelement_3(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, tuple_size + 1) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, tuple_size + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term new_tuple = term_alloc_tuple(tuple_size, ctx);
@@ -1532,7 +1532,7 @@ static term nif_erlang_tuple_to_list_1(Context *ctx, int argc, term argv[])
 
     int tuple_size = term_get_tuple_arity(argv[0]);
 
-    if (UNLIKELY(memory_ensure_free(ctx, tuple_size * 2) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, tuple_size * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1558,7 +1558,7 @@ static term nif_erlang_list_to_tuple_1(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(len)) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(len), MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term tuple = term_alloc_tuple(len, ctx);
@@ -1656,7 +1656,7 @@ static term parse_float(Context *ctx, const char *buf, int len)
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, FLOAT_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     return term_from_float(fvalue, ctx);
@@ -1708,7 +1708,7 @@ static term nif_erlang_binary_to_list_1(Context *ctx, int argc, term argv[])
     VALIDATE_VALUE(value, term_is_binary);
 
     int bin_size = term_binary_size(value);
-    if (UNLIKELY(memory_ensure_free(ctx, bin_size * 2) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, bin_size * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1836,7 +1836,7 @@ static term nif_erlang_atom_to_binary_2(Context *ctx, int argc, term argv[])
 
     int atom_len = atom_string_len(atom_string);
 
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(atom_len) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(atom_len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1856,7 +1856,7 @@ static term nif_erlang_atom_to_list_1(Context *ctx, int argc, term argv[])
 
     int atom_len = atom_string_len(atom_string);
 
-    if (UNLIKELY(memory_ensure_free(ctx, atom_len * 2) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, atom_len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -1919,7 +1919,7 @@ static term nif_erlang_integer_to_binary_2(Context *ctx, int argc, term argv[])
     avm_int64_t int_value = term_maybe_unbox_int64(value);
     size_t len = lltoa(int_value, base, NULL);
 
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term result = term_create_empty_binary(len, ctx);
@@ -1945,7 +1945,7 @@ static term nif_erlang_integer_to_list_2(Context *ctx, int argc, term argv[])
     char integer_string[integer_string_len];
     lltoa(int_value, base, integer_string);
 
-    if (UNLIKELY(memory_ensure_free(ctx, integer_string_len * 2) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, integer_string_len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2070,7 +2070,7 @@ static term nif_erlang_float_to_binary(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2102,7 +2102,7 @@ static term nif_erlang_float_to_list(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, len * 2) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2127,7 +2127,7 @@ static term nif_erlang_list_to_binary_1(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(BADARG_ATOM);
     }
 
@@ -2370,7 +2370,7 @@ static term nif_erlang_processes(Context *ctx, int argc, term argv[])
     UNUSED(argc);
 
     size_t num_processes = nif_num_processes(ctx->global);
-    if (memory_ensure_free(ctx, 2 * num_processes) != MEMORY_GC_OK) {
+    if (memory_ensure_free_opt(ctx, 2 * num_processes, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     return nif_list_processes(ctx);
@@ -2393,7 +2393,7 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
     int local_process_id = term_to_local_process_id(pid);
     Context *target = globalcontext_get_process(ctx->global, local_process_id);
 
-    if (memory_ensure_free(ctx, 3) != MEMORY_GC_OK) {
+    if (memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2447,7 +2447,7 @@ static term nif_erlang_system_info(Context *ctx, int argc, term argv[])
         return term_from_int32(TERM_BYTES);
     }
     if (key == MACHINE_ATOM) {
-        if (memory_ensure_free(ctx, (sizeof("ATOM") - 1) * 2) != MEMORY_GC_OK) {
+        if (memory_ensure_free_opt(ctx, (sizeof("ATOM") - 1) * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_string((const uint8_t *) "ATOM", sizeof("ATOM") - 1, ctx);
@@ -2459,7 +2459,7 @@ static term nif_erlang_system_info(Context *ctx, int argc, term argv[])
         char buf[128];
         snprintf(buf, 128, "%s-%s-%s", SYSTEM_NAME, SYSTEM_VERSION, SYSTEM_ARCHITECTURE);
         size_t len = strnlen(buf, 128);
-        if (memory_ensure_free(ctx, term_binary_data_size_in_terms(len)) != MEMORY_GC_OK) {
+        if (memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len), MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_literal_binary((const uint8_t *) buf, len, ctx);
@@ -2511,13 +2511,11 @@ static term nif_erlang_binary_to_term(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM)
     }
     if (return_used) {
-        // Trick: use x[0] as a gc root.
-        ctx->x[0] = dst;
-        if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK, 1, &dst) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term ret = term_alloc_tuple(2, ctx);
-        term_put_tuple_element(ret, 0, ctx->x[0]);
+        term_put_tuple_element(ret, 0, dst);
         term_put_tuple_element(ret, 1, term_from_int(bytes_read));
         return ret;
     } else {
@@ -2616,7 +2614,7 @@ static term nif_binary_part_3(Context *ctx, int argc, term argv[])
     }
 
     size_t size = term_sub_binary_heap_size(bin_term, len);
-    if (UNLIKELY(memory_ensure_free(ctx, size) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     return term_maybe_create_sub_binary(argv[0], pos, len, ctx);
@@ -2654,7 +2652,7 @@ static term nif_binary_split_2(Context *ctx, int argc, term argv[])
         size_t rest_size_in_terms = term_sub_binary_heap_size(bin_term, rest_size);
 
         // + 4 which is the result cons
-        if (UNLIKELY(memory_ensure_free(ctx, tok_size_in_terms + rest_size_in_terms + 4) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, tok_size_in_terms + rest_size_in_terms + 4, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
 
@@ -2668,7 +2666,7 @@ static term nif_binary_split_2(Context *ctx, int argc, term argv[])
         return result_list;
 
     } else {
-        if (UNLIKELY(memory_ensure_free(ctx, 2) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
 
@@ -2723,7 +2721,7 @@ static term nif_erlang_pid_to_list(Context *ctx, int argc, term argv[])
 
     int str_len = strnlen(buf, 17);
 
-    if (UNLIKELY(memory_ensure_free(ctx, str_len * 2) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2754,7 +2752,7 @@ static term nif_erlang_ref_to_list(Context *ctx, int argc, term argv[])
 
     int str_len = strnlen(buf, 33);
 
-    if (UNLIKELY(memory_ensure_free(ctx, str_len * 2) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2789,7 +2787,7 @@ static term nif_erlang_fun_to_list(Context *ctx, int argc, term argv[])
 
     int str_len = strnlen(buf, 47);
 
-    if (UNLIKELY(memory_ensure_free(ctx, str_len * 2) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2855,18 +2853,8 @@ static term nif_erlang_garbage_collect(Context *ctx, int argc, term argv[])
         }
     }
 
-    size_t memory_size = context_memory_size(c);
-    if (UNLIKELY(memory_gc(c, memory_size + MIN_FREE_SPACE_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, 0, MEMORY_FORCE_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-    }
-
-    size_t free_space = context_avail_free_memory(c);
-    size_t minimum_free_space = 2 * MIN_FREE_SPACE_SIZE;
-    if (free_space > minimum_free_space) {
-        memory_size = context_memory_size(c);
-        if (UNLIKELY(memory_gc(c, (memory_size - free_space) + minimum_free_space) != MEMORY_GC_OK)) {
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-        }
     }
 
     return TRUE_ATOM;
@@ -2947,7 +2935,7 @@ static term nif_erlang_monitor(Context *ctx, int argc, term argv[])
     Context *target = globalcontext_get_process(ctx->global, local_process_id);
     if (IS_NULL_PTR(target)) {
         int res_size = REF_SIZE + TUPLE_SIZE(5);
-        if (UNLIKELY(memory_ensure_free(ctx, res_size) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, res_size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term ref = nif_erlang_make_ref_0(ctx, argc, argv);
@@ -2965,7 +2953,7 @@ static term nif_erlang_monitor(Context *ctx, int argc, term argv[])
 
     uint64_t ref_ticks = context_monitor(target, callee_pid, false);
 
-    if (UNLIKELY(memory_ensure_free(ctx, REF_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, REF_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -3113,7 +3101,7 @@ static term nif_atomvm_read_priv(Context *ctx, int argc, term argv[])
         if (avmpack_find_section_by_name(avmpack_data->data, complete_path, &bin_data, &size)) {
             uint32_t file_size = READ_32_ALIGNED((uint32_t *) bin_data);
             free(complete_path);
-            if (UNLIKELY(memory_ensure_free(ctx, TERM_BOXED_REFC_BINARY_SIZE) != MEMORY_GC_OK)) {
+            if (UNLIKELY(memory_ensure_free_opt(ctx, TERM_BOXED_REFC_BINARY_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
             }
             return term_from_const_binary(((uint8_t *) bin_data) + sizeof(uint32_t), file_size, ctx);
@@ -3191,7 +3179,7 @@ static term base64_encode(Context *ctx, int argc, term argv[], bool return_binar
         }
         if (src_size == 0) {
             if (return_binary) {
-                if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+                if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
                     RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                 }
                 return term_create_empty_binary(0, ctx);
@@ -3235,7 +3223,7 @@ static term base64_encode(Context *ctx, int argc, term argv[], bool return_binar
     size_t heap_free = return_binary ?
         term_binary_data_size_in_terms(dst_size_with_pad) + BINARY_HEADER_SIZE
         : 2*dst_size_with_pad;
-    if (UNLIKELY(memory_ensure_free(ctx, heap_free) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, heap_free, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     if (term_is_binary(argv[0])) {
@@ -3338,7 +3326,7 @@ static term base64_decode(Context *ctx, int argc, term argv[], bool return_binar
         }
         if (src_size == 0) {
             if (return_binary) {
-                if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+                if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
                     RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                 }
                 return term_create_empty_binary(0, ctx);
@@ -3382,7 +3370,7 @@ static term base64_decode(Context *ctx, int argc, term argv[], bool return_binar
     size_t heap_free = return_binary ?
         term_binary_data_size_in_terms(dst_size) + BINARY_HEADER_SIZE
         : 2*dst_size;
-    if (UNLIKELY(memory_ensure_free(ctx, heap_free) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, heap_free, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term dst = term_invalid_term();
@@ -3482,7 +3470,7 @@ static term nif_maps_next(Context *ctx, int argc, term argv[])
         return NONE_ATOM;
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, 6) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, 6, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -3547,7 +3535,7 @@ static term math_unary_op(Context *ctx, term x_term, unary_math_f f)
         return exception;
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, FLOAT_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         return OUT_OF_MEMORY_ATOM;
     }
     return term_from_float(y, ctx);
@@ -3567,7 +3555,7 @@ static term math_binary_op(Context *ctx, term x_term, term y_term, binary_math_f
         return exception;
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, FLOAT_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, FLOAT_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
         return OUT_OF_MEMORY_ATOM;
     }
     return term_from_float(z, ctx);

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1137,7 +1137,7 @@ term make_fun(Context *ctx, const Module *mod, int fun_index)
     uint32_t n_freeze = module_get_fun_freeze(mod, fun_index);
 
     int size = BOXED_FUN_SIZE + n_freeze;
-    if (memory_ensure_free_opt(ctx, size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
+    if (memory_ensure_free_opt(ctx, size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
         return term_invalid_term();
     }
     term *boxed_func = memory_heap_alloc(ctx, size);
@@ -1764,7 +1764,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     context_clean_registers(ctx, live);
 
                     if (ctx->heap_ptr > ctx->e - (stack_need + 1)) {
-                        if (UNLIKELY(memory_ensure_free_opt(ctx, stack_need + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                        if (UNLIKELY(memory_ensure_free_opt(ctx, stack_need + 1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         }
                     }
@@ -1800,7 +1800,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     context_clean_registers(ctx, live);
 
                     if ((ctx->heap_ptr + heap_need) > ctx->e - (stack_need + 1)) {
-                        if (UNLIKELY(memory_ensure_free_opt(ctx, heap_need + stack_need + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                        if (UNLIKELY(memory_ensure_free_opt(ctx, heap_need + stack_need + 1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         }
                     }
@@ -1833,7 +1833,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     context_clean_registers(ctx, live);
 
                     if (ctx->heap_ptr > ctx->e - (stack_need + 1)) {
-                        if (UNLIKELY(memory_ensure_free_opt(ctx, stack_need + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                        if (UNLIKELY(memory_ensure_free_opt(ctx, stack_need + 1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         }
                     }
@@ -1873,7 +1873,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     context_clean_registers(ctx, live);
 
                     if ((ctx->heap_ptr + heap_need) > ctx->e - (stack_need + 1)) {
-                        if (UNLIKELY(memory_ensure_free_opt(ctx, heap_need + stack_need + 1, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                        if (UNLIKELY(memory_ensure_free_opt(ctx, heap_need + stack_need + 1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         }
                     }
@@ -1904,14 +1904,14 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     // if we need more heap space than is currently free, then try to GC the needed space
                     if (heap_free < heap_need) {
                         context_clean_registers(ctx, live_registers);
-                        if (UNLIKELY(memory_ensure_free_opt(ctx, heap_need, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                        if (UNLIKELY(memory_ensure_free_opt(ctx, heap_need, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         }
                     // otherwise, there is enough space for the needed heap, but there might
                     // more more than necessary.  In that case, try to shrink the heap.
                     } else if (heap_free > heap_need * HEAP_NEED_GC_SHRINK_THRESHOLD_COEFF) {
                         context_clean_registers(ctx, live_registers);
-                        if (UNLIKELY(memory_ensure_free_opt(ctx, heap_need * (HEAP_NEED_GC_SHRINK_THRESHOLD_COEFF / 2), MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                        if (UNLIKELY(memory_ensure_free_opt(ctx, heap_need * (HEAP_NEED_GC_SHRINK_THRESHOLD_COEFF / 2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                             TRACE("Unable to ensure free memory.  heap_need=%i\n", heap_need);
                             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         }
@@ -3044,7 +3044,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
             case OP_BADMATCH: {
                 #ifdef IMPL_EXECUTE_LOOP
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                 #endif
@@ -3095,7 +3095,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
             case OP_CASE_END: {
                 #ifdef IMPL_EXECUTE_LOOP
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                 #endif
@@ -3144,7 +3144,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
                     term fun = ctx->x[args_count];
                     if (UNLIKELY(!term_is_function(fun))) {
-                        if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                        if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         }
                         term new_error_tuple = term_alloc_tuple(2, ctx);
@@ -3333,7 +3333,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
             case OP_TRY_CASE_END: {
                 #ifdef IMPL_EXECUTE_LOOP
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                 #endif
@@ -3425,7 +3425,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         case ERROR_ATOM_INDEX: {
                             ctx->x[2] = stacktrace_build(ctx, &ctx->x[2]);
 
-                            if (UNLIKELY(memory_ensure_free_opt(ctx, 6, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                            if (UNLIKELY(memory_ensure_free_opt(ctx, 6, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                             }
                             term reason_tuple = term_alloc_tuple(2, ctx);
@@ -3439,7 +3439,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                             break;
                         }
                         case LOWERCASE_EXIT_ATOM_INDEX: {
-                            if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                            if (UNLIKELY(memory_ensure_free_opt(ctx, 3, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                             }
                             term exit_tuple = term_alloc_tuple(2, ctx);
@@ -3516,7 +3516,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
                     TRACE("bs_init2/6, fail=%u size=%li words=%u regs=%u dreg=%c%i\n", (unsigned) fail, size_val, (unsigned) words, (unsigned) regs, T_DEST_REG(dreg_type, dreg));
 
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(size_val) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(size_val) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     term t = term_create_empty_binary(size_val, ctx);
@@ -3565,7 +3565,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
                     TRACE("bs_init_bits/6, fail=%i size=%li words=%i regs=%i dreg=%c%i\n", fail, size_val, words, regs, T_DEST_REG(dreg_type, dreg));
 
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(size_val / 8) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(size_val / 8) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     term t = term_create_empty_binary(size_val / 8, ctx);
@@ -4018,7 +4018,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 TRACE("bs_init_writable/0\n");
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     term t = term_create_empty_binary(0, ctx);
@@ -4082,7 +4082,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
                     size_t src_size = term_binary_size(src);
                     // TODO: further investigate extra_val
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, src_size + term_binary_data_size_in_terms(size_val / 8) + extra_val + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, src_size + term_binary_data_size_in_terms(size_val / 8) + extra_val + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     DECODE_COMPACT_TERM(src, code, i, src_off)
@@ -4137,7 +4137,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     TRACE("bs_private_append/6, fail=%u size=%li unit=%u src=0x%lx dreg=%c%i\n", (unsigned) fail, size_val, (unsigned) unit, src, T_DEST_REG(dreg_type, dreg));
 
                     size_t src_size = term_binary_size(src);
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, src_size + term_binary_data_size_in_terms(size_val / 8) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, src_size + term_binary_data_size_in_terms(size_val / 8) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     DECODE_COMPACT_TERM(src, code, i, src_off)
@@ -4307,7 +4307,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 #ifdef IMPL_EXECUTE_LOOP
                     int slots = term_to_int(slots_term);
 
-                    if (memory_ensure_free_opt(ctx, TERM_BOXED_BIN_MATCH_STATE_SIZE + slots, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
+                    if (memory_ensure_free_opt(ctx, TERM_BOXED_BIN_MATCH_STATE_SIZE + slots, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
 
@@ -4339,7 +4339,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
             case OP_BS_START_MATCH3: {
                 #ifdef IMPL_EXECUTE_LOOP
-                    if (memory_ensure_free_opt(ctx, TERM_BOXED_BIN_MATCH_STATE_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
+                    if (memory_ensure_free_opt(ctx, TERM_BOXED_BIN_MATCH_STATE_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                 #endif
@@ -4446,7 +4446,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                             size_t heap_size = term_sub_binary_heap_size(bs_bin, src_size - start_pos);
 
 
-                            if (UNLIKELY(memory_ensure_free_opt(ctx, heap_size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                            if (UNLIKELY(memory_ensure_free_opt(ctx, heap_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                             }
                             DECODE_COMPACT_TERM(src, code, i, src_off);
@@ -4834,7 +4834,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     term_set_match_state_offset(src, bs_offset + size_val * unit);
 
                     size_t heap_size = term_sub_binary_heap_size(bs_bin, size_val);
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, heap_size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, heap_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     // re-compute src
@@ -4880,7 +4880,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                             term src_bin = term_get_match_state_binary(src);
                             int len = term_binary_size(src_bin) - offset / 8;
                             size_t heap_size = term_sub_binary_heap_size(src_bin, len);
-                            if (UNLIKELY(memory_ensure_free_opt(ctx, heap_size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                            if (UNLIKELY(memory_ensure_free_opt(ctx, heap_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                             }
                             // src might be invalid after a GC
@@ -5378,7 +5378,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     size_t new_map_size = src_size + new_entries;
                     bool is_shared = new_entries == 0;
                     size_t heap_needed = term_map_size_in_terms_maybe_shared(new_map_size, is_shared);
-                    if (memory_ensure_free_opt(ctx, heap_needed, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
+                    if (memory_ensure_free_opt(ctx, heap_needed, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     DECODE_COMPACT_TERM(src, code, i, src_offset);
@@ -5506,7 +5506,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     // Maybe GC, and reset the src term in case it changed
                     //
                     size_t src_size = term_get_map_size(src);
-                    if (memory_ensure_free_opt(ctx, term_map_size_in_terms_maybe_shared(src_size, true), MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
+                    if (memory_ensure_free_opt(ctx, term_map_size_in_terms_maybe_shared(src_size, true), MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     DECODE_COMPACT_TERM(src, code, i, src_offset);
@@ -6069,7 +6069,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
             case OP_BS_START_MATCH4: {
                 #ifdef IMPL_EXECUTE_LOOP
-                    if (memory_ensure_free_opt(ctx, TERM_BOXED_BIN_MATCH_STATE_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
+                    if (memory_ensure_free_opt(ctx, TERM_BOXED_BIN_MATCH_STATE_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                 #endif
@@ -6331,7 +6331,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         RAISE_ERROR(UNSUPPORTED_ATOM);
                     }
                     context_clean_registers(ctx, live);
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, alloc + term_binary_data_size_in_terms(binary_size / 8) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, alloc + term_binary_data_size_in_terms(binary_size / 8) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     term t = term_create_empty_binary(binary_size / 8, ctx);
@@ -6490,7 +6490,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
                 #ifdef IMPL_EXECUTE_LOOP
                     if (UNLIKELY(!term_is_function(fun))) {
-                        if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                        if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                         }
                         // Decode the function again after GC was possibly run
@@ -6515,7 +6515,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 TRACE("badrecord/1\n");
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     term value;
@@ -6734,7 +6734,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                                     goto bs_match_jump_to_fail;
                                 }
                                 size_t heap_size = term_sub_binary_heap_size(bs_bin, matched_bits / 8);
-                                if (UNLIKELY(memory_ensure_free_opt(ctx, heap_size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                                if (UNLIKELY(memory_ensure_free_opt(ctx, heap_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                                     RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                                 }
                                 // re-compute match_state as GC could have moved it
@@ -6768,7 +6768,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                                     RAISE_ERROR(BADARG_ATOM);
                                 }
                                 size_t heap_size = term_sub_binary_heap_size(bs_bin, tail_bits / 8);
-                                if (UNLIKELY(memory_ensure_free_opt(ctx, heap_size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK)) {
+                                if (UNLIKELY(memory_ensure_free_opt(ctx, heap_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                                     RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                                 }
                                 // re-compute match_state as GC could have moved it
@@ -6874,7 +6874,7 @@ handle_error:
             bool throw = ctx->x[0] == THROW_ATOM;
 
             int exit_reason_tuple_size = (throw ? TUPLE_SIZE(2) : 0) + TUPLE_SIZE(2);
-            if (memory_ensure_free_opt(ctx, exit_reason_tuple_size, MEMORY_CAN_SHRINK, 0, NULL) != MEMORY_GC_OK) {
+            if (memory_ensure_free_opt(ctx, exit_reason_tuple_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
                 ctx->exit_reason = OUT_OF_MEMORY_ATOM;
             } else {
                 term error_term;


### PR DESCRIPTION
Update `memory_ensure_free` so it never reduces the amount of free memory.

Update `memory_gc` to optionally handle additional roots.

Introduce `memory_ensure_free_opt` that can shrink the heap a little bit
more aggressively (including when amount of free memory is higher than what
is required plus a margin) and use it instead where it is safe.

Replace usage of `memory_gc` with `memory_ensure_free_opt` and remove it
from `memory.h` header.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
