### PR TITLE
Erlang documentation additions and corrections

### DIFF
--- a/libs/eavmlib/src/atomvm.erl
+++ b/libs/eavmlib/src/atomvm.erl
@@ -1,27 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2018-2022 Fred Dushin <fred@dushin.net>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
-%
-% This file is part of AtomVM.
-%
-% Copyright 2019 Fred Dushin <fred@dushin.net>
+% Copyright 2018-2023 Fred Dushin <fred@dushin.net>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.

--- a/libs/eavmlib/src/console.erl
+++ b/libs/eavmlib/src/console.erl
@@ -1,27 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2018-2022 Fred Dushin <fred@dushin.net>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
-%
-% This file is part of AtomVM.
-%
-% Copyright 2018 Fred Dushin <fred@dushin.net>
+% Copyright 2018-2023 Fred Dushin <fred@dushin.net>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.

--- a/libs/eavmlib/src/esp.erl
+++ b/libs/eavmlib/src/esp.erl
@@ -179,6 +179,8 @@ nvs_set_binary(Namespace, Key, Value) when
     throw(nif_error).
 
 %%-----------------------------------------------------------------------------
+%% @param   Key NVS key
+%% @returns ok
 %% @doc Equivalent to nvs_erase_key(?ATOMVM_NVS_NS, Key).
 %% @end
 %%-----------------------------------------------------------------------------
@@ -240,6 +242,7 @@ rtc_slow_get_binary() ->
     throw(nif_error).
 
 %%-----------------------------------------------------------------------------
+%% @param   Bin binary to be stored in RTC slow memory
 %% @returns ok
 %% @doc     Store a binary to RTC slow memory. This memory is not erased on
 %%          software reset and deep sleeps.

--- a/libs/eavmlib/src/gpio.erl
+++ b/libs/eavmlib/src/gpio.erl
@@ -1,27 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2018-2022 Davide Bettio <davide@uninstall.it>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
-%
-% This file is part of AtomVM.
-%
-% Copyright 2019 Davide Bettio <davide@uninstall.it>
+% Copyright 2018-2023 Davide Bettio <davide@uninstall.it>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -118,9 +98,9 @@ open() ->
 %%          `gpio:set_direction/3' it will always read as low.
 %% @end
 %%-----------------------------------------------------------------------------
--spec read(GPIO :: gpio(), GPIONum :: pin()) -> high | low.
-read(GPIO, GPIONum) ->
-    port:call(GPIO, {read, GPIONum}).
+-spec read(GPIO :: gpio(), Pin :: pin()) -> high | low.
+read(GPIO, Pin) ->
+    port:call(GPIO, {read, Pin}).
 
 %%-----------------------------------------------------------------------------
 %% @param   GPIO pid that was returned from `gpio:start/0'
@@ -132,9 +112,9 @@ read(GPIO, GPIONum) ->
 %%          Pins can be used for input, output, or output with open drain.
 %% @end
 %%-----------------------------------------------------------------------------
--spec set_direction(GPIO :: gpio(), GPIONum :: pin(), Direction :: direction()) -> ok | error.
-set_direction(GPIO, GPIONum, Direction) ->
-    port:call(GPIO, {set_direction, GPIONum, Direction}).
+-spec set_direction(GPIO :: gpio(), Pin :: pin(), Direction :: direction()) -> ok | error.
+set_direction(GPIO, Pin, Direction) ->
+    port:call(GPIO, {set_direction, Pin, Direction}).
 
 %%-----------------------------------------------------------------------------
 %% @param   GPIO pid that was returned from `gpio:start/0'
@@ -146,9 +126,9 @@ set_direction(GPIO, GPIONum, Direction) ->
 %%          Set a pin to `high' (1) or `low' (0).
 %% @end
 %%-----------------------------------------------------------------------------
--spec set_level(GPIO :: gpio(), GPIONum :: pin(), Level :: level()) -> ok | error.
-set_level(GPIO, GPIONum, Level) ->
-    port:call(GPIO, {set_level, GPIONum, Level}).
+-spec set_level(GPIO :: gpio(), Pin :: pin(), Level :: level()) -> ok | error.
+set_level(GPIO, Pin, Level) ->
+    port:call(GPIO, {set_level, Pin, Level}).
 
 %%-----------------------------------------------------------------------------
 %% @param   GPIO pid that was returned from `gpio:start/0'
@@ -165,9 +145,9 @@ set_level(GPIO, GPIONum, Level) ->
 %%          of the pin that triggered the interrupt.
 %% @end
 %%-----------------------------------------------------------------------------
--spec set_int(GPIO :: gpio(), GPIONum :: pin(), Trigger :: trigger()) -> ok | error.
-set_int(GPIO, GPIONum, Trigger) ->
-    port:call(GPIO, {set_int, GPIONum, Trigger}).
+-spec set_int(GPIO :: gpio(), Pin :: pin(), Trigger :: trigger()) -> ok | error.
+set_int(GPIO, Pin, Trigger) ->
+    port:call(GPIO, {set_int, Pin, Trigger}).
 
 %%-----------------------------------------------------------------------------
 %% @param   GPIO pid that was returned from `gpio:start/0'
@@ -178,9 +158,9 @@ set_int(GPIO, GPIONum, Trigger) ->
 %%          Removes an interrupt from the specified pin.
 %% @end
 %%-----------------------------------------------------------------------------
--spec remove_int(GPIO :: gpio(), GPIONum :: pin()) -> ok | error.
-remove_int(GPIO, GPIONum) ->
-    port:call(GPIO, {remove_int, GPIONum}).
+-spec remove_int(GPIO :: gpio(), Pin :: pin()) -> ok | error.
+remove_int(GPIO, Pin) ->
+    port:call(GPIO, {remove_int, Pin}).
 
 %%-----------------------------------------------------------------------------
 %% @param   Pin number to set operational mode
@@ -191,8 +171,8 @@ remove_int(GPIO, GPIONum) ->
 %%          Pins can be used for input, output, or output with open drain.
 %% @end
 %%-----------------------------------------------------------------------------
--spec set_pin_mode(GPIONum :: pin(), Direction :: direction()) -> ok | error.
-set_pin_mode(_GPIONum, _Mode) ->
+-spec set_pin_mode(Pin :: pin(), Direction :: direction()) -> ok | error.
+set_pin_mode(_Pin, _Mode) ->
     throw(nif_error).
 
 %%-----------------------------------------------------------------------------
@@ -205,8 +185,8 @@ set_pin_mode(_GPIONum, _Mode) ->
 %%          both directions), or left `floating'.
 %% @end
 %%-----------------------------------------------------------------------------
--spec set_pin_pull(GPIONum :: pin(), Pull :: pull()) -> ok | error.
-set_pin_pull(_GPIONum, _Pull) ->
+-spec set_pin_pull(Pin :: pin(), Pull :: pull()) -> ok | error.
+set_pin_pull(_Pin, _Pull) ->
     throw(nif_error).
 
 %%-----------------------------------------------------------------------------
@@ -229,8 +209,8 @@ set_pin_pull(_GPIONum, _Pull) ->
 %%          Deep-sleep `gpio:deep_sleep_hold_en' should also be called.
 %% @end
 %%-----------------------------------------------------------------------------
--spec hold_en(GPIONum :: pin()) -> ok | error.
-hold_en(_GPIONum) ->
+-spec hold_en(Pin :: pin()) -> ok | error.
+hold_en(_Pin) ->
     throw(nif_error).
 
 %%-----------------------------------------------------------------------------
@@ -249,8 +229,8 @@ hold_en(_GPIONum) ->
 %%          set it to hight level before calling `gpio:hold_dis'.
 %% @end
 %%-----------------------------------------------------------------------------
--spec hold_dis(GPIONum :: pin()) -> ok | error.
-hold_dis(_GPIONum) ->
+-spec hold_dis(Pin :: pin()) -> ok | error.
+hold_dis(_Pin) ->
     throw(nif_error).
 
 %%-----------------------------------------------------------------------------
@@ -294,8 +274,8 @@ deep_sleep_hold_dis() ->
 %%          Set a pin to `high' (1) or `low' (0).
 %% @end
 %%-----------------------------------------------------------------------------
