### PR TITLE
Further implement `io_lib:format/2` (fix #594)

### DIFF
--- a/libs/estdlib/src/io_lib.erl
+++ b/libs/estdlib/src/io_lib.erl
@@ -58,8 +58,7 @@ format(Format, Args) ->
     {FormatTokens, Instr} = split(Format),
     case length(FormatTokens) == length(Args) + 1 of
         true ->
-            StringList = interleave(FormatTokens, Instr, Args, []),
-            lists:flatten(StringList);
+            interleave(FormatTokens, Instr, Args, []);
         false ->
             throw(badarg)
     end.
@@ -75,10 +74,12 @@ split(Format) ->
 %% @private
 split([], Cur, Accum, Instr) ->
     {lists:reverse([lists:reverse(Cur) | Accum]), lists:reverse(Instr)};
-split([$~, $p | Rest], Cur, Accum, Instr) ->
-    split(Rest, [], [lists:reverse(Cur) | Accum], [quote | Instr]);
 split([$~, $s | Rest], Cur, Accum, Instr) ->
-    split(Rest, [], [lists:reverse(Cur) | Accum], [literal | Instr]);
+    split(Rest, [], [lists:reverse(Cur) | Accum], [fun(T) -> format_spw(s, T) end | Instr]);
+split([$~, $p | Rest], Cur, Accum, Instr) ->
+    split(Rest, [], [lists:reverse(Cur) | Accum], [fun(T) -> format_spw(p, T) end | Instr]);
+split([$~, $w | Rest], Cur, Accum, Instr) ->
+    split(Rest, [], [lists:reverse(Cur) | Accum], [fun(T) -> format_spw(w, T) end | Instr]);
 split([$~, $n | Rest], Cur, Accum, Instr) ->
     split(Rest, [$\n | Cur], Accum, Instr);
 split([$~, $~ | Rest], Cur, Accum, Instr) ->
@@ -89,64 +90,91 @@ split([Char | Rest], Cur, Accum, Instr) ->
 %% @private
 interleave([LastToken], _Instr, [], Accum) ->
     lists:reverse([LastToken | Accum]);
-interleave([Token | Tokens], [Q | Instr], [Arg | Args], Accum) ->
-    interleave(Tokens, Instr, Args, [to_string(Arg, Q), Token | Accum]).
+interleave([Token | Tokens], [Formatter | Instr], [Arg | Args], Accum) ->
+    interleave(Tokens, Instr, Args, [Formatter(Arg), Token | Accum]).
 
 %% @private
-to_string(T, _Q) when is_atom(T) ->
+format_spw(_Mode, T) when is_atom(T) ->
     erlang:atom_to_list(T);
-to_string(T, _Q) when is_integer(T) ->
-    erlang:integer_to_list(T);
-to_string(T, _Q) when is_float(T) ->
-    erlang:float_to_list(T);
-to_string(T, _Q) when is_pid(T) ->
-    erlang:pid_to_list(T);
-to_string(T, _Q) when is_reference(T) ->
-    erlang:ref_to_list(T);
-to_string(T, _Q) when is_function(T) ->
-    erlang:fun_to_list(T);
-to_string(T, Q) when is_list(T) ->
-    case is_printable_ascii(T) of
-        true ->
-            case Q of
-                quote -> [$"] ++ T ++ [$"];
-                _ -> T
-            end;
-        _ ->
-            "[" ++ lists:join(",", [to_string(E, quote) || E <- T]) ++ "]"
-    end;
-to_string(T, Q) when is_binary(T) ->
-    BinList = erlang:binary_to_list(T),
-    Data =
-        case is_printable_ascii(BinList) of
-            true ->
-                case Q of
-                    quote -> [$"] ++ BinList ++ [$"];
-                    _ -> BinList
-                end;
-            _ ->
-                lists:join(",", [erlang:integer_to_list(E) || E <- BinList])
+format_spw(s, T) when is_binary(T) ->
+    erlang:binary_to_list(T);
+format_spw(Mode, T) when is_binary(T) ->
+    L = erlang:binary_to_list(T),
+    FormattedStr =
+        case {Mode, test_string_class(L, printable)} of
+            {p, printable} -> format_p_string(L, []);
+            _ -> lists:join($,, [integer_to_list(B) || B <- L])
         end,
-    "<<" ++ Data ++ ">>";
-to_string(T, _Q) when is_tuple(T) ->
-    "{" ++
-        lists:flatten(lists:join(",", [to_string(E, quote) || E <- erlang:tuple_to_list(T)])) ++
-        "}";
-to_string(T, _Q) when is_map(T) ->
-    "#{" ++
-        lists:flatten(
-            lists:join(",", [
-                to_string(K, quote) ++ " => " ++ to_string(V, quote)
-             || {K, V} <- maps:to_list(T)
-            ])
-        ) ++ "}";
-to_string(_T, _Q) ->
-    "unknown".
+    [$<, $<, FormattedStr, $>, $>];
+format_spw(Mode, L) when is_list(L) ->
+    case {Mode, test_string_class(L, printable)} of
+        {s, not_a_string} -> throw(badarg);
+        {s, _} -> L;
+        {p, printable} -> format_p_string(L, []);
+        _ -> [$[, lists:join($,, [format_spw(Mode, E) || E <- L]), $]]
+    end;
+format_spw(s, _) ->
+    throw(badarg);
+format_spw(_Mode, T) when is_integer(T) ->
+    erlang:integer_to_list(T);
+format_spw(_Mode, T) when is_float(T) ->
+    erlang:float_to_list(T);
+format_spw(_Mode, T) when is_pid(T) ->
+    erlang:pid_to_list(T);
+format_spw(_Mode, T) when is_reference(T) ->
+    erlang:ref_to_list(T);
+format_spw(_Mode, T) when is_function(T) ->
+    erlang:fun_to_list(T);
+format_spw(Mode, T) when is_tuple(T) ->
+    [${, lists:join($,, [format_spw(Mode, E) || E <- tuple_to_list(T)]), $}];
+format_spw(Mode, T) when is_map(T) ->
+    [
+        $#,
+        ${,
+        lists:join($,, [
+            [format_spw(Mode, K), " => ", format_spw(Mode, V)]
+         || {K, V} <- maps:to_list(T)
+        ]),
+        $}
+    ].
 
 %% @private
-is_printable_ascii([]) ->
-    true;
-is_printable_ascii([E | R]) when is_integer(E) andalso 32 =< E andalso E < 127 ->
-    is_printable_ascii(R);
-is_printable_ascii(_) ->
-    false.
+test_string_class([H | T], _Class) when is_integer(H) andalso H >= 0 andalso H < 8 ->
+    test_string_class(T, unprintable);
+test_string_class([H | T], _Class) when is_integer(H) andalso H >= 14 andalso H < 27 ->
+    test_string_class(T, unprintable);
+test_string_class([H | T], _Class) when is_integer(H) andalso H >= 28 andalso H < 32 ->
+    test_string_class(T, unprintable);
+test_string_class([H | T], _Class) when is_integer(H) andalso H >= 127 andalso H < 160 ->
+    test_string_class(T, unprintable);
+test_string_class([H | T], Class) when is_integer(H) andalso H >= 8 andalso H < 256 ->
+    test_string_class(T, Class);
+test_string_class([H | T], _Class) when is_list(H) ->
+    case test_string_class(H, iolist) of
+        iolist -> test_string_class(T, iolist);
+        Other -> Other
+    end;
+test_string_class([], Class) ->
+    Class;
+test_string_class(_, _Class) ->
+    not_a_string.
+
+%% @private
+format_p_string([], Acc) ->
+    [$", lists:reverse(Acc), $"];
+format_p_string([8 | T], Acc) ->
+    format_p_string(T, ["\\b" | Acc]);
+format_p_string([9 | T], Acc) ->
+    format_p_string(T, ["\\t" | Acc]);
+format_p_string([10 | T], Acc) ->
+    format_p_string(T, ["\\n" | Acc]);
+format_p_string([11 | T], Acc) ->
+    format_p_string(T, ["\\v" | Acc]);
+format_p_string([12 | T], Acc) ->
+    format_p_string(T, ["\\f" | Acc]);
+format_p_string([13 | T], Acc) ->
+    format_p_string(T, ["\\r" | Acc]);
+format_p_string([27 | T], Acc) ->
+    format_p_string(T, ["\\e" | Acc]);
+format_p_string([H | T], Acc) ->
+    format_p_string(T, [H | Acc]).

--- a/libs/include/etest.hrl
+++ b/libs/include/etest.hrl
@@ -23,10 +23,9 @@
         ok ->
             ok;
         fail ->
-            erlang:display(
+            throw(
                 {failed_assert_match, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, A, B}
-            ),
-            fail
+            )
     end
 ).
 -define(ASSERT_EQUALS(A, B),
@@ -34,10 +33,9 @@
         ok ->
             ok;
         fail ->
-            erlang:display(
+            throw(
                 {failed_assert_equals, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, A, B}
-            ),
-            fail
+            )
     end
 ).
 -define(ASSERT_TRUE(C),
@@ -45,10 +43,9 @@
         ok ->
             ok;
         fail ->
-            erlang:display(
+            throw(
                 {failed_assert_true, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, C}
-            ),
-            fail
+            )
     end
 ).
 -define(ASSERT_FAILURE(A),
@@ -56,10 +53,9 @@
         ok ->
             ok;
         fail ->
-            erlang:display(
+            throw(
                 {failed_assert_failure, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, A}
-            ),
-            fail
+            )
     end
 ).
 -define(ASSERT_FAILURE(A, E),
@@ -67,9 +63,8 @@
         ok ->
             ok;
         fail ->
-            erlang:display(
+            throw(
                 {failed_assert_failure, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}, A, E}
-            ),
-            fail
+            )
     end
 ).

