### PR TITLE
Update esp32 `flash.sh` tool for IDF 5.x compatibility

### DIFF
--- a/tools/dev/flash.sh
+++ b/tools/dev/flash.sh
@@ -36,7 +36,7 @@ echo "%%"
 echo "%% Flashing ${1} (size=${filesize}k)"
 echo "%%"
 
-exec "${IDF_PATH}/components/esptool_py/esptool/esptool.py" \
+exec `which esptool.py` \
     --chip auto \
     --port "${FLASH_SERIAL_PORT}" \
     --baud "${FLASH_BAUD_RATE}" \


### PR DESCRIPTION
The esptool.py resides in a different in ESP-IDF v5.x than it does in v4.x, and it can also be installed independantly from ESP-IDF. This updates the `flash.sh` tool to use whichever esptool.py is active in the users path. This is prepended to the `PATH` when the IDF is activated using `. ./export.sh`, so it will work with both major versions. This also allows the user to flash the most recent build again without having to first activate the ESP-IDF, if they have esptool.py installed independantly, which is quite likely as it simplifies working with rebar3.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
