### PR TITLE
Fix typo s/temp_stack_destory/temp_stack_destroy/g

### DIFF
--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -157,7 +157,7 @@ InteropFunctionResult interop_iolist_size(term t, size_t *size)
     }
 
     if (UNLIKELY(temp_stack_push(&temp_stack, t) != TempStackOk)) {
-        temp_stack_destory(&temp_stack);
+        temp_stack_destroy(&temp_stack);
         return InteropMemoryAllocFail;
     }
 
@@ -171,7 +171,7 @@ InteropFunctionResult interop_iolist_size(term t, size_t *size)
 
         } else if (term_is_nonempty_list(t)) {
             if (UNLIKELY(temp_stack_push(&temp_stack, term_get_list_tail(t)) != TempStackOk)) {
-                temp_stack_destory(&temp_stack);
+                temp_stack_destroy(&temp_stack);
                 return InteropMemoryAllocFail;
             }
             t = term_get_list_head(t);
@@ -181,12 +181,12 @@ InteropFunctionResult interop_iolist_size(term t, size_t *size)
             t = temp_stack_pop(&temp_stack);
 
         } else {
-            temp_stack_destory(&temp_stack);
+            temp_stack_destroy(&temp_stack);
             return InteropBadArg;
         }
     }
 
-    temp_stack_destory(&temp_stack);
+    temp_stack_destroy(&temp_stack);
 
     *size = acc;
     return InteropOk;
@@ -206,7 +206,7 @@ InteropFunctionResult interop_write_iolist(term t, char *p)
     }
 
     if (UNLIKELY(temp_stack_push(&temp_stack, t) != TempStackOk)) {
-        temp_stack_destory(&temp_stack);
+        temp_stack_destroy(&temp_stack);
         return InteropMemoryAllocFail;
     }
 
@@ -221,7 +221,7 @@ InteropFunctionResult interop_write_iolist(term t, char *p)
 
         } else if (term_is_nonempty_list(t)) {
             if (UNLIKELY(temp_stack_push(&temp_stack, term_get_list_tail(t)) != TempStackOk)) {
-                temp_stack_destory(&temp_stack);
+                temp_stack_destroy(&temp_stack);
                 return InteropMemoryAllocFail;
             }
             t = term_get_list_head(t);
@@ -233,12 +233,12 @@ InteropFunctionResult interop_write_iolist(term t, char *p)
             t = temp_stack_pop(&temp_stack);
 
         } else {
-            temp_stack_destory(&temp_stack);
+            temp_stack_destroy(&temp_stack);
             return InteropBadArg;
         }
     }
 
-    temp_stack_destory(&temp_stack);
+    temp_stack_destroy(&temp_stack);
     return InteropOk;
 }
 

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -312,7 +312,7 @@ unsigned long memory_estimate_usage(term t)
         }
     }
 
-    temp_stack_destory(&temp_stack);
+    temp_stack_destroy(&temp_stack);
 
     return acc;
 }

--- a/src/libAtomVM/tempstack.h
+++ b/src/libAtomVM/tempstack.h
@@ -49,7 +49,7 @@ NO_DISCARD static inline TempStackResult temp_stack_init(struct TempStack *temp_
     return TempStackOk;
 }
 
-static inline void temp_stack_destory(struct TempStack *temp_stack)
+static inline void temp_stack_destroy(struct TempStack *temp_stack)
 {
     free(temp_stack->stack_end - temp_stack->size);
 }

--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -648,7 +648,7 @@ TermCompareResult term_compare(term t, term other, TermCompareOpts opts, GlobalC
         }
     }
 
-    temp_stack_destory(&temp_stack);
+    temp_stack_destroy(&temp_stack);
 
     return result;
 }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
