### PR TITLE
Fix synchronization issue with refc binaries

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -118,7 +118,7 @@ void context_destroy(Context *ctx)
 
     free(ctx->fr);
 
-    memory_destroy_heap(&ctx->heap);
+    memory_destroy_heap(&ctx->heap, ctx->global);
 
     dictionary_destroy(&ctx->dictionary);
 

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -27,6 +27,7 @@
 #include "context.h"
 #include "defaultatoms.h"
 #include "list.h"
+#include "refc_binary.h"
 #include "synclist.h"
 #include "sys.h"
 #include "utils.h"
@@ -165,7 +166,16 @@ COLD_FUNC void globalcontext_destroy(GlobalContext *glb)
 #endif
     synclist_destroy(&glb->registered_processes);
     synclist_destroy(&glb->processes_table);
+    // Destroy every remaining refc binaries.
+    struct ListHead *item;
+    struct ListHead *tmp;
+    struct ListHead *refc_binaries = synclist_nolock(&glb->refc_binaries);
+    MUTABLE_LIST_FOR_EACH (item, tmp, refc_binaries) {
+        struct RefcBinary *refc = GET_LIST_ENTRY(item, struct RefcBinary, head);
+        refc_binary_destroy(refc, glb);
+    }
     synclist_destroy(&glb->refc_binaries);
+
     synclist_destroy(&glb->avmpack_data);
     free(glb);
 }

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -179,7 +179,7 @@ static enum MemoryGCResult memory_gc(Context *ctx, size_t new_size, size_t num_r
 
     ctx->heap.heap_ptr = temp_end;
 
-    memory_sweep_mso_list(old_mso_list);
+    memory_sweep_mso_list(old_mso_list, ctx->global);
     ctx->heap.root->mso_list = new_mso_list;
 
     memory_destroy_heap_fragment(old_root_fragment);
@@ -598,7 +598,7 @@ void memory_heap_append_fragment(Heap *heap, HeapFragment *fragment, term mso_li
     }
 }
 
-void memory_sweep_mso_list(term mso_list)
+void memory_sweep_mso_list(term mso_list, GlobalContext *global)
 {
     term l = mso_list;
     while (l != term_nil()) {
@@ -610,7 +610,7 @@ void memory_sweep_mso_list(term mso_list)
             // it has been moved, so it is referenced
         } else if (term_is_refc_binary(h) && !term_refc_binary_is_const(h)) {
             // unreferenced binary; decrement reference count
-            refc_binary_decrement_refcount((struct RefcBinary *) term_refc_binary_ptr(h));
+            refc_binary_decrement_refcount((struct RefcBinary *) term_refc_binary_ptr(h), global);
         }
         l = term_get_list_tail(l);
     }

--- a/src/libAtomVM/refc_binary.c
+++ b/src/libAtomVM/refc_binary.c
@@ -55,14 +55,21 @@ void refc_binary_increment_refcount(struct RefcBinary *refc)
     refc->ref_count++;
 }
 
-bool refc_binary_decrement_refcount(struct RefcBinary *refc)
+bool refc_binary_decrement_refcount(struct RefcBinary *refc, struct GlobalContext *global)
 {
     if (--refc->ref_count == 0) {
-        list_remove(&refc->head);
-        free(refc);
+        synclist_remove(&global->refc_binaries, &refc->head);
+        refc_binary_destroy(refc, global);
         return true;
     }
     return false;
+}
+
+void refc_binary_destroy(struct RefcBinary *refc, struct GlobalContext *global)
+{
+    UNUSED(global);
+
+    free(refc);
 }
 
 term refc_binary_create_binary_info(Context *ctx)