--spec digital_write(GPIONum :: pin(), Level :: level()) -> ok | error.
-digital_write(_GPIONum, _Level) ->
+-spec digital_write(Pin :: pin(), Level :: level()) -> ok | error.
+digital_write(_Pin, _Level) ->
     throw(nif_error).
 
 %%-----------------------------------------------------------------------------
@@ -308,8 +288,8 @@ digital_write(_GPIONum, _Level) ->
 %%          `gpio:set_pin_mode/2' it will always read as low.
 %% @end
 %%-----------------------------------------------------------------------------
--spec digital_read(GPIONum :: pin()) -> high | low.
-digital_read(_GPIONum) ->
+-spec digital_read(Pin :: pin()) -> high | low.
+digital_read(_Pin) ->
     throw(nif_error).
 
 %%-----------------------------------------------------------------------------
@@ -328,9 +308,9 @@ digital_read(_GPIONum) ->
 %%          a race condition when start() is called internally by this function.
 %% @end
 %%-----------------------------------------------------------------------------
--spec attach_interrupt(GPIONum :: pin(), Trigger :: trigger()) -> ok | error.
-attach_interrupt(GPIONum, Trigger) ->
-    set_int(start(), GPIONum, Trigger).
+-spec attach_interrupt(Pin :: pin(), Trigger :: trigger()) -> ok | error.
+attach_interrupt(Pin, Trigger) ->
+    set_int(start(), Pin, Trigger).
 
 %-----------------------------------------------------------------------------
 %% @param   Pin number of the pin to remove the interrupt
@@ -344,6 +324,6 @@ attach_interrupt(GPIONum, Trigger) ->
 %%          regardless of the number of interrupt pins used in the application.
 %% @end
 %%-----------------------------------------------------------------------------
--spec detach_interrupt(GPIONum :: pin()) -> ok | error.
-detach_interrupt(GPIONum) ->
-    remove_int(whereis(gpio), GPIONum).
+-spec detach_interrupt(Pin :: pin()) -> ok | error.
+detach_interrupt(Pin) ->
+    remove_int(whereis(gpio), Pin).

--- a/libs/eavmlib/src/http_server.erl
+++ b/libs/eavmlib/src/http_server.erl
@@ -18,26 +18,6 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
-%
-% This file is part of AtomVM.
-%
-% Copyright 2019 Davide Bettio <davide@uninstall.it>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
 -module(http_server).
 
 -export([start_server/2, reply/3, parse_query_string/1]).

--- a/libs/eavmlib/src/i2c.erl
+++ b/libs/eavmlib/src/i2c.erl
@@ -19,7 +19,7 @@
 %
 
 %%-----------------------------------------------------------------------------
-%% @doc AtomvVM I2c interface
+%% @doc AtomVM I2c interface
 %%
 %% This module provides and interface into the AtomVM I2C driver.
 %%
@@ -79,13 +79,13 @@ close(I2C) ->
 %% @param   I2C I2C instance created via `open/1'
 %% @param   Address I2C Address of the device (typically fixed for the device type)
 %% @returns `ok' or `error'
-%% @doc     Begin a transimission of I2C commands
+%% @doc     Begin a transmission of I2C commands
 %%
 %%          This command is typically followed by one or more calls to
 %%          `write_byte/2' and then a call to `end_transmission/1'
 %% @end
 %%-----------------------------------------------------------------------------
--spec begin_transmission(I2c :: i2c(), Address :: address()) -> ok | error.
+-spec begin_transmission(I2C :: i2c(), Address :: address()) -> ok | error.
 begin_transmission(I2C, Address) ->
     port:call(I2C, {begin_transmission, Address}).
 
@@ -99,13 +99,13 @@ begin_transmission(I2C, Address) ->
 %%          and `end_transmission/1' call.
 %% @end
 %%-----------------------------------------------------------------------------
--spec write_byte(I2c :: i2c(), Byte :: byte()) -> ok | error.
+-spec write_byte(I2C :: i2c(), Byte :: byte()) -> ok | error.
 write_byte(I2C, Byte) ->
     port:call(I2C, {write_byte, Byte}).
 
 %%-----------------------------------------------------------------------------
 %% @param   I2C I2C instance created via `open/1'
-%% @param   Byte value to write
+%% @param   Bytes value to write
 %% @returns `ok' or `error'
 %% @doc     Write a sequence of bytes to the device.
 %%
@@ -113,7 +113,7 @@ write_byte(I2C, Byte) ->
 %%          and `end_transmission/1' call.
 %% @end
 %%-----------------------------------------------------------------------------
--spec write_bytes(I2c :: i2c(), Bytes :: binary()) -> ok | error.
+-spec write_bytes(I2C :: i2c(), Bytes :: binary()) -> ok | error.
 write_bytes(I2C, Bytes) ->
     port:call(I2C, {write_bytes, Bytes}).
 
@@ -121,13 +121,13 @@ write_bytes(I2C, Bytes) ->
 %% @param   I2C I2C instance created via `open/1'
 %% @param   Address I2C Address of the device (typically fixed for the device type)
 %% @returns `ok' or `error'
-%% @doc     End a transimission of I2C commands
+%% @doc     End a transmission of I2C commands
 %%
 %%          This command is typically preceded by a call to `begin_transmission/2'
 %%          and one or more calls to `write_byte/2'.
 %% @end
 %%-----------------------------------------------------------------------------
--spec end_transmission(I2c :: i2c()) -> ok | error.
+-spec end_transmission(I2C :: i2c()) -> ok | error.
 end_transmission(I2C) ->
     port:call(I2C, {end_transmission}).
 
@@ -142,7 +142,7 @@ end_transmission(I2C) ->
 %%          and `end_transmission/1' call.
 %% @end
 %%-----------------------------------------------------------------------------
--spec read_bytes(I2c :: i2c(), Address :: address(), Count :: non_neg_integer()) ->
+-spec read_bytes(I2C :: i2c(), Address :: address(), Count :: non_neg_integer()) ->
     error | binary().
 read_bytes(I2C, Address, Count) ->
     port:call(I2C, {read_bytes, Address, Count}).
@@ -161,7 +161,7 @@ read_bytes(I2C, Address, Count) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec read_bytes(
-    I2c :: i2c(), Address :: address(), Register :: register(), Count :: non_neg_integer()
+    I2C :: i2c(), Address :: address(), Register :: register(), Count :: non_neg_integer()
 ) -> error | binary().
 read_bytes(I2C, Address, Register, Count) ->
     port:call(I2C, {read_bytes, Address, Count, Register}).
@@ -177,7 +177,7 @@ read_bytes(I2C, Address, Register, Count) ->
 %%          and `end_transmission/1' call.
 %% @end
 %%-----------------------------------------------------------------------------
--spec write_bytes(I2c :: i2c(), Address :: address(), BinOrInt :: binary() | byte()) -> ok | error.
+-spec write_bytes(I2C :: i2c(), Address :: address(), BinOrInt :: binary() | byte()) -> ok | error.
 write_bytes(I2C, Address, BinOrInt) ->
     port:call(I2C, {write_bytes, Address, BinOrInt}).
 
@@ -195,7 +195,7 @@ write_bytes(I2C, Address, BinOrInt) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec write_bytes(
-    I2c :: i2c(), Address :: address(), Register :: register(), BinOrInt :: binary() | integer()
+    I2C :: i2c(), Address :: address(), Register :: register(), BinOrInt :: binary() | integer()
 ) -> ok | error.
 write_bytes(I2C, Address, Register, BinOrInt) ->
     port:call(I2C, {write_bytes, Address, BinOrInt, Register}).

