### PR TITLE
Fix test_gc on OTP26 on Linux using official docker image

### DIFF
--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -23,6 +23,7 @@ on:
 jobs:
   run-tests:
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +51,7 @@ jobs:
         - os: "ubuntu-22.04"
           test_erlang_opts: "-s prime_smp"
           otp: "26"
+          container: erlang:26
 
         - os: "macos-latest"
           otp: "23"
@@ -73,15 +75,21 @@ jobs:
         submodules: 'recursive'
 
     - uses: erlef/setup-beam@v1
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.container == ''
       with:
         otp-version: ${{ matrix.otp }}
 
     - name: "Install deps (Linux)"
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.container == ''
       run: |
         sudo apt update -y
         sudo apt install -y cmake gperf zlib1g-dev ninja-build
+
+    - name: "Install deps (container)"
+      if: runner.os == 'Linux' && matrix.container != ''
+      run: |
+        apt update -y
+        apt install -y cmake gperf zlib1g-dev ninja-build
 
     - name: "Install deps (macOS)"
       if: runner.os == 'macOS'


### PR DESCRIPTION
Test weirdfully fails with binary provided by erlef/setup-beam.
Use [Erlang/OTP official docker image](https://registry.hub.docker.com/_/erlang/) instead.
See erlef/setup-beam#220

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
