### PR TITLE
Add first CodeQL custom query

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -49,9 +49,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: "Initialize CodeQL"
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        queries: ./code-queries/term-to-non-term-func.ql
 
     - name: "Build"
       run: |
@@ -61,4 +62,4 @@ jobs:
         ninja
 
     - name: "Perform CodeQL Analysis"
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/code-queries/qlpack.yml
+++ b/code-queries/qlpack.yml
@@ -1,0 +1,12 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2023 Davide Bettio <davide@uninstall.it>
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+name: atomvm/cpp-atomvmql
+groups: [cpp]
+libraryPathDependencies: codeql/cpp-all
+extractor: cpp

--- a/code-queries/term-to-non-term-func.ql
+++ b/code-queries/term-to-non-term-func.ql
@@ -1,0 +1,24 @@
+/**
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * @name Passing a term to a function expecting a non-term
+ * @kind problem
+ * @problem.severity error
+ * @id atomvm/term-to-non-term-func
+ * @tags correctness
+ * @precision high
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+import cpp
+
+from FunctionCall functioncall, Type expected_type, Expr expr, int i
+where
+  functioncall.getExpectedParameterType(i) = expected_type and
+  expected_type.getName() != "term" and
+  expected_type.getName() != "unknown" and // This includes variadic arguments
+  expr.getExplicitlyConverted().getType().getName() = "term" and
+  functioncall.getArgument(i) = expr
+select functioncall, "Passing a term to a function expecting a non-term, without an explicit cast"


### PR DESCRIPTION
Start checking code with custom queries, starting from a new based on an observed error.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
