### PR TITLE
Fix typedef macro for GlobalContext

### DIFF
--- a/src/libAtomVM/memory.h
+++ b/src/libAtomVM/memory.h
@@ -44,8 +44,8 @@ extern "C" {
 typedef struct Context Context;
 #endif
 
-#ifndef TYPEDEF_GLOBAL_CONTEXT
-#define TYPEDEF_GLOBAL_CONTEXT
+#ifndef TYPEDEF_GLOBALCONTEXT
+#define TYPEDEF_GLOBALCONTEXT
 typedef struct GlobalContext GlobalContext;
 #endif
 

--- a/src/libAtomVM/refc_binary.h
+++ b/src/libAtomVM/refc_binary.h
@@ -35,8 +35,8 @@ extern "C" {
 typedef struct Context Context;
 #endif
 
-#ifndef TYPEDEF_GLOBAL_CONTEXT
-#define TYPEDEF_GLOBAL_CONTEXT
+#ifndef TYPEDEF_GLOBALCONTEXT
+#define TYPEDEF_GLOBALCONTEXT
 typedef struct GlobalContext GlobalContext;
 #endif
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
