### PR TITLE
Add support to esp-idf 5.0

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -34,6 +34,7 @@ jobs:
         - 4.2.4
         - 4.3.5
         - 4.4.4
+        - 5.0.2
 
     steps:
     - name: Checkout repo

--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -276,7 +276,7 @@ int term_funprint(PrinterFun *fun, term t, const GlobalContext *global)
 
     } else if (term_is_binary(t)) {
         int len = term_binary_size(t);
-        const char *binary_data = term_binary_data(t);
+        const unsigned char *binary_data = (const unsigned char *) term_binary_data(t);
 
         int is_printable = 1;
         for (int i = 0; i < len; i++) {

--- a/src/platforms/esp32/components/avm_builtins/CMakeLists.txt
+++ b/src/platforms/esp32/components/avm_builtins/CMakeLists.txt
@@ -33,7 +33,7 @@ set(AVM_BUILTIN_COMPONENT_SRCS
 idf_component_register(
     SRCS ${AVM_BUILTIN_COMPONENT_SRCS}
     INCLUDE_DIRS "include"
-    PRIV_REQUIRES "libatomvm" "avm_sys" "nvs_flash"
+    PRIV_REQUIRES "libatomvm" "avm_sys" "nvs_flash" "driver" "esp_event" "esp_wifi"
 )
 
 idf_build_set_property(

--- a/src/platforms/esp32/components/avm_builtins/CMakeLists.txt
+++ b/src/platforms/esp32/components/avm_builtins/CMakeLists.txt
@@ -22,13 +22,18 @@ set(AVM_BUILTIN_COMPONENT_SRCS
     "gpio_driver.c"
     "i2c_driver.c"
     "ledc_nif.c"
-    "network_driver.c"
     "nvs_nif.c"
     "rtc_slow_nif.c"
     "socket_driver.c"
     "spi_driver.c"
     "uart_driver.c"
 )
+
+if (IDF_VERSION_MAJOR EQUAL 4)
+    list(APPEND AVM_BUILTIN_COMPONENT_SRCS "network_driver.c")
+else()
+    message(WARNING "network driver is not supported yet with esp-idf 5.x.")
+endif()
 
 idf_component_register(
     SRCS ${AVM_BUILTIN_COMPONENT_SRCS}

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -206,7 +206,7 @@ struct ReadyConnection
 
 QueueHandle_t netconn_events = NULL;
 
-void ESP_IRAM_ATTR socket_callback(struct netconn *netconn, enum netconn_evt evt, u16_t len)
+void IRAM_ATTR socket_callback(struct netconn *netconn, enum netconn_evt evt, u16_t len)
 {
     TRACE("socket_callback netconn=%p, evt=%d, len=%d\n", (void *) netconn, evt, len);
 

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -46,7 +46,6 @@
 #include <lwip/api.h>
 #include <lwip/inet.h>
 #include <lwip/ip_addr.h>
-#include <tcpip_adapter.h>
 #pragma GCC diagnostic pop
 
 //#define ENABLE_TRACE 1

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -204,7 +204,7 @@ struct ReadyConnection
 // This pattern makes sure all accesses to netconn API are serialized. They
 // may be called in different scheduler threads, though.
 
-xQueueHandle netconn_events = NULL;
+QueueHandle_t netconn_events = NULL;
 
 void ESP_IRAM_ATTR socket_callback(struct netconn *netconn, enum netconn_evt evt, u16_t len)
 {

--- a/src/platforms/esp32/components/avm_builtins/uart_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/uart_driver.c
@@ -59,7 +59,7 @@ static NativeHandlerResult uart_driver_consume_mailbox(Context *ctx);
 
 struct UARTData
 {
-    xQueueHandle rxqueue;
+    QueueHandle_t rxqueue;
     EventListener listener;
     term reader_process_pid;
     uint64_t reader_ref_ticks;
@@ -100,7 +100,7 @@ EventListener *uart_interrupt_callback(GlobalContext *glb, EventListener *listen
     struct UARTData *uart_data = GET_LIST_ENTRY(listener, struct UARTData, listener);
 
     uart_event_t event;
-    if (xQueueReceive(uart_data->rxqueue, (void *) &event, (portTickType) portMAX_DELAY)) {
+    if (xQueueReceive(uart_data->rxqueue, (void *) &event, (TickType_t) portMAX_DELAY)) {
         switch (event.type) {
             case UART_DATA:
                 if (uart_data->reader_process_pid != term_invalid_term()) {

--- a/src/platforms/esp32/components/avm_sys/CMakeLists.txt
+++ b/src/platforms/esp32/components/avm_sys/CMakeLists.txt
@@ -27,11 +27,20 @@ set(AVM_SYS_COMPONENT_SRCS
     "platform_defaultatoms.c"
 )
 
+if (IDF_VERSION_MAJOR GREATER_EQUAL 5)
+    set(ADDITIONAL_COMPONENTS "esp_partition")
+    # available starting from v4.4
+    set(ADDITIONAL_PRIV_REQUIRES "esp_hw_support")
+else()
+    set(ADDITIONAL_COMPONENTS "")
+    set(ADDITIONAL_PRIV_REQUIRES "")
+endif()
+
 idf_component_register(
     SRCS ${AVM_SYS_COMPONENT_SRCS}
     INCLUDE_DIRS "include"
-    REQUIRES "spi_flash" "soc" "newlib" "pthread"
-    PRIV_REQUIRES "libatomvm"
+    REQUIRES "spi_flash" "soc" "newlib" "pthread" ${ADDITIONAL_COMPONENTS}
+    PRIV_REQUIRES "libatomvm" "esp_timer" ${ADDITIONAL_PRIV_REQUIRES}
 )
 
 target_compile_features(${COMPONENT_LIB} INTERFACE c_std_11)

--- a/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
+++ b/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
@@ -122,7 +122,7 @@ extern struct PortDriverDefListItem *port_driver_list;
 extern struct NifCollectionDefListItem *nif_collection_list;
 
 extern QueueSetHandle_t event_set;
-extern xQueueHandle event_queue;
+extern QueueHandle_t event_queue;
 void esp32_sys_queue_init();
 
 void sys_event_listener_init(EventListener *listener, void *sender, event_handler_t handler, void *data);

--- a/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
+++ b/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
@@ -25,6 +25,10 @@
 #include <esp_partition.h>
 #include <freertos/queue.h>
 
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include <spi_flash_mmap.h>
+#endif
+
 #include <time.h>
 
 #include "sys.h"

--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -54,6 +54,11 @@
 #include "esp32s3/rom/md5_hash.h"
 #endif
 
+// introduced starting with 4.4
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include <esp_random.h>
+#endif
+
 //#define ENABLE_TRACE
 #include "trace.h"
 

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -43,6 +43,11 @@
 #include <stdint.h>
 #include <sys/socket.h>
 
+// introduced starting with 4.4
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include "esp_chip_info.h"
+#endif
+
 #ifdef HAVE_SOC_CPU_CORES_NUM
 #include "soc/soc_caps.h"
 #endif

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -30,8 +30,6 @@
 // #define ENABLE_TRACE
 #include "trace.h"
 
-#include "esp_event.h"
-#include "esp_event_loop.h"
 #include "esp_heap_caps.h"
 #include "esp_idf_version.h"
 #include "esp_pthread.h"

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -83,7 +83,7 @@ static const char *const revision_atom = "\x8" "revision";
 struct PortDriverDefListItem *port_driver_list;
 struct NifCollectionDefListItem *nif_collection_list;
 
-xQueueHandle event_queue = NULL;
+QueueHandle_t event_queue = NULL;
 QueueSetHandle_t event_set = NULL;
 
 void esp32_sys_queue_init()

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -230,8 +230,8 @@ const void *esp32_sys_mmap_partition(const char *partition_name, spi_flash_mmap_
         ESP_LOGE(TAG, "Failed to map BEAM partition for %s", partition_name);
         return NULL;
     }
-    ESP_LOGI(TAG, "Loaded BEAM partition %s at address 0x%x (size=%i bytes)", partition_name,
-        partition->address, partition->size);
+    ESP_LOGI(TAG, "Loaded BEAM partition %s at address 0x%"PRIx32" (size=%"PRIu32" bytes)",
+        partition_name, partition->address, partition->size);
 
     return mapped_memory;
 }

--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -18,12 +18,10 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
-#include <esp_event.h>
-#include <esp_event_loop.h>
 #include <esp_log.h>
-#include <esp_partition.h>
 #include <esp_system.h>
 #include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 #include <sdkconfig.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
**WARNING: network driver is not available with esp-idf v5.x, so v5.x is not yet officially supported**

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
