### PR TITLE
Fix no-smp ESP32* builds

### DIFF
--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -396,7 +396,8 @@ static void listener_event_remove_from_polling_set(listener_event_t listener_eve
 
 void sys_unregister_listener(GlobalContext *global, struct EventListener *listener)
 {
-    synclist_wrlock(&global->listeners);
+    struct ListHead *dummy = synclist_wrlock(&global->listeners);
+    UNUSED(dummy);
 #ifndef AVM_NO_SMP
     sys_signal(global);
 #endif


### PR DESCRIPTION
This PR fixes a warning that is treated as an error on ESP32 builds that don't support SMP.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
