### PR TITLE
Fix Publish docs workflow not committing

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -94,7 +94,7 @@ jobs:
           make GitHub_CI_Publish_Docs
 
       - name: Commit files
-        if: ${{ vars.GITHUB_REPOSITORY == 'atomvm/AtomVM' }}
+        if: github.repository == 'atomvm/AtomVM'
         working-directory: /home/runner/work/AtomVM/AtomVM/www
         run: |
           git checkout Production
@@ -103,7 +103,7 @@ jobs:
           git add .
           git commit -m "Update Documentation"
       - name: Push changes
-        if: ${{ vars.GITHUB_REPOSITORY == 'atomvm/AtomVM' }}
+        if: github.repository == 'atomvm/AtomVM'
         working-directory: /home/runner/work/AtomVM/AtomVM/www
         run: |
           eval `ssh-agent -t 60 -s`


### PR DESCRIPTION
Fixes workflow to make sure it still publishes for the official atomvm/AtomVM repo.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
