### PR TITLE
Implement destruction of esp32 nifs/ports

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -513,7 +513,7 @@ static void IRAM_ATTR gpio_isr_handler(void *arg)
     xQueueSendFromISR(event_queue, &arg, NULL);
 }
 
-REGISTER_PORT_DRIVER(gpio, gpio_driver_init, gpio_driver_create_port)
+REGISTER_PORT_DRIVER(gpio, gpio_driver_init, NULL, gpio_driver_create_port)
 
 #endif
 
@@ -685,7 +685,7 @@ const struct Nif *gpio_nif_get_nif(const char *nifname)
     return NULL;
 }
 
-REGISTER_NIF_COLLECTION(gpio, NULL, gpio_nif_get_nif)
+REGISTER_NIF_COLLECTION(gpio, NULL, NULL, gpio_nif_get_nif)
 #endif
 
 #endif

--- a/src/platforms/esp32/components/avm_builtins/i2c_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/i2c_driver.c
@@ -471,6 +471,6 @@ static NativeHandlerResult i2cdriver_consume_mailbox(Context *ctx)
     return cmd == I2CCloseCmd ? NativeTerminate : NativeContinue;
 }
 
-REGISTER_PORT_DRIVER(i2c, i2c_driver_init, i2c_driver_create_port)
+REGISTER_PORT_DRIVER(i2c, i2c_driver_init, NULL, i2c_driver_create_port)
 
 #endif

--- a/src/platforms/esp32/components/avm_builtins/ledc_nif.c
+++ b/src/platforms/esp32/components/avm_builtins/ledc_nif.c
@@ -475,6 +475,6 @@ const struct Nif *ledc_nif_get_nif(const char *nifname)
     return NULL;
 }
 
-REGISTER_NIF_COLLECTION(ledc, NULL, ledc_nif_get_nif)
+REGISTER_NIF_COLLECTION(ledc, NULL, NULL, ledc_nif_get_nif)
 
 #endif

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -822,6 +822,6 @@ Context *network_driver_create_port(GlobalContext *global, term opts)
 
 #ifdef CONFIG_AVM_ENABLE_NETWORK_PORT_DRIVER
 
-REGISTER_PORT_DRIVER(network, network_driver_init, network_driver_create_port)
+REGISTER_PORT_DRIVER(network, network_driver_init, NULL, network_driver_create_port)
 
 #endif

--- a/src/platforms/esp32/components/avm_builtins/nvs_nif.c
+++ b/src/platforms/esp32/components/avm_builtins/nvs_nif.c
@@ -308,6 +308,6 @@ static int write_atom_c_string(Context *ctx, char *buf, size_t bufsize, term t)
     return 0;
 }
 
-REGISTER_NIF_COLLECTION(nvs, nvs_nif_init, nvs_nif_get_nif)
+REGISTER_NIF_COLLECTION(nvs, nvs_nif_init, NULL, nvs_nif_get_nif)
 
 #endif

--- a/src/platforms/esp32/components/avm_builtins/rtc_slow_nif.c
+++ b/src/platforms/esp32/components/avm_builtins/rtc_slow_nif.c
@@ -94,11 +94,6 @@ static const struct Nif esp_rtc_slow_set_binary_nif = {
     .nif_ptr = nif_esp_rtc_slow_set_binary
 };
 
-void rtc_slow_nif_init(GlobalContext *gloabl)
-{
-    // no-op
-}
-
 const struct Nif *rtc_slow_nif_get_nif(const char *nifname)
 {
     if (strcmp("esp:rtc_slow_get_binary/0", nifname) == 0) {
@@ -112,6 +107,6 @@ const struct Nif *rtc_slow_nif_get_nif(const char *nifname)
     return NULL;
 }
 
-REGISTER_NIF_COLLECTION(rtc_slow, rtc_slow_nif_init, rtc_slow_nif_get_nif)
+REGISTER_NIF_COLLECTION(rtc_slow, NULL, NULL, rtc_slow_nif_get_nif)
 
 #endif

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -649,6 +649,6 @@ bool spi_driver_get_peripheral(term spi_port, spi_host_device_t *host_dev, Globa
     return true;
 }
 
-REGISTER_PORT_DRIVER(spi, spi_driver_init, spi_driver_create_port)
+REGISTER_PORT_DRIVER(spi, spi_driver_init, NULL, spi_driver_create_port)
 
 #endif

--- a/src/platforms/esp32/components/avm_builtins/uart_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/uart_driver.c
@@ -505,6 +505,6 @@ static NativeHandlerResult uart_driver_consume_mailbox(Context *ctx)
     return is_closed ? NativeTerminate : NativeContinue;
 }
 
