### PR TITLE
Allow registering .avm using name

### DIFF
--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -535,14 +535,12 @@ For example:
     AVMData = ... %% load AVM data into memory as a binary
     ok = atomvm:add_avm_pack_binary(AVMData, [{name, my_avm}])
 
-You can also load AVM data from a file (on the `generic_unix` platform) or from a flash partition (on ESP32 platforms) using the `atomvm:add_avm_pack_file/2` function.  Specify a string (or binary) as the path to the AVM file, together with a list of options.
+You can also load AVM data from a file (on the `generic_unix` platform) or from a flash partition (on ESP32 platforms) using the `atomvm:add_avm_pack_file/2` function.  Specify a string (or binary) as the path to the AVM file, together with a list of options, such as `name`.
 
 For example:
 
     %% erlang
-    ok = atomvm:add_avm_pack_file("/path/to/file.avm", [])
-
-> Note.  Currently, the options parameter is ignored, so use the empty list (`[]`) for foward compatibility.
+    ok = atomvm:add_avm_pack_file("/path/to/file.avm", [{name, my_avm}])
 
 On `esp32` platforms, the partition name should be prefixed with the string `/dev/partition/by-name/`.  Thus, for example, if you specify `/dev/partition/by-name/main2.avm` as the partition, the ESP32 flash should contain a data partition with the name `main2.avm`
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3418,6 +3418,11 @@ static term nif_atomvm_add_avm_pack_file(Context *ctx, int argc, term argv[])
 
     term abs_term = argv[0];
 
+    term opts = argv[1];
+    if (!term_is_list(argv[1])) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
     int ok;
     char *abs = interop_list_to_string(abs_term, &ok);
     if (UNLIKELY(!ok)) {
@@ -3428,6 +3433,15 @@ static term nif_atomvm_add_avm_pack_file(Context *ctx, int argc, term argv[])
     if (IS_NULL_PTR(avmpack_data)) {
         free(abs);
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    term name = interop_kv_get_value_default(opts, ATOM_STR("\x4", "name"), UNDEFINED_ATOM, ctx->global);
+    if (!term_is_atom(name)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    if (name != UNDEFINED_ATOM) {
+        avmpack_data->name_atom_id = term_to_atom_index(name);
     }
     synclist_append(&ctx->global->avmpack_data, &avmpack_data->avmpack_head);
 


### PR DESCRIPTION
Add support to name option to atomvm:add_avm_pack_file/2.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
