### PR TITLE
Avoid unnecessary warning with Apple Clang 13.0.0

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1312,6 +1312,8 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 #endif
 #else
 #pragma clang diagnostic push
+// Apple Clang 13.0.0 and clang < 13 do not know -Wunused-but-set-variable
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #endif
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
