### PR TITLE
Add CodeQL query for non-term to term problems

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -52,7 +52,9 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        queries: ./code-queries/term-to-non-term-func.ql
+        queries:
+          - ./code-queries/term-to-non-term-func.ql
+          - ./code-queries/non-term-to-term-func.ql
 
     - name: "Build"
       run: |

--- a/code-queries/non-term-to-term-func.ql
+++ b/code-queries/non-term-to-term-func.ql
@@ -1,0 +1,43 @@
+/**
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * @name Passing a non-term to a function expecting a term
+ * @kind problem
+ * @problem.severity error
+ * @id atomvm/non-term-to-term-func
+ * @tags correctness
+ * @precision high
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+import cpp
+
+predicate isNotTermOrAtom(Expr expr) {
+  expr.getExplicitlyConverted().getType().getName() != "term" and
+  not (
+    expr.isInMacroExpansion() and
+    expr.isConstant() and
+    // Allow for %_ATOM and TERM_% macros until these include an explicit cast to term
+    exists(MacroInvocation mi |
+      expr = mi.getAGeneratedElement() and
+      (mi.toString().matches("%_ATOM") or mi.toString().matches("TERM_%"))
+    )
+  ) and
+  (
+    not expr instanceof ConditionalExpr
+    or
+    isNotTermOrAtom(expr.(ConditionalExpr).getThen()) and
+    isNotTermOrAtom(expr.(ConditionalExpr).getElse())
+  )
+}
+
+from FunctionCall functioncall, Type expected_type, Expr expr, int i
+where
+  functioncall.getExpectedParameterType(i) = expected_type and
+  expected_type.getName() = "term" and
+  functioncall.getArgument(i) = expr and
+  isNotTermOrAtom(expr)
+select expr, "Passing a non-term to a function expecting a term, without an explicit cast"


### PR DESCRIPTION
Add new query based on Paul Guyot work for detecting when a non-term, such an integer is passed to a function expecting a term without using term_from_int(...).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
