### PR TITLE
Add support for erlang:memory(binary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for FP opcodes 94-102 thus removing the need for `AVM_DISABLE_FP=On` with OTP-22+
 - Added support for stacktraces
 - Added support for `utf-8`, `utf-16`, and `utf-32` bit syntax modifiers (put and match)
+- Added support for `erlang:memory(binary)`
 
 
 ### Fixed

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -340,6 +340,16 @@ The 0-arity version of this function will run the garbage collector on the curre
     Pid = ... %% get a reference to some pid
     ok = erlang:garbage_collect(Pid).
 
+Use the `erlang:memory/1` function to obtain information about allocated memory.
+
+Currently, AtomVM supports the following types:
+
+| Type | Description |
+|------|-------------|
+| `binary` | Return the total amount of memory (in bytes) occupied by (reference counted) binaries |
+
+> Note.  Binary data small enough to be stored in the Erlang process heap are not counted in this measurement.
+
 ### System Time
 
 AtomVM supports numerous function for accessing the current time on the device.

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -38,7 +38,8 @@
     map_get/2,
     map_is_key/2,
     min/2,
-    max/2
+    max/2,
+    memory/1
 ]).
 
 %%
@@ -47,6 +48,8 @@
 %% * return value needs to be {ok, cancel} or {error, Reason}
 %% * review API documentation for timer functions in this module
 %%
+
+-type mem_type() :: binary.
 
 %%-----------------------------------------------------------------------------
 %% @param   Time time in milliseconds after which to send the timeout message.
@@ -281,3 +284,14 @@ min(_A, B) -> B.
 %%-----------------------------------------------------------------------------
 max(A, B) when A > B -> A;
 max(_A, B) -> B.
+
+%%-----------------------------------------------------------------------------
+%% @param   Type the type of memory to request
+%% @returns the amount of memory (in bytes) used of the specified type
+%% @doc     Return the amount of memory (in bytes) used of the specified type
+%%
+%% @end
+%%-----------------------------------------------------------------------------
+-spec memory(Type :: mem_type()) -> non_neg_integer().
+memory(_Type) ->
+    throw(nif_error).

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -145,6 +145,7 @@ static term nif_erlang_fun_to_list(Context *ctx, int argc, term argv[]);
 static term nif_erlang_function_exported(Context *ctx, int argc, term argv[]);
 static term nif_erlang_garbage_collect(Context *ctx, int argc, term argv[]);
 static term nif_erlang_group_leader(Context *ctx, int argc, term argv[]);
+static term nif_erlang_memory(Context *ctx, int argc, term argv[]);
 static term nif_erlang_monitor(Context *ctx, int argc, term argv[]);
 static term nif_erlang_demonitor(Context *ctx, int argc, term argv[]);
 static term nif_erlang_unlink(Context *ctx, int argc, term argv[]);
@@ -564,6 +565,12 @@ static const struct Nif make_fun_nif =
 {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_erlang_make_fun_3
+};
+
+static const struct Nif memory_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_erlang_memory
 };
 
 static const struct Nif monitor_nif =
@@ -2463,6 +2470,7 @@ static term nif_erlang_system_info(Context *ctx, int argc, term argv[])
         return term_from_literal_binary((const uint8_t *) ATOMVM_VERSION, strlen(ATOMVM_VERSION), ctx);
     }
     if (key == REFC_BINARY_INFO_ATOM) {
+        fprintf(stderr, "WARNING: The refc_binary_info system info tag is deprecated.  Use erlang:memory(binary) instead.\n");
         term ret = refc_binary_create_binary_info(ctx);
         if (term_is_invalid_term(ret)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
@@ -2912,6 +2920,25 @@ static term nif_erlang_erase_1(Context *ctx, int argc, term argv[])
     }
 
     return old;
+}
+
+static term nif_erlang_memory(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+
+    term type = argv[0];
+    VALIDATE_VALUE(type, term_is_atom);
+
+    if (type == BINARY_ATOM) {
+        size_t size = refc_binary_total_size(ctx);
+        size_t term_size = term_boxed_integer_size(size);
+        if (UNLIKELY(memory_ensure_free_opt(ctx, term_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
+        return term_make_maybe_boxed_int64(ctx, size);
+    } else {
+        RAISE_ERROR(BADARG_ATOM);
+    }
 }
 
 static term nif_erlang_monitor(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -71,6 +71,7 @@ erlang:open_port/2, &open_port_nif
 erlang:make_fun/3, &make_fun_nif
 erlang:make_ref/0, &make_ref_nif
 erlang:make_tuple/2, &make_tuple_nif
+erlang:memory/1, &memory_nif
 erlang:monitor/2, &monitor_nif
 erlang:demonitor/1, &demonitor_nif
 erlang:is_process_alive/1, &is_process_alive_nif

--- a/src/libAtomVM/refc_binary.c
+++ b/src/libAtomVM/refc_binary.c
@@ -89,3 +89,14 @@ term refc_binary_create_binary_info(Context *ctx)
     }
     return ret;
 }
+
+size_t refc_binary_total_size(Context *ctx)
+{
+    size_t size = 0;
+    struct ListHead *item;
+    LIST_FOR_EACH (item, &ctx->global->refc_binaries) {
+        struct RefcBinary *refc = GET_LIST_ENTRY(item, struct RefcBinary, head);
+        size += refc->size;
+    }
+    return size;
+}

--- a/src/libAtomVM/refc_binary.h
+++ b/src/libAtomVM/refc_binary.h
@@ -77,6 +77,13 @@ bool refc_binary_decrement_refcount(struct RefcBinary *ptr);
  */
 term refc_binary_create_binary_info(Context *ctx);
 
+/**
+ * @brief Return the total size (in bytes) of all reference counted binaries
+ *
+ * @return the total size (in bytes) of all reference counted binaries
+ */
+size_t refc_binary_total_size(Context *ctx);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR adds support for the `erlang:memory/1` function, with initial support only for the `binary` type.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
