### PR TITLE
Fix monotonic_time on esp32 (fix #597)

### DIFF
--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -169,7 +169,7 @@ void sys_monotonic_time(struct timespec *t)
     int64_t us_since_boot = esp_timer_get_time();
 
     t->tv_sec = us_since_boot / 1000000UL;
-    t->tv_nsec = us_since_boot * 1000UL;
+    t->tv_nsec = (us_since_boot % 1000000UL) * 1000UL;
 }
 
 uint64_t sys_monotonic_millis()

--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -37,6 +37,7 @@ function(compile_erlang module_name)
 endfunction()
 
 compile_erlang(test_md5)
+compile_erlang(test_monotonic_time)
 compile_erlang(test_rtc_slow)
 compile_erlang(test_socket)
 compile_erlang(test_time_and_processes)
@@ -47,6 +48,7 @@ add_custom_command(
     COMMAND HostAtomVM-prefix/src/HostAtomVM-build/tools/packbeam/PackBEAM -i esp32_test_modules.avm
         HostAtomVM-prefix/src/HostAtomVM-build/libs/atomvmlib.avm
         test_md5.beam
+        test_monotonic_time.beam
         test_rtc_slow.beam
         test_socket.beam
         test_time_and_processes.beam
@@ -54,6 +56,7 @@ add_custom_command(
     DEPENDS
         HostAtomVM
         "${CMAKE_CURRENT_BINARY_DIR}/test_md5.beam"
+        "${CMAKE_CURRENT_BINARY_DIR}/test_monotonic_time.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_rtc_slow.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_socket.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_time_and_processes.beam"

--- a/src/platforms/esp32/test/main/test_erl_sources/test_monotonic_time.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_monotonic_time.erl
@@ -1,0 +1,45 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_monotonic_time).
+-export([start/0]).
+
+start() ->
+    ok = test_monotonic_time(),
+    ok.
+
+test_monotonic_time() ->
+    test_monotonic_time([500, 1000, 1500, 2500, 5000]).
+
+test_monotonic_time([]) ->
+    ok;
+test_monotonic_time([Delay | Tail]) ->
+    BeginMonotonic = erlang:monotonic_time(millisecond),
+    BeginSystem = erlang:system_time(millisecond),
+    timer:sleep(Delay),
+    EndMonotonic = erlang:monotonic_time(millisecond),
+    EndSystem = erlang:system_time(millisecond),
+    Mono = EndMonotonic - BeginMonotonic,
+    System = EndSystem - BeginSystem,
+    true = Mono >= Delay,
+    true = Mono + 10 > System,
+    true = System + 10 > Mono,
+    true = System + 10 > Delay,
+    test_monotonic_time(Tail).

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -170,6 +170,12 @@ TEST_CASE("test_md5", "[test_run]")
     TEST_ASSERT(ret_value == OK_ATOM);
 }
 
+TEST_CASE("test_monotonic_time", "[test_run]")
+{
+    term ret_value = avm_test_case("test_monotonic_time.beam");
+    TEST_ASSERT(ret_value == OK_ATOM);
+}
+
 TEST_CASE("test_time_and_processes", "[test_run]")
 {
     term ret_value = avm_test_case("test_time_and_processes.beam");


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
