### PR TITLE
Fix check-formatting.yaml GitHub workflow

### DIFF
--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: erlef/setup-beam@v1.10.0
+    - uses: erlef/setup-beam@v1
       with:
         otp-version: 24.3
         elixir-version: 1.12


### PR DESCRIPTION
Use setup-beam@v1 instead of a specific (old) version.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
