### PR TITLE
Fix call and encoding/decoding of function references

### DIFF
--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -116,6 +116,13 @@ term bif_erlang_is_boolean_1(Context *ctx, term arg1)
     return (arg1 == TRUE_ATOM || arg1 == FALSE_ATOM) ? TRUE_ATOM : FALSE_ATOM;
 }
 
+term bif_erlang_is_function_1(Context *ctx, term arg1)
+{
+    UNUSED(ctx);
+
+    return term_is_function(arg1) ? TRUE_ATOM : FALSE_ATOM;
+}
+
 term bif_erlang_is_integer_1(Context *ctx, term arg1)
 {
     UNUSED(ctx);

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -50,6 +50,7 @@ term bif_erlang_length_1(Context *ctx, int live, term arg1);
 term bif_erlang_is_atom_1(Context *ctx, term arg1);
 term bif_erlang_is_binary_1(Context *ctx, term arg1);
 term bif_erlang_is_boolean_1(Context *ctx, term arg1);
+term bif_erlang_is_function_1(Context *ctx, term arg1);
 term bif_erlang_is_integer_1(Context *ctx, term arg1);
 term bif_erlang_is_list_1(Context *ctx, term arg1);
 term bif_erlang_is_number_1(Context *ctx, term arg1);

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -40,6 +40,7 @@ erlang:get/1, bif_erlang_get_1, false
 erlang:is_atom/1, bif_erlang_is_atom_1, false
 erlang:is_binary/1, bif_erlang_is_binary_1, false
 erlang:is_boolean/1, bif_erlang_is_boolean_1, false
+erlang:is_function/1, bif_erlang_is_function_1, false
 erlang:is_integer/1, bif_erlang_is_integer_1, false
 erlang:is_list/1, bif_erlang_is_list_1, false
 erlang:is_number/1, bif_erlang_is_number_1, false

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -758,7 +758,7 @@ typedef union
         AtomString function_name = globalcontext_atomstring_from_term(mod->global, index_or_function); \
         struct Nif *nif = (struct Nif *) nifs_get(module_name, function_name, fun_arity); \
         if (!IS_NULL_PTR(nif)) {                                        \
-            term return_value = nif->nif_ptr(ctx, arity, ctx->x);       \
+            term return_value = nif->nif_ptr(ctx, fun_arity, ctx->x);   \
             if (UNLIKELY(term_is_invalid_term(return_value))) {         \
                 HANDLE_ERROR();                                         \
             }                                                           \
@@ -770,7 +770,7 @@ typedef union
             if (IS_NULL_PTR(fun_module)) {                              \
                 HANDLE_ERROR();                                         \
             }                                                           \
-            label = module_search_exported_function(fun_module, function_name, arity); \
+            label = module_search_exported_function(fun_module, function_name, fun_arity); \
             if (UNLIKELY(label == 0)) {                                 \
                 HANDLE_ERROR();                                         \
             }                                                           \


### PR DESCRIPTION
Fix a bug where call of function references would fail Fix a warning related to encoding of function references Implement decoding of function references

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
