### PR TITLE
Add support for `erlang:localtime/0` and introduce `erlang:localtime/1`

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -146,6 +146,8 @@ GlobalContext *globalcontext_new()
     glb->online_schedulers = smp_get_online_processors();
     glb->running_schedulers = 0;
     glb->waiting_scheduler = false;
+
+    smp_spinlock_init(&glb->env_spinlock);
 #endif
     glb->scheduler_stop_all = false;
 

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -116,6 +116,10 @@ struct GlobalContext
     bool scheduler_stop_all;
 #endif
 
+#ifndef AVM_NO_SMP
+    SpinLock env_spinlock;
+#endif
+
     void *platform_data;
 };
 

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -92,6 +92,8 @@ erlang:monotonic_time/1, &monotonic_time_nif
 erlang:system_time/1, &system_time_nif
 erlang:tuple_to_list/1, &tuple_to_list_nif
 erlang:universaltime/0, &universaltime_nif
+erlang:localtime/0, &localtime_nif
+erlang:localtime/1, &localtime_nif
 erlang:timestamp/0, &timestamp_nif
 erlang:process_flag/2, &process_flag_nif
 erlang:process_flag/3, &process_flag_nif

--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -38,6 +38,7 @@ endfunction()
 
 compile_erlang(test_socket)
 compile_erlang(test_time_and_processes)
+compile_erlang(test_tz)
 
 add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/esp32_test_modules.avm"
@@ -45,10 +46,12 @@ add_custom_command(
         HostAtomVM-prefix/src/HostAtomVM-build/libs/atomvmlib.avm
         test_socket.beam
         test_time_and_processes.beam
+        test_tz.beam
     DEPENDS
         HostAtomVM
         "${CMAKE_CURRENT_BINARY_DIR}/test_socket.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_time_and_processes.beam"
+        "${CMAKE_CURRENT_BINARY_DIR}/test_tz.beam"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     VERBATIM
 )

--- a/src/platforms/esp32/test/main/test_erl_sources/test_tz.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_tz.erl
@@ -1,0 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_tz).
+-export([start/0]).
+
+start() ->
+    UTCTime1 = erlang:universaltime(),
+    LocalTimeUTC = erlang:localtime("UTC"),
+    UTCTime2 = erlang:universaltime(),
+    true = UTCTime1 =< LocalTimeUTC andalso LocalTimeUTC =< UTCTime2,
+    ParisTime = erlang:localtime("CET-1CEST,M3.5.0,M10.5.0/3"),
+    UTCTime3 = erlang:universaltime(),
+    true = UTCTime2 =/= ParisTime andalso UTCTime3 =/= ParisTime,
+    ok.

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -183,6 +183,12 @@ TEST_CASE("test_time_and_processes", "[test_run]")
     TEST_ASSERT(term_to_int(ret_value) == 6);
 }
 
+TEST_CASE("test_tz", "[test_run]")
+{
+    term ret_value = avm_test_case("test_tz.beam");
+    TEST_ASSERT(ret_value == OK_ATOM);
+}
+
 #ifndef AVM_NO_SMP
 TEST_CASE("atomvm_smp_0", "[smp]")
 {

--- a/tests/erlang_tests/datetime.erl
+++ b/tests/erlang_tests/datetime.erl
@@ -23,10 +23,35 @@
 -export([start/0]).
 
 start() ->
+    3 = test_localtime(),
+    3 = test_universaltime(),
+    case erlang:system_info(machine) of
+        "BEAM" ->
+            % BEAM currently has no API to get the localtime for a given TZ
+            % https://github.com/erlang/otp/issues/7228
+            ok;
+        _ ->
+            ok = test_timezone()
+    end,
+    3.
+
+test_localtime() ->
+    {Date, Time} = erlang:localtime(),
+    test_date(Date) + test_time(Time).
+
+test_universaltime() ->
     {Date, Time} = erlang:universaltime(),
     test_date(Date) + test_time(Time).
 
-test_date({Y, M, D}) when Y >= 2018 andalso M >= 1 andalso M =< 12 andalso D >= 1 andalso D =< 31 ->
+test_timezone() ->
+    UTCDate = erlang:universaltime(),
+    ParisDate = erlang:localtime("Europe/Paris"),
+    LondonDate = erlang:localtime("Europe/London"),
+    true = ParisDate =/= UTCDate,
+    true = ParisDate =/= LondonDate,
+    ok.
+
+test_date({Y, M, D}) when Y >= 2023 andalso M >= 1 andalso M =< 12 andalso D >= 1 andalso D =< 31 ->
     1.
 
 test_time({HOUR, MIN, SEC}) when


### PR DESCRIPTION
Add support for `erlang:localtime/0` and introduce `erlang:localtime/1` to get the local time for a given timezone.
`erlang:localtime/1` takes a string conforming to [POSIX.1-2017](https://pubs.opengroup.org/onlinepubs/9699919799/) TZ environment variable.

See the conversation in ticket erlang/otp#7228

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
