### PR TITLE
Compile ESP32 tests with C11

### DIFF
--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -29,10 +29,15 @@ endif()
 
 project(atomvm-esp32)
 
+# esp-idf does not use compile_feature but instead sets version in
+# c_compile_options
+# Ensure project is compiled with at least C11
 idf_build_get_property(c_compile_options C_COMPILE_OPTIONS)
-list(REMOVE_ITEM c_compile_options -std=gnu99)
-list(APPEND c_compile_options -std=gnu11)
-idf_build_set_property(C_COMPILE_OPTIONS ${c_compile_options})
+if (-std=gnu99 IN_LIST c_compile_options )
+    list(REMOVE_ITEM c_compile_options -std=gnu99)
+    list(APPEND c_compile_options -std=gnu11)
+    idf_build_set_property(C_COMPILE_OPTIONS ${c_compile_options})
+endif()
 
 # Options that make sense for this platform
 option(AVM_DISABLE_SMP "Disable SMP." OFF)

--- a/src/platforms/esp32/test/CMakeLists.txt
+++ b/src/platforms/esp32/test/CMakeLists.txt
@@ -31,3 +31,13 @@ set(TEST_COMPONENTS "testable" CACHE STRING "List of components to test")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(atomvm-esp32-test)
+
+# esp-idf does not use compile_feature but instead sets version in
+# c_compile_options
+# Ensure project is compiled with at least C11
+idf_build_get_property(c_compile_options C_COMPILE_OPTIONS)
+if (-std=gnu99 IN_LIST c_compile_options )
+    list(REMOVE_ITEM c_compile_options -std=gnu99)
+    list(APPEND c_compile_options -std=gnu11)
+    idf_build_set_property(C_COMPILE_OPTIONS ${c_compile_options})
+endif()


### PR DESCRIPTION
Also fix issues with 5.x sdk by not requiring C11 if IDF selected C11 or higher.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