--- a/libs/eavmlib/src/json_encoder.erl
+++ b/libs/eavmlib/src/json_encoder.erl
@@ -18,29 +18,22 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
-%
-% This file is part of AtomVM.
-%
-% Copyright 2019 Davide Bettio <davide@uninstall.it>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
+%%-----------------------------------------------------------------------------
+%% @doc JSON specific APIs
+%%
+%% This module contains functions for working with json data.
+%% @end
+%%-----------------------------------------------------------------------------
 -module(json_encoder).
 -export([encode/1]).
 
+%%-----------------------------------------------------------------------------
+%% @param   Data data to encode to json
+%% @returns JSON encoded data
+%% @doc Convert data to json encoded binary
+%% @end
+%%-----------------------------------------------------------------------------
+-spec encode(Data :: any()) -> binary().
 encode(false) ->
     <<"false">>;
 encode(true) ->

--- a/libs/eavmlib/src/ledc.erl
+++ b/libs/eavmlib/src/ledc.erl
@@ -1,27 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2020-2022 Fred Dushin <fred@dushin.net>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
-%
-% This file is part of AtomVM.
-%
-% Copyright 2020 Fred Dushin <fred@dushin.net>
+% Copyright 2020-2023 Fred Dushin <fred@dushin.net>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -73,14 +53,14 @@
 -type freq_hz_cfg() :: {freq_hz, freq_hz()}.
 -type speed_mode() :: ?LEDC_LOW_SPEED_MODE | ?LEDC_HIGH_SPEED_MODE.
 -type speed_mode_cfg() :: {speed_mode, speed_mode()}.
--type timer_num() :: non_neg_integer().
+-type timer_num() :: 0..3.
 -type timer_num_cfg() :: {timer_num, timer_num()}.
 
 -type timer_config() :: [
     duty_resolution_cfg() | freq_hz_cfg() | speed_mode_cfg() | timer_num_cfg()
 ].
 
--type channel() :: non_neg_integer().
+-type channel() :: 0..7.
 -type channel_cfg() :: {channel, channel()}.
 -type duty() :: non_neg_integer().
 -type duty_cfg() :: {duty, duty()}.
@@ -99,9 +79,9 @@
 -type fade_mode() :: non_neg_integer().
 
 %%-----------------------------------------------------------------------------
-%% @param   Config      timer configuration
+%% @param   Config      channel configuration
 %% @returns ok | {error, ledc_error_code()}
-%% @doc     LEDC timer configuration.
+%% @doc     LEDC channel configuration.
 %%
 %%          Configure LEDC timer with the given source timer/frequency(Hz)/duty_resolution.
 %% @end
@@ -123,8 +103,9 @@ timer_config(_Config) ->
     throw(nif_error).
 
 %%-----------------------------------------------------------------------------
-%% @param   Flags   Flags used to allocate the interrupt. One or multiple (ORred)
-%%                  ESP_INTR_FLAG_* values. See esp_intr_alloc.h for more info.
+%% @param   Flags   Flags used to allocate the interrupt. One (or multiple, using
+%%                  an ORred mask) ESP_INTR_FLAG_* values. See esp_intr_alloc.h
+%%                  for more info.
 %% @returns         ok | {error, ledc_error_code()}
 %% @doc     Install LEDC fade function.
 %%
@@ -148,7 +129,7 @@ fade_func_uninstall() ->
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
 %%                      Note that not all targets support high speed mode.
 %% @param   Channel     LEDC channel index (0-7).
-%% @param   TargetDuty  Target duty of fading.(0..(2^duty_resolution-1)))
+%% @param   TargetDuty  Target duty of fading. (0..(2^duty_resolution)-1)
 %% @param   MaxFadeTimeMs The maximum time of the fading (ms).
 %% @returns         ok | {error, ledc_error_code()}
 %% @doc     Set LEDC fade function, with a limited time.
@@ -171,7 +152,7 @@ set_fade_with_time(_SpeedMode, _Channel, _TargetDuty, _MaxFadeTimeMs) ->
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
 %%                      Note that not all targets support high speed mode.
 %% @param   Channel     LEDC channel index (0-7).
-%% @param   TargetDuty  Target duty of fading.(0..(2^duty_resolution-1)))
+%% @param   TargetDuty  Target duty of fading. (0..(2^duty_resolution)-1)
 %% @param   Scale       Controls the increase or decrease step scale.
 %% @param   CycleNum    increase or decrease the duty every cycle_num cycles
 %% @returns         ok | {error, ledc_error_code()}
@@ -224,7 +205,7 @@ get_duty(_SpeedMode, _Channel) ->
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
 %%                      Note that not all targets support high speed mode.
 %% @param   Channel     LEDC channel index (0-7).
-%% @param   Duty        Set the LEDC duty, the range of duty setting is [0, (2**duty_resolution)]
+%% @param   Duty        Set the LEDC duty, the range of setting is [0, (2^duty_resolution)-1].
 %% @returns ok | {error, ledc_error_code()}
 %% @doc     LEDC set duty.
 %% @end
@@ -262,8 +243,9 @@ get_freq(_SpeedMode, _TimerNum) ->
 %%-----------------------------------------------------------------------------
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
 %% @param   TimerNum    LEDC timer index (0-3).
+%% @param   FreqHz      Set the LEDC frequency.
 %% @returns ok | {error, ledc_error_code()}
-%% @doc     LEDC get channel frequency (Hz)
+%% @doc     LEDC set channel frequency (Hz)
 %% @end
 %%-----------------------------------------------------------------------------
 -spec set_freq(SpeedMode :: speed_mode(), TimerNum :: timer_num(), FreqHz :: non_neg_integer()) ->

--- a/libs/eavmlib/src/logger.erl
+++ b/libs/eavmlib/src/logger.erl
@@ -1,27 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2019-2022 Fred Dushin <fred@dushin.net>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
-%
-% This file is part of AtomVM.
-%
-% Copyright 2019 Fred Dushin <fred@dushin.net>
+% Copyright 2019-2023 Fred Dushin <fred@dushin.net>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -139,6 +119,8 @@ stop() ->
 
 %%-----------------------------------------------------------------------------
 %% @param   Location the location in the source module
+%% @param   Level the loglevel
+%% @param   MsgFormat {String, [Args]} in io:format/1,2 notation.
 %% @doc     Log a message the the specified location with the specified level.
 %%
 %%          Users should use the logging macros in logger.hrl instead of

--- a/libs/eavmlib/src/network.erl
+++ b/libs/eavmlib/src/network.erl
@@ -18,26 +18,6 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
-%
-% This file is part of AtomVM.
-%
-% Copyright 2020 Fred Dushin <fred@dushin.net>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
 -module(network).
 
 -behavior(gen_server).
@@ -119,6 +99,7 @@ wait_for_sta() ->
     wait_for_sta(15000).
 
 %%-----------------------------------------------------------------------------
+%% @param   TimeoutOrStaConfig The STA network configuration or timeout in ms.
 %% @doc     Equivalent to wait_for_sta([], Timeout) or wait_for_sta(StaConfig, 15000).
 %% @end
 %%-----------------------------------------------------------------------------
@@ -132,11 +113,11 @@ wait_for_sta(StaConfig) when is_list(StaConfig) ->
 %%-----------------------------------------------------------------------------
 %% @param   StaConfig The STA network configuration
 %% @param   Timeout amount of time in milliseconds to wait for a connection
-%% @returns {ok, IpInfo}, if the network_fsm was started, or {error, Reason} if
+%% @returns {ok, IpInfo}, if the network interface was started, or {error, Reason} if
 %%          a failure occurred (e.g., due to malformed network configuration).
-%% @doc     Start a network_fsm in station mode and wait for a connection to be established
+%% @doc     Start a network interface in station mode and wait for a connection to be established
 %%