-REGISTER_PORT_DRIVER(uart, NULL, uart_driver_create_port)
+REGISTER_PORT_DRIVER(uart, NULL, NULL, uart_driver_create_port)
 
 #endif

--- a/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
+++ b/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
@@ -28,10 +28,11 @@
 
 #include "sys.h"
 
-#define REGISTER_PORT_DRIVER(NAME, INIT_CB, CREATE_CB)                \
+#define REGISTER_PORT_DRIVER(NAME, INIT_CB, DESTROY_CB, CREATE_CB)    \
     struct PortDriverDef NAME##_port_driver_def = {                   \
         .port_driver_name = #NAME,                                    \
         .port_driver_init_cb = INIT_CB,                               \
+        .port_driver_destroy_cb = DESTROY_CB,                         \
         .port_driver_create_port_cb = CREATE_CB                       \
     };                                                                \
                                                                       \
@@ -45,9 +46,10 @@
         port_driver_list = &NAME##_port_driver_def_list_item;         \
     }
 
-#define REGISTER_NIF_COLLECTION(NAME, INIT_CB, RESOLVE_NIF_CB)              \
+#define REGISTER_NIF_COLLECTION(NAME, INIT_CB, DESTROY_CB, RESOLVE_NIF_CB)  \
     struct NifCollectionDef NAME##_nif_collection_def = {                   \
         .nif_collection_init_cb = INIT_CB,                                  \
+        .nif_collection_destroy_cb = DESTROY_CB,                            \
         .nif_collection_resove_nif_cb = RESOLVE_NIF_CB                      \
     };                                                                      \
                                                                             \
@@ -74,17 +76,21 @@ struct EventListener
 
 struct ESP32PlatformData
 {
+    // socket_driver
+    EventListener *socket_listener;
     struct SyncList sockets;
     struct ListHead ready_connections;
 };
 
 typedef void (*port_driver_init_t)(GlobalContext *global);
+typedef void (*port_driver_destroy_t)(GlobalContext *global);
 typedef Context *(*port_driver_create_port_t)(GlobalContext *global, term opts);
 
 struct PortDriverDef
 {
     const char *port_driver_name;
     const port_driver_init_t port_driver_init_cb;
+    const port_driver_destroy_t port_driver_destroy_cb;
     const port_driver_create_port_t port_driver_create_port_cb;
 };
 
@@ -95,11 +101,13 @@ struct PortDriverDefListItem
 };
 
 typedef void (*nif_collection_init_t)(GlobalContext *global);
+typedef void (*nif_collection_destroy_t)(GlobalContext *global);
 typedef const struct Nif *(*nif_collection_resolve_nif_t)(const char *name);
 
 struct NifCollectionDef
 {
     const nif_collection_init_t nif_collection_init_cb;
+    const nif_collection_destroy_t nif_collection_destroy_cb;
     const nif_collection_resolve_nif_t nif_collection_resove_nif_cb;
 };
 
@@ -121,7 +129,9 @@ void sys_event_listener_init(EventListener *listener, void *sender, event_handle
 void socket_init(Context *ctx, term opts);
 
 void port_driver_init_all(GlobalContext *global);
+void port_driver_destroy_all(GlobalContext *global);
 void nif_collection_init_all(GlobalContext *global);
+void nif_collection_destroy_all(GlobalContext *global);
 const struct Nif *nif_collection_resolve_nif(const char *name);
 
 #endif

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -336,6 +336,15 @@ void port_driver_init_all(GlobalContext *global)
     }
 }
 
+void port_driver_destroy_all(GlobalContext *global)
+{
+    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
+        if (item->def->port_driver_destroy_cb) {
+            item->def->port_driver_destroy_cb(global);
+        }
+    }
+}
+
 static Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts)
 {
     for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
@@ -352,6 +361,15 @@ void nif_collection_init_all(GlobalContext *global)
     for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
         if (item->def->nif_collection_init_cb) {
             item->def->nif_collection_init_cb(global);
+        }
+    }
+}
+
+void nif_collection_destroy_all(GlobalContext *global)
+{
+    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
+        if (item->def->nif_collection_destroy_cb) {
+            item->def->nif_collection_destroy_cb(global);
         }
     }
 }

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -155,9 +155,11 @@ term avm_test_case(const char *test_module)
     term_display(stdout, ret_value, ctx);
     fprintf(stdout, "\n");
 
-    // We cannot really cleanup for now as ports are not clean-able.
-    // globalcontext_destroy(glb);
-    // free(avmpack_data);
+    nif_collection_destroy_all(glb);
+    port_driver_destroy_all(glb);
+
+    globalcontext_destroy(glb);
+    free(avmpack_data);
 
     return ret_value;
 }


### PR DESCRIPTION
Required hygiene for qemu-based testing

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
