### PR TITLE
Add enif_select support to esp32

### DIFF
--- a/src/libAtomVM/erl_nif.h
+++ b/src/libAtomVM/erl_nif.h
@@ -201,6 +201,8 @@ ERL_NIF_TERM enif_make_resource(ErlNifEnv *env, void *obj);
  * Please note that `kqueue(2)` and `poll(2)` behave differently for some
  * objects, for example for vnodes and EOF.
  *
+ * On `esp32`, this is currently implemented using `poll(2)`.
+ *
  * @param env current environment
  * @param event event object (typically a file descriptor)
  * @param mode select mode (`ERL_NIF_SELECT_READ` and/or `ERL_NIF_SELECT_WRITE`)

--- a/src/platforms/esp32/components/avm_sys/CMakeLists.txt
+++ b/src/platforms/esp32/components/avm_sys/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 idf_component_register(
     SRCS ${AVM_SYS_COMPONENT_SRCS}
     INCLUDE_DIRS "include"
-    REQUIRES "spi_flash" "soc" "newlib" "pthread" ${ADDITIONAL_COMPONENTS}
+    REQUIRES "spi_flash" "soc" "newlib" "pthread" "vfs" ${ADDITIONAL_COMPONENTS}
     PRIV_REQUIRES "libatomvm" "esp_timer" ${ADDITIONAL_PRIV_REQUIRES}
 )
 

--- a/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
+++ b/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
@@ -24,12 +24,14 @@
 #include "freertos/FreeRTOS.h"
 #include <esp_partition.h>
 #include <freertos/queue.h>
+#include "esp_pthread.h"
 
 #if ESP_IDF_VERSION_MAJOR >= 5
 #include <spi_flash_mmap.h>
 #endif
 
 #include <time.h>
+#include <sys/poll.h>
 
 #include "sys.h"
 
@@ -81,6 +83,13 @@ struct EventListener
 
 struct ESP32PlatformData
 {
+    pthread_t select_thread;
+    bool select_thread_exit;
+    bool eventfd_registered;
+    int signal_fd;
+    int ATOMIC select_events_poll_count;
+    struct pollfd *fds;
+
     // socket_driver
     EventListener *socket_listener;
     struct SyncList sockets;

--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -42,6 +42,7 @@ compile_erlang(test_list_to_binary)
 compile_erlang(test_md5)
 compile_erlang(test_monotonic_time)
 compile_erlang(test_rtc_slow)
+compile_erlang(test_select)
 compile_erlang(test_socket)
 compile_erlang(test_time_and_processes)
 compile_erlang(test_tz)
@@ -56,6 +57,7 @@ add_custom_command(
         test_md5.beam
         test_monotonic_time.beam
         test_rtc_slow.beam
+        test_select.beam
         test_socket.beam
         test_time_and_processes.beam
         test_tz.beam
@@ -67,6 +69,7 @@ add_custom_command(
         "${CMAKE_CURRENT_BINARY_DIR}/test_md5.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_monotonic_time.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_rtc_slow.beam"
+        "${CMAKE_CURRENT_BINARY_DIR}/test_select.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_socket.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_time_and_processes.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_tz.beam"

--- a/src/platforms/esp32/test/main/test_erl_sources/test_select.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_select.erl
@@ -1,0 +1,79 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_select).
+
+-export([start/0]).
+
+% This test relies on a special vfs registered under /pipe.
+
+start() ->
+    {ok, WrFd} = atomvm:posix_open("/pipe/0", [o_wronly]),
+    {ok, RdFd} = atomvm:posix_open("/pipe/0", [o_rdonly]),
+    % Make sure this test vfs works as expected
+    {ok, 1} = atomvm:posix_write(WrFd, <<42>>),
+    {error, eagain} = atomvm:posix_write(WrFd, <<43>>),
+    {ok, <<42>>} = atomvm:posix_read(RdFd, 1),
+    {error, eagain} = atomvm:posix_read(RdFd, 1),
+
+    % Write fd should be selectable.
+    SelectWriteRef = make_ref(),
+    ok = atomvm:posix_select_write(WrFd, self(), SelectWriteRef),
+    ok =
+        receive
+            {select, WrFd, SelectWriteRef, ready_output} -> ok;
+            M -> {unexpected, M}
+        after 200 -> fail
+        end,
+    ok = atomvm:posix_select_stop(WrFd),
+
+    % Write and check that rd is selectable fd should be selectable.
+    {ok, 1} = atomvm:posix_write(WrFd, <<42>>),
+    SelectReadRef = make_ref(),
+    ok = atomvm:posix_select_read(RdFd, self(), SelectReadRef),
+    ok =
+        receive
+            {select, RdFd, SelectReadRef, ready_input} -> ok
+        after 200 -> fail
+        end,
+    {ok, <<42>>} = atomvm:posix_read(RdFd, 1),
+    ok = atomvm:posix_select_read(RdFd, self(), SelectReadRef),
+    ok =
+        receive
+            {select, RdFd, SelectReadRef, _} -> fail
+        after 200 -> ok
+        end,
+    {ok, 1} = atomvm:posix_write(WrFd, <<43>>),
+    ok =
+        receive
+            {select, RdFd, SelectReadRef, ready_input} -> ok;
+            M2 -> {unexpected, M2}
+        after 200 -> fail
+        end,
+    ok = atomvm:posix_select_stop(RdFd),
+    ok =
+        receive
+            Message -> {unexpected, Message}
+        after 200 -> ok
+        end,
+
+    ok = atomvm:posix_close(WrFd),
+    ok = atomvm:posix_close(RdFd),
+    ok.


### PR DESCRIPTION
This is based on a specific select thread loop using esp-idf's `poll(2)`.

Qemu-based test uses a custom simple vfs pipe implementation to demonstrate usage.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
