### PR TITLE
Fix tests to run on OTP24, 25 and 26

### DIFF
--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -24,29 +24,47 @@ jobs:
   run-tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: ["macos-latest", "ubuntu-20.04"]
-        otp: ["21", "22", "23"]
-
         include:
         - os: "ubuntu-20.04"
           test_erlang_opts: "-s prime_smp"
-
-        - os: "macos-latest"
-          cmake_opts: "-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
-
-        - os: "macos-latest"
           otp: "21"
-          path_prefix: "/usr/local/opt/erlang@21/bin:"
 
-        - os: "macos-latest"
+        - os: "ubuntu-20.04"
+          test_erlang_opts: "-s prime_smp"
           otp: "22"
-          path_prefix: "/usr/local/opt/erlang@22/bin:"
+
+        - os: "ubuntu-20.04"
+          test_erlang_opts: "-s prime_smp"
+          otp: "23"
+
+        - os: "ubuntu-22.04"
+          test_erlang_opts: "-s prime_smp"
+          otp: "24"
+
+        - os: "ubuntu-22.04"
+          test_erlang_opts: "-s prime_smp"
+          otp: "25"
+
+        - os: "ubuntu-22.04"
+          test_erlang_opts: "-s prime_smp"
+          otp: "26"
 
         - os: "macos-latest"
           otp: "23"
           path_prefix: "/usr/local/opt/erlang@23/bin:"
+          cmake_opts: "-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
 
+        - os: "macos-latest"
+          otp: "24"
+          path_prefix: "/usr/local/opt/erlang@24/bin:"
+          cmake_opts: "-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
+
+        - os: "macos-latest"
+          otp: "25"
+          path_prefix: "/usr/local/opt/erlang@25/bin:"
+          cmake_opts: "-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
     steps:
     # Setup
     - name: "Checkout repo"
@@ -73,7 +91,7 @@ jobs:
     - name: "Build: create build dir"
       run: mkdir build
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: cache
       with:
         path: 'build/tests/**/*.beam'

--- a/tests/erlang_tests/test_system_flag.erl
+++ b/tests/erlang_tests/test_system_flag.erl
@@ -31,21 +31,27 @@ test_schedulers_online() ->
         % probably not an SMP build
         1 ->
             ok;
-        N when is_integer(N) ->
-            N = erlang:system_flag(schedulers_online, 1),
+        Schedulers when is_integer(Schedulers) ->
+            Online = erlang:system_info(schedulers_online),
+            Online = erlang:system_flag(schedulers_online, 1),
+            true = Online =< Schedulers,
             1 = erlang:system_info(schedulers_online),
             1 = erlang:system_flag(schedulers_online, 2),
             2 = erlang:system_info(schedulers_online),
-            M = N + 2,
+            Overflow =
+                if
+                    Online < Schedulers -> Schedulers;
+                    true -> Online
+                end + 1,
             ok =
                 try
-                    erlang:system_flag(schedulers_online, M),
+                    erlang:system_flag(schedulers_online, Overflow),
                     expected_error
                 catch
                     error:badarg -> ok
                 end,
-            2 = erlang:system_flag(schedulers_online, N),
-            N = erlang:system_info(schedulers_online),
+            2 = erlang:system_flag(schedulers_online, Online),
+            Online = erlang:system_info(schedulers_online),
             ok =
                 try
                     erlang:system_flag(schedulers_online, 0),
@@ -53,6 +59,6 @@ test_schedulers_online() ->
                 catch
                     error:badarg -> ok
                 end,
-            N = erlang:system_info(schedulers_online),
+            Online = erlang:system_info(schedulers_online),
             ok
     end.

--- a/tests/erlang_tests/tuple_size0.erl
+++ b/tests/erlang_tests/tuple_size0.erl
@@ -23,7 +23,18 @@
 -export([start/0, make_tuple/0]).
 
 start() ->
-    erts_debug:flat_size(make_tuple()).
+    EmptyTupleSize =
+        case erlang:system_info(machine) of
+            "BEAM" ->
+                case erlang:system_info(version) >= "13." of
+                    true -> 0;
+                    false -> 1
+                end;
+            "ATOM" ->
+                1
+        end,
+    EmptyTupleSize = erts_debug:flat_size(make_tuple()),
+    0.
 
 make_tuple() ->
     {}.

