### PR TITLE
Fix bug in publish-docs.yaml handling branch names containing slashes

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -45,8 +45,8 @@ add_custom_target(edown-escript
     COMMENT "Preparing edown escript" VERBATIM
 )
 
-# Get branch name
-execute_process(COMMAND git branch --show-current OUTPUT_VARIABLE BRANCH_NAME OUTPUT_STRIP_TRAILING_WHITESPACE)
+# Get branch name replacing any `/` with `-` in name for URLs.
+execute_process(COMMAND "bash" "-c" "sed -e 'y/\\//-/' <<< `git branch --show-current`" OUTPUT_VARIABLE BRANCH_NAME OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 ##
 ## Erlang API documentation

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -140,7 +140,11 @@ html_context['display_lower_left'] = 'True'
 # SET CURRENT_VERSION
 from git import Repo
 repo = Repo( search_parent_directories=True )
-current_version = repo.active_branch.name
+current_v = repo.active_branch.name
+if ("/" in current_v):
+    current_version = current_v.replace("/", "-")
+else:
+    current_version = current_v
 
 # tell the theme which version we're currently on ('current_version' affects
 # the lower-left rtd menu and 'version' affects the logo-area version)
@@ -152,10 +156,12 @@ html_context['versions'] = list()
 
 versions = [branch.name for branch in repo.branches]
 print("Sphinx config found repository branches: %r." % (versions))
-for version in versions:
-   html_context['versions'].append( (version, '/doc/' +version+ '/') )
-
-#html_context['test_versions'] = html_context['versions']
+for add_version in versions:
+    if ("/" in add_version):
+        version = add_version.replace("/", "-")
+    else:
+        version = add_version
+    html_context['versions'].append( (version, '/doc/' +version+ '/') )
 
 html_sidebars = {
     '**': [


### PR DESCRIPTION
Convert slash `/` in branch names to a `-` for URLs and file names in the published documentation.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
