### PR TITLE
Fix ESP32 test after #469

### DIFF
--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -134,6 +134,7 @@ term avm_test_case(const char *test_module)
     TEST_ASSERT(avmpack_data != NULL);
 
     avmpack_data_init(&avmpack_data->base, &const_avm_pack_info);
+    avmpack_data->base.in_use = true;
     avmpack_data->base.data = main_avm;
     synclist_append(&glb->avmpack_data, &avmpack_data->base.avmpack_head);
 

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -159,7 +159,6 @@ term avm_test_case(const char *test_module)
     port_driver_destroy_all(glb);
 
     globalcontext_destroy(glb);
-    free(avmpack_data);
 
     return ret_value;
 }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
