### PR TITLE
Fixes publish-docs.yml for platfoms and forks

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -82,11 +82,14 @@ jobs:
           path: /home/runner/work/AtomVM/AtomVM/www
 
       - name: Build Site
+        shell: bash
         run: |
           . /home/runner/python-env/sphinx/bin/activate
-          for remote in `git branch -r | grep -v "/HEAD\|${{ github.ref_name }}"`; do git checkout --track $remote; done
-          git switch ${{ github.ref_name }}
-          git branch
+          if [ ${GITHUB_REPOSITORY} == 'atomvm/AtomVM' ]; then {
+            for remote in `git branch -r | grep -v "/HEAD\|${{ github.ref_name }}"`; do git checkout --track $remote; done
+            git switch ${{ github.ref_name }}
+          };
+          fi
           mkdir build
           cd build
           cmake ..

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -140,7 +140,7 @@ endif()
 foreach(LIBAVM_ERL_LIB estdlib eavmlib alisp etest)
     add_custom_command(TARGET edoc-${LIBAVM_ERL_LIB}
         POST_BUILD
-        COMMAND sed -i -e "s/\.md/\.html/g" -e "s/application/library/g" ${CMAKE_CURRENT_BINARY_DIR}/src/apidocs/erlang/${LIBAVM_ERL_LIB}/README.md
+        COMMAND sed -i -e "s/\.md/\.html/g; s/application/library/g" ${CMAKE_CURRENT_BINARY_DIR}/src/apidocs/erlang/${LIBAVM_ERL_LIB}/README.md
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Fixing html link locations for ${LIBAVM_ERL_LIB}." VERBATIM
     )


### PR DESCRIPTION
Changes the workflow to only checkout other branches if the documentation is being published by `atomvm/AtomVM` repository.
Changes the use of `sed` in CMakeLists.txt to be POSIX compliant.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
