### PR TITLE
Fix warnings on some targets

### DIFF
--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -508,6 +508,7 @@ void do_register_listener(struct GenericUnixPlatformData *platform, struct Event
     }
     platform->poll_count++;
 #else
+    UNUSED(listener);
     platform->poll_count = -1;
 #endif
 }
@@ -539,6 +540,7 @@ static void do_unregister_listener(struct GenericUnixPlatformData *platform, int
     }
     platform->poll_count--;
 #else
+    UNUSED(listener_fd);
     platform->poll_count = -1;
 #endif
 }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
