### PR TITLE
ESP32: fix loading avm from partition when using add_avm_pack_file

### DIFF
--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -278,7 +278,7 @@ struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *pa
         }
 
         struct ESP32PartAVMPack *part_avm = malloc(sizeof(struct ESP32PartAVMPack));
-        if (IS_NULL_PTR(avmpack_data)) {
+        if (IS_NULL_PTR(part_avm)) {
             // use esp_partition_munmap
             return NULL;
         }


### PR DESCRIPTION
atomvm:add_avm_pack_file("/dev/partition/by-name/ ...) wasn't working due to a small bug.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
