### PR TITLE
Prevent commit and push operations in Publish docs workflow in forks

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: atomvm/AtomVM
+          repository: ${{ vars.GITHUB_REPOSITORY }}
           fetch-depth: 0
 
       - uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
       - name: Build Site
         run: |
           . /home/runner/python-env/sphinx/bin/activate
-          for remote in `git branch -r | grep -v /HEAD | grep -v ${{ github.ref_name }}`; do git checkout --track $remote; done
+          for remote in `git branch -r | grep -v "/HEAD\|${{ github.ref_name }}"`; do git checkout --track $remote; done
           git switch ${{ github.ref_name }}
           git branch
           mkdir build
@@ -94,6 +94,7 @@ jobs:
           make GitHub_CI_Publish_Docs
 
       - name: Commit files
+        if: ${{ vars.GITHUB_REPOSITORY == 'atomvm/AtomVM' }}
         working-directory: /home/runner/work/AtomVM/AtomVM/www
         run: |
           git checkout Production
@@ -102,6 +103,7 @@ jobs:
           git add .
           git commit -m "Update Documentation"
       - name: Push changes
+        if: ${{ vars.GITHUB_REPOSITORY == 'atomvm/AtomVM' }}
         working-directory: /home/runner/work/AtomVM/AtomVM/www
         run: |
           eval `ssh-agent -t 60 -s`


### PR DESCRIPTION
Adds checks before commiting or pushing the generated documentation. This will allow the workflow to run in forks to ensure that doxygen style comments for documentation can still be parsed, without actually atempting to publish the documentation from outside of the offical `atomvm/AtomVM` repo.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
