### PR TITLE
CI: test it on RISC-V 64 / Linux

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["arm32v5", "arm32v7", "arm64v8"]
+        arch: ["arm32v5", "arm32v7", "arm64v8", "riscv64"]
 
         include:
         - arch: "arm32v5"


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
