### PR TITLE
Fix base_url for archived stretch

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -23,7 +23,7 @@ jobs:
         include:
         - arch: "armel"
           distro: "stretch"
-          base_url: "http://deb.debian.org/debian/"
+          base_url: "http://archive.debian.org/debian-archive/debian/"
           cflags: "-O2 -mthumb -mthumb-interwork -march=armv4t"
           additional_packages: |
             http://ftp.us.debian.org/debian/pool/main/c/cmake/cmake-data_3.13.2-1~bpo9+1_all.deb \


### PR DESCRIPTION
This fixes CI on armel which requires Debian stretch distribution by using the archive URL.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
