### PR TITLE
Fix inet:port implementation

### DIFF
--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -191,7 +191,7 @@ static term do_bind(Context *ctx, term address, term port)
         if (getsockname(socket_data->sockfd, (struct sockaddr *) &serveraddr, &address_len) == -1) {
             return port_create_sys_error_tuple(ctx, GETSOCKNAME_ATOM, errno);
         } else {
-            socket_data->port = term_from_int(ntohs(serveraddr.sin_port));
+            socket_data->port = ntohs(serveraddr.sin_port);
             return OK_ATOM;
         }
     }
@@ -511,7 +511,7 @@ term socket_driver_get_port(Context *ctx)
 {
     SocketDriverData *socket_data = (SocketDriverData *) ctx->platform_data;
     port_ensure_available(ctx, 7);
-    return port_create_ok_tuple(ctx, socket_data->port);
+    return port_create_ok_tuple(ctx, term_from_int(socket_data->port));
 }
 
 term socket_driver_sockname(Context *ctx)


### PR DESCRIPTION
SocketDriverData.port is a uint16_t and cannot hold a term.
This bug was shown by test_gen_udp test.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
