### PR TITLE
Fix bug in interop_kv_get_value_default

### DIFF
--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -242,14 +242,14 @@ InteropFunctionResult interop_write_iolist(term t, char *p)
     return InteropOk;
 }
 
-term interop_map_get_value(Context *ctx, term map, term key)
+term interop_map_get_value(GlobalContext *glb, term map, term key)
 {
-    return interop_map_get_value_default(ctx, map, key, term_nil());
+    return interop_map_get_value_default(glb, map, key, term_nil());
 }
 
-term interop_map_get_value_default(Context *ctx, term map, term key, term default_value)
+term interop_map_get_value_default(GlobalContext *glb, term map, term key, term default_value)
 {
-    int pos = term_find_map_pos(map, key, ctx->global);
+    int pos = term_find_map_pos(map, key, glb);
     if (pos == TERM_MAP_NOT_FOUND) {
         return default_value;
     } else if (UNLIKELY(pos == TERM_MAP_MEMORY_ALLOC_FAIL)) {
@@ -281,7 +281,7 @@ term interop_kv_get_value_default(term kv, AtomString key, term default_value, G
     if (term_is_nonempty_list(kv)) {
         return interop_proplist_get_value_default(kv, key_term, default_value);
     } else if (term_is_map(kv)) {
-        return interop_proplist_get_value_default(kv, key_term, default_value);
+        return interop_map_get_value_default(glb, kv, key_term, default_value);
     } else {
         return default_value;
     }

--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -59,8 +59,8 @@ char *interop_list_to_string(term list, int *ok);
 char *interop_atom_to_string(Context *ctx, term atom);
 term interop_proplist_get_value(term list, term key);
 term interop_proplist_get_value_default(term list, term key, term default_value);
-term interop_map_get_value(Context *ctx, term map, term key);
-term interop_map_get_value_default(Context *ctx, term map, term key, term default_value);
+term interop_map_get_value(GlobalContext *glb, term map, term key);
+term interop_map_get_value_default(GlobalContext *glb, term map, term key, term default_value);
 
 NO_DISCARD InteropFunctionResult interop_iolist_size(term t, size_t *size);
 NO_DISCARD InteropFunctionResult interop_write_iolist(term t, char *p);


### PR DESCRIPTION
interop_kv_get_value_default wasn't working with maps, fix it.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
