### PR TITLE
Fix esp32 gpio:set_level/3 and gpio:digital_write/2

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -192,7 +192,7 @@ static inline term gpio_digital_write(Context *ctx, term gpio_num_term, term lev
 
     int level;
     if (term_is_integer(level_term)) {
-        level = term_from_int(level_term);
+        level = term_to_int32(level_term);
         if (UNLIKELY((level != 0) && (level != 1))) {
             return ERROR_ATOM;
         }


### PR DESCRIPTION
Fixes a problem in the esp32 gpio driver where if a numeric level is used (`0` or `1`) rather than atoms (`low` or `high`) the numeric input would be silently ignored.

Closes issue #584

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
