### PR TITLE
Run workflows conditionally based on file changes

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -6,7 +6,19 @@
 
 name: Build and Test on macOS
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'src/platforms/esp32/**'
+      - 'src/platforms/stm32/**'
+      - 'doc/**'
+      - 'LICENSES/**'
+  pull_request:
+    paths-ignore:
+      - 'src/platforms/esp32/**'
+      - 'src/platforms/stm32/**'
+      - 'doc/**'
+      - 'LICENSES/**'
 
 jobs:
   build-and-test:

--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -6,7 +6,19 @@
 
 name: Build and Test on Other Architectures
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'src/platforms/esp32/**'
+      - 'src/platforms/stm32/**'
+      - 'doc/**'
+      - 'LICENSES/**'
+  pull_request:
+    paths-ignore:
+      - 'src/platforms/esp32/**'
+      - 'src/platforms/stm32/**'
+      - 'doc/**'
+      - 'LICENSES/**'
 
 env:
   otp_version: 24

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -6,7 +6,19 @@
 
 name: Build and Test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'src/platforms/esp32/**'
+      - 'src/platforms/stm32/**'
+      - 'doc/**'
+      - 'LICENSES/**'
+  pull_request:
+    paths-ignore:
+      - 'src/platforms/esp32/**'
+      - 'src/platforms/stm32/**'
+      - 'doc/**'
+      - 'LICENSES/**'
 
 jobs:
   build-and-test:

--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -6,7 +6,21 @@
 
 name: "Check formatting"
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'src/**'
+      - 'tests/**'
+      - '**/*.erl'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'src/**'
+      - 'tests/**'
+      - '**/*.erl'
 
 jobs:
   clang-format-check:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -8,7 +8,19 @@ name: "CodeQL"
 
 on:
   push:
+    paths-ignore:
+      - 'src/platforms/esp32/**'
+      - 'src/platforms/stm32/**'
+      - 'libs/**'
+      - 'doc/**'
+      - 'LICENSES/**'
   pull_request:
+    paths-ignore:
+      - 'src/platforms/esp32/**'
+      - 'src/platforms/stm32/**'
+      - 'libs/**'
+      - 'doc/**'
+      - 'LICENSES/**'
   schedule:
     - cron: '45 18 * * 5'
 

--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -6,7 +6,20 @@
 
 name: ESP32 Builds
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'libs/**'
+      - 'src/platforms/esp32/**'
+      - 'src/libAtomVM/**'
+      - 'tools/packbeam/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'src/platforms/esp32/**'
+      - 'src/libAtomVM/**'
 
 jobs:
   esp-idf:

--- a/.github/workflows/esp32-test.yaml
+++ b/.github/workflows/esp32-test.yaml
@@ -6,7 +6,19 @@
 
 name: ESP32 Test
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'src/platforms/esp32/**'
+      - 'src/libAtomVM/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'src/platforms/esp32/**'
+      - 'src/libAtomVM/**'
 
 jobs:
   esp32-test:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -12,6 +12,12 @@ name: Publish Docs
 on:
   # Triggers the workflow on push request events for all branches
   push:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'doc/**'
+      - 'libs/**'
+      - 'src/libAtomVM/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -6,7 +6,19 @@
 
 name: Run tests with BEAM
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'src/platforms/esp32/**'
+      - 'src/platforms/stm32/**'
+      - 'doc/**'
+      - 'LICENSES/**'
+  pull_request:
+    paths-ignore:
+      - 'src/platforms/esp32/**'
+      - 'src/platforms/stm32/**'
+      - 'doc/**'
+      - 'LICENSES/**'
 
 jobs:
   run-tests:

--- a/.github/workflows/stm32-build.yaml
+++ b/.github/workflows/stm32-build.yaml
@@ -6,7 +6,19 @@
 
 name: STM32 Build
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'src/platforms/stm32/**'
+      - 'src/libAtomVM/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'src/platforms/stm32/**'
+      - 'src/libAtomVM/**'
 
 jobs:
   stm32:


### PR DESCRIPTION
These changes will skip running individual workflows if they do not utilize the changed files. The exception is the `esp32-build.yaml` workflow, which will also run on `push` if the only changes are to modules in the `libs` directory, so that the `esp32-mkimage.yaml` workflow will run and create a new esp32 binary image containing the updated modules.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
