### PR TITLE
Fix tuple comparison

### DIFF
--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -476,7 +476,7 @@ TermCompareResult term_compare(term t, term other, TermCompareOpts opts, GlobalC
             }
 
             if (tuple_size > 0) {
-                for (int i = 1; i < tuple_size; i++) {
+                for (int i = tuple_size - 1; i >= 1; i--) {
                     if (UNLIKELY(temp_stack_push(&temp_stack, term_get_tuple_element(t, i))
                             != TempStackOk)) {
                         return TermCompareMemoryAllocFail;

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -431,6 +431,7 @@ compile_erlang(bs_append_extra_words)
 compile_erlang(test_monotonic_time)
 
 compile_erlang(exactly_eq)
+compile_erlang(tuple_comparisons)
 
 compile_erlang(spawn_opt_monitor_normal)
 compile_erlang(spawn_opt_monitor_throw)
@@ -851,6 +852,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_monotonic_time.beam
 
     exactly_eq.beam
+    tuple_comparisons.beam
 
     spawn_opt_monitor_normal.beam
     spawn_opt_monitor_throw.beam

--- a/tests/erlang_tests/tuple_comparisons.erl
+++ b/tests/erlang_tests/tuple_comparisons.erl
@@ -1,0 +1,43 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(tuple_comparisons).
+
+-export([start/0]).
+
+start() ->
+    A = fact(4, 1, 1),
+    B = fact(4, 1.0, 1.0),
+    C = fact(5, 1, 1),
+    D = fact(6, 1, 1),
+
+    test(not ({0, 0, 0, D, 0} > {0, 0, D, 0, 0})) +
+        test(not ({A, B, C, D} > {D, C, B, A})) * 2 +
+        test({A, A, A} > {D, D}) * 3.
+
+test(true) ->
+    1;
+test(false) ->
+    0.
+
+fact(N, _D, Acc) when N < 1 ->
+    Acc;
+fact(N, D, Acc) ->
+    fact(N - D, D, Acc * N).

--- a/tests/test.c
+++ b/tests/test.c
@@ -457,6 +457,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(test_monotonic_time, 1),
 
     TEST_CASE_EXPECTED(exactly_eq, 7),
+    TEST_CASE_EXPECTED(tuple_comparisons, 6),
 
     // Tests relying on echo driver
     TEST_CASE_ATOMVM_ONLY(pingpong, 1),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
