### PR TITLE
Force non-SMP build with esp32 targets with no SMP primitive

### DIFF
--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -20,6 +20,13 @@
 
 cmake_minimum_required (VERSION 3.13)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# Disable SMP with esp32 socs that have only one core
+if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32h2")
+    message("Disabling SMP as selected target only has one core")
+    set(AVM_DISABLE_SMP YES FORCE)
+endif()
+
 project(atomvm-esp32)
 
 idf_build_get_property(c_compile_options C_COMPILE_OPTIONS)


### PR DESCRIPTION
This should fix ci issue when building esp32 images.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
