### PR TITLE
Fix early return in the socket driver for esp32.

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -774,8 +774,8 @@ static bool bool_term_to_bool(term b, bool *ok)
             return false;
 
         default:
-            return false;
             *ok = false;
+            return false;
     }
 }
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later