### PR TITLE
Implement basic POSIX file functions as nifs

### DIFF
--- a/CMakeModules/DefineIfExists.cmake
+++ b/CMakeModules/DefineIfExists.cmake
@@ -1,0 +1,40 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+include(CheckSymbolExists)
+include(CheckCSourceCompiles)
+
+function(define_if_symbol_exists target symbol header scope macro)
+    check_symbol_exists(${symbol} ${header} ${macro})
+    if (${macro})
+        target_compile_definitions(${target} ${scope} ${macro})
+    endif(${macro})
+endfunction()
+function(define_if_function_exists target symbol header scope macro)
+    check_c_source_compiles("
+    #include <${header}>
+    int main(int argc)
+    {
+          return ((int*)(&${symbol}))[argc];
+    }" ${macro})
+    if (${macro})
+        target_compile_definitions(${target} ${scope} ${macro})
+    endif(${macro})
+endfunction()

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -49,6 +49,7 @@ set(HEADER_FILES
     nifs.h
     platform_nifs.h
     port.h
+    posix_nifs.h
     refc_binary.h
     resources.h
     scheduler.h
@@ -84,6 +85,7 @@ set(SOURCE_FILES
     module.c
     nifs.c
     port.c
+    posix_nifs.c
     refc_binary.c
     resources.c
     scheduler.c
@@ -109,7 +111,7 @@ endif()
 
 target_link_libraries(libAtomVM PUBLIC m)
 include(CheckCSourceCompiles)
-set(CMAKE_REQUIRED_FLAGS -Werror=unknown-pragmas)
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -Werror=unknown-pragmas")
 check_c_source_compiles("
      #include <fenv.h>
      int main() {
@@ -149,6 +151,20 @@ else()
         endif()
     endif()
 endif()
+
+include(DefineIfExists)
+# HAVE_OPEN & HAVE_CLOSE are used in globalcontext.h
+define_if_function_exists(libAtomVM open "fcntl.h" PUBLIC HAVE_OPEN)
+define_if_function_exists(libAtomVM close "unistd.h" PUBLIC HAVE_CLOSE)
+define_if_function_exists(libAtomVM unlink "unistd.h" PRIVATE HAVE_UNLINK)
+define_if_symbol_exists(libAtomVM O_CLOEXEC "fcntl.h" PRIVATE HAVE_O_CLOEXEC)
+define_if_symbol_exists(libAtomVM O_DIRECTORY "fcntl.h" PRIVATE HAVE_O_DIRECTORY)
+define_if_symbol_exists(libAtomVM O_DSYNC "fcntl.h" PRIVATE HAVE_O_DSYNC)
+define_if_symbol_exists(libAtomVM O_EXEC "fcntl.h" PRIVATE HAVE_O_EXEC)
+define_if_symbol_exists(libAtomVM O_NOFOLLOW "fcntl.h" PRIVATE HAVE_O_NOFOLLOW)
+define_if_symbol_exists(libAtomVM O_RSYNC "fcntl.h" PRIVATE HAVE_O_RSYNC)
+define_if_symbol_exists(libAtomVM O_SEARCH "fcntl.h" PRIVATE HAVE_O_SEARCH)
+define_if_symbol_exists(libAtomVM O_TTY_INIT "fcntl.h" PRIVATE HAVE_O_TTY_INIT)
 
 if (AVM_USE_32BIT_FLOAT)
     target_compile_definitions(libAtomVM PUBLIC AVM_USE_SINGLE_PRECISION)

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -35,6 +35,7 @@ extern "C" {
 #include <stdint.h>
 
 #include "atom.h"
+#include "erl_nif.h"
 #include "list.h"
 #include "smp.h"
 #include "synclist.h"
@@ -119,6 +120,10 @@ struct GlobalContext
 
 #ifndef AVM_NO_SMP
     SpinLock env_spinlock;
+#endif
+
+#if HAVE_OPEN && HAVE_CLOSE
+    ErlNifResourceType *posix_fd_resource_type;
 #endif
 
     void *platform_data;

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -24,6 +24,12 @@
 
 #include "nifs.h"
 
+#include <fenv.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
 #include "atomshashtable.h"
 #include "avmpack.h"
 #include "bif.h"
@@ -36,6 +42,7 @@
 #include "module.h"
 #include "platform_nifs.h"
 #include "port.h"
+#include "posix_nifs.h"
 #include "scheduler.h"
 #include "smp.h"
 #include "sys.h"
@@ -43,21 +50,8 @@
 #include "utils.h"
 #include "version.h"
 
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
-
-#include <errno.h>
-#include <fenv.h>
-#include <math.h>
-
 #define MAX_NIF_NAME_LEN 260
 #define FLOAT_BUF_SIZE 64
-
-#define RAISE_ERROR(error_type_atom) \
-    ctx->x[0] = ERROR_ATOM;          \
-    ctx->x[1] = (error_type_atom);   \
-    return term_invalid_term();
 
 #define RAISE(a, b)  \
     ctx->x[0] = (a); \
@@ -722,6 +716,18 @@ DEFINE_MATH_NIF(sinh)
 DEFINE_MATH_NIF(sqrt)
 DEFINE_MATH_NIF(tan)
 DEFINE_MATH_NIF(tanh)
+
+//Handle optional nifs
+#if HAVE_OPEN && HAVE_CLOSE
+#define IF_HAVE_OPEN_CLOSE(expr) (expr)
+#else
+#define IF_HAVE_OPEN_CLOSE(expr) NULL
+#endif
+#if HAVE_UNLINK
+#define IF_HAVE_UNLINK(expr) (expr)
+#else
+#define IF_HAVE_UNLINK(expr) NULL
+#endif
 
 //Ignore warning caused by gperf generated code
 #pragma GCC diagnostic push

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -120,6 +120,12 @@ atomvm:add_avm_pack_binary/2, &atomvm_add_avm_pack_binary_nif
 atomvm:add_avm_pack_file/2, &atomvm_add_avm_pack_file_nif
 atomvm:close_avm_pack/2, &atomvm_close_avm_pack_nif
 atomvm:read_priv/2, &atomvm_read_priv_nif
+atomvm:posix_open/2, IF_HAVE_OPEN_CLOSE(&atomvm_posix_open_nif)
+atomvm:posix_open/3, IF_HAVE_OPEN_CLOSE(&atomvm_posix_open_nif)
+atomvm:posix_close/1, IF_HAVE_OPEN_CLOSE(&atomvm_posix_close_nif)
+atomvm:posix_read/2, IF_HAVE_OPEN_CLOSE(&atomvm_posix_read_nif)
+atomvm:posix_write/2, IF_HAVE_OPEN_CLOSE(&atomvm_posix_write_nif)
+atomvm:posix_unlink/1, IF_HAVE_UNLINK(&atomvm_posix_unlink_nif)
 code:load_abs/1, &code_load_abs_nif
 code:load_binary/3, &code_load_binary_nif
 console:print/1, &console_print_nif

--- a/src/libAtomVM/posix_nifs.c
+++ b/src/libAtomVM/posix_nifs.c
@@ -1,0 +1,419 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+/**
+ * @file posix_nifs.c
+ * @brief Implementation of NIFs based on POSIX functions
+ */
+
+#if HAVE_OPEN && HAVE_CLOSE
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+#include "defaultatoms.h"
+#include "erl_nif_priv.h"
+#include "interop.h"
+#include "nifs.h"
+#include "posix_nifs.h"
+
+term posix_errno_to_term(int err, GlobalContext *glb)
+{
+#if HAVE_OPEN && HAVE_CLOSE
+    // These are defined in SUSv1
+    switch (err) {
+        case EACCES:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "eacces"));
+        case EAGAIN:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "eagain"));
+        case EBADF:
+            return globalcontext_make_atom(glb, ATOM_STR("\x5", "ebadf"));
+        case EBUSY:
+            return globalcontext_make_atom(glb, ATOM_STR("\x5", "ebusy"));
+        case EDQUOT:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "edquot"));
+        case EEXIST:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "eexist"));
+        case EFAULT:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "efault"));
+        case EFBIG:
+            return globalcontext_make_atom(glb, ATOM_STR("\x5", "efbig"));
+        case EINTR:
+            return globalcontext_make_atom(glb, ATOM_STR("\x5", "eintr"));
+        case EINVAL:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "einval"));
+        case EIO:
+            return globalcontext_make_atom(glb, ATOM_STR("\x3", "eio"));
+        case EISDIR:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "eisdir"));
+        case ELOOP:
+            return globalcontext_make_atom(glb, ATOM_STR("\x5", "eloop"));
+        case EMFILE:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "emfile"));
+        case EMLINK:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "emlink"));
+        case ENAMETOOLONG:
+            return globalcontext_make_atom(glb, ATOM_STR("\xC", "enametoolong"));
+        case ENFILE:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "enfile"));
+        case ENODEV:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "enodev"));
+        case ENOENT:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "enoent"));
+        case ENOMEM:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "enomem"));
+        case ENOSPC:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "enospc"));
+        case ENOTDIR:
+            return globalcontext_make_atom(glb, ATOM_STR("\x7", "enotdir"));
+        case ENXIO:
+            return globalcontext_make_atom(glb, ATOM_STR("\x5", "enxio"));
+        case EPERM:
+            return globalcontext_make_atom(glb, ATOM_STR("\x5", "eperm"));
+        case EPIPE:
+            return globalcontext_make_atom(glb, ATOM_STR("\x5", "epipe"));
+        case EROFS:
+            return globalcontext_make_atom(glb, ATOM_STR("\x5", "erofs"));
+        case ESPIPE:
+            return globalcontext_make_atom(glb, ATOM_STR("\x6", "espipe"));
+        case ESRCH:
+            return globalcontext_make_atom(glb, ATOM_STR("\x5", "esrch"));
+        case EXDEV:
+            return globalcontext_make_atom(glb, ATOM_STR("\x5", "exdev"));
+    }
+#else
+    UNUSED(glb);
+#endif
+    return term_from_int(err);
+}
+
+#if HAVE_OPEN && HAVE_CLOSE
+#define CLOSED_FD (-1)
+
+struct PosixFd
+{
+    int fd;
+};
+
+static void posix_fd_dtor(ErlNifEnv *caller_env, void *obj)
+{
+    UNUSED(caller_env);
+
+    struct PosixFd *fd_obj = (struct PosixFd *) obj;
+    if (fd_obj->fd) {
+        close(fd_obj->fd);
+        fd_obj->fd = CLOSED_FD;
+    }
+}
+
+const ErlNifResourceTypeInit posix_fd_resource_type_init = {
+    .members = 1,
+    .dtor = posix_fd_dtor,
+};
+
+#define O_EXEC_ATOM_STR ATOM_STR("\x6", "o_exec")
+#define O_RDONLY_ATOM_STR ATOM_STR("\x8", "o_rdonly")
+#define O_RDWR_ATOM_STR ATOM_STR("\x6", "o_rdwr")
+#define O_SEARCH_ATOM_STR ATOM_STR("\x8", "o_search")
+#define O_WRONLY_ATOM_STR ATOM_STR("\x8", "o_wronly")
+
+#define O_APPEND_ATOM_STR ATOM_STR("\x8", "o_append")
+#define O_CLOEXEC_ATOM_STR ATOM_STR("\x9", "o_cloexec")
+#define O_CREAT_ATOM_STR ATOM_STR("\x7", "o_creat")
+#define O_DIRECTORY_ATOM_STR ATOM_STR("\xB", "o_directory")
+#define O_DSYNC_ATOM_STR ATOM_STR("\x7", "o_dsync")
+#define O_EXCL_ATOM_STR ATOM_STR("\x6", "o_excl")
+#define O_NOCTTY_ATOM_STR ATOM_STR("\x8", "o_noctty")
+#define O_NOFOLLOW_ATOM_STR ATOM_STR("\xA", "o_nofollow")
+// #define O_NONBLOCK_ATOM_STR ATOM_STR("\xA", "o_nonblock")
+#define O_RSYNC_ATOM_STR ATOM_STR("\x8", "o_rsync")
+#define O_SYNC_ATOM_STR ATOM_STR("\x7", "o_sync")
+#define O_TRUNC_ATOM_STR ATOM_STR("\x8", "o_trunc")
+#define O_TTY_INIT_ATOM_STR ATOM_STR("\xA", "o_tty_init")
+
+static term nif_atomvm_posix_open(Context *ctx, int argc, term argv[])
+{
+    GlobalContext *glb = ctx->global;
+
+    term path_term = argv[0];
+    term flags = argv[1];
+    VALIDATE_VALUE(flags, term_is_list);
+    int posix_flags = O_NONBLOCK; // Always be non-blocking
+    while (term_is_nonempty_list(flags)) {
+        term flag = term_get_list_head(flags);
+        VALIDATE_VALUE(flag, term_is_atom);
+        // SUSv1 flags
+        if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_RDONLY_ATOM_STR)) {
+            posix_flags |= O_RDONLY;
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_WRONLY_ATOM_STR)) {
+            posix_flags |= O_WRONLY;
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_RDWR_ATOM_STR)) {
+            posix_flags |= O_RDWR;
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_APPEND_ATOM_STR)) {
+            posix_flags |= O_APPEND;
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_CREAT_ATOM_STR)) {
+            posix_flags |= O_CREAT;
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_EXCL_ATOM_STR)) {
+            posix_flags |= O_EXCL;
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_NOCTTY_ATOM_STR)) {
+            posix_flags |= O_NOCTTY;
+            // O_NONBLOCK is not optional
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_SYNC_ATOM_STR)) {
+            posix_flags |= O_SYNC;
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_TRUNC_ATOM_STR)) {
+            posix_flags |= O_TRUNC;
+            // SUSv4/2018 edition flags
+#if HAVE_O_EXEC
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_EXEC_ATOM_STR)) {
+            posix_flags |= O_EXEC;
+#endif
+#if HAVE_O_SEARCH
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_SEARCH_ATOM_STR)) {
+            posix_flags |= O_SEARCH;
+#endif
+#if HAVE_O_CLOEXEC
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_CLOEXEC_ATOM_STR)) {
+            posix_flags |= O_CLOEXEC;
+#endif
+#if HAVE_O_DIRECTORY
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_DIRECTORY_ATOM_STR)) {
+            posix_flags |= O_DIRECTORY;
+#endif
+#if HAVE_O_DSYNC
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_DSYNC_ATOM_STR)) {
+            posix_flags |= O_DSYNC;
+#endif
+#if HAVE_O_NOFOLLOW
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_NOFOLLOW_ATOM_STR)) {
+            posix_flags |= O_NOFOLLOW;
+#endif
+#if HAVE_O_RSYNC
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_RSYNC_ATOM_STR)) {
+            posix_flags |= O_RSYNC;
+#endif
+#if HAVE_O_TTY_INIT
+        } else if (globalcontext_is_term_equal_to_atom_string(glb, flag, O_TTY_INIT_ATOM_STR)) {
+            posix_flags |= O_TTY_INIT;
+#endif
+        } else {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        flags = term_get_list_tail(flags);
+    }
+
+    int ok;
+    char *path = interop_term_to_string(path_term, &ok);
+    if (UNLIKELY(!ok)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    term result;
+    int fd;
+    if (argc == 3) {
+        term mode_term = argv[2];
+        if (UNLIKELY(!term_is_integer(mode_term))) {
+            free(path);
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        int mode = term_to_int(mode_term);
+        fd = open(path, posix_flags, mode);
+    } else {
+        fd = open(path, posix_flags);
+    }
+    free(path);
+    if (UNLIKELY(fd < 0)) {
+        // Return an error.
+        if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
+        result = term_alloc_tuple(2, &ctx->heap);
+        term_put_tuple_element(result, 0, ERROR_ATOM);
+        term_put_tuple_element(result, 1, posix_errno_to_term(errno, glb));
+    } else {
+        // Return a resource object
+        struct PosixFd *fd_obj = enif_alloc_resource(glb->posix_fd_resource_type, sizeof(struct PosixFd));
+        if (IS_NULL_PTR(fd_obj)) {
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
+        fd_obj->fd = fd;
+        if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2) + TERM_BOXED_RESOURCE_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
+        term obj = term_from_resource(fd_obj, &ctx->heap);
+        result = term_alloc_tuple(2, &ctx->heap);
+        term_put_tuple_element(result, 0, OK_ATOM);
+        term_put_tuple_element(result, 1, obj);
+    }
+
+    return result;
+}
+
+static term nif_atomvm_posix_close(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+
+    term result = OK_ATOM;
+
+    void *fd_obj_ptr;
+    if (UNLIKELY(!enif_get_resource(erl_nif_env_from_context(ctx), argv[0], ctx->global->posix_fd_resource_type, &fd_obj_ptr))) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    struct PosixFd *fd_obj = (struct PosixFd *) fd_obj_ptr;
+    if (fd_obj->fd != CLOSED_FD) {
+        if (UNLIKELY(close(fd_obj->fd) < 0)) {
+            fd_obj->fd = CLOSED_FD; // even if bad things happen, do not close twice.
+            if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            }
+            result = term_alloc_tuple(2, &ctx->heap);
+            term_put_tuple_element(result, 0, ERROR_ATOM);
+            term_put_tuple_element(result, 1, posix_errno_to_term(errno, ctx->global));
+        }
+        fd_obj->fd = CLOSED_FD;
+    }
+
+    return result;
+}
+
+static term nif_atomvm_posix_read(Context *ctx, int argc, term argv[])
+{
+    GlobalContext *glb = ctx->global;
+    UNUSED(argc);
+    term count_term = argv[1];
+    VALIDATE_VALUE(count_term, term_is_integer);
+    int count = term_to_int(count_term);
+
+    void *fd_obj_ptr;
+    if (UNLIKELY(!enif_get_resource(erl_nif_env_from_context(ctx), argv[0], glb->posix_fd_resource_type, &fd_obj_ptr))) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    struct PosixFd *fd_obj = (struct PosixFd *) fd_obj_ptr;
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(count) + BINARY_HEADER_SIZE + TERM_BOXED_SUB_BINARY_SIZE + TUPLE_SIZE(2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    term bin_term = term_create_uninitialized_binary(count, &ctx->heap, glb);
+    int res = read(fd_obj->fd, (void *) term_binary_data(bin_term), count);
+    if (UNLIKELY(res < 0)) {
+        // Return an error.
+        if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
+        term ret = term_alloc_tuple(2, &ctx->heap);
+        term_put_tuple_element(ret, 0, ERROR_ATOM);
+        term_put_tuple_element(ret, 1, posix_errno_to_term(errno, glb));
+        return ret;
+    }
+    if (res == 0) {
+        return globalcontext_make_atom(glb, ATOM_STR("\x3", "eof"));
+    }
+    if (res < count) {
+        bin_term = term_alloc_sub_binary(bin_term, 0, res, &ctx->heap);
+    }
+    term result = term_alloc_tuple(2, &ctx->heap);
+    term_put_tuple_element(result, 0, OK_ATOM);
+    term_put_tuple_element(result, 1, bin_term);
+
+    return result;
+}
+
+static term nif_atomvm_posix_write(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    term data_term = argv[1];
+    VALIDATE_VALUE(data_term, term_is_binary);
+
+    void *fd_obj_ptr;
+    if (UNLIKELY(!enif_get_resource(erl_nif_env_from_context(ctx), argv[0], ctx->global->posix_fd_resource_type, &fd_obj_ptr))) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    struct PosixFd *fd_obj = (struct PosixFd *) fd_obj_ptr;
+    const char *data = term_binary_data(data_term);
+    unsigned long n = term_binary_size(data_term);
+    term result;
+    int res = write(fd_obj->fd, data, n);
+    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    result = term_alloc_tuple(2, &ctx->heap);
+    if (res < 0) {
+        term_put_tuple_element(result, 0, ERROR_ATOM);
+        term_put_tuple_element(result, 1, posix_errno_to_term(errno, ctx->global));
+    } else {
+        term_put_tuple_element(result, 0, OK_ATOM);
+        term_put_tuple_element(result, 1, term_from_int(res));
+    }
+
+    return result;
+}
+#endif
+
+#if HAVE_UNLINK
+static term nif_atomvm_posix_unlink(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    term path_term = argv[0];
+
+    int ok;
+    const char *path = interop_term_to_string(path_term, &ok);
+    if (UNLIKELY(!ok)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    int res = unlink(path);
+    free((void *) path);
+    if (res < 0) {
+        // Return an error.
+        if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
+        term result = term_alloc_tuple(2, &ctx->heap);
+        term_put_tuple_element(result, 0, ERROR_ATOM);
+        term_put_tuple_element(result, 1, posix_errno_to_term(errno, ctx->global));
+        return result;
+    }
+    return OK_ATOM;
+}
+#endif
+
+#if HAVE_OPEN && HAVE_CLOSE
+const struct Nif atomvm_posix_open_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_atomvm_posix_open
+};
+const struct Nif atomvm_posix_close_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_atomvm_posix_close
+};
+const struct Nif atomvm_posix_read_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_atomvm_posix_read
+};
+const struct Nif atomvm_posix_write_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_atomvm_posix_write
+};
+#endif
+#if HAVE_UNLINK
+const struct Nif atomvm_posix_unlink_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_atomvm_posix_unlink
+};
+#endif

