### PR TITLE
Fix wrong sx127x SPI example

### DIFF
--- a/examples/erlang/esp32/sx127x.erl
+++ b/examples/erlang/esp32/sx127x.erl
@@ -74,7 +74,7 @@
     {device_config, [
         {my_device, [
             {spi_clock_hz, 1000000},
-            {spi_mode, 0},
+            {mode, 0},
             {spi_cs_io_num, 18},
             {address_len_bits, 8}
         ]}


### PR DESCRIPTION
The example was still using `spi_mode` instead of `mode`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