--- a/tests/libs/estdlib/test_io_lib.erl
+++ b/tests/libs/estdlib/test_io_lib.erl
@@ -30,19 +30,84 @@ test() ->
     ?ASSERT_MATCH(?FLT(io_lib:format("", [])), ""),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo", [])), "foo"),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo~n", [])), "foo\n"),
+    % atom
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [bar])), "foo: bar\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~s~n", [bar])), "foo: bar\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~w~n", [bar])), "foo: bar\n"),
+    % strings
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", ["bar"])), "foo: \"bar\"\n"),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~s~n", ["bar"])), "foo: bar\n"),
-    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [123])), "foo: 123\n"),
-    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [-123])), "foo: -123\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~w~n", ["bar"])), "foo: [98,97,114]\n"),
+    % printable binaries
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [<<"bar">>])), "foo: <<\"bar\">>\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~s~n", [<<"bar">>])), "foo: bar\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~w~n", [<<"bar">>])), "foo: <<98,97,114>>\n"),
+    % unprintable binaries
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [<<1, 2, 3>>])), "foo: <<1,2,3>>\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~s~n", [<<1, 2, 3>>])), ?FLT(["foo: ", 1, 2, 3, "\n"])),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~w~n", [<<1, 2, 3>>])), "foo: <<1,2,3>>\n"),
+    % unprintable strings
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [[1, 2, 3]])), "foo: [1,2,3]\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~s~n", [[1, 2, 3]])), "foo: \1\2\3\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~w~n", [[1, 2, 3]])), "foo: [1,2,3]\n"),
+    % unprintable lists
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [[-1]])), "foo: [-1]\n"),
+    ?ASSERT_FAILURE(io_lib:format("foo: ~s~n", [[-1]]), badarg),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~w~n", [[-1]])), "foo: [-1]\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [[256]])), "foo: [256]\n"),
+    ?ASSERT_FAILURE(io_lib:format("foo: ~s~n", [[256]]), badarg),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~w~n", [[256]])), "foo: [256]\n"),
+    % escapable strings
+    ?ASSERT_MATCH(
+        ?FLT(io_lib:format("foo: ~p~n", ["bar\b\t\n\v\f\r\e"])),
+        "foo: \"bar\\b\\t\\n\\v\\f\\r\\e\"\n"
+    ),
+    ?ASSERT_MATCH(
+        ?FLT(io_lib:format("foo: ~s~n", ["bar\b\t\n\v\f\r\e"])), "foo: bar\b\t\n\v\f\r\e\n"
+    ),
+    ?ASSERT_MATCH(
+        ?FLT(io_lib:format("foo: ~w~n", ["bar\b\t\n\v\f\r\e"])),
+        "foo: [98,97,114,8,9,10,11,12,13,27]\n"
+    ),
+    % escapable binaries
+    ?ASSERT_MATCH(
+        ?FLT(io_lib:format("foo: ~p~n", [<<"bar\b\t\n\v\f\r\e">>])),
+        "foo: <<\"bar\\b\\t\\n\\v\\f\\r\\e\">>\n"
+    ),
+    ?ASSERT_MATCH(
+        ?FLT(io_lib:format("foo: ~s~n", [<<"bar\b\t\n\v\f\r\e">>])), "foo: bar\b\t\n\v\f\r\e\n"
+    ),
+    ?ASSERT_MATCH(
+        ?FLT(io_lib:format("foo: ~w~n", [<<"bar\b\t\n\v\f\r\e">>])),
+        "foo: <<98,97,114,8,9,10,11,12,13,27>>\n"
+    ),
+    % nested lists of strings and chars
+    ?ASSERT_MATCH(
+        ?FLT(io_lib:format("foo: ~p~n", [[["hello", " "], "world"]])),
+        "foo: [[\"hello\",\" \"],\"world\"]\n"
+    ),
+    ?ASSERT_MATCH(
+        ?FLT(io_lib:format("foo: ~s~n", [[["hello", " "], "world"]])), "foo: hello world\n"
+    ),
+    ?ASSERT_MATCH(
+        ?FLT(io_lib:format("foo: ~w~n", [[["hello", " "], "world"]])),
+        "foo: [[[104,101,108,108,111],[32]],[119,111,114,108,100]]\n"
+    ),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [[1, 2, 3]])), "foo: [1,2,3]\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~s~n", [[1, 2, 3]])), "foo: \1\2\3\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~w~n", [[1, 2, 3]])), "foo: [1,2,3]\n"),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [[1, 2, [3]]])), "foo: [1,2,[3]]\n"),
+    % integers
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [123])), "foo: 123\n"),
+    ?ASSERT_FAILURE(io_lib:format("foo: ~s~n", [123]), badarg),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~w~n", [123])), "foo: 123\n"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [-123])), "foo: -123\n"),
+    ?ASSERT_FAILURE(io_lib:format("foo: ~s~n", [-123]), badarg),
+    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~w~n", [-123])), "foo: -123\n"),
     ?ASSERT_MATCH(
         ?FLT(io_lib:format("foo: ~p~n", [[65, 116, 111, 109, 86, 77]])), "foo: \"AtomVM\"\n"
     ),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~s~n", [[65, 116, 111, 109, 86, 77]])), "foo: AtomVM\n"),
-    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [<<"bar">>])), "foo: <<\"bar\">>\n"),
-    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [<<1, 2, 3>>])), "foo: <<1,2,3>>\n"),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [{bar, tapas}])), "foo: {bar,tapas}\n"),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [{bar, "tapas"}])), "foo: {bar,\"tapas\"}\n"),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [#{}])), "foo: #{}\n"),
@@ -66,7 +131,6 @@ test() ->
     ?ASSERT_FAILURE(io_lib:format("no pattern", id([foo])), badarg),
     ?ASSERT_FAILURE(io_lib:format("too ~p many ~p patterns", id([foo])), badarg),
     ?ASSERT_FAILURE(io_lib:format("not enough ~p patterns", id([foo, bar])), badarg),
-
     ok.
 
 id(X) ->


### PR DESCRIPTION
Fix implementation of ~s format
Add ~w format
Fix tests

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
