### PR TITLE
Fix CI for armel

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -39,7 +39,7 @@ jobs:
           cflags: "-O2 -mthumb -mthumb-interwork -march=armv4t"
           additional_packages: |
             http://ftp.us.debian.org/debian/pool/main/c/cmake/cmake-data_3.13.2-1~bpo9+1_all.deb \
-            http://ftp.us.debian.org/debian/pool/main/r/rhash/librhash0_1.3.3-1+b2_armel.deb \
+            http://ftp.us.debian.org/debian/pool/main/r/rhash/librhash0_1.3.8-1_armel.deb \
             http://ftp.us.debian.org/debian/pool/main/libu/libuv1/libuv1_1.34.2-1~bpo9+1_armel.deb \
             http://ftp.us.debian.org/debian/pool/main/c/cmake/cmake_3.13.2-1~bpo9+1_armel.deb
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
