### PR TITLE
Fix erlc compiler warnings

### DIFF
--- a/libs/alisp/src/sexp_parser.erl
+++ b/libs/alisp/src/sexp_parser.erl
@@ -32,7 +32,7 @@ parse([{'(', _Line} | T], Acc) ->
     parse(NewTail, [L | Acc]);
 parse([{')', _Line} | T], Acc) ->
     {T, reverse(Acc)};
-parse([{symbol_prefix, _Line, SymPrefix}, {symbol, _Line, Sym} | T], Acc) ->
+parse([{symbol_prefix, _Line1, SymPrefix}, {symbol, _Line2, Sym} | T], Acc) ->
     parse(T, [[symbol_pair, erlang:list_to_atom(SymPrefix), erlang:list_to_atom(Sym)] | Acc]);
 parse([{symbol, _Line, Sym} | T], Acc) ->
     parse(T, [erlang:list_to_atom(Sym) | Acc]);

--- a/libs/estdlib/src/gen_event.erl
+++ b/libs/estdlib/src/gen_event.erl
@@ -116,7 +116,7 @@ handle_call(_Request, _From, State) ->
     {reply, {error, unimplemented}, State}.
 
 %% @hidden
-handle_info(Msg, State) ->
+handle_info(_Msg, State) ->
     {noreply, State}.
 
 %% @hidden

--- a/libs/etest/src/etest.erl
+++ b/libs/etest/src/etest.erl
@@ -150,7 +150,7 @@ check_results([]) ->
     ok;
 check_results([{_Test, ok} | T]) ->
     check_results(T);
-check_results([Failure | T]) ->
+check_results([Failure | _T]) ->
     {fail, Failure}.
 
 id(X) -> X.

--- a/tests/erlang_tests/test_types_ordering.erl
+++ b/tests/erlang_tests/test_types_ordering.erl
@@ -49,8 +49,3 @@ check(T) when T == [1, foo, {}, {1}, {1, 2}, [], [1, 2], <<"bar">>] ->
     1;
 check(_T) ->
     0.
-
-bool_to_n(true) ->
-    1;
-bool_to_n(false) ->
-    0.

--- a/tests/libs/estdlib/test_io_lib.erl
+++ b/tests/libs/estdlib/test_io_lib.erl
@@ -63,8 +63,11 @@ test() ->
     ),
     ?ASSERT_MATCH(?FLT(io_lib:format("escape ~~p~n", [])), "escape ~p\n"),
 
-    ?ASSERT_FAILURE(io_lib:format("no pattern", [foo]), badarg),
-    ?ASSERT_FAILURE(io_lib:format("too ~p many ~p patterns", [foo]), badarg),
-    ?ASSERT_FAILURE(io_lib:format("not enough ~p patterns", [foo, bar]), badarg),
+    ?ASSERT_FAILURE(io_lib:format("no pattern", id([foo])), badarg),
+    ?ASSERT_FAILURE(io_lib:format("too ~p many ~p patterns", id([foo])), badarg),
+    ?ASSERT_FAILURE(io_lib:format("not enough ~p patterns", id([foo, bar])), badarg),
 
     ok.
+
+id(X) ->
+    X.


### PR DESCRIPTION
This PR fixes some annoying Erlang compiler warnings.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
