### PR TITLE
Fix compiler warning about SHT31.ex

### DIFF
--- a/examples/elixir/esp32/SHT31.ex
+++ b/examples/elixir/esp32/SHT31.ex
@@ -24,7 +24,7 @@ defmodule SHT31 do
   # not needed or recommended for user apps.
   @compile {:no_warn_undefined, [I2C]}
 
-  use Bitwise
+  import Bitwise
 
   @sht31_base_addr 0x44
   @sht31_meas_high_rep 0x2400


### PR DESCRIPTION
Update to suppress compile warning and stop showing up at the bottom of the "Files changed" tab on GitHub for every pull request under the `Unchanged files with check annotations` section at the bottom of the page.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
