### PR TITLE
Update check-formatting.yaml workflow

### DIFF
--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -30,8 +30,8 @@ jobs:
 
     - uses: erlef/setup-beam@v1.10.0
       with:
-        otp-version: 23.0
-        elixir-version: 1.9
+        otp-version: 24.3
+        elixir-version: 1.12
 
     - name: "Install run-clang-format"
       run: |


### PR DESCRIPTION
Updates the currently broken workflow, which emmits an error that rebarr3 is compiled for a later version.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