--- a/src/libAtomVM/posix_nifs.h
+++ b/src/libAtomVM/posix_nifs.h
@@ -1,0 +1,65 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+/**
+ * @file posix_nifs.h
+ * @brief Declaration of NIFs based on POSIX functions
+ */
+
+#ifndef _POSIX_NIFS_H_
+#define _POSIX_NIFS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "exportedfunction.h"
+#include "globalcontext.h"
+#include "term.h"
+
+#if HAVE_OPEN && HAVE_CLOSE
+extern const ErlNifResourceTypeInit posix_fd_resource_type_init;
+extern const struct Nif atomvm_posix_open_nif;
+extern const struct Nif atomvm_posix_close_nif;
+extern const struct Nif atomvm_posix_read_nif;
+extern const struct Nif atomvm_posix_write_nif;
+#endif
+#if HAVE_UNLINK
+extern const struct Nif atomvm_posix_unlink_nif;
+#endif
+
+/**
+ * @brief Convenient function to return posix errors as atom.
+ *
+ * @details POSIX does not define the values of errno errors, so this function
+ * makes sure Erlang code can interpret error codes whatever the platform.
+ *
+ * @param err the error code, typically obtained from `errno(3)`
+ * @param glb the global context
+ * @return an atom representing the error or an integer if the error
+ * number is not known.
+ */
+term posix_errno_to_term(int err, GlobalContext *glb);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libAtomVM/resources.c
+++ b/src/libAtomVM/resources.c
@@ -102,5 +102,7 @@ ERL_NIF_TERM enif_make_resource(ErlNifEnv *env, void *obj)
     if (UNLIKELY(memory_erl_nif_env_ensure_free(env, TERM_BOXED_RESOURCE_SIZE) != MEMORY_GC_OK)) {
         AVM_ABORT();
     }