--- a/src/libAtomVM/refc_binary.h
+++ b/src/libAtomVM/refc_binary.h
@@ -30,6 +30,15 @@ extern "C" {
 
 #include "list.h"
 #include "smp.h"
+#ifndef TYPEDEF_CONTEXT
+#define TYPEDEF_CONTEXT
+typedef struct Context Context;
+#endif
+
+#ifndef TYPEDEF_GLOBAL_CONTEXT
+#define TYPEDEF_GLOBAL_CONTEXT
+typedef struct GlobalContext GlobalContext;
+#endif
 
 struct RefcBinary
 {
@@ -41,10 +50,9 @@ struct RefcBinary
 /**
  * @brief Create a reference-counted binary outside of the process heap
  *
- * @details This function will create a reference-counted binary outside of the context heap.  If the binary is non-const,
- * a blob will be allocated in the VM memory (e.g., via malloc).  The allocated data will include
- * an internal data structure that includes the data size and reference count.  If the supplied
- * data is non-NULL, the supplied data will be copied to the newly allocated region.
+ * @details This function will create a reference-counted binary outside of the context heap.
+ * A blob will be allocated in the VM memory (e.g., via malloc).   The allocated data will include
+ * an internal data structure that includes the data size and reference count.
  * @param size the size of the data to create
  * @returns a pointer to the out-of-context data.
  */
@@ -67,12 +75,23 @@ void refc_binary_increment_refcount(struct RefcBinary *ptr);
 /**
  * @brief Decrement the reference count on the refc binary
  *
- * @details This function will free the the refc binary if the
+ * @details This function will call `refc_binary_destroy` if the
  * reference count reaches 0.
  * @param ptr the refc binary
+ * @param global the global context
  * @return true if the refc binary was free'd; false, otherwise
  */
-bool refc_binary_decrement_refcount(struct RefcBinary *ptr);
+bool refc_binary_decrement_refcount(struct RefcBinary *ptr, GlobalContext *global);
+
+/**
+ * @brief Destroy a refc binary after its reference count reached 0.
+ *
+ * @details This function will call the destructor if the refc binary is a
+ * resource and will free the refc binary.
+ * @param refc the binary to destroy
+ * @param global the global context
+ */
+void refc_binary_destroy(struct RefcBinary *refc, struct GlobalContext *global);
 
 /**
  * TODO consider implementing erlang:memory/0,1 instead

--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -301,7 +301,7 @@ EventListener *gpio_interrupt_callback(GlobalContext *glb, EventListener *listen
 
     globalcontext_send_message(glb, listening_pid, int_msg);
 
-    END_WITH_STACK_HEAP(heap);
+    END_WITH_STACK_HEAP(heap, glb);
 
     return listener;
 }

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -135,7 +135,7 @@ static void send_got_ip(struct ClientData *data, tcpip_adapter_ip_info_t *info)
         term reply = port_heap_create_tuple2(&heap, make_atom(data->global, sta_got_ip_atom), ip_info);
         send_term(&heap, data, reply);
     }
-    END_WITH_STACK_HEAP(heap);
+    END_WITH_STACK_HEAP(heap, data->global);
 }
 
 static void send_sta_connected(struct ClientData *data)
@@ -147,7 +147,7 @@ static void send_sta_connected(struct ClientData *data)
     {
         send_term(&heap, data, make_atom(data->global, sta_connected_atom));
     }
-    END_WITH_STACK_HEAP(heap);
+    END_WITH_STACK_HEAP(heap, data->global);
 }
 
 static void send_sta_disconnected(struct ClientData *data)
@@ -159,7 +159,7 @@ static void send_sta_disconnected(struct ClientData *data)
     {
         send_term(&heap, data, make_atom(data->global, sta_disconnected_atom));
     }
-    END_WITH_STACK_HEAP(heap);
+    END_WITH_STACK_HEAP(heap, data->global);
 }
 
 static void send_ap_started(struct ClientData *data)
@@ -171,7 +171,7 @@ static void send_ap_started(struct ClientData *data)
     {
         send_term(&heap, data, make_atom(data->global, ap_started_atom));
     }
-    END_WITH_STACK_HEAP(heap);
+    END_WITH_STACK_HEAP(heap, data->global);
 }
 
 static void send_atom_mac(struct ClientData *data, term atom, uint8_t *mac)
@@ -183,7 +183,7 @@ static void send_atom_mac(struct ClientData *data, term atom, uint8_t *mac)
         term reply = port_heap_create_tuple2(&heap, atom, mac_term);
         send_term(&heap, data, reply);
     }
-    END_WITH_STACK_HEAP(heap);
+    END_WITH_STACK_HEAP(heap, data->global);
 }
 
 static void send_ap_sta_connected(struct ClientData *data, uint8_t *mac)
@@ -208,7 +208,7 @@ static void send_ap_sta_ip_assigned(struct ClientData *data, esp_ip4_addr_t *ip)
         term reply = port_heap_create_tuple2(&heap, make_atom(data->global, ap_sta_ip_assigned_atom), ip_term);
         send_term(&heap, data, reply);
     }
-    END_WITH_STACK_HEAP(heap);
+    END_WITH_STACK_HEAP(heap, data->global);
 }
 
 static void send_sntp_sync(struct ClientData *data, struct timeval *tv)
@@ -222,7 +222,7 @@ static void send_sntp_sync(struct ClientData *data, struct timeval *tv)
         term reply = port_heap_create_tuple2(&heap, make_atom(data->global, sntp_sync_atom), tv_tuple);
         send_term(&heap, data, reply);
     }
-    END_WITH_STACK_HEAP(heap);
+    END_WITH_STACK_HEAP(heap, data->global);
 }
 
 #define UNLIKELY_NOT_ESP_OK(E) UNLIKELY((E) != ESP_OK)

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -269,7 +269,7 @@ EventListener *socket_events_handler(GlobalContext *glb, EventListener *listener
             term_put_tuple_element(message, 0, globalcontext_make_atom(glb, netconn_event_internal));
             term_put_tuple_element(message, 1, term_from_int(event.len));
             globalcontext_send_message(glb, socket->process_id, message);
-            END_WITH_STACK_HEAP(heap)
+            END_WITH_STACK_HEAP(heap, glb)
         }
     }
     return listener;

--- a/src/platforms/esp32/components/avm_builtins/uart_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/uart_driver.c
@@ -129,7 +129,7 @@ EventListener *uart_interrupt_callback(GlobalContext *glb, EventListener *listen
                     int local_pid = term_to_local_process_id(uart_data->reader_process_pid);
                     globalcontext_send_message(glb, local_pid, result_tuple);
 
-                    memory_destroy_heap(&heap);
+                    memory_destroy_heap(&heap, glb);
 
                     uart_data->reader_process_pid = term_invalid_term();
                     uart_data->reader_ref_ticks = 0;

--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -704,7 +704,7 @@ static EventListener *active_recv_callback(GlobalContext *glb, EventListener *ba
         mailbox_send(ctx, globalcontext_make_atom(glb, close_internal));
         free(listener);
         result = NULL;
-        END_WITH_STACK_HEAP(heap);
+        END_WITH_STACK_HEAP(heap, glb);
     } else {
         TRACE("socket_driver|active_recv_callback: received data of len %li from fd %i\n", len, socket_data->sockfd);
         int ensure_packet_avail;
@@ -724,7 +724,7 @@ static EventListener *active_recv_callback(GlobalContext *glb, EventListener *ba
         term msgs[3] = { TCP_ATOM, term_from_local_process_id(ctx->process_id), packet };
         term msg = port_heap_create_tuple_n(&heap, 3, msgs);
         port_send_message_nolock(glb, pid, msg);
-        memory_destroy_heap(&heap);
+        memory_destroy_heap(&heap, glb);
     }
     globalcontext_get_process_unlock(glb, ctx);
     free(buf);
@@ -768,7 +768,7 @@ static EventListener *passive_recv_callback(GlobalContext *glb, EventListener *b
         term reply = port_heap_create_reply(&heap, ref, port_heap_create_error_tuple(&heap, globalcontext_make_atom(glb, closed_a)));
         port_send_message_nolock(glb, pid, reply);
         mailbox_send(ctx, globalcontext_make_atom(glb, close_internal));
-        END_WITH_STACK_HEAP(heap);
+        END_WITH_STACK_HEAP(heap, glb);
     } else if (len < 0) {
         // {Ref, {error, {SysCall, Errno}}}
         BEGIN_WITH_STACK_HEAP(12, heap);
@@ -777,7 +777,7 @@ static EventListener *passive_recv_callback(GlobalContext *glb, EventListener *b
         term reply = port_heap_create_reply(&heap, ref, port_heap_create_sys_error_tuple(&heap, RECV_ATOM, errno));
         port_send_message_nolock(glb, pid, reply);
         mailbox_send(ctx, globalcontext_make_atom(glb, close_internal));
-        END_WITH_STACK_HEAP(heap);
+        END_WITH_STACK_HEAP(heap, glb);
     } else {
         TRACE("socket_driver|passive_recv_callback: passive received data of len: %li\n", len);
         int ensure_packet_avail;
@@ -798,7 +798,7 @@ static EventListener *passive_recv_callback(GlobalContext *glb, EventListener *b
         term payload = port_heap_create_ok_tuple(&heap, packet);
         term reply = port_heap_create_reply(&heap, ref, payload);
         port_send_message_nolock(glb, pid, reply);
-        memory_destroy_heap(&heap);
+        memory_destroy_heap(&heap, glb);
     }
     socket_data->passive_listener = NULL;
     globalcontext_get_process_unlock(glb, ctx);
@@ -841,7 +841,7 @@ static EventListener *active_recvfrom_callback(GlobalContext *glb, EventListener
         term msgs[3] = { UDP_ATOM, term_from_local_process_id(ctx->process_id), port_heap_create_sys_error_tuple(&heap, RECVFROM_ATOM, errno) };
         term msg = port_heap_create_tuple_n(&heap, 3, msgs);
         port_send_message_nolock(glb, pid, msg);
-        END_WITH_STACK_HEAP(heap);
+        END_WITH_STACK_HEAP(heap, glb);
         // Not closing the listener here as there is no connection to close.
     } else {
         int ensure_packet_avail;
@@ -863,7 +863,7 @@ static EventListener *active_recvfrom_callback(GlobalContext *glb, EventListener
         term msgs[5] = { UDP_ATOM, term_from_local_process_id(ctx->process_id), addr, port, packet };
         term msg = port_heap_create_tuple_n(&heap, 5, msgs);
         port_send_message_nolock(glb, pid, msg);
-        memory_destroy_heap(&heap);
+        memory_destroy_heap(&heap, glb);
     }
     globalcontext_get_process_unlock(glb, ctx);
     free(buf);
@@ -908,7 +908,7 @@ static EventListener *passive_recvfrom_callback(GlobalContext *glb, EventListene
         term ref = term_from_ref_ticks(listener->ref_ticks, &heap);
         term reply = port_heap_create_reply(&heap, ref, port_heap_create_sys_error_tuple(&heap, RECVFROM_ATOM, errno));
         port_send_message_nolock(glb, pid, reply);
-        END_WITH_STACK_HEAP(heap);
+        END_WITH_STACK_HEAP(heap, glb);
     } else {
         int ensure_packet_avail;
         if (socket_data->binary) {
@@ -931,7 +931,7 @@ static EventListener *passive_recvfrom_callback(GlobalContext *glb, EventListene
         term payload = port_heap_create_ok_tuple(&heap, addr_port_packet);
         term reply = port_heap_create_reply(&heap, ref, payload);
         port_send_message_nolock(glb, pid, reply);
-        memory_destroy_heap(&heap);
+        memory_destroy_heap(&heap, glb);
     }
     socket_data->passive_listener = NULL;
     globalcontext_get_process_unlock(glb, ctx);
@@ -1010,7 +1010,7 @@ static EventListener *accept_callback(GlobalContext *glb, EventListener *base_li
         term ref = term_from_ref_ticks(listener->ref_ticks, &heap);
         term reply = port_heap_create_reply(&heap, ref, port_heap_create_sys_error_tuple(&heap, ACCEPT_ATOM, errno));
         port_send_message_nolock(glb, pid, reply);
-        END_WITH_STACK_HEAP(heap);
+        END_WITH_STACK_HEAP(heap, glb);
     } else {
         TRACE("socket_driver|accept_callback: accepted connection.  fd: %i\n", fd);
 
@@ -1042,7 +1042,7 @@ static EventListener *accept_callback(GlobalContext *glb, EventListener *base_li
         term payload = port_heap_create_ok_tuple(&heap, socket_pid);
         term reply = port_heap_create_reply(&heap, ref, payload);
         port_send_message_nolock(glb, pid, reply);
-        END_WITH_STACK_HEAP(heap);
+        END_WITH_STACK_HEAP(heap, glb);
     }
     socket_data->passive_listener = NULL;
     globalcontext_get_process_unlock(glb, ctx);


### PR DESCRIPTION
Also slightly change API for destroying heaps as we now need the global context

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
