### PR TITLE
Use PRI(u/i)32 as format string for (u)int32_t instead of %i

### DIFF
--- a/src/libAtomVM/debug.c
+++ b/src/libAtomVM/debug.c
@@ -110,7 +110,7 @@ COLD_FUNC void debug_print_processes_list(struct ListHead *processes)
     Context *context = contexts;
     printf("Processes list:\n");
     do {
-        printf("%i: %p\n", context->process_id, (void *) context);
+        printf("%" PRIu32 ": %p\n", context->process_id, (void *) context);
         context = GET_LIST_ENTRY(context->processes_list_head.next, Context, processes_list_head);
     } while (context != contexts);
     printf("\n");

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -536,7 +536,7 @@ static void parse_line_table(uint16_t **line_refs, struct ModuleFilename **filen
     CHECK_FREE_SPACE(4, "Error reading Line chunk: version\n");
     uint32_t version = READ_32_UNALIGNED(pos);
     if (UNLIKELY(version != 0)) {
-        fprintf(stderr, "Warning: Unsupported line version %u.  Line information in stacktraces may be missing\n", version);
+        fprintf(stderr, "Warning: Unsupported line version %" PRIu32 ". Line information in stacktraces may be missing\n", version);
         return;
     }
     pos += 4;

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2889,7 +2889,7 @@ static term nif_erlang_pid_to_list(Context *ctx, int argc, term argv[])
     // 2^32 = 4294967296 (10 chars)
     // 6 chars of static text + '\0'
     char buf[17];
-    snprintf(buf, 17, "<0.%i.0>", term_to_local_process_id(t));
+    snprintf(buf, 17, "<0.%" PRIu32 ".0>", term_to_local_process_id(t));
 
     int str_len = strnlen(buf, 17);
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1719,7 +1719,7 @@ schedule_in:
                             break;
                         }
                         default: {
-                            fprintf(stderr, "Invalid function type %i at index: %i\n", func->type, index);
+                            fprintf(stderr, "Invalid function type %i at index: %" PRIu32 "\n", func->type, index);
                             AVM_ABORT();
                         }
                     }
@@ -1795,7 +1795,7 @@ schedule_in:
                             break;
                         }
                         default: {
-                            fprintf(stderr, "Invalid function type %i at index: %i\n", func->type, index);
+                            fprintf(stderr, "Invalid function type %i at index: %" PRIu32 "\n", func->type, index);
                             AVM_ABORT();
                         }
                     }

--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -190,7 +190,7 @@ int term_funprint(PrinterFun *fun, term t, const GlobalContext *global)
             return ret;
         }
     } else if (term_is_pid(t)) {
-        return fun->print(fun, "<0.%i.0>", term_to_local_process_id(t));
+        return fun->print(fun, "<0.%" PRIu32 ".0>", term_to_local_process_id(t));
 
     } else if (term_is_function(t)) {
         const term *boxed_value = term_to_const_term_ptr(t);

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -279,7 +279,7 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
             }
 
             default:
-                ESP_LOGI(TAG, "Unhandled wifi event: %i.", event_id);
+                ESP_LOGI(TAG, "Unhandled wifi event: %" PRIi32 ".", event_id);
                 break;
         }
 
@@ -302,7 +302,7 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
             }
 
             default:
-                ESP_LOGI(TAG, "Unhandled ip event: %i.", event_id);
+                ESP_LOGI(TAG, "Unhandled ip event: %" PRIi32 ".", event_id);
                 break;
         }
     } else if (event_base == sntp_event_base) {
@@ -315,12 +315,12 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
             }
 
             default:
-                ESP_LOGI(TAG, "Unhandled sntp event: %i.", event_id);
+                ESP_LOGI(TAG, "Unhandled sntp event: %" PRIi32 ".", event_id);
                 break;
         }
 
     } else {
-        ESP_LOGI(TAG, "Unhandled network event: %i.", event_id);
+        ESP_LOGI(TAG, "Unhandled network event: %" PRIi32 ".", event_id);
     }
 }
 


### PR DESCRIPTION
This change will be required for esp-idf 5.0 that has stricter compile options.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
