### PR TITLE
Fix bug in decoding of literals in DECODE_COMPACT_TERM

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -121,7 +121,7 @@ typedef union
                     break;                                                              \
                                                                                         \
                 case 1:                                                                 \
-                    dest_term = term_from_int4(((first_byte & 0xE0) << 3) | code_chunk[(base_index) + (off) + 1]); \
+                    dest_term = term_from_int(((first_byte & 0xE0) << 3) | code_chunk[(base_index) + (off) + 1]); \
                     off += 2;                                                           \
                     break;                                                              \
                                                                                         \
@@ -425,7 +425,7 @@ typedef union
                     break;                                                                                              \
                                                                                                                         \
                 case 1:                                                                                                 \
-                    dest_term = term_from_int4(((first_byte & 0xE0) << 3) | code_chunk[(base_index) + (off) + 1]);      \
+                    dest_term = term_from_int(((first_byte & 0xE0) << 3) | code_chunk[(base_index) + (off) + 1]);      \
                     off += 2;                                                                                           \
                     break;                                                                                              \
                                                                                                                         \

--- a/tests/erlang_tests/test_bs.erl
+++ b/tests/erlang_tests/test_bs.erl
@@ -91,6 +91,8 @@ start() ->
 
     ok = test_iterate_binary(),
 
+    ok = test_large(),
+
     0.
 
 test_pack_small_ints({A, B, C}, Expect) ->
@@ -360,6 +362,11 @@ test_iterate_binary() ->
 
 traverse(<<"">>, Accum) -> Accum;
 traverse(<<H:8, T/binary>>, Accum) -> traverse(T, Accum ++ [H]).
+
+test_large() ->
+    X = <<42:1024>>,
+    true = id(X) =:= <<42:1024>>,
+    ok.
 
 % Prevent optimization from the compiler
 id(X) ->


### PR DESCRIPTION
The test generates such a term with OTP21 compiler.
This is the current CI crash of #579

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
