### PR TITLE
Support for `gpio:close/1` on feature/smp branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for FP opcodes 94-102 thus removing the need for `AVM_DISABLE_FP=On` with OTP-22+
 - Added support for stacktraces
 - Added support for `utf-8`, `utf-16`, and `utf-32` bit syntax modifiers (put and match)
+- Added support for Erlang `gpio:close/1` and Elixir `GPIO.close/1` for ESP32
 
 
 ### Fixed

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -641,6 +641,16 @@ When a trigger event occurs, such as a pin rising in voltage, a tuple will be de
 
 Interrupts can be removed by using the `gpio:remove_int/2` function.
 
+Use the `gpio:close/1` function to close the GPIO driver and free any resources in use by it, supplying a reference to a previously opened GPIO driver instance.  Any references to the closed GPIO instance are no longer valid after a successful call to this function, and all interrupts will be removed.
+
+    %% erlang
+    ok = gpio:close(GPIO).
+
+Since only one instance of the GPIO driver is allowed, you may also simply use `gpio:stop/0` to remove all interrupts, free the resouces, and close the GPIO driver port.
+
+    %% erlang
+    ok = gpio:stop().
+
 
 ### I2C
 

--- a/libs/eavmlib/src/gpio.erl
+++ b/libs/eavmlib/src/gpio.erl
@@ -1,27 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2018-2022 Davide Bettio <davide@uninstall.it>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
-%
-% This file is part of AtomVM.
-%
-% Copyright 2019 Davide Bettio <davide@uninstall.it>
+% Copyright 2018-2023 Davide Bettio <davide@uninstall.it>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -47,7 +27,9 @@
 %%-----------------------------------------------------------------------------
 -module(gpio).
 
--export([start/0, open/0, read/2, set_direction/3, set_level/3, set_int/3, remove_int/2]).
+-export([
+    start/0, open/0, read/2, set_direction/3, set_level/3, set_int/3, remove_int/2, stop/0, close/1
+]).
 -export([
     set_pin_mode/2,
     set_pin_pull/2,
@@ -103,6 +85,31 @@ start() ->
 -spec open() -> gpio().
 open() ->
     open_port({spawn, "gpio"}, []).
+
+%%-----------------------------------------------------------------------------
+%% @param   GPIO pid that was returned from gpio:start/0
+%% @returns ok atom
+%% @doc     Stop the GPIO interrupt port
+%%
+%%          This function disables any interrupts that are set, stops
+%%          the listening port, and frees all of its resources.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec close(GPIO :: gpio()) -> ok | error.
+close(GPIO) ->
+    port:call(GPIO, {close}).
+
+%%-----------------------------------------------------------------------------
+%% @returns ok atom
+%% @doc     Stop the GPIO interrupt port
+%%
+%%          This function disables any interrupts that are set, stops
+%%          the listening port, and frees all of its resources.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec stop() -> ok | error.
+stop() ->
+    close(whereis(gpio)).
 
 %%-----------------------------------------------------------------------------
 %% @param   GPIO pid that was returned from gpio:start/0

--- a/libs/exavmlib/lib/GPIO.ex
+++ b/libs/exavmlib/lib/GPIO.ex
@@ -102,6 +102,22 @@ defmodule GPIO do
   end
 
   @doc """
+  Stop the gpio driver and remove any interrupts that have been set.
+  Use the pid returned from GPIO.start/0 as a parameter.
+  """
+  @spec close(pid()) :: :ok | :error
+  def close(gpio),
+    do: AVMPort.call(gpio, {:close})
+
+  @doc """
+  Stop the gpio driver and remove any interrupts that have been set.
+  Takes no parameters.
+  """
+  @spec stop() :: :ok | :error
+  def stop(),
+    do: close(:erlang.whereis(:gpio))
+
+  @doc """
   Read the state of a gpio input pin.
 
   ## Parameters


### PR DESCRIPTION
Adds support for both erlang and elixir to stop and free the resources of the gpio port driver on esp32.

Closes issue #277

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
