### PR TITLE
Reduce ESP32 compilation warnings

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -34,14 +34,17 @@
 // #define ENABLE_TRACE 1
 #include <trace.h>
 
-#include <esp32_sys.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <esp_log.h>
+#include <esp_sntp.h>
 #include <esp_wifi.h>
+#include <esp32_sys.h>
 #include <lwip/inet.h>
+#pragma GCC diagnostic pop
 
 #include <string.h>
 
-#include <esp_sntp.h>
 
 #define TCPIP_HOSTNAME_MAX_SIZE 255
 

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -40,12 +40,14 @@
 #include "esp32_sys.h"
 #include "platform_defaultatoms.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <esp_log.h>
-
 #include <lwip/api.h>
 #include <lwip/inet.h>
 #include <lwip/ip_addr.h>
 #include <tcpip_adapter.h>
+#pragma GCC diagnostic pop
 
 //#define ENABLE_TRACE 1
 #include "trace.h"

--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -18,7 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "atom.h"
 #include "defaultatoms.h"


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
