### PR TITLE
Fix sleep test by reducing it to contract

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1387,10 +1387,10 @@ term nif_erlang_monotonic_time_1(Context *ctx, int argc, term argv[])
         return make_maybe_boxed_int64(ctx, ts.tv_sec);
 
     } else if (argv[0] == MILLISECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000 + ts.tv_nsec / 1000000);
+        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000UL + ts.tv_nsec / 1000000UL);
 
     } else if (argv[0] == MICROSECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000 + ts.tv_nsec / 1000);
+        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000UL + ts.tv_nsec / 1000UL);
 
     } else {
         RAISE_ERROR(BADARG_ATOM);
@@ -1409,10 +1409,10 @@ term nif_erlang_system_time_1(Context *ctx, int argc, term argv[])
         return make_maybe_boxed_int64(ctx, ts.tv_sec);
 
     } else if (argv[0] == MILLISECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000 + ts.tv_nsec / 1000000);
+        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000UL + ts.tv_nsec / 1000000UL);
 
     } else if (argv[0] == MICROSECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000 + ts.tv_nsec / 1000);
+        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000UL + ts.tv_nsec / 1000UL);
 
     } else {
         RAISE_ERROR(BADARG_ATOM);

--- a/src/libAtomVM/scheduler.c
+++ b/src/libAtomVM/scheduler.c
@@ -52,7 +52,7 @@ static int update_timer_list(GlobalContext *global)
         // Do not fetch the current date if there is no timer
         return -1;
     }
-    uint64_t millis_now = sys_millis(global);
+    uint64_t millis_now = sys_monotonic_millis();
     timer_list_next(tw, millis_now, scheduler_timeout_callback);
     if (tw->next_timer == 0) {
         return -1;
@@ -367,7 +367,7 @@ static void scheduler_timeout_callback(struct TimerListItem *it)
 void scheduler_set_timeout(Context *ctx, avm_int64_t timeout)
 {
     GlobalContext *glb = ctx->global;
-    uint64_t millis_now = sys_millis(glb);
+    uint64_t millis_now = sys_monotonic_millis();
     uint64_t expiry = millis_now + timeout;
 
     context_update_flags(ctx, ~NoFlags, WaitingTimeout);

--- a/src/libAtomVM/sys.h
+++ b/src/libAtomVM/sys.h
@@ -157,6 +157,8 @@ void sys_signal(GlobalContext *glb);
 
 #endif
 
+struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *path);
+
 /**
  * @brief gets wall clock time
  *
@@ -165,15 +167,24 @@ void sys_signal(GlobalContext *glb);
  */
 void sys_time(struct timespec *t);
 
-struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *path);
-
 /**
  * @brief gets monotonic time
  *
- * @details gets monotonic time.
+ * @details gets monotonic time. Must have the same origin as
+ * `sys_monotonic_millis`.
  * @param t the timespec that will be updated.
  */
 void sys_monotonic_time(struct timespec *t);
+
+/**
+ * @brief gets monotonic time in milliseconds.
+ * @details This function must have the same origin as `sys_monotonic_time`.
+ * The native format depends on platform and this function should be fast as it
+ * is used in timers.
+ *
+ * @return a monotonic time in milliseconds
+ */
+uint64_t sys_monotonic_millis();
 
 /**
  * @brief Loads a BEAM module using platform dependent methods.
@@ -220,8 +231,6 @@ void sys_init_platform(GlobalContext *global);
  * global_context_destroy.
  */
 void sys_free_platform(GlobalContext *global);
-
-uint64_t sys_millis(GlobalContext *global);
 
 #ifdef __cplusplus
 }

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -165,8 +165,14 @@ void sys_monotonic_time(struct timespec *t)
 {
     int64_t us_since_boot = esp_timer_get_time();
 
-    t->tv_sec = us_since_boot / 1000000;
-    t->tv_nsec = us_since_boot * 1000;
+    t->tv_sec = us_since_boot / 1000000UL;
+    t->tv_nsec = us_since_boot * 1000UL;
+}
+
+uint64_t sys_monotonic_millis()
+{
+    int64_t usec = esp_timer_get_time();
+    return usec / 1000UL;
 }
 
 void sys_init_platform(GlobalContext *glb)
