### PR TITLE
Fix loading of avm data on stm32

### DIFF
--- a/src/platforms/stm32/src/main.c
+++ b/src/platforms/stm32/src/main.c
@@ -130,7 +130,7 @@ int main()
     avmpack_data_init(&avmpack_data->base, &const_avm_pack_info);
     avmpack_data->base.data = flashed_avm;
     avmpack_data->base.in_use = true;
-    list_append(&glb->avmpack_data, &avmpack_data->base.avmpack_head);
+    synclist_append(&glb->avmpack_data, &avmpack_data->base.avmpack_head);
 
     Module *mod = module_new_from_iff_binary(glb, startup_beam, startup_beam_size);
     globalcontext_insert_module(glb, mod);


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
