### PR TITLE
Fix missing module in eavmlib CMakeLists.txt

### DIFF
--- a/libs/eavmlib/src/CMakeLists.txt
+++ b/libs/eavmlib/src/CMakeLists.txt
@@ -24,6 +24,7 @@ include(BuildErlang)
 
 set(ERLANG_MODULES
     atomvm
+    avm_pubsub
     console
     esp
     gpio


### PR DESCRIPTION
avm_pubsub wasn't built with eavmlib.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