-%%          This function will start a network_fsm in station mode, and will wait
+%%          This function will start a network interface in station mode, and will wait
 %%          for a connection to be established.  This is a convenience function,
 %%          for applications that do not need to be notified of connectivity
 %%          changes in the network.
@@ -169,10 +150,11 @@ wait_for_ap() ->
     wait_for_ap(15000).
 
 %%-----------------------------------------------------------------------------
+%% @param   TimeoutOrApConfig The AP network configuration or timeout in ms.
 %% @doc     Equivalent to wait_for_ap([], Timeout) or wait_for_ap(StaConfig, 15000).
 %% @end
 %%-----------------------------------------------------------------------------
--spec wait_for_ap(TimeoutOrStaConfig :: non_neg_integer() | [ap_config_property()]) ->
+-spec wait_for_ap(TimeoutOrApConfig :: non_neg_integer() | [ap_config_property()]) ->
     ok | {error, Reason :: term()}.
 wait_for_ap(Timeout) when is_integer(Timeout) ->
     wait_for_ap([], Timeout);
@@ -182,12 +164,12 @@ wait_for_ap(ApConfig) when is_list(ApConfig) ->
 %%-----------------------------------------------------------------------------
 %% @param   ApConfig The AP network configuration
 %% @param   Timeout amount of time in milliseconds to wait for a connection
-%% @returns ok, when the nework_fsm has started the AP, or {error, Reason} if
+%% @returns ok, when the network has started the AP, or {error, Reason} if
 %%          a failure occurred (e.g., due to malformed network configuration).
-%% @doc     Start a network_fsm in access point mode and wait the AP to be
+%% @doc     Start a network interface in access point mode and wait the AP to be
 %%          up and running
 %%
-%%          This function will start a network_fsm in AP mode, and will wait
+%%          This function will start a network interface in AP mode, and will wait
 %%          until the network is up and ready to be connected.  This is a convenience function,
 %%          for applications that do not need to be notified of connectivity
 %%          changes in the network.
@@ -211,11 +193,11 @@ wait_for_ap(ApConfig, Timeout) ->
 
 %%-----------------------------------------------------------------------------
 %% @param   Config The network configuration
-%% @returns ok, if the network_fsm was started, or {error, Reason} if
+%% @returns ok, if the network interface was started, or {error, Reason} if
 %%          a failure occurred (e.g., due to malformed network configuration).
-%% @doc     Start a network_fsm.
+%% @doc     Start a network interface.
 %%
-%%          This function will start a network_fsm, which will attempt to
+%%          This function will start a network interface, which will attempt to
 %%          connect to an AP endpoint in the background.  Specify callback
 %%          functions to receive definitive
 %%          information that the connection succeeded.  See the AtomVM Network
@@ -251,9 +233,9 @@ start_link(Config) ->
     end.
 
 %%-----------------------------------------------------------------------------
-%% @returns ok, if the network_fsm was stopped, or {error, Reason} if
+%% @returns ok, if the network interface was stopped, or {error, Reason} if
 %%          a failure occurred.
-%% @doc     Stop a network_fsm.
+%% @doc     Stop a network interface.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec stop() -> ok | {error, Reason :: term()}.

