### PR TITLE
Add enif_monitor

### DIFF
--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -388,8 +388,16 @@ Module *globalcontext_get_module_by_index(GlobalContext *global, int index);
  */
 Module *globalcontext_get_module(GlobalContext *global, AtomString module_name_atom);
 
+/**
+ * @brief remove a monitor
+ *
+ * @details iterate on the list of all processes and then on each monitor
+ * to find a given monitor, and remove it
+ * @param global the global context
+ * @param ref_ticks the reference to the monitor
+ * @return true if the monitor was found
+ */
 bool globalcontext_demonitor(GlobalContext *global, uint64_t ref_ticks);
-void globalcontext_unlink(GlobalContext *global, term pid);
 
 #ifndef __cplusplus
 static inline uint64_t globalcontext_get_ref_ticks(GlobalContext *global)

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1110,9 +1110,13 @@ COLD_FUNC static void dump(Context *ctx)
     struct ListHead *item;
     LIST_FOR_EACH (item, &ctx->monitors_head) {
         struct Monitor *monitor = GET_LIST_ENTRY(item, struct Monitor, monitor_list_head);
-        term_display(stderr, monitor->monitor_pid, ctx);
+        if (term_is_pid(monitor->monitor_obj)) {
+            term_display(stderr, monitor->monitor_obj, ctx);
+        } else {
+            fprintf(stderr, "<resource %p>", (void *) term_to_const_term_ptr(monitor->monitor_obj));
+        }
         fprintf(stderr, " ");
-        if (monitor->linked) {
+        if (monitor->ref_ticks == 0) {
             fprintf(stderr, "<");
         }
         fprintf(stderr, "---> ");

--- a/src/libAtomVM/refc_binary.c
+++ b/src/libAtomVM/refc_binary.c
@@ -77,10 +77,16 @@ void refc_binary_destroy(struct RefcBinary *refc, struct GlobalContext *global)
 {
     UNUSED(global);
 
-    if (refc->resource_type && refc->resource_type->dtor) {
-        ErlNifEnv env;
-        erl_nif_env_partial_init_from_globalcontext(&env, global);
-        refc->resource_type->dtor(&env, (void *) &refc->data);
+    if (refc->resource_type) {
+        if (refc->resource_type->down) {
+            // There may be monitors associated with this resource.
+            destroy_resource_monitors(refc, global);
+        }
+        if (refc->resource_type->dtor) {
+            ErlNifEnv env;
+            erl_nif_env_partial_init_from_globalcontext(&env, global);
+            refc->resource_type->dtor(&env, (void *) &refc->data);
+        }
     }
     free(refc);
 }

--- a/src/libAtomVM/resources.c
+++ b/src/libAtomVM/resources.c
@@ -43,12 +43,17 @@ ErlNifResourceType *enif_init_resource_type(ErlNifEnv *env, const char *name, co
     result->name = strdup(name);
     result->global = env->global;
     list_init(&result->head);
+    list_init(&result->monitors);
     result->dtor = NULL;
     result->stop = NULL;
+    result->down = NULL;
     if (init->members >= 1) {
         result->dtor = init->dtor;
         if (init->members >= 2) {
             result->stop = init->stop;
+            if (init->members >= 3) {
+                result->down = init->down;
+            }
         }
     }
     synclist_append(&env->global->resource_types, &result->head);
@@ -297,4 +302,88 @@ void select_event_count_and_destroy_closed(size_t *read, size_t *write, size_t *
     if (either) {
         *either = either_count;
     }
+}
+
+int enif_monitor_process(ErlNifEnv *env, void *obj, const ErlNifPid *target_pid, ErlNifMonitor *mon)
+{
+    struct RefcBinary *resource = refc_binary_from_data(obj);
+    if (resource->resource_type == NULL || resource->resource_type->down == NULL) {
+        return -1;
+    }
+
+    Context *target = globalcontext_get_process_lock(env->global, *target_pid);
+    if (IS_NULL_PTR(target)) {
+        return 1;
+    }
+
+    struct ResourceMonitor *monitor = context_resource_monitor(target, obj);
+    list_append(&resource->resource_type->monitors, &monitor->resource_list_head);
+    globalcontext_get_process_unlock(env->global, target);
+
+    if (mon) {
+        *mon = monitor->base.ref_ticks;
+    }
+
+    return 0;
+}
+
+int enif_demonitor_process(ErlNifEnv *env, void *obj, const ErlNifMonitor *mon)
+{
+    GlobalContext *global = env->global;
+    struct RefcBinary *resource = refc_binary_from_data(obj);
+    if (resource->resource_type == NULL || resource->resource_type->down == NULL) {
+        return -1;
+    }
+
+    struct ListHead *processes_table_list = synclist_wrlock(&global->processes_table);
+    UNUSED(processes_table_list);
+
+    struct ListHead *item;
+    LIST_FOR_EACH (item, &resource->resource_type->monitors) {
+        struct ResourceMonitor *monitor = GET_LIST_ENTRY(item, struct ResourceMonitor, resource_list_head);
+        if (monitor->base.ref_ticks == *mon) {
+            list_remove(&monitor->resource_list_head);
+            list_remove(&monitor->base.monitor_list_head);
+            free(monitor);
+            synclist_unlock(&global->processes_table);
+            return 0;
+        }
+    }
+
+    synclist_unlock(&global->processes_table);
+
+    return -1;
+}
+
+void destroy_resource_monitors(struct RefcBinary *resource, GlobalContext *global)
+{
+    struct ListHead *processes_table_list = synclist_wrlock(&global->processes_table);
+    UNUSED(processes_table_list);
+    term monitor_obj = ((term) resource->data) | TERM_BOXED_VALUE_TAG;
+
+    struct ListHead *item;
+    struct ListHead *tmp;
+    MUTABLE_LIST_FOR_EACH (item, tmp, &resource->resource_type->monitors) {
+        struct ResourceMonitor *monitor = GET_LIST_ENTRY(item, struct ResourceMonitor, resource_list_head);
+        if (monitor->base.monitor_obj == monitor_obj) {
+            list_remove(&monitor->resource_list_head);
+            list_remove(&monitor->base.monitor_list_head);
+            free(monitor);
+        }
+    }
+
+    synclist_unlock(&global->processes_table);
+}
+
+int enif_compare_monitors(const ErlNifMonitor *monitor1, const ErlNifMonitor *monitor2)
+{
+    uint64_t ref_ticks1 = *monitor1;
+    uint64_t ref_ticks2 = *monitor2;
+    if (ref_ticks1 < ref_ticks2) {
+        return -1;
+    }
+    if (ref_ticks1 > ref_ticks2) {
+        return 1;
+    }
+    return 0;
 }

--- a/src/libAtomVM/resources.h
+++ b/src/libAtomVM/resources.h
@@ -50,8 +50,10 @@ struct ResourceType
     struct ListHead head;
     const char *name;
     GlobalContext *global;
+    struct ListHead monitors;
     ErlNifResourceDtor *dtor;
     ErlNifResourceStop *stop;
+    ErlNifResourceDown *down;
 };
 
 /**
@@ -106,6 +108,14 @@ bool select_event_notify(ErlNifEvent event, bool is_read, bool is_write, GlobalC
  * @param global the global context
  */
 void select_event_count_and_destroy_closed(size_t *read, size_t *write, size_t *either, GlobalContext *global);
+
+/**
+ * @brief Destroy monitors associated with a resource.
+ *
+ * @param resource resource to destroy monitors for
+ * @param global the global context
+ */
+void destroy_resource_monitors(struct RefcBinary *resource, GlobalContext *global);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Continuation of PR #617

NIF monitors are required for enif_select-based drivers that do not leak, so they can release resources when the target process dies.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
