### PR TITLE
Documentation updates

### DIFF
--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -15,7 +15,7 @@ These release notes provide information about the current release of AtoVM.
 The following software is required to develop Erlang or Elixir applications on AtomVM:
 
 * The [`esptool`](https://github.com/espressif/esptool) program, for flashing the AtomVM image and AtomVM programs to ESP32 MCUs.
-* An [Erlang/OTP](https://erlang.org)
+* An [Erlang/OTP](https://erlang.org) compiler (`erlc`)
 * The [Elixir](https://elixir-lang.org) runtime, if developing Elixir applications.
 * A serial console program, such as `minicom` or `screen`, so that you can view console output from your AtomVM application.
 * (recommended) For Erlang programs, [`rebar3`](https://rebar3.org)
@@ -25,12 +25,12 @@ AtomVM will run BEAM files that have been compiled using the following Erlang an
 
 | Erlang Version | Elixir Version |
 |----------------|----------------|
-| OTP 21 | ✅ | 1.7 | ✅ |
-| OTP 22 | ✅ | 1.8 | ✅ |
-| OTP 23 | ✅ | 1.11 | ✅ |
-| OTP 24 | ✅ | 1.14 | ✅ |
-| OTP 25 | ✅ | 1.14 | ✅ |
-| OTP 26 | * | 1.15 | * |
+| ✅ OTP 21 | ✅ 1.7 |
+| ✅ OTP 22 | ✅ 1.8 |
+| ✅ OTP 23 | ✅ 1.11 |
+| ✅ OTP 24 | ✅ 1.14 |
+| ✅ OTP 25 | ✅ 1.14 |
+| ✅ OTP 26* | ✅ 1.15* |
 
 `*` OTP 26 is still a release candidate and should be considered experimental.
 Other versions of Elixir that are compatible with a particular OTP version may work, this chart reflects the versions that are tested.
@@ -47,8 +47,8 @@ Espressif provides excellent installation documentation on their website at:
 
 AtomVM currently supports the following versions of ESP-IDF:
 
-| Espressif supported Versions |
-|------------------------------|
+| Espressif supported versions | AtomVM support |
+|------------------------------|----------------|
 | ESP-IDF v4.2 | ✅ |
 | ESP-IDF v4.3 | ✅ |
 | ESP-IDF v4.4 | ✅ |

--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -58,7 +58,10 @@ The following software is required in order to build AtomVM in generic UNIX syst
 * `make`
 * `gperf`
 * `zlib`
-* Erlang/OTP (consult [Release Notes](release-notes.md) for currently supported versions)
+* Erlang/OTP compiler (`erlc`)
+* Elixir compiler
+
+Consult [Release Notes](./release-notes.md) for currently supported versions of required software.
 
 Consult your local OS documentation for instructions about how to install these components.
 
@@ -81,6 +84,21 @@ This command will create all of the required make files for creating the AtomVM 
 Upon completion, the `AtomVM` executable can be found in the `build/src` directory.
 
 The AtomVM core Erlang library can be found in the generated `libs/atomvmlib.avm` AVM file.
+
+Use the `install` target to install the `atomvm` command and associated binary files.  On most UNIX systems, these artifacts will be installed in the `/usr/local` directory tree.
+
+> Note.  On some systems, you may need to run this target with `root` or `sudo` permissions.
+
+    shell$ sudo make install
+
+Once installed, you can use the `atomvm` command to execute an AtomVM application.  E.g.,
+
+    shell$ atomvm /path/to/myapp.avm
+
+For users doing incremental development on the AtomVM virtual machine, you may want to run the `AtomVM` binary directly instead of installing the VM on your machine.  If you do, you will typically need to also specify the path to the AtomVM core Erlang library.  For example,
+
+    shell$ cd build
+    shell$ ./src/AtomVM /path/to/myapp.avm ./libs/atomvmlib.avm
 
 #### Special Note for MacOS users
 
@@ -129,7 +147,7 @@ In order to build a complete AtomVM image for ESP32, you will also need to build
 The following software is required in order to build AtomVM for the ESP32 platform:
 
 * Espressif Xtensa tool chains
-* [Espressif IDF SDK](https://www.espressif.com/en/products/sdks/esp-idf) (consult [Release Notes](release-notes.md) for currently supported versions)
+* [Espressif IDF SDK](https://www.espressif.com/en/products/sdks/esp-idf) (consult [Release Notes](./release-notes.md) for currently supported versions)
 * `cmake`
 
 Instructions for downloading and installing the Espressif IDF SDK and tool chains are outside of the scope of this document.  Please consult the [IDF SDKGetting Started](https://docs.espressif.com/projects/esp-idf/en/release-v4.4/get-started/index.html) guide for more information.

--- a/doc/src/getting-started-guide.md
+++ b/doc/src/getting-started-guide.md
@@ -212,13 +212,13 @@ Once the application has been flashed, you may connect to the ESP32 over the ser
 
 ## Getting Started on the Generic UNIX platform
 
-AtomVM may be run on UNIX-like platforms using the `AtomVM` executable.
+AtomVM may be run on UNIX-like platforms using the `atomvm` command.
 
-You may specify one or more AVM files on the command line when running the `AtomVM` command.  BEAM modules defined in earlier AVM modules on the command line take higher precedence that BEAM modules included in AVM files later in the argument list.
+You may specify one or more AVM files on the command line when running the `atom` command.  BEAM modules defined in earlier AVM modules on the command line take higher precedence that BEAM modules included in AVM files later in the argument list.
 
-    shell$ AtomVM /path/to/myapp.avm
+    shell$ atomvm /path/to/myapp.avm
 
-Currently, the `AtomVM` executable must be built from source.
+Currently, the `atomvm` command and libraries must be built and installed from source.
 
 > See the AtomVM [Build Instructions](./build-instructions.md) for instructions about how to build AtomVM on the Generic UNIX platform.
 


### PR DESCRIPTION
Udate new ESP-IDF support versions. Documentation fixes and updates.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