+    struct RefcBinary *refc = refc_binary_from_data(obj);
+    refc_binary_increment_refcount(refc);
     return term_from_resource(obj, &env->heap);
 }

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -1679,7 +1679,7 @@ static inline term term_get_sub_binary_ref(term t)
 
 /**
  * @brief Create a resource on the heap.
- * @details This function creats a resource (obtained from `enif_alloc_resource`)
+ * @details This function creates a resource (obtained from `enif_alloc_resource`)
  * on the heap which must have `TERM_BOXED_RESOURCE_SIZE` free terms.
  *
  * @param resource resource obtained from `enif_alloc_resource`
@@ -1697,8 +1697,7 @@ static inline term term_from_resource(void *resource, Heap *heap)
     boxed_value[2] = (term) RefcNoFlags;
     term ret = ((term) boxed_value) | TERM_BOXED_VALUE_TAG;
     boxed_value[3] = (term) refc;
-    // Increment ref count and add the resource to the mso list
-    refc_binary_increment_refcount(refc);
+    // Add the resource to the mso list
     heap->root->mso_list = term_list_init_prepend(boxed_value + 4, ret, heap->root->mso_list);
     return ret;
 }

--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -21,6 +21,8 @@
 cmake_minimum_required (VERSION 3.13)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules")
+
 # Disable SMP with esp32 socs that have only one core
 if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32h2")
     message("Disabling SMP as selected target only has one core")

--- a/src/platforms/esp32/test/CMakeLists.txt
+++ b/src/platforms/esp32/test/CMakeLists.txt
@@ -29,6 +29,8 @@ set(EXTRA_COMPONENT_DIRS "../components")
 #
 set(TEST_COMPONENTS "testable" CACHE STRING "List of components to test")
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../CMakeModules")
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(atomvm-esp32-test)
 

--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -36,6 +36,7 @@ function(compile_erlang module_name)
     set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.beam")
 endfunction()
 
+compile_erlang(test_file)
 compile_erlang(test_md5)
 compile_erlang(test_monotonic_time)
 compile_erlang(test_rtc_slow)
@@ -47,6 +48,7 @@ add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/esp32_test_modules.avm"
     COMMAND HostAtomVM-prefix/src/HostAtomVM-build/tools/packbeam/PackBEAM -i esp32_test_modules.avm
         HostAtomVM-prefix/src/HostAtomVM-build/libs/atomvmlib.avm
+        test_file.beam
         test_md5.beam
         test_monotonic_time.beam
         test_rtc_slow.beam
@@ -55,6 +57,7 @@ add_custom_command(
         test_tz.beam
     DEPENDS
         HostAtomVM
+        "${CMAKE_CURRENT_BINARY_DIR}/test_file.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_md5.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_monotonic_time.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_rtc_slow.beam"

--- a/src/platforms/esp32/test/main/test_erl_sources/test_file.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_file.erl
@@ -1,0 +1,103 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_file).
+
+-export([start/0]).
+
+start() ->
+    ok = test_basic_file(),
+    ok = test_gc(),
+    ok.
+
+% esp-idf limitations:
+% filenames should be up to 8+3
+% O_CREAT | O_WRONLY doesn't work in v4.4.4 (https://github.com/espressif/esp-idf/issues/1817)
+% files are not selectable
+
+test_basic_file() ->
+    Path = "/sdcard/atomvm-1.txt",
+    {ok, Fd} = atomvm:posix_open(Path, [o_wronly, o_creat, o_excl], 8#644),
+    {ok, 5} = atomvm:posix_write(Fd, <<"Hello">>),
+    ok = atomvm:posix_close(Fd),
+    {ok, Fd2} = atomvm:posix_open(Path, [o_rdwr]),
+    {ok, <<"He">>} = atomvm:posix_read(Fd2, 2),
+    {ok, <<"llo">>} = atomvm:posix_read(Fd2, 10),
+    eof = atomvm:posix_read(Fd2, 10),
+    {ok, 6} = atomvm:posix_write(Fd2, <<" World">>),
+    eof = atomvm:posix_read(Fd2, 10),
+    ok = atomvm:posix_close(Fd2),
+    ok = atomvm:posix_unlink(Path).
+
+% Test is based on the fact that `erlang:memory(binary)` count resources.
+test_gc() ->
+    Path = "/sdcard/atomvm-2.txt",
+    GCSubPid = spawn(fun() -> gc_loop(Path, undefined) end),
+    MemorySize0 = erlang:memory(binary),
+    call_gc_loop(GCSubPid, open),
+    MemorySize1 = erlang:memory(binary),
+    true = MemorySize1 > MemorySize0,
+    call_gc_loop(GCSubPid, close),
+    call_gc_loop(GCSubPid, gc),
+    MemorySize2 = erlang:memory(binary),
+    true = MemorySize2 =:= MemorySize0,
+
+    call_gc_loop(GCSubPid, open),
+    MemorySize3 = erlang:memory(binary),
+    true = MemorySize3 =:= MemorySize1,
+    call_gc_loop(GCSubPid, open),
+    call_gc_loop(GCSubPid, gc),
+    MemorySize4 = erlang:memory(binary),
+    true = MemorySize4 =:= MemorySize1,
+    call_gc_loop(GCSubPid, forget),
+    call_gc_loop(GCSubPid, gc),
+    MemorySize5 = erlang:memory(binary),
+    true = MemorySize5 =:= MemorySize0,
+
+    call_gc_loop(GCSubPid, quit),
+    ok = atomvm:posix_unlink(Path),
+    ok.
+
+call_gc_loop(Pid, Message) ->
+    Pid ! {self(), Message},
+    receive
+        {Pid, Message} -> ok
+    end.
+
+gc_loop(Path, File) ->
+    receive
+        {Caller, open} ->
+            {ok, Fd} = atomvm:posix_open(Path, [o_rdwr, o_creat, o_append], 8#644),
+            Caller ! {self(), open},
+            gc_loop(Path, Fd);
+        {Caller, forget} ->
+            Caller ! {self(), forget},
+            gc_loop(Path, undefined);
+        {Caller, gc} ->
+            erlang:garbage_collect(),
+            Caller ! {self(), gc},
+            gc_loop(Path, File);
+        {Caller, close} ->
+            atomvm:posix_close(File),
+            Caller ! {self(), close},
+            gc_loop(Path, undefined);
+        {Caller, quit} ->
+            Caller ! {self(), quit}
+    end.

--- a/src/platforms/esp32/test/test_atomvm.py
+++ b/src/platforms/esp32/test/test_atomvm.py
@@ -20,11 +20,20 @@
 
 from pytest_embedded import Dut
 import pytest
+import os
+
+@pytest.fixture(autouse=True)
+def create_sd_image():
+    path = 'sd_image.bin'
+    with open(path, 'wb') as f:
+        f.truncate(1 * 1024 * 1024)
+    yield path
+    os.unlink(path)
 
 @pytest.mark.parametrize(
     'qemu_extra_args',
     [
-        '-nic user,model=open_eth',
+        '-nic user,model=open_eth -drive file=sd_image.bin,if=sd,format=raw',
     ],
     indirect=True,
 )

--- a/src/platforms/rp2040/CMakeLists.txt
+++ b/src/platforms/rp2040/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 include(pico_sdk_import.cmake)
 
 project(AtomVM)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules")
 
 # initialize the Raspberry Pi Pico SDK
 pico_sdk_init()
@@ -37,6 +38,11 @@ include(${CMAKE_ROOT}/Modules/CMakeDetermineCompileFeatures.cmake)
 CMAKE_DETERMINE_COMPILE_FEATURES(C)
 
 enable_language( C CXX ASM )
+
+# Pico SDK currently forces -nostdlib when using TRY_COMPILE
+# This will make test of availability of POSIX functions fail but open and close
+# are implemented to always return -1 anyway.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
 
 # Options that make sense for this platform
 option(AVM_DISABLE_SMP "Disable SMP support." OFF)

--- a/src/platforms/stm32/CMakeLists.txt
+++ b/src/platforms/stm32/CMakeLists.txt
@@ -20,6 +20,7 @@
 
 cmake_minimum_required (VERSION 3.13)
 project(AtomVM)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 

--- a/src/platforms/stm32/cmake/libopencm3.cmake
+++ b/src/platforms/stm32/cmake/libopencm3.cmake
@@ -153,6 +153,10 @@ set(TARGET_SPECIFIC_FLAGS "${GENLINK_CPPFLAGS} ${ARCH_FLAGS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${TARGET_SPECIFIC_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TARGET_SPECIFIC_FLAGS}")
 
+# Use linker flags to detect symbols
+set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
+set(CMAKE_REQUIRED_FLAGS ${LINKER_FLAGS})
+
 message(STATUS "Target Specific Flags   : ${TARGET_SPECIFIC_FLAGS}")
 
 # Replace `add_executable` with custom macro with same name that adds libopencm3 as a linking target

--- a/tests/libs/eavmlib/CMakeLists.txt
+++ b/tests/libs/eavmlib/CMakeLists.txt
@@ -23,6 +23,7 @@ project(test_eavmlib)
 include(BuildErlang)
 
 set(ERLANG_MODULES
+    test_file
     test_logger
     test_port
     test_timer_manager

--- a/tests/libs/eavmlib/test_file.erl
+++ b/tests/libs/eavmlib/test_file.erl
@@ -1,0 +1,100 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_file).
+
+-export([test/0]).
+
+-include("etest.hrl").
+
+test() ->
+    ok = test_basic_file(),
+    ok = test_gc(),
+    ok.
+
+test_basic_file() ->
+    Path = "/tmp/atomvm.tmp." ++ integer_to_list(erlang:system_time(millisecond)),
+    {ok, Fd} = atomvm:posix_open(Path, [o_wronly, o_creat], 8#644),
+    {ok, 5} = atomvm:posix_write(Fd, <<"Hello">>),
+    ok = atomvm:posix_close(Fd),
+    {ok, Fd2} = atomvm:posix_open(Path, [o_rdwr]),
+    {ok, <<"He">>} = atomvm:posix_read(Fd2, 2),
+    {ok, <<"llo">>} = atomvm:posix_read(Fd2, 10),
+    eof = atomvm:posix_read(Fd2, 10),
+    {ok, 6} = atomvm:posix_write(Fd2, <<" World">>),
+    eof = atomvm:posix_read(Fd2, 10),
+    ok = atomvm:posix_close(Fd2),
+    ok = atomvm:posix_unlink(Path).
+
+% Test is based on the fact that `erlang:memory(binary)` count resources.
+test_gc() ->
+    Path = "/tmp/atomvm.tmp." ++ integer_to_list(erlang:system_time(millisecond)),
+    GCSubPid = spawn(fun() -> gc_loop(Path, undefined) end),
+    MemorySize0 = erlang:memory(binary),
+    call_gc_loop(GCSubPid, open),
+    MemorySize1 = erlang:memory(binary),
+    ?ASSERT_TRUE(MemorySize1 > MemorySize0),
+    call_gc_loop(GCSubPid, close),
+    call_gc_loop(GCSubPid, gc),
+    MemorySize2 = erlang:memory(binary),
+    ?ASSERT_EQUALS(MemorySize2, MemorySize0),
+
+    call_gc_loop(GCSubPid, open),
+    MemorySize3 = erlang:memory(binary),
+    ?ASSERT_EQUALS(MemorySize3, MemorySize1),
+    call_gc_loop(GCSubPid, open),
+    call_gc_loop(GCSubPid, gc),
+    MemorySize4 = erlang:memory(binary),
+    ?ASSERT_EQUALS(MemorySize4, MemorySize1),
+    call_gc_loop(GCSubPid, forget),
+    call_gc_loop(GCSubPid, gc),
+    MemorySize5 = erlang:memory(binary),
+    ?ASSERT_EQUALS(MemorySize5, MemorySize0),
+
+    call_gc_loop(GCSubPid, quit),
+    ok = atomvm:posix_unlink(Path),
+    ok.
+
+call_gc_loop(Pid, Message) ->
+    Pid ! {self(), Message},
+    receive
+        {Pid, Message} -> ok
+    end.
+
+gc_loop(Path, File) ->
+    receive
+        {Caller, open} ->
+            {ok, Fd} = atomvm:posix_open(Path, [o_rdwr, o_creat], 8#644),
+            Caller ! {self(), open},
+            gc_loop(Path, Fd);
+        {Caller, forget} ->
+            Caller ! {self(), forget},
+            gc_loop(Path, undefined);
+        {Caller, gc} ->
+            erlang:garbage_collect(),
+            Caller ! {self(), gc},
+            gc_loop(Path, File);
+        {Caller, close} ->
+            atomvm:posix_close(File),
+            Caller ! {self(), close},
+            gc_loop(Path, undefined);
+        {Caller, quit} ->
+            Caller ! {self(), quit}
+    end.

--- a/tests/libs/eavmlib/tests.erl
+++ b/tests/libs/eavmlib/tests.erl
@@ -24,6 +24,7 @@
 
 start() ->
     etest:test([
+        test_file,
         test_logger,
         test_port,
         test_timer_manager


### PR DESCRIPTION
NIFs are compiled if platform features common POSIX functions `open`, `close`,
`read`, `write` and `unlink`.

Implementation is non-blocking and a more complete implementation of a file
module may require `enif_select`, at least to work with FIFO pipes and devices.

On ESP32, implementation depends on vfs_fat driver which is always blocking
(and does not support select). Qemu-based test writes to a (virtual) SD card.
However, support for SD card still requires C code to mount it which is not
the object of this PR.
    
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
