### PR TITLE
Ensure timer is removed from list when it fires or it is canceled

### DIFF
--- a/libs/eavmlib/src/timer_manager.erl
+++ b/libs/eavmlib/src/timer_manager.erl
@@ -173,11 +173,11 @@ run_timer(MgrPid, Time, TimerRef, Dest, Msg) ->
     Start = erlang:system_time(millisecond),
     receive
         {cancel, From} ->
-            gen_server:reply(From, Time - (erlang:system_time(millisecond) - Start)),
-            MgrPid ! {canceled, self()}
+            MgrPid ! {canceled, self()},
+            gen_server:reply(From, Time - (erlang:system_time(millisecond) - Start))
     after Time ->
-        Dest ! {timeout, TimerRef, Msg},
-        MgrPid ! {fired, self()}
+        MgrPid ! {fired, self()},
+        Dest ! {timeout, TimerRef, Msg}
     end.
 
 %% @private


### PR DESCRIPTION
test_timer_manager test would sometimes fail because of a race condition. The timer sent the timeout message, the client would then send a message to list timers before the timer sent a message to remove the timer fom the list.

The same issue existed with canceled timers.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