--- a/tests/erlang_tests/tuple_size5.erl
+++ b/tests/erlang_tests/tuple_size5.erl
@@ -23,7 +23,20 @@
 -export([start/0, make_tuple/0]).
 
 start() ->
-    erts_debug:flat_size(make_tuple()).
+    EmptyTupleSize =
+        case erlang:system_info(machine) of
+            "BEAM" ->
+                case erlang:system_info(version) >= "13." of
+                    true -> 0;
+                    false -> 1
+                end;
+            "ATOM" ->
+                1
+        end,
+    EmptyTupleSize = erts_debug:flat_size({}),
+    TupleSize = erts_debug:flat_size(make_tuple()),
+    TupleSize = 6 + EmptyTupleSize,
+    0.
 
 make_tuple() ->
     {{{{}}}}.

--- a/tests/erlang_tests/tuple_size6.erl
+++ b/tests/erlang_tests/tuple_size6.erl
@@ -23,7 +23,20 @@
 -export([start/0, make_tuple/0]).
 
 start() ->
-    erts_debug:flat_size(make_tuple()).
+    EmptyTupleSize =
+        case erlang:system_info(machine) of
+            "BEAM" ->
+                case erlang:system_info(version) >= "13." of
+                    true -> 0;
+                    false -> 1
+                end;
+            "ATOM" ->
+                1
+        end,
+    EmptyTupleSize = erts_debug:flat_size({}),
+    TupleSize = erts_debug:flat_size(make_tuple()),
+    TupleSize = 16 + EmptyTupleSize,
+    0.
 
 make_tuple() ->
     {[{[{[{[{}]}]}]}]}.

--- a/tests/erlang_tests/tuples_and_list_size0.erl
+++ b/tests/erlang_tests/tuples_and_list_size0.erl
@@ -23,7 +23,20 @@
 -export([start/0, make_tuples_and_list/0]).
 
 start() ->
-    erts_debug:flat_size(make_tuples_and_list()).
+    EmptyTupleSize =
+        case erlang:system_info(machine) of
+            "BEAM" ->
+                case erlang:system_info(version) >= "13." of
+                    true -> 0;
+                    false -> 1
+                end;
+            "ATOM" ->
+                1
+        end,
+    EmptyTupleSize = erts_debug:flat_size({}),
+    TupleAndListSize = erts_debug:flat_size(make_tuples_and_list()),
+    TupleAndListSize = 2 + EmptyTupleSize,
+    0.
 
 make_tuples_and_list() ->
     [{}].

--- a/tests/test.c
+++ b/tests/test.c
@@ -208,15 +208,15 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(simple_list_size0, 2),
     TEST_CASE_EXPECTED(simple_list_size1, 10),
 
-    TEST_CASE_EXPECTED(tuple_size0, 1),
+    TEST_CASE(tuple_size0),
     TEST_CASE_EXPECTED(tuple_size1, 2),
     TEST_CASE_EXPECTED(tuple_size2, 3),
     TEST_CASE_EXPECTED(tuple_size3, 4),
     TEST_CASE_EXPECTED(tuple_size4, 13),
-    TEST_CASE_EXPECTED(tuple_size5, 7),
-    TEST_CASE_EXPECTED(tuple_size6, 17),
+    TEST_CASE(tuple_size5),
+    TEST_CASE(tuple_size6),
 
-    TEST_CASE_EXPECTED(tuples_and_list_size0, 3),
+    TEST_CASE(tuples_and_list_size0),
     TEST_CASE_EXPECTED(tuples_and_list_size1, 5),
     TEST_CASE_EXPECTED(tuples_and_list_size2, 10),
 


### PR DESCRIPTION
- various size tests failed with OTP25+ following OTP-17608
- test_binary_to_term failed with OTP26 following OTP-18505
- test_gen_server failed with OTP24+ following OTP-16718
- test_maps failed with OTP24+ as badarg is preferred over bad_map when both exception would occur (passing not a function and not a map to map:filter/2)
- test_maps failed with OTP26 as iteration order changed following OTP-18414

Change fail-fast strategy

Update CI matrix to 21-26 on Ubuntu and 23-25 on macOS (versions currently supported by Homebrew)

Also update cache action version to 3 as 2 is deprecated

Also fix test_system_flag test for BEAM on AMD CPUs

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
