### PR TITLE
Enable clang warnings and fix some GCC/clang warnings

### DIFF
--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -91,8 +91,10 @@ set(SOURCE_FILES
 add_library(libAtomVM ${SOURCE_FILES} ${HEADER_FILES})
 target_include_directories(libAtomVM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(libAtomVM PUBLIC c_std_11)
-if(CMAKE_COMPILER_IS_GNUCC)
-    target_compile_options(libAtomVM PUBLIC -Wall -pedantic -Wextra -ggdb)
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(libAtomVM PUBLIC -Wall -pedantic -Wextra -ggdb -Werror=incompatible-pointer-types)
+elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
+    target_compile_options(libAtomVM PUBLIC -Wall --extra-warnings -Werror=incompatible-pointer-types)
 endif()
 
 # AtomVM options used in libAtomVM

--- a/src/libAtomVM/bitstring.c
+++ b/src/libAtomVM/bitstring.c
@@ -68,8 +68,8 @@ bool bitstring_insert_any_integer(uint8_t *dst, avm_int_t offset, avm_int64_t va
         offset += n - (8 * sizeof(value));
         n = 8 * sizeof(value);
     }
-    for (int i = 0; i < n; ++i) {
-        int k = (n - 1) - i;
+    for (size_t i = 0; i < n; ++i) {
+        size_t k = (n - 1) - i;
         int bit_val = (value & (0x01LL << k)) >> k;
         if (bit_val) {
             int bit_pos = offset + i;

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -18,7 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "nifs.h"
 
@@ -50,13 +52,6 @@
 
 #define MAX_NIF_NAME_LEN 260
 #define FLOAT_BUF_SIZE 64
-
-#define VALIDATE_VALUE(value, verify_function) \
-    if (UNLIKELY(!verify_function((value)))) { \
-        argv[0] = ERROR_ATOM;                  \
-        argv[1] = BADARG_ATOM;                 \
-        return term_invalid_term();            \
-    }
 
 #define RAISE_ERROR(error_type_atom) \
     ctx->x[0] = ERROR_ATOM;          \

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -87,6 +87,10 @@ typedef union
 } dreg_type_t;
 
 #ifdef IMPL_EXECUTE_LOOP
+// Override nifs.h RAISE_ERROR macro
+#ifdef RAISE_ERROR
+#undef RAISE_ERROR
+#endif
 #define RAISE_ERROR(error_type_atom)                               \
     ctx->x[0] = ERROR_ATOM;                                        \
     ctx->x[1] = error_type_atom;                                   \
@@ -1301,11 +1305,14 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 
 #endif
 
+#ifndef __clang__
 #pragma GCC diagnostic push
 #ifdef __GNUC__
-#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
+#else
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
 #ifdef IMPL_CODE_LOADER
@@ -3661,9 +3668,6 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 int next_off = 1;
                 uint32_t fail;
                 DECODE_LABEL(fail, code, i, next_off)
-                #ifdef IMPL_EXECUTE_LOOP
-                    int next_off_back = next_off;
-                #endif
                 term src;
                 DECODE_COMPACT_TERM(src, code, i, next_off);
                 term arg2;
@@ -3707,9 +3711,6 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 int next_off = 1;
                 uint32_t fail;
                 DECODE_LABEL(fail, code, i, next_off)
-                #ifdef IMPL_EXECUTE_LOOP
-                    int next_off_back = next_off;
-                #endif
                 term src;
                 DECODE_COMPACT_TERM(src, code, i, next_off);
                 term arg2;
@@ -3815,9 +3816,6 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 int next_off = 1;
                 uint32_t fail;
                 DECODE_LABEL(fail, code, i, next_off)
-                #ifdef IMPL_EXECUTE_LOOP
-                    int next_off_back = next_off;
-                #endif
                 term src;
                 DECODE_COMPACT_TERM(src, code, i, next_off);
                 term arg2;
@@ -3861,9 +3859,6 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 int next_off = 1;
                 uint32_t fail;
                 DECODE_LABEL(fail, code, i, next_off)
-                #ifdef IMPL_EXECUTE_LOOP
-                    int next_off_back = next_off;
-                #endif
                 term src;
                 DECODE_COMPACT_TERM(src, code, i, next_off);
                 term arg2;
@@ -3941,9 +3936,6 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 int next_off = 1;
                 uint32_t fail;
                 DECODE_LABEL(fail, code, i, next_off)
-                #ifdef IMPL_EXECUTE_LOOP
-                    int next_off_back = next_off;
-                #endif
                 term src;
                 DECODE_COMPACT_TERM(src, code, i, next_off);
                 term arg2;
@@ -3986,9 +3978,6 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 int next_off = 1;
                 uint32_t fail;
                 DECODE_LABEL(fail, code, i, next_off)
-                #ifdef IMPL_EXECUTE_LOOP
-                    int next_off_back = next_off;
-                #endif
                 term src;
                 DECODE_COMPACT_TERM(src, code, i, next_off);
                 term arg2;
@@ -4577,7 +4566,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         AVM_ABORT();
                     }
 
-                    TRACE("bs_save2/2, src=0x%lx pos=%li\n", src, index_val);
+                    TRACE("bs_save2/2, src=0x%lx pos=%li\n", src, index == START_ATOM ? -1 : index_val);
                 #endif
 
                 NEXT_INSTRUCTION(next_off);
@@ -4608,7 +4597,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                         AVM_ABORT();
                     }
 
-                    TRACE("bs_restore2/2, src=0x%lx pos=%li\n", src, index_val);
+                    TRACE("bs_restore2/2, src=0x%lx pos=%li\n", src, index == START_ATOM ? -1 : index_val);
                 #endif
 
                 NEXT_INSTRUCTION(next_off);
@@ -5583,7 +5572,11 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 term src;
                 DECODE_COMPACT_TERM(src, code, i, next_off);
 
-                TRACE("has_map_fields/3: label: %i src: 0x%lx\n", label, src);
+                #ifdef IMPL_EXECUTE_LOOP
+                    TRACE("has_map_fields/3: label: %i src: 0x%lx\n", label, src);
+                #else
+                    TRACE("has_map_fields/3: label: %i\n", label);
+                #endif
 
                 DECODE_EXTENDED_LIST_TAG(code, i, next_off);
                 uint32_t list_len;
@@ -5615,7 +5608,11 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                 DECODE_LABEL(label, code, i, next_off)
                 term src;
                 DECODE_COMPACT_TERM(src, code, i, next_off);
-                TRACE("get_map_elements/3: label: %i src: 0x%lx\n", label, src);
+                #ifdef IMPL_EXECUTE_LOOP
+                    TRACE("get_map_elements/3: label: %i src: 0x%lx\n", label, src);
+                #else
+                    TRACE("get_map_elements/3: label: %i\n", label);
+                #endif
 
                 DECODE_EXTENDED_LIST_TAG(code, i, next_off);
                 uint32_t list_len;
@@ -6927,6 +6924,10 @@ terminate_context:
     }
 }
 
+#ifndef __clang__
 #pragma GCC diagnostic pop
+#else
+#pragma clang diagnostic pop
+#endif
 
 #undef DECODE_COMPACT_TERM

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -1031,7 +1031,7 @@ static inline term term_maybe_create_sub_binary(term binary, size_t offset, size
     }
 }
 
-static inline void term_set_refc_binary_data(term t, const char *data)
+static inline void term_set_refc_binary_data(term t, const void *data)
 {
     TERM_DEBUG_ASSERT(term_is_refc_binary(t));
     term *boxed_value = term_to_term_ptr(t);


### PR DESCRIPTION
Also make incompatible pointer type warnings an error for both compilers

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
