### PR TITLE
Update morse_server example

### DIFF
--- a/examples/erlang/esp32/morse_server.erl
+++ b/examples/erlang/esp32/morse_server.erl
@@ -116,7 +116,6 @@ get_gpio() ->
     case whereis(gpio) of
         undefined ->
             GPIO = gpio:open(),
-            register(gpio, GPIO),
             GPIO;
         GPIO ->
             GPIO


### PR DESCRIPTION
Remove call to register/2 since the driver does this internally and the extra call now causes an error.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