@@ -200,12 +206,6 @@ void sys_free_platform(GlobalContext *glb)
 {
     struct ESP32PlatformData *platform = glb->platform_data;
     free(platform);
-}
-
-uint64_t sys_millis(GlobalContext *glb)
-{
-    int64_t usec = esp_timer_get_time();
-    return usec / 1000UL;
 }
 
 const void *esp32_sys_mmap_partition(const char *partition_name, spi_flash_mmap_handle_t *handle, int *size)

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -309,6 +309,14 @@ void sys_monotonic_time(struct timespec *t)
     }
 }
 
+uint64_t sys_monotonic_millis()
+{
+    // On generic unix, native format is timespec.
+    struct timespec ts;
+    sys_monotonic_time(&ts);
+    return (ts.tv_nsec / 1000000UL) + (ts.tv_sec * 1000UL);
+}
+
 struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *path)
 {
     TRACE("sys_open_avm_from_file: Going to open: %s\n", path);
@@ -523,18 +531,6 @@ void sys_free_platform(GlobalContext *global)
 #endif
 #endif
     free(platform);
-}
-
-uint64_t sys_millis(GlobalContext *glb)
-{
-    UNUSED(glb);
-    struct timespec ts;
-    if (UNLIKELY(clock_gettime(CLOCK_MONOTONIC, &ts))) {
-        fprintf(stderr, "Failed clock_gettime.\n");
-        AVM_ABORT();
-    }
-
-    return (ts.tv_nsec / 1000000UL) + (ts.tv_sec * 1000UL);
 }
 
 void event_listener_add_to_polling_set(struct EventListener *listener, GlobalContext *global)

--- a/src/platforms/rp2040/src/lib/sys.c
+++ b/src/platforms/rp2040/src/lib/sys.c
@@ -114,9 +114,8 @@ void sys_monotonic_time(struct timespec *t)
     sys_time(t);
 }
 
-uint64_t sys_millis(GlobalContext *glb)
+uint64_t sys_monotonic_millis()
 {
-    UNUSED(glb);
     absolute_time_t now = get_absolute_time();
     uint64_t usec = to_us_since_boot(now);
     return usec / 1000;

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -29,7 +29,6 @@
 #include "trace.h"
 
 void sys_tick_handler();
-void sys_set_timestamp_from_relative_to_abs(struct timespec *t, int32_t millis);
 
 // Monotonically increasing number of milliseconds from reset
 static volatile uint64_t system_millis;
@@ -42,8 +41,9 @@ void sys_tick_handler()
 
 static inline void sys_clock_gettime(struct timespec *t)
 {
-    t->tv_sec = (time_t) system_millis / 1000;
-    t->tv_nsec = ((int32_t) system_millis % 1000) * 1000000;
+    uint64_t now = sys_monotonic_millis();
+    t->tv_sec = (time_t) now / 1000;
+    t->tv_nsec = ((int32_t) now % 1000) * 1000000;
 }
 
 static int32_t timespec_diff_to_ms(struct timespec *timespec1, struct timespec *timespec2)
@@ -72,13 +72,6 @@ void sys_listener_destroy(struct ListHead *item)
     UNUSED(item);
 }
 
-void sys_set_timestamp_from_relative_to_abs(struct timespec *t, int32_t millis)
-{
-    sys_clock_gettime(t);
-    t->tv_sec += millis / 1000;
-    t->tv_nsec += (millis % 1000) * 1000000;
-}
-
 void sys_time(struct timespec *t)
 {
     sys_clock_gettime(t);
@@ -89,9 +82,8 @@ void sys_monotonic_time(struct timespec *t)
     sys_clock_gettime(t);
 }
 
