### PR TITLE
SPI module: fix proplists handling

### DIFF
--- a/libs/eavmlib/src/spi.erl
+++ b/libs/eavmlib/src/spi.erl
@@ -331,8 +331,8 @@ validate_device_config(DeviceConfig) when is_map(DeviceConfig) ->
 validate_device_config(DeviceConfig) when is_list(DeviceConfig) ->
     lists:foldl(
         fun validate_device_config_fold/2,
-        DeviceConfig,
-        #{}
+        #{},
+        DeviceConfig
     );
 validate_device_config(DeviceConfig) ->
     throw({bardarg, {not_a_map_or_list, DeviceConfig}}).


### PR DESCRIPTION
Accumulator parameter was swapped, so it was crashing when using a proplist as device config.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
