### PR TITLE
Fix socket driver in feature/smp branch

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -133,6 +133,15 @@ void context_destroy(Context *ctx)
     }
 
     free(ctx->heap_start);
+    // Platform data is freed here to allow drivers to use the
+    // globalcontext_get_process_lock lock to protect this pointer
+    // Typically, another thread or an interrupt would call
+    // globalcontext_get_process_lock before accessing platform_data.
+    // Here, the context can no longer be acquired with
+    // globalcontext_get_process_lock, so it's safe to free the pointer.
+    if (ctx->platform_data) {
+        free(ctx->platform_data);
+    }
     free(ctx);
 }
 

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -209,7 +209,6 @@ static esp_err_t network_event_handler(void *data, system_event_t *event)
     return ESP_OK;
 }
 
-#ifdef ENABLE_TEST_SOCKET
 TEST_CASE("test_socket", "[test_run]")
 {
     ESP_LOGI(TAG, "Starting event loop\n");
@@ -227,7 +226,6 @@ TEST_CASE("test_socket", "[test_run]")
     ESP_LOGI(TAG, "Stopping network\n");
     eth_stop(eth_netif);
 }
-#endif
 
 void app_main(void)
 {


### PR DESCRIPTION
- Fix a bug where the message was not &netconn but &&netconn
- Fix several cases of memory_ensure_free that may garbage collect terms
- Change logic to only call lwip send & receive from the native handler
- Factorize code
- Enable socket test that was disabled
- Modify context_destroy to free platform_data to avoid possible (unobserved) crashes

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