-uint64_t sys_millis(GlobalContext *glb)
+uint64_t sys_monotonic_millis()
 {
-    UNUSED(glb);
     return system_millis;
 }
 

--- a/tests/erlang_tests/sleep.erl
+++ b/tests/erlang_tests/sleep.erl
@@ -20,72 +20,55 @@
 
 -module(sleep).
 
--export([start/0, sleep_1/1, sleep_2/1, sleep_3/1, sleep_4/1]).
+-export([start/0]).
 
+% The only contract of timers is that it is at least a given time
+% We check it works by spawning several processes
 start() ->
-    test_10(0, 0).
+    ok = test_main_sleep(),
+    ok = test_four_sleeping_processes(),
+    0.
 
-% Tolerate 2 failures out of 10
-test_10(10, Failed) when Failed > 2 -> 1;
-test_10(10, _) ->
-    0;
-test_10(N, FailCount) ->
-    case test(N) of
-        ok -> test_10(N + 1, FailCount);
-        fail -> test_10(N + 1, FailCount + 1)
-    end.
+test_main_sleep() ->
+    sub_sleep(242),
+    ok.
 
-test(Index) ->
-    spawn(sleep, sleep_1, [self()]),
-    spawn(sleep, sleep_2, [self()]),
-    spawn(sleep, sleep_3, [self()]),
-    sleep(400),
-    FirstValue =
+test_four_sleeping_processes() ->
+    Pids = spawn_sleeping_processes([182, 242, 202, 222], []),
+    wait_for_sleeping_processes(Pids),
+    ok.
+
+spawn_sleeping_processes([], Pids) ->
+    Pids;
+spawn_sleeping_processes([Timeout | T], Acc) ->
+    Parent = self(),
+    Pid = spawn(fun() ->
+        ok = sub_sleep(Timeout),
+        Parent ! {self(), ok}
+    end),
+    spawn_sleeping_processes(T, [Pid | Acc]).
+
+wait_for_sleeping_processes([]) ->
+    ok;
+wait_for_sleeping_processes([Pid | T]) ->
+    ok =
         receive
-            Value1 ->
-                Value1 * 8
+            {Pid, ok} -> ok
+        after 1000 -> {fail, timeout}
         end,
-    SecondValue =
-        receive
-            Value2 ->
-                Value2 * 16
-        end,
-    ThirdValue =
-        receive
-            Value3 ->
-                Value3 * 32
-        end,
-    FourthValue =
-        receive
-            Value4 ->
-                Value4 * 64
-        end,
-    case FirstValue + SecondValue + ThirdValue + FourthValue of
-        392 ->
-            ok;
-        Other ->
-            erlang:display({Index, fail, Other, 392}),
-            fail
-    end.
+    wait_for_sleeping_processes(T).
 
-sleep_1(ParentPid) ->
-    sleep(100),
-    ParentPid ! 1,
-    spawn(sleep, sleep_4, [ParentPid]).
-
-sleep_2(ParentPid) ->
-    sleep(200),
-    ParentPid ! 2.
-
-sleep_3(ParentPid) ->
-    sleep(300),
-    ParentPid ! 3.
-
-sleep_4(ParentPid) ->
-    sleep(250),
-    ParentPid ! 4.
-
-sleep(T) ->
+sub_sleep(T) ->
+    Before = erlang:monotonic_time(millisecond),
     receive
     after T -> ok
-    end.
+    end,
+    After = erlang:monotonic_time(millisecond),
+    ok =
+        if
+            After - Before >= T ->
+                ok;
+            true ->
+                {fail, Before, After, T}
+        end,
+    ok.


### PR DESCRIPTION
Also rename `sys_millis` to `sys_monotonic_millis`, remove unused parameter and clarify its usage.

Also fix a potential overrun bug on STM32. The milliseconds timer was read twice to generate a timespec, so it could end with 999 when being read for seconds and be incremented by 1 before being read for nsecs, thus returning a timespec 1 second in the past.

This PR fixes flappiness on macOS CI builds.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