--- a/libs/eavmlib/src/network_fsm.erl
+++ b/libs/eavmlib/src/network_fsm.erl
@@ -1,7 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2019-2022 Fred Dushin <fred@dushin.net>
+% Copyright 2019-2023 Fred Dushin <fred@dushin.net>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -18,26 +18,12 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
-%
-% This file is part of AtomVM.
-%
-% Copyright 2021 Fred Dushin <fred@dushin.net>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
+%%-----------------------------------------------------------------------------
+%% @doc network_fsm
+%%
+%% This module is depreciated. Use the network module instead.
+%% @end
+%%-----------------------------------------------------------------------------
 -module(network_fsm).
 
 -export([

--- a/libs/eavmlib/src/port.erl
+++ b/libs/eavmlib/src/port.erl
@@ -19,11 +19,38 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
+%%-----------------------------------------------------------------------------
+%% @doc AtomVM port driver APIs
+%%
+%% This module contains functions that are intended to be used by drivers that
+%% rely on a `port' interface rather than `niffs'.
+%%
+%% The port driver should be initialized with:
+%% `open_port({spawn, "Name"}, Param)'
+%% Where Name is an atom(), and is the name of the driver. The return from `open_port/2'
+%% will be the Pid that will be required for future `port:call/2' or `port:call/3' use.
+%%
+%% Examples:
+%% ```open_port({spawn, "i2c"}, Param)'''
+%% or
+%% ```open_port({spawn, "spi"}, Params)'''
+%% @end
+%%-----------------------------------------------------------------------------
 -module(port).
 
 -export([call/2, call/3]).
 
--spec call(pid(), Message :: term()) -> term().
+%%-----------------------------------------------------------------------------
+%% @param   Pid Pid to which to send messages
+%% @param   Message the message to send
+%% @returns term() | {error, Reason}.
+%% @doc     Send a message to a given port driver pid.
+%%
+%% This function is used to send a message to an open port divers pid and will
+%% return a term or `{error, Reason}'.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec call(Pid :: pid(), Message :: term()) -> term() | {error, Reason :: term()}.
 call(Pid, Message) ->
     case erlang:is_process_alive(Pid) of
         false ->
@@ -37,7 +64,19 @@ call(Pid, Message) ->
             end
     end.
 
--spec call(pid(), Message :: term(), TimeoutMs :: non_neg_integer()) -> term() | {error, timeout}.
+%%-----------------------------------------------------------------------------
+%% @param   Pid Pid to which to send messages
+%% @param   Message the message to send
+%% @param   TimeoutMs the timeout value in milliseconds
+%% @returns term() | {error, Reason}.
+%% @doc     Send a message to a given port driver pid with a timeout.
+%%
+%% This function is used to send a message to an open port divers pid and will return
+%% a term or `{error, Reason}', or`{error, timeout}' if the TimeoutMs is reached first.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec call(Pid :: pid(), Message :: term(), TimeoutMs :: non_neg_integer()) ->
+    term() | {error, timeout}.
 call(Pid, Message, TimeoutMs) ->
     case erlang:is_process_alive(Pid) of
         false ->

--- a/libs/eavmlib/src/spi.erl
+++ b/libs/eavmlib/src/spi.erl
@@ -172,7 +172,9 @@ close(SPI) ->
 
 %%-----------------------------------------------------------------------------
 %% @param   SPI SPI instance created via `open/1'
+%% @param   DeviceName device name from configuration
 %% @param   Address SPI Address from which to read
+%% @param   Len in bytes to read
 %% @returns `{ok, Value}' or `error'
 %% @doc     Read a value from and address on the device.
 %% @end
@@ -186,7 +188,10 @@ read_at(SPI, DeviceName, Address, Len) ->
 
 %%-----------------------------------------------------------------------------
 %% @param   SPI SPI instance created via `open/1'
+%% @param   DeviceName device name from configuration
 %% @param   Address SPI Address to which to write
+%% @param   Len in bytes to read
+%% @param   Data byte(s) to write
 %% @returns `{ok, Value}' or `error'
 %% @doc     Write a value to and address on the device.
 %%
@@ -211,7 +216,7 @@ write_at(SPI, DeviceName, Address, Len, Data) ->
 %% @param   DeviceName SPI device name (use key in `device_config')
 %% @param   Transaction transaction map.
 %% @returns `ok' or `{error, Reason}', if an error occurred.
-%% @doc     Write data to the SPI device, using the intructions encoded in the supplied transaction.
+%% @doc     Write data to the SPI device, using the instructions encoded in the supplied transaction.
 %%
 %% The supplied `Transaction' encodes information about how data is to be written to the selected SPI device.
 %% See the description above for the fields that may be specified in this map.
@@ -242,7 +247,7 @@ write(SPI, DeviceName, Transaction) when
 %% @param   DeviceName SPI device name (use key in `device_config')
 %% @param   Transaction transaction.
 %% @returns `{ok, binary()}' or `{error, Reason}', if an error occurred.
-%% @doc     Write data to the SPI device, using the intructions encoded in the supplied transaction.
+%% @doc     Write data to the SPI device, using the instructions encoded in the supplied transaction.
 %% device, and simultaneously read data back from the device, returning the read data in a binary.
 %%
 %% The supplied `Transaction' encodes information about how data is to be written to the selected SPI device.

--- a/libs/eavmlib/src/timestamp_util.erl
+++ b/libs/eavmlib/src/timestamp_util.erl
@@ -18,26 +18,6 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
-%
-% This file is part of AtomVM.
-%
-% Copyright 2019 Fred Dushin <fred@dushin.net>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
 %%-----------------------------------------------------------------------------
 %% @doc Utility functions for comparing timestamps.
 %%

--- a/libs/estdlib/src/calendar.erl
+++ b/libs/estdlib/src/calendar.erl
@@ -18,21 +18,62 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
+%%-----------------------------------------------------------------------------
+%% @doc A partial implementation of the Erlang/OTP calendar functions.
+%%
+%% This module provides an implementation of a subset of the functionality of
+%% the Erlang/OTP calendar functions.
+%%
+%% All dates conform to the Gregorian calendar. This calendar was introduced by
+%% Pope Gregory XIII in 1582 and was used in all Catholic countries from this year.
+%% Protestant parts of Germany and the Netherlands adopted it in 1698, England followed
+%% in 1752, and Russia in 1918 (the October revolution of 1917 took place in November
+%% according to the Gregorian calendar).
+%%
+%% The Gregorian calendar in this module is extended back to year 0. For a given date,
+%% the gregorian day is the number of days up to and including the date specified.
+%% @end
+%%-----------------------------------------------------------------------------
 -module(calendar).
 
 -export([date_to_gregorian_days/1, date_to_gregorian_days/3, day_of_the_week/1, day_of_the_week/3]).
 
--type year() :: integer().
+-type date() :: {year(), month(), day()}.
+
+%%-----------------------------------------------------------------------------
+%% @doc Year cannot be abbreviated.
+%%
+%% For example, 93 denotes year 93, not 1993. The valid range depends on the
+%% underlying operating system. The date tuple must denote a valid date.
+%%
+%% @end
+%%-----------------------------------------------------------------------------
+-type year() :: non_neg_integer().
+
 -type month() :: 1..12.
 -type day() :: 1..31.
 -type gregorian_days() :: integer().
 -type day_of_week() :: 1..7.
 
--spec date_to_gregorian_days({year(), month(), day()}) -> gregorian_days().
+%%-----------------------------------------------------------------------------
+%% @equiv date_to_gregorian_days(Year, M, D)
+%% @param   Date    the date to get the gregorian day count of
+%% @returns Days    number of days
+%% @end
+%%-----------------------------------------------------------------------------
+-spec date_to_gregorian_days(Date :: date()) -> Days :: gregorian_days().
 date_to_gregorian_days({Y, M, D}) ->
     date_to_gregorian_days(Y, M, D).
 
--spec date_to_gregorian_days(year(), month(), day()) -> gregorian_days().
+%%-----------------------------------------------------------------------------
+%% @param   Year    ending year
+%% @param   M       ending month
+%% @param   D       ending day
+%% @returns Days    number of days
+%% @doc     Computes the number of gregorian days starting with year 0 and ending at the specified date.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec date_to_gregorian_days(Year :: year(), M :: month(), D :: day()) -> gregorian_days().
 date_to_gregorian_days(Year, M, D) when M =< 12 andalso D =< 31 ->
     Y =
         if
@@ -54,10 +95,30 @@ date_to_gregorian_days(Year, M, D) when M =< 12 andalso D =< 31 ->
     DoE = YoE * 365 + YoE div 4 - YoE div 100 + DoY,
     Era * 146097 + DoE + 60.
 
--spec day_of_the_week({year(), month(), day()}) -> day_of_week().
+%%-----------------------------------------------------------------------------
+%% @equiv day_of_the_week(Y, M, D)
+%% @param   Date the date for which to retreive the weekday
+%% @returns Weekday day of the week
+%% @doc     Computes the day of the week from the specified date tuple {Year, Month, Day}.
+%%          Returns the day of the week as 1: Monday, 2: Tuesday, and so on.
+%% @end
+%%-----------------------------------------------------------------------------
+%%          Returns the day of the week as 1: Monday, 2: Tuesday, and so on.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec day_of_the_week(Date :: date()) -> day_of_week().
 day_of_the_week({Y, M, D}) ->
     day_of_the_week(Y, M, D).
 
--spec day_of_the_week(year(), month(), day()) -> day_of_week().
+%%-----------------------------------------------------------------------------
+%% @param   Y year of the desired day
+%% @param   M month of the desired day
+%% @param   D year of the desired day
+%% @returns Weekday day of the week
+%% @doc     Computes the day of the week from the specified Year, Month, and Day.
+%%          Returns the day of the week as 1: Monday, 2: Tuesday, and so on.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec day_of_the_week(Y :: year(), M :: month(), D :: day()) -> day_of_week().
 day_of_the_week(Y, M, D) ->
     (date_to_gregorian_days(Y, M, D) + 5) rem 7 + 1.

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -50,8 +50,7 @@
 %% * review API documentation for timer functions in this module
 %%
 
--type mem_type() :: binary.
-
+-type mem_type() :: binary().
 -type time_unit() :: second | millisecond | microsecond.
 
 %%-----------------------------------------------------------------------------
@@ -63,7 +62,7 @@
 %%          Time ms, where TimerRef is the reference returned from this function.
 %% @end
 %%-----------------------------------------------------------------------------
--spec start_timer(non_neg_integer(), pid() | atom(), term()) -> reference().
+-spec start_timer(Time :: non_neg_integer(), Dest :: pid() | atom(), Msg :: term()) -> reference().
 start_timer(Time, Dest, Msg) ->
     start_timer(Time, Dest, Msg, []).
 
@@ -79,7 +78,9 @@ start_timer(Time, Dest, Msg) ->
 %%
 %%          <em><b>Note.</b>  The Options argument is currently ignored.</em>
 %%-----------------------------------------------------------------------------
--spec start_timer(non_neg_integer(), pid() | atom(), term(), list()) -> reference().
+-spec start_timer(
+    Time :: non_neg_integer(), Dest :: pid() | atom(), Msg :: term(), _Options :: list()
+) -> reference().
 start_timer(Time, Dest, Msg, _Options) ->
     timer_manager:start_timer(Time, Dest, Msg).
 
@@ -107,7 +108,7 @@ cancel_timer(TimerRef) ->
 %% @doc     Send Msg to Dest after Time ms.
 %% @end
 %%-----------------------------------------------------------------------------
--spec send_after(non_neg_integer(), pid() | atom(), term()) -> reference().
+-spec send_after(Time :: non_neg_integer(), Dest :: pid() | atom(), Msg :: term()) -> reference().
 send_after(Time, Dest, Msg) ->
     timer_manager:send_after(Time, Dest, Msg).
 
@@ -182,6 +183,23 @@ system_info(_Key) ->
 md5(Data) when is_binary(Data) ->
     throw(nif_error).
 
+%%-----------------------------------------------------------------------------
+%% @param   Module Name of module
+%% @param   Function Exported function name
+%% @param   Args Parameters to pass to function (max 6)
+%% @returns Returns the result of Module:Function(Args).
+%% @doc     Returns the result of applying Function in Module to Args. The applied
+%%          function must be exported from Module. The arity of the function is the
+%%          length of Args. Example:
+%%          ```> apply(lists, reverse, [[a, b, c]]).
+%%          [c,b,a]
+%%          > apply(erlang, atom_to_list, ['AtomVM']).
+%%          "AtomVM"'''
+%%          If the number of arguments are known at compile time, the call is better
+%%          written as Module:Function(Arg1, Arg2, ..., ArgN).
+%% @end
+%%-----------------------------------------------------------------------------
+-spec apply(Module :: module(), Function :: function(), Args :: [term()]) -> term().
 apply(Module, Function, Args) ->
     case Args of
         [] ->
@@ -272,6 +290,7 @@ map_is_key(_Key, _Map) ->
 %% https://www.erlang.org/doc/reference_manual/expressions.html#term-comparisons
 %% @end
 %%-----------------------------------------------------------------------------
+-spec min(A :: any(), B :: any()) -> any().
 min(A, B) when A < B -> A;
 min(_A, B) -> B.
 
@@ -285,6 +304,7 @@ min(_A, B) -> B.
 %% https://www.erlang.org/doc/reference_manual/expressions.html#term-comparisons
 %% @end
 %%-----------------------------------------------------------------------------
+-spec max(A :: any(), B :: any()) -> any().
 max(A, B) when A > B -> A;
 max(_A, B) -> B.
 

--- a/libs/estdlib/src/gen_server.erl
+++ b/libs/estdlib/src/gen_server.erl
@@ -21,7 +21,7 @@
 %%-----------------------------------------------------------------------------
 %% @doc An implementation of the Erlang/OTP gen_server interface.
 %%
-%% This module implements a strict susbset of the Erlang/OTP gen_server
+%% This module implements a strict subset of the Erlang/OTP gen_server
 %% interface, supporting operations for local creation and management of
 %% gen_server instances.
 %%
@@ -272,6 +272,8 @@ stop(ServerRef) ->
 
 %%-----------------------------------------------------------------------------
 %% @param   ServerRef a reference to the gen_server acquired via start
+%% @param   Reason reason to be supplied to callback function
+%% @param   Timeout ms to wait for successful stop
 %% @returns ok, if the gen_server stopped; {error, Reason}, otherwise.
 %% @doc     Stop a previously started gen_server instance.
 %%
@@ -307,7 +309,7 @@ call(ServerRef, Request) ->
 %%-----------------------------------------------------------------------------
 %% @param   ServerRef a reference to the gen_server acquired via start
 %% @param   Request the request to send to the gen_server
-%% @param   Timeout the amount of time in milliseconds to wait for a reply
+%% @param   TimeoutMs the amount of time in milliseconds to wait for a reply
 %% @returns the reply sent back from the gen_server; {error, Reason}, otherwise.
 %% @doc     Send a request to a gen_server instance, and wait for a reply.
 %%
@@ -362,7 +364,7 @@ cast(Pid, Request) when is_pid(Pid) ->
 %%          function can be safely ignored.
 %% @end
 %%-----------------------------------------------------------------------------
--spec reply(from(), Reply :: term) -> term().
+-spec reply(From :: from(), Reply :: term) -> term().
 reply({Pid, Ref}, Reply) ->
     Pid ! {Ref, Reply},
     ok.

--- a/libs/estdlib/src/gen_statem.erl
+++ b/libs/estdlib/src/gen_statem.erl
@@ -1,7 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2019-2022 Fred Dushin <fred@dushin.net>
+% Copyright 2019-2023 Fred Dushin <fred@dushin.net>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
 %%     <li>No support for start_link</li>
 %%     <li>Support only for locally named gen_statem instances</li>
 %%     <li>Support only for state function event handlers</li>
-%%     <li>No support for keeep_state or repeat_state return values from Module:StateName/3 callbacks</li>
+%%     <li>No support for keep_state or repeat_state return values from Module:StateName/3 callbacks</li>
 %%     <li>No support for postpone or hibernate state transition actions</li>
 %%     <li>No support for state enter calls</li>
 %%     <li>No support for multi_call</li>
@@ -208,6 +208,7 @@ call(ServerRef, Request, Timeout) ->
 %%          gen_statem instance, but will not wait for a reply.
 %% @end
 %%-----------------------------------------------------------------------------
+-spec cast(ServerRef :: server_ref(), Request :: term()) -> ok | {error, Reason :: term()}.
 cast(ServerRef, Request) ->
     gen_server:cast(ServerRef, Request).
 
@@ -222,6 +223,7 @@ cast(ServerRef, Request) ->
 %%          function can be safely ignored.
 %% @end
 %%-----------------------------------------------------------------------------
+-spec reply(Client :: pid(), Reply :: term()) -> term().
 reply(Client, Reply) ->
     gen_server:reply(Client, Reply).
 

--- a/libs/estdlib/src/gen_udp.erl
+++ b/libs/estdlib/src/gen_udp.erl
@@ -50,12 +50,13 @@
 -define(DEFAULT_PARAMS, [{active, true}, {buffer, 128}, {timeout, infinity}]).
 
 %%-----------------------------------------------------------------------------
+%% @equiv   open(PortNum, [])
 %% @doc     Create a UDP socket.  This function will instantiate a UDP socket
 %%          that may be used to
 %%          send or receive UDP messages.
 %% @end
 %%-----------------------------------------------------------------------------
--spec open(inet:port_number()) -> {ok, inet:socket()} | {error, Reason :: reason()}.
+-spec open(PortNum :: inet:port()) -> {ok, inet:socket()} | {error, Reason :: reason()}.
 open(PortNum) ->
     open(PortNum, []).
 
@@ -63,7 +64,7 @@ open(PortNum) ->
 %% @param   Port the port number to bind to.  Specify 0 to use an OS-assigned
 %%          port number, which can then be retrieved via the inet:port/1
 %%          function.
-%% @param   Params A list of configuration parameters.
+%% @param   Options A list of configuration parameters.
 %% @returns an opaque reference to the socket instance, used in subsequent
 %%          commands.
 %% @throws  bad_arg
@@ -75,10 +76,11 @@ open(PortNum) ->
 %%          <em><b>Note.</b>  The Params argument is currently ignored.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec open(inet:port_number(), proplist()) -> {ok, inet:socket()} | {error, Reason :: reason()}.
-open(PortNum, Params0) ->
+-spec open(PortNum :: inet:port(), Options :: proplist()) ->
+    {ok, inet:socket()} | {error, Reason :: reason()}.
+open(PortNum, Options) ->
     DriverPid = open_port({spawn, "socket"}, []),
-    Params = merge(Params0, ?DEFAULT_PARAMS),
+    Params = merge(Options, ?DEFAULT_PARAMS),
     init(DriverPid, PortNum, Params).
 
 %%-----------------------------------------------------------------------------
@@ -92,7 +94,12 @@ open(PortNum, Params0) ->
 %%          <em><b>Note.</b> Currently only ipv4 addresses are supported.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec send(inet:socket(), inet:address(), inet:port_number(), packet()) -> ok | {error, reason()}.
+-spec send(
+    Socket :: inet:socket(),
+    Address :: inet:address(),
+    PortNum :: inet:port(),
+    Packet :: packet()
+) -> ok | {error, reason()}.
 send(Socket, Address, PortNum, Packet) ->
     case call(Socket, {sendto, Address, PortNum, Packet}) of
         {ok, _Sent} ->
@@ -106,8 +113,8 @@ send(Socket, Address, PortNum, Packet) ->
 %% @doc     Receive a packet over a UDP socket from a source address/port.
 %% @end
 %%-----------------------------------------------------------------------------
--spec recv(inet:socket(), non_neg_integer()) ->
-    {ok, {inet:address(), inet:port_number(), packet()}} | {error, reason()}.
+-spec recv(Socket :: inet:socket(), Length :: non_neg_integer()) ->
+    {ok, {inet:address(), inet:port(), packet()}} | {error, reason()}.
 recv(Socket, Length) ->
     recv(Socket, Length, infinity).
 
@@ -115,7 +122,7 @@ recv(Socket, Length) ->
 %% @param   Socket the socket over which to receive a packet
 %% @param   Length the maximum length to read of the received packet
 %% @param   Timeout the amount of time to wait for a packet to arrive
-%% @returns {ok, Address, Port, Packet}} | {error, Reason}
+%% @returns {ok, {Address, Port, Packet}} | {error, Reason}
 %% @doc     Receive a packet over a UDP socket from a source address/port.
 %%          The address and port of the received packet, as well as
 %%          the received packet data, are returned from this call.  This
@@ -128,8 +135,8 @@ recv(Socket, Length) ->
 %%          is limited to 128 bytes.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec recv(inet:socket(), non_neg_integer(), non_neg_integer()) ->
-    {ok, {inet:address(), inet:port_number(), packet()}} | {error, reason()}.
+-spec recv(Socket :: inet:socket(), Length :: non_neg_integer(), Timeout :: non_neg_integer()) ->
+    {ok, {inet:address(), inet:port(), packet()}} | {error, reason()}.
 recv(Socket, Length, Timeout) ->
     call(Socket, {recvfrom, Length, Timeout}).
 
@@ -140,7 +147,7 @@ recv(Socket, Length, Timeout) ->
 %% @doc     Close the socket.
 %% @end
 %%-----------------------------------------------------------------------------
--spec close(inet:socket()) -> ok | {error, Reason :: reason()}.
+-spec close(Socket :: inet:socket()) -> ok | {error, Reason :: reason()}.
 close(Socket) ->
     call(Socket, {close}).
 
@@ -152,12 +159,14 @@ close(Socket) ->
 %% process will receive messages from the socket.
 %%
 %% This function will return `{error, not_owner}' if the calling process
-%% is not the current controlling proces.
+%% is not the current controlling process.
 %%
 %% By default, the controlling process is the process associated with
 %% the creation of the Socket.
 %% @end
 %%-----------------------------------------------------------------------------
+-spec controlling_process(Socket :: inet:socket(), Pid :: pid()) ->
+    ok | {error, Reason :: reason()}.
 controlling_process(Socket, Pid) ->
     call(Socket, {controlling_process, Pid}).
 

--- a/libs/estdlib/src/inet.erl
+++ b/libs/estdlib/src/inet.erl
@@ -18,26 +18,6 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
-%
-% This file is part of AtomVM.
-%
-% Copyright 2019 Fred Dushin <fred@dushin.net>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
 -module(inet).
 
 -export([port/1, close/1, sockname/1, peername/1]).

--- a/libs/estdlib/src/io.erl
+++ b/libs/estdlib/src/io.erl
@@ -19,6 +19,12 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
+%%-----------------------------------------------------------------------------
+%% @doc An implementation of the Erlang/OTP io interface.
+%%
+%% This module implements a strict subset of the Erlang/OTP io interface.
+%% @end
+%%-----------------------------------------------------------------------------
 -module(io).
 
 -export([format/1, format/2, get_line/1, put_chars/1]).
@@ -51,6 +57,13 @@ format(Format, Args) when is_list(Format) andalso is_list(Args) ->
         end,
     put_chars(Msg).
 
+%%-----------------------------------------------------------------------------
+%% @param   Prompt prompt for user input
+%% @returns string
+%% @doc     Read string from console with prompt.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec get_line(Prompt :: string()) -> string().
 get_line(Prompt) ->
     Self = self(),
     case erlang:group_leader() of
@@ -64,6 +77,13 @@ get_line(Prompt) ->
             end
     end.
 
+%%-----------------------------------------------------------------------------
+%% @param   Chars character(s) to write to console
+%% @returns ok
+%% @doc     Writes the given character(s) to the console.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec put_chars(Chars :: list() | binary()) -> ok.
 put_chars(Chars) ->
     Self = self(),
     case erlang:group_leader() of

--- a/libs/estdlib/src/io_lib.erl
+++ b/libs/estdlib/src/io_lib.erl
@@ -18,26 +18,13 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
-%
-% This file is part of AtomVM.
-%
-% Copyright 2019 Fred Dushin <fred@dushin.net>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
+%%-----------------------------------------------------------------------------
+%% @doc An implementation of the Erlang/OTP io_lib interface.
+%%
+%% This module implements a strict subset of the Erlang/OTP io_lib
+%% interface.
+%% @end
+%%-----------------------------------------------------------------------------
 -module(io_lib).
 
 -export([format/2]).

--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -1,27 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2018-2022 Davide Bettio <davide@uninstall.it>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
-%
-% This file is part of AtomVM.
-%
-% Copyright 2017 Fred Dushin <fred@dushin.net>
+% Copyright 2017-2023 Fred Dushin <fred@dushin.net>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -90,7 +70,7 @@ map(F, []) when is_function(F, 1) ->
 %% @doc     Get the value in a list at position N.
 %%
 %%          Returns the value at the specified position in the list.
-%%          The bhavior of this function is undefined if N is outside of the
+%%          The behavior of this function is undefined if N is outside of the
 %%          {1..length(L)}.
 %% @end
 %%-----------------------------------------------------------------------------
@@ -248,11 +228,12 @@ keymember(K, I, [_H | T]) ->
     keymember(K, I, T).
 
 %%-----------------------------------------------------------------------------
-%% @param   K the key to match
-%% @param   I the position in the tuple to compare (1..tuple_size)
-%% @param   L the list from which to find the element
-%% @returns result of replacing the first element in L who's Ith element matches K.
-%% @doc     Returns the result of replacing the first element in L who's Ith element matches K.
+%% @param   K           the key to match
+%% @param   I           the position in the tuple to compare (1..tuple_size)
+%% @param   L           the list from which to find the element
+%% @param   NewTuple    tuple containing the new key to replace param `K'
+%% @returns result of replacing the first element in L who's Ith element matches K with the contents of NewTuple.
+%% @doc     Returns the result of replacing NewTuple for the first element in L with who's Ith element matches K.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec keyreplace(
@@ -431,21 +412,22 @@ join([E | R], Sep, Accum) ->
     join(R, Sep, [E, Sep | Accum]).
 
 %%-----------------------------------------------------------------------------
-%% @param   From from integer
-%% @param   To to Integer
+%% @param   From    from integer
+%% @param   To      to Integer
 %% @returns list of integers from [From..To]
 %% @doc     Returns a sequence of integers in a specified range.
 %%
 %%          This function is equivalent to `lists:seq(From, To, 1)'.
 %% @end
 %%-----------------------------------------------------------------------------
+-spec seq(From :: integer(), To :: integer()) -> list().
 seq(From, To) ->
     seq(From, To, 1).
 
 %%-----------------------------------------------------------------------------
-%% @param   From from integer
-%% @param   To to Integer
-%% @param   Incr increment value
+%% @param   From    from integer
+%% @param   To      to Integer
+%% @param   Incr    increment value
 %% @returns list of integers `[From, From+Incr, ..., N]', where `N' is the largest integer `<=' `To' incremented by `Incr'
 %% @doc     Returns a sequence of integers in a specified range incremented by a specified value.
 %%

--- a/libs/estdlib/src/maps.erl
+++ b/libs/estdlib/src/maps.erl
@@ -28,7 +28,7 @@
 %% many operations in this module present entries in lexical order, users should
 %% in general make no assumptions about the ordering of entries in a map.
 %%
-%% This module implements a susbset of the Erlang/OTP `maps' interface.
+%% This module implements a subset of the Erlang/OTP `maps' interface.
 %% Some OTP functions are not implemented, and the approach favors
 %% correctness and readability over speed and performance.
 %% @end
@@ -143,7 +143,7 @@ put(_Key, _Value, Map) when not is_map(Map) ->
 %% @doc Return an iterator structure that can be used to iterate over associations
 %% in a map.
 %%
-%% In general, users shouuld make no assumptions about the order in which entries
+%% In general, users should make no assumptions about the order in which entries
 %% appear in an iterator.  The order of entries in a map is implementation-defined.
 %%
 %% This function throws a `{badmap, Map}' exception if `Map' is not a map.
@@ -217,7 +217,7 @@ values(Map) ->
     throw({badmap, Map}).
 
 %%-----------------------------------------------------------------------------
-%% @param   Map
+%% @param   Map     the map
 %% @returns a list of `[{Key, Value}]' tuples
 %% @doc Return the list of entries, expressed as `{Key, Value}' pairs, in the supplied map.
 %%

--- a/libs/estdlib/src/proplists.erl
+++ b/libs/estdlib/src/proplists.erl
@@ -1,27 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2018-2022 Fred Dushin <fred@dushin.net>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
-%
-% This file is part of AtomVM.
-%
-% Copyright 2019 Fred Dushin <fred@dushin.net>
+% Copyright 2018-2023 Fred Dushin <fred@dushin.net>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -41,7 +21,7 @@
 %%-----------------------------------------------------------------------------
 %% @doc An implementation of the Erlang/OTP proplists interface.
 %%
-%% This module implements a strict susbset of the Erlang/OTP proplists
+%% This module implements a strict subset of the Erlang/OTP proplists
 %% interface.
 %% @end
 %%-----------------------------------------------------------------------------
@@ -74,7 +54,7 @@ get_value(Key, List) ->
 %%          function returns the atom true.
 %% @end
 %%-----------------------------------------------------------------------------
--spec get_value(Key :: term(), list(property()), Default :: term()) -> term().
+-spec get_value(Key :: term(), List :: list(property()), Default :: term()) -> term().
 get_value(_Key, [], Default) ->
     Default;
 get_value(Key, [{Key, Value} | _T], _Default) ->

--- a/libs/estdlib/src/string.erl
+++ b/libs/estdlib/src/string.erl
@@ -1,27 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2018-2022 Davide Bettio <davide@uninstall.it>
-%
-% Licensed under the Apache License, Version 2.0 (the "License");
-% you may not use this file except in compliance with the License.
-% You may obtain a copy of the License at
-%
-%    http://www.apache.org/licenses/LICENSE-2.0
-%
-% Unless required by applicable law or agreed to in writing, software
-% distributed under the License is distributed on an "AS IS" BASIS,
-% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-% See the License for the specific language governing permissions and
-% limitations under the License.
-%
-% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
-%
-
-%
-% This file is part of AtomVM.
-%
-% Copyright 2019 Davide Bettio <davide@uninstall.it>
+% Copyright 2018-2023 Davide Bettio <davide@uninstall.it>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -41,7 +21,7 @@
 %%-----------------------------------------------------------------------------
 %% @doc An implementation of the Erlang/OTP string interface.
 %%
-%% This module implements a strict susbset of the Erlang/OTP string
+%% This module implements a strict subset of the Erlang/OTP string
 %% interface.
 %% @end
 %%-----------------------------------------------------------------------------
@@ -49,6 +29,16 @@
 
 -export([to_upper/1, split/2, split/3, trim/1, trim/2]).
 
+%%-----------------------------------------------------------------------------
+%% @param Input a string or character to convert
+%% @returns a Character or string
+%% @doc Convert string or character to uppercase.
+%%
+%% The specified string or character is case-converted. Notice that the supported character
+%% set is ISO/IEC 8859-1 (also called Latin 1); all values outside this set are unchanged
+%% @end
+%%-----------------------------------------------------------------------------
+-spec to_upper(Input :: string() | char()) -> string() | char().
 to_upper(S) when is_list(S) ->
     [upper_char(C) || C <- S];
 to_upper(C) when is_integer(C) ->
@@ -59,9 +49,36 @@ upper_char(C) when is_integer(C) andalso C >= $a andalso C =< $z ->
 upper_char(C) when is_integer(C) ->
     C.
 
+%%-----------------------------------------------------------------------------
+%% @equiv split(String, Pattern, leading)
+%% @param String a string to split
+%% @param Pattern the search pattern to split at
+%% @returns chardata
+%% @end
+%%-----------------------------------------------------------------------------
+-spec split(String :: string(), Pattern :: string()) -> string() | char().
 split(String, Pattern) ->
     split(String, Pattern, leading).
 
+%%-----------------------------------------------------------------------------
+%% @param String a string to split
+%% @param Pattern the search pattern to split at
+%% @param Where position to split (leading, trailing, or all)
+%% @returns chardata
+%% @doc Splits String where SearchPattern is encountered and return the remaining parts.
+%%
+%% Where, default leading, indicates whether the leading, the trailing or all encounters of SearchPattern will split String.
+%%
+%% Example:
+%% ```0> string:split("ab..bc..cd", "..").
+%% ["ab","bc..cd"]
+%% 1> string:split(<<"ab..bc..cd">>, "..", trailing).
+%% [<<"ab..bc">>,<<"cd">>]
+%% 2> string:split(<<"ab..bc....cd">>, "..", all).
+%% [<<"ab">>,<<"bc">>,<<>>,<<"cd">>]'''
+%% @end
+%%-----------------------------------------------------------------------------
+-spec split(String :: string(), Pattern :: string() | char(), Where :: atom()) -> string() | char().
 split(String, Pattern, Where) ->
     split(String, Pattern, Where, [], []).
 
@@ -90,9 +107,34 @@ prefix_match([Char | Rest], [Char | PRest]) ->
 prefix_match(_String, _Pattern) ->
     no.
 
+%%-----------------------------------------------------------------------------
+%% @equiv trim(String, both)
+%% @param String a string or character to trim whitespace
+%% @returns a Character or string
+%% @end
+%%-----------------------------------------------------------------------------
+-spec trim(String :: string()) -> string() | char().
 trim(String) ->
     trim(String, both).
 
+%%-----------------------------------------------------------------------------
+%% @param String a string or character to trim
+%% @param Direction an atom indicating the direction from which to remove whitespace
+%% @returns a Character or string
+%% @doc Returns a string, where leading or trailing, or both, whitespace has been removed.
+%%
+%% If omitted, Direction is both.
+%%
+%% Example:
+%% ```1> string:trim("\t  Hello  \n").
+%% "Hello"
+%% 2> string:trim(<<"\t  Hello  \n">>, leading).
+%% <<"Hello  \n">>
+%% 3> string:trim(<<".Hello.\n">>, trailing, "\n.").
+%% <<".Hello">>'''
+%% @end
+%%-----------------------------------------------------------------------------
+-spec trim(String :: string, Direction :: atom()) -> string() | char().
 trim(String, leading) ->
     triml(String);
 trim(String, trailing) ->

--- a/libs/estdlib/src/timer.erl
+++ b/libs/estdlib/src/timer.erl
@@ -18,11 +18,26 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
+%%-----------------------------------------------------------------------------
+%% @doc An implementation of the Erlang/OTP timer interface.
+%%
+%% This module implements a strict subset of the Erlang/OTP timer
+%% interface.
+%% @end
+%%-----------------------------------------------------------------------------
 -module(timer).
 
 -export([sleep/1]).
 
--spec sleep(non_neg_integer() | infinity) -> ok.
+%%-----------------------------------------------------------------------------
+%% @parm Timeout number of milliseconds to sleep or `infinity'
+%% @returns `ok'
+%%
+%% @doc Pauses the execution of the current process for a given number of
+%%      milliseconds, or forever, using `infinity' as the parameter.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec sleep(Timeout :: non_neg_integer() | infinity) -> ok.
 sleep(Timeout) ->
     receive
     after Timeout ->


### PR DESCRIPTION
Adds documentaion for several of the modules that lack it, and expands others that were missing entries for some functions. Fixes many incomple function specs, and typos. Removed duplicate coyright entries.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
