### PR TITLE
Replace process dictionary trick with `memory_ensure_free_opt`

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -34,7 +34,6 @@
 #include "context.h"
 #include "debug.h"
 #include "defaultatoms.h"
-#include "dictionary.h"
 #include "globalcontext.h"
 #include "interop.h"
 #include "mailbox.h"
@@ -458,25 +457,12 @@ static void consume_gpio_mailbox(Context *ctx)
             ret = ERROR_ATOM;
     }
 
-    term old;
-    if (UNLIKELY(dictionary_put(&ctx->dictionary, gpio_driver, ret, &old, ctx->global) != DictionaryOk)) {
-        // TODO: handle alloc error
-        AVM_ABORT();
-    }
     term ret_msg;
-    if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &ret, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         ret_msg = OUT_OF_MEMORY_ATOM;
     } else {
-        if (UNLIKELY(dictionary_get(&ctx->dictionary, gpio_driver, &ret, ctx->global) != DictionaryOk)) {
-            // TODO: handle alloc error
-            AVM_ABORT();
-        }
         term ref = term_get_tuple_element(msg, 1);
         ret_msg = create_pair(ctx, ref, ret);
-    }
-    if (UNLIKELY(dictionary_erase(&ctx->dictionary, gpio_driver, &old, ctx->global) != DictionaryOk)) {
-        // TODO: handle alloc error
-        AVM_ABORT();
     }
 
     mailbox_send(target, ret_msg);

--- a/src/platforms/esp32/components/avm_builtins/i2c_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/i2c_driver.c
@@ -33,7 +33,6 @@
 #include "context.h"
 #include "debug.h"
 #include "defaultatoms.h"
-#include "dictionary.h"
 #include "globalcontext.h"
 #include "interop.h"
 #include "mailbox.h"
@@ -458,25 +457,12 @@ static void i2cdriver_consume_mailbox(Context *ctx)
             ret = ERROR_ATOM;
     }
 
-    term old;
-    if (UNLIKELY(dictionary_put(&ctx->dictionary, i2c_driver, ret, &old, ctx->global) != DictionaryOk)) {
-        // TODO: handle alloc error
-        AVM_ABORT();
-    }
     term ret_msg;
-    if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &ret, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         ret_msg = OUT_OF_MEMORY_ATOM;
     } else {
-        if (UNLIKELY(dictionary_get(&ctx->dictionary, i2c_driver, &ret, ctx->global) != DictionaryOk)) {
-            // TODO: handle alloc error
-            AVM_ABORT();
-        }
         term ref = term_get_tuple_element(msg, 1);
         ret_msg = create_pair(ctx, ref, ret);
-    }
-    if (UNLIKELY(dictionary_erase(&ctx->dictionary, i2c_driver, &old, ctx->global) != DictionaryOk)) {
-        // TODO: handle alloc error
-        AVM_ABORT();
     }
 
     mailbox_send(target, ret_msg);

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -36,7 +36,6 @@
 #include "context.h"
 #include "debug.h"
 #include "defaultatoms.h"
-#include "dictionary.h"
 #include "globalcontext.h"
 #include "interop.h"
 #include "mailbox.h"
@@ -610,25 +609,12 @@ static void spidriver_consume_mailbox(Context *ctx)
             ret = ERROR_ATOM;
     }
 
-    term old;
-    if (UNLIKELY(dictionary_put(&ctx->dictionary, spi_driver, ret, &old, ctx->global) != DictionaryOk)) {
-        // TODO: handle alloc error
-        AVM_ABORT();
-    }
     term ret_msg;
-    if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &ret, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         ret_msg = OUT_OF_MEMORY_ATOM;
     } else {
-        if (UNLIKELY(dictionary_get(&ctx->dictionary, spi_driver, &ret, ctx->global) != DictionaryOk)) {
-            // TODO: handle alloc error
-            AVM_ABORT();
-        }
         ref = term_get_tuple_element(msg, 1);
         ret_msg = create_pair(ctx, ref, ret);
-    }
-    if (UNLIKELY(dictionary_erase(&ctx->dictionary, spi_driver, &old, ctx->global) != DictionaryOk)) {
-        // handle alloc error
-        AVM_ABORT();
     }
 
     mailbox_send(target, ret_msg);


### PR DESCRIPTION
This PR is a successor of #516

Replace the process dictionary trick in esp32 drivers with `memory_ensure_free_opt` which provides additional GC roots.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
