### PR TITLE
Fix CI issues introduced with #469

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -136,7 +136,9 @@ jobs:
         cd build &&
         cmake .. ${{ matrix.cmake_opts }} &&
         cp ../build_tests/tests/erlang_tests/*.beam tests/erlang_tests/ &&
-        cp ../build_tests/tests/erlang_tests/code_load/*.beam tests/erlang_tests/code_load/ &&
+        cp ../build_tests/tests/erlang_tests/code_load/*.{avm,beam,hrl} tests/erlang_tests/code_load/ &&
+        mkdir -p tests/erlang_tests/code_load/beams/ &&
+        cp ../build_tests/tests/erlang_tests/code_load/beams/*.beam tests/erlang_tests/code_load/beams/ &&
         cp ../build_tests/tests/libs/estdlib/*.avm tests/libs/estdlib/  &&
         cp ../build_tests/tests/libs/eavmlib/*.avm tests/libs/eavmlib/ &&
         cp ../build_tests/tests/libs/alisp/*.avm tests/libs/alisp/ &&

--- a/tests/test.c
+++ b/tests/test.c
@@ -481,9 +481,9 @@ struct Test tests[] = {
 
     TEST_CASE_EXPECTED(test_code_load_binary, 24),
     TEST_CASE_EXPECTED(test_code_load_abs, 24),
-    TEST_CASE_EXPECTED(test_add_avm_pack_binary, 24),
-    TEST_CASE_EXPECTED(test_add_avm_pack_file, 24),
-    TEST_CASE(test_close_avm_pack),
+    TEST_CASE_ATOMVM_ONLY(test_add_avm_pack_binary, 24),
+    TEST_CASE_ATOMVM_ONLY(test_add_avm_pack_file, 24),
+    TEST_CASE_ATOMVM_ONLY(test_close_avm_pack, 0),
 
     // noisy tests, keep them at the end
     TEST_CASE_EXPECTED(spawn_opt_monitor_normal, 1),


### PR DESCRIPTION
Fix 2 CI workflows that stopped working after #469.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
