### PR TITLE
Add erlang:is_float/1 BIF

### DIFF
--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -116,6 +116,13 @@ term bif_erlang_is_boolean_1(Context *ctx, term arg1)
     return (arg1 == TRUE_ATOM || arg1 == FALSE_ATOM) ? TRUE_ATOM : FALSE_ATOM;
 }
 
+term bif_erlang_is_float_1(Context *ctx, term arg1)
+{
+    UNUSED(ctx);
+
+    return term_is_float(arg1) ? TRUE_ATOM : FALSE_ATOM;
+}
+
 term bif_erlang_is_function_1(Context *ctx, term arg1)
 {
     UNUSED(ctx);

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -50,6 +50,7 @@ term bif_erlang_length_1(Context *ctx, int live, term arg1);
 term bif_erlang_is_atom_1(Context *ctx, term arg1);
 term bif_erlang_is_binary_1(Context *ctx, term arg1);
 term bif_erlang_is_boolean_1(Context *ctx, term arg1);
+term bif_erlang_is_float_1(Context *ctx, term arg1);
 term bif_erlang_is_function_1(Context *ctx, term arg1);
 term bif_erlang_is_integer_1(Context *ctx, term arg1);
 term bif_erlang_is_list_1(Context *ctx, term arg1);

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -40,6 +40,7 @@ erlang:get/1, bif_erlang_get_1, false
 erlang:is_atom/1, bif_erlang_is_atom_1, false
 erlang:is_binary/1, bif_erlang_is_binary_1, false
 erlang:is_boolean/1, bif_erlang_is_boolean_1, false
+erlang:is_float/1, bif_erlang_is_float_1, false
 erlang:is_function/1, bif_erlang_is_function_1, false
 erlang:is_integer/1, bif_erlang_is_integer_1, false
 erlang:is_list/1, bif_erlang_is_list_1, false


### PR DESCRIPTION
Add missing is_type BIF.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
