### PR TITLE
Add missing call to `memory_ensure_free` for `erlang:md5/1` nif

### DIFF
--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -381,7 +381,9 @@ static term nif_rom_md5(Context *ctx, int argc, term argv[])
     MD5Update(&md5, (const unsigned char *) term_binary_data(data), term_binary_size(data));
     MD5Final(digest, &md5);
     #endif
-
+    if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(MD5_DIGEST_LENGTH) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
     return term_from_literal_binary(digest, MD5_DIGEST_LENGTH, &ctx->heap, ctx->global);
 }
 

--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -36,6 +36,7 @@ function(compile_erlang module_name)
     set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.beam")
 endfunction()
 
+compile_erlang(test_md5)
 compile_erlang(test_socket)
 compile_erlang(test_time_and_processes)
 
@@ -43,10 +44,12 @@ add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/esp32_test_modules.avm"
     COMMAND HostAtomVM-prefix/src/HostAtomVM-build/tools/packbeam/PackBEAM -i esp32_test_modules.avm
         HostAtomVM-prefix/src/HostAtomVM-build/libs/atomvmlib.avm
+        test_md5.beam
         test_socket.beam
         test_time_and_processes.beam
     DEPENDS
         HostAtomVM
+        "${CMAKE_CURRENT_BINARY_DIR}/test_md5.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_socket.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_time_and_processes.beam"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/src/platforms/esp32/test/main/test_erl_sources/test_md5.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_md5.erl
@@ -1,0 +1,29 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_md5).
+
+-export([start/0]).
+
+start() ->
+    <<62, 37, 150, 10, 121, 219, 198, 155, 103, 76, 212, 236, 103, 167, 44, 98>> = erlang:md5(
+        <<"Hello world">>
+    ),
+    ok.

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -177,6 +177,12 @@ term avm_test_case(const char *test_module)
     return ret_value;
 }
 
+TEST_CASE("test_md5", "[test_run]")
+{
+    term ret_value = avm_test_case("test_md5.beam");
+    TEST_ASSERT(ret_value == OK_ATOM);
+}
+
 TEST_CASE("test_time_and_processes", "[test_run]")
 {
     term ret_value = avm_test_case("test_time_and_processes.beam");


### PR DESCRIPTION
The missing call `memory_ensure_free` could yield a crash, yet it was not observed.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
