### PR TITLE
Remove unused `term_match_state_get_save_offset`

### DIFF
--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -1501,19 +1501,12 @@ static inline void term_set_match_state_offset(term match_state, avm_int_t offse
     boxed_value[2] = offset;
 }
 
-static inline int term_match_state_get_save_offset(term match_state, int index)
-{
-    term *boxed_value = term_to_term_ptr(match_state);
-    return boxed_value[4 + index];
-}
-
 static inline void term_match_state_save_offset(term match_state, int index)
 {
     term *boxed_value = term_to_term_ptr(match_state);
     boxed_value[4 + index] = boxed_value[2];
 }
 
-// TODO: not sure we really need this function
 static inline void term_match_state_save_start_offset(term match_state)
 {
     term *boxed_value = term_to_term_ptr(match_state);


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
