### PR TITLE
Fix messages printed from io:format

### DIFF
--- a/examples/erlang/esp32/tcp_server_blink.erl
+++ b/examples/erlang/esp32/tcp_server_blink.erl
@@ -43,7 +43,7 @@ start() ->
 tcp_server_start() ->
     case gen_tcp:listen(44404, [{active, true}]) of
         {ok, ListenSocket} ->
-            io:format("Listening on ~p.~n", [local_address(ListenSocket)]),
+            io:format("Listening on ~s.~n", [local_address(ListenSocket)]),
             Gpio = gpio:open(),
             gpio:set_direction(Gpio, ?PIN, output),
             spawn(fun() -> accept(ListenSocket, Gpio) end),

--- a/examples/erlang/network_console.erl
+++ b/examples/erlang/network_console.erl
@@ -31,7 +31,7 @@ start() ->
 listen(Port) ->
     case gen_tcp:listen(Port, []) of
         {ok, ListenSocket} ->
-            io:format("Listening on ~p.~n", [local_address(ListenSocket)]),
+            io:format("Listening on ~s.~n", [local_address(ListenSocket)]),
             spawn(fun() -> accept(ListenSocket) end);
         Error ->
             io:format("An error occurred listening: ~p~n", [Error])
@@ -42,7 +42,7 @@ accept(ListenSocket) ->
     case gen_tcp:accept(ListenSocket) of
         {ok, Socket} ->
             spawn_opt(?MODULE, start_repl, [self()], [link]),
-            io:format("Accepted shell connection. local: ~p peer: ~p~n", [
+            io:format("Accepted shell connection. local: ~s peer: ~s~n", [
                 local_address(Socket), peer_address(Socket)
             ]),
             spawn(fun() -> accept(ListenSocket) end),

--- a/examples/erlang/tcp_server.erl
+++ b/examples/erlang/tcp_server.erl
@@ -25,7 +25,7 @@
 start() ->
     case gen_tcp:listen(44404, [{active, true}, binary]) of
         {ok, ListenSocket} ->
-            io:format("Listening on ~p.~n", [local_address(ListenSocket)]),
+            io:format("Listening on ~s.~n", [local_address(ListenSocket)]),
             spawn(fun() -> accept(ListenSocket) end),
             sleep_forever();
         Error ->


### PR DESCRIPTION
io_lib:format returns a iolist() so `~s` should be used instead of `~p`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
