### PR TITLE
Clean up binary heap size calculations

### DIFF
--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -181,8 +181,8 @@ term externalterm_to_binary(Context *ctx, term t)
     //
     // Ensure enough free space in heap for binary
     //
-    int size_in_terms = term_binary_data_size_in_terms(len);
-    if (UNLIKELY(memory_ensure_free(ctx, size_in_terms + 1) != MEMORY_GC_OK)) {
+    int size_in_terms = term_binary_heap_size(len);
+    if (UNLIKELY(memory_ensure_free(ctx, size_in_terms) != MEMORY_GC_OK)) {
         fprintf(stderr, "Unable to ensure %i free words in heap\n", size_in_terms);
         return term_invalid_term();
     }

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -832,7 +832,7 @@ static term nif_erlang_iolist_to_binary_1(Context *ctx, int argc, term argv[])
             RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(bin_size) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_heap_size(bin_size), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         free(bin_buf);
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
@@ -1964,7 +1964,7 @@ static term nif_erlang_atom_to_binary_2(Context *ctx, int argc, term argv[])
 
     int atom_len = atom_string_len(atom_string);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(atom_len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_heap_size(atom_len), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2047,7 +2047,7 @@ static term nif_erlang_integer_to_binary_2(Context *ctx, int argc, term argv[])
     avm_int64_t int_value = term_maybe_unbox_int64(value);
     size_t len = lltoa(int_value, base, NULL);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_heap_size(len), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term result = term_create_empty_binary(len, &ctx->heap, ctx->global);
@@ -2198,7 +2198,7 @@ static term nif_erlang_float_to_binary(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_heap_size(len), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -2255,7 +2255,7 @@ static term nif_erlang_list_to_binary_1(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_heap_size(len), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(BADARG_ATOM);
     }
 
@@ -2586,7 +2586,7 @@ static term nif_erlang_system_info(Context *ctx, int argc, term argv[])
         char buf[128];
         snprintf(buf, 128, "%s-%s-%s", SYSTEM_NAME, SYSTEM_VERSION, SYSTEM_ARCHITECTURE);
         size_t len = strnlen(buf, 128);
-        if (memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(len), MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
+        if (memory_ensure_free_opt(ctx, term_binary_heap_size(len), MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_literal_binary((const uint8_t *) buf, len, &ctx->heap, ctx->global);
@@ -3572,7 +3572,7 @@ static term base64_encode(Context *ctx, int argc, term argv[], bool return_binar
         }
         if (src_size == 0) {
             if (return_binary) {
-                if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_heap_size(0), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                     RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                 }
                 return term_create_empty_binary(0, &ctx->heap, ctx->global);
@@ -3614,7 +3614,7 @@ static term base64_encode(Context *ctx, int argc, term argv[], bool return_binar
     }
     size_t dst_size_with_pad = dst_size + pad;
     size_t heap_free = return_binary ?
-        term_binary_data_size_in_terms(dst_size_with_pad) + BINARY_HEADER_SIZE
+        term_binary_heap_size(dst_size_with_pad)
         : 2*dst_size_with_pad;
     if (UNLIKELY(memory_ensure_free_opt(ctx, heap_free, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
@@ -3719,7 +3719,7 @@ static term base64_decode(Context *ctx, int argc, term argv[], bool return_binar
         }
         if (src_size == 0) {
             if (return_binary) {
-                if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_heap_size(0), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                     RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                 }
                 return term_create_empty_binary(0, &ctx->heap, ctx->global);
@@ -3761,7 +3761,7 @@ static term base64_decode(Context *ctx, int argc, term argv[], bool return_binar
     }
     dst_size -= pad;
     size_t heap_free = return_binary ?
-        term_binary_data_size_in_terms(dst_size) + BINARY_HEADER_SIZE
+        term_binary_heap_size(dst_size)
         : 2*dst_size;
     if (UNLIKELY(memory_ensure_free_opt(ctx, heap_free, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -3719,7 +3719,7 @@ wait_timeout_trap_handler:
 
                     TRACE("bs_init2/6, fail=%u size=%li words=%u regs=%u dreg=%c%i\n", (unsigned) fail, size_val, (unsigned) words, (unsigned) regs, T_DEST_REG(dreg_type, dreg));
 
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(size_val) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_heap_size(size_val), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     term t = term_create_empty_binary(size_val, &ctx->heap, ctx->global);
@@ -3768,7 +3768,7 @@ wait_timeout_trap_handler:
 
                     TRACE("bs_init_bits/6, fail=%i size=%li words=%i regs=%i dreg=%c%i\n", fail, size_val, words, regs, T_DEST_REG(dreg_type, dreg));
 
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(size_val / 8) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_heap_size(size_val / 8), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     term t = term_create_empty_binary(size_val / 8, &ctx->heap, ctx->global);
@@ -4203,7 +4203,7 @@ wait_timeout_trap_handler:
                 TRACE("bs_init_writable/0\n");
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_heap_size(0), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     term t = term_create_empty_binary(0, &ctx->heap, ctx->global);
@@ -4267,7 +4267,7 @@ wait_timeout_trap_handler:
 
                     size_t src_size = term_binary_size(src);
                     // TODO: further investigate extra_val
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, src_size + term_binary_data_size_in_terms(size_val / 8) + extra_val + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, src_size + term_binary_heap_size(size_val / 8) + extra_val, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     DECODE_COMPACT_TERM(src, code, i, src_off)
@@ -4322,7 +4322,7 @@ wait_timeout_trap_handler:
                     TRACE("bs_private_append/6, fail=%u size=%li unit=%u src=0x%lx dreg=%c%i\n", (unsigned) fail, size_val, (unsigned) unit, src, T_DEST_REG(dreg_type, dreg));
 
                     size_t src_size = term_binary_size(src);
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, src_size + term_binary_data_size_in_terms(size_val / 8) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, src_size + term_binary_heap_size(size_val / 8), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     DECODE_COMPACT_TERM(src, code, i, src_off)
@@ -6517,7 +6517,7 @@ wait_timeout_trap_handler:
                         RAISE_ERROR(UNSUPPORTED_ATOM);
                     }
                     context_clean_registers(ctx, live);
-                    if (UNLIKELY(memory_ensure_free_opt(ctx, alloc + term_binary_data_size_in_terms(binary_size / 8) + BINARY_HEADER_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_opt(ctx, alloc + term_binary_heap_size(binary_size / 8), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                     term t = term_create_empty_binary(binary_size / 8, &ctx->heap, ctx->global);

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -893,6 +893,18 @@ static inline int term_binary_data_size_in_terms(uint32_t size)
 }
 
 /**
+ * @brief The size (in terms) of a binary of size-many bytes in the heap
+ *
+ * @details Returns the number of terms needed in the heap to store a binary of a given size (in bytes)
+ * @param size the size of the binary (in bytes)
+ * @return the size (in terms) of a binary of size-many bytes in the heap
+ */
+static inline int term_binary_heap_size(uint32_t size)
+{
+    return term_binary_data_size_in_terms(size) + BINARY_HEADER_SIZE;
+}
+
+/**
  * @brief Gets binary size
  *
  * @details Returns binary size for a given binary term.
@@ -1005,7 +1017,7 @@ static inline size_t term_sub_binary_heap_size(term binary, size_t len)
     if (term_is_refc_binary(binary) && len >= SUB_BINARY_MIN) {
         return TERM_BOXED_SUB_BINARY_SIZE;
     } else {
-        return term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE;
+        return term_binary_heap_size(len);
     }
 }
 

--- a/src/platforms/esp32/components/avm_builtins/rtc_slow_nif.c
+++ b/src/platforms/esp32/components/avm_builtins/rtc_slow_nif.c
@@ -61,7 +61,7 @@ static term nif_esp_rtc_slow_get_binary(Context *ctx, int argc, term argv[])
     if (checksum != rtc_slow_data_checksum) {
         RAISE_ERROR(BADARG_ATOM);
     }
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(rtc_slow_data_size) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(rtc_slow_data_size)) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -651,7 +651,7 @@ static NativeHandlerResult do_receive_data(Context *ctx)
 
     int recv_terms_size;
     if (socket_data->binary) {
-        recv_terms_size = term_binary_data_size_in_terms(data_len) + BINARY_HEADER_SIZE;
+        recv_terms_size = term_binary_heap_size(data_len);
     } else {
         recv_terms_size = data_len * 2;
     }

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -543,13 +543,13 @@ static term spidriver_write_read(Context *ctx, term req)
     if (err_term != OK_ATOM) {
         ESP_LOGE(TAG, "Invalid transaction");
         // gc is ok as err_term is an atom
-        if (UNLIKELY(memory_ensure_free(ctx, 3) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
             return OUT_OF_MEMORY_ATOM;
         }
         return create_pair(ctx, ERROR_ATOM, err_term);
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(output_size) + BINARY_HEADER_SIZE + 3) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(output_size) + TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
         return OUT_OF_MEMORY_ATOM;
     }
     term output_data_term = term_create_empty_binary(output_size, &ctx->heap, ctx->global);

--- a/src/platforms/esp32/components/avm_builtins/uart_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/uart_driver.c
@@ -104,7 +104,7 @@ EventListener *uart_interrupt_callback(GlobalContext *glb, EventListener *listen
         switch (event.type) {
             case UART_DATA:
                 if (uart_data->reader_process_pid != term_invalid_term()) {
-                    int bin_size = term_binary_data_size_in_terms(event.size) + BINARY_HEADER_SIZE;
+                    int bin_size = term_binary_heap_size(event.size);
 
                     Heap heap;
                     if (UNLIKELY(memory_init_heap(&heap, bin_size + REF_SIZE + TUPLE_SIZE(2) * 2) != MEMORY_GC_OK)) {
@@ -329,7 +329,7 @@ static void uart_driver_do_read(Context *ctx, term msg)
     uart_get_buffered_data_len(uart_data->uart_num, &count);
 
     if (count > 0) {
-        int bin_size = term_binary_data_size_in_terms(count) + BINARY_HEADER_SIZE;
+        int bin_size = term_binary_heap_size(count);
         if (UNLIKELY(memory_ensure_free(ctx, bin_size + TUPLE_SIZE(2) * 2 + REF_SIZE) != MEMORY_GC_OK)) {
             ESP_LOGE(TAG, "[uart_driver_do_read] Failed to allocate space for return value");
             globalcontext_send_message(glb, local_pid, MEMORY_ATOM);

--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -102,7 +102,7 @@ static term nif_esp_random_bytes(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
     if (len == 0) {
-        if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(0) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(0)) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term binary = term_create_empty_binary(0, &ctx->heap, ctx->global);
@@ -113,7 +113,7 @@ static term nif_esp_random_bytes(Context *ctx, int argc, term argv[])
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         esp_fill_random(buf, len);
-        if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(len)) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         term binary = term_from_literal_binary(buf, len, &ctx->heap, ctx->global);
@@ -388,7 +388,7 @@ static term nif_rom_md5(Context *ctx, int argc, term argv[])
     MD5Update(&md5, (const unsigned char *) term_binary_data(data), term_binary_size(data));
     MD5Final(digest, &md5);
     #endif
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(MD5_DIGEST_LENGTH) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(MD5_DIGEST_LENGTH)) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     return term_from_literal_binary(digest, MD5_DIGEST_LENGTH, &ctx->heap, ctx->global);

--- a/src/platforms/generic_unix/lib/platform_nifs.c
+++ b/src/platforms/generic_unix/lib/platform_nifs.c
@@ -57,7 +57,7 @@ static term nif_openssl_md5(Context *ctx, int argc, term argv[])
 
     unsigned char digest[MD5_DIGEST_LENGTH];
     MD5((const unsigned char *) term_binary_data(data), term_binary_size(data), digest);
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(MD5_DIGEST_LENGTH) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(MD5_DIGEST_LENGTH)) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     return term_from_literal_binary(digest, MD5_DIGEST_LENGTH, &ctx->heap, ctx->global);
@@ -81,7 +81,7 @@ static term nif_openssl_rand_bytes(Context *ctx, int argc, term argv[])
         RAISE_ERROR(LOW_ENTROPY_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_data_size_in_terms(n) + BINARY_HEADER_SIZE) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(n)) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term ret = term_from_literal_binary(buf, n, &ctx->heap, ctx->global);

--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -709,7 +709,7 @@ static EventListener *active_recv_callback(GlobalContext *glb, EventListener *ba
         TRACE("socket_driver|active_recv_callback: received data of len %li from fd %i\n", len, socket_data->sockfd);
         int ensure_packet_avail;
         if (socket_data->binary) {
-            ensure_packet_avail = term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE;
+            ensure_packet_avail = term_binary_heap_size(len);
         } else {
             ensure_packet_avail = len * 2;
         }
@@ -782,7 +782,7 @@ static EventListener *passive_recv_callback(GlobalContext *glb, EventListener *b
         TRACE("socket_driver|passive_recv_callback: passive received data of len: %li\n", len);
         int ensure_packet_avail;
         if (socket_data->binary) {
-            ensure_packet_avail = term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE;
+            ensure_packet_avail = term_binary_heap_size(len);
         } else {
             ensure_packet_avail = len * 2;
         }
@@ -846,7 +846,7 @@ static EventListener *active_recvfrom_callback(GlobalContext *glb, EventListener
     } else {
         int ensure_packet_avail;
         if (socket_data->binary) {
-            ensure_packet_avail = term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE;
+            ensure_packet_avail = term_binary_heap_size(len);
         } else {
             ensure_packet_avail = len * 2;
         }
@@ -912,7 +912,7 @@ static EventListener *passive_recvfrom_callback(GlobalContext *glb, EventListene
     } else {
         int ensure_packet_avail;
         if (socket_data->binary) {
-            ensure_packet_avail = term_binary_data_size_in_terms(len) + BINARY_HEADER_SIZE;
+            ensure_packet_avail = term_binary_heap_size(len);
         } else {
             ensure_packet_avail = len * 2;
         }


### PR DESCRIPTION
This PR refactors uses of `term_binary_data_size_in_terms` into a new `term_binary_heap_size` function that encapsulates the number of terms needed in the heap to store a binary.  This change allows users to calculate needed heap sizes without having to remember to add the `BINARY_HEADER_SIZE` macro to the calculation.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
