### PR TITLE
Run the mkimage workflow on any push or PR

### DIFF
--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -7,10 +7,19 @@
 name: esp32-mkimage
 
 on:
-  workflow_run:
-    workflows: ["ESP32 Builds"]
-    types: ["completed"]
-
+  push:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'libs/**'
+      - 'src/platforms/esp32/**'
+      - 'src/libAtomVM/**'
+      - 'tools/packbeam/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'src/platforms/esp32/**'
+      - 'src/libAtomVM/**'
 
 jobs:
   esp32-release:


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
