### PR TITLE
Fix warnings when building without SMP

### DIFF
--- a/src/libAtomVM/synclist.h
+++ b/src/libAtomVM/synclist.h
@@ -102,8 +102,8 @@ static inline int synclist_is_empty(struct SyncList *synclist)
 #define synclist_rdlock(list) list
 #define synclist_wrlock(list) list
 #define synclist_nolock(list) list
-#define synclist_unlock(list)
-#define synclist_destroy(list)
+#define synclist_unlock(list) UNUSED(list)
+#define synclist_destroy(list) UNUSED(list)
 #define synclist_append(list, new_item) list_append(list, new_item)
 #define synclist_remove(list, new_item) list_remove(new_item)
 #define synclist_is_empty(list) list_is_empty(list)


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
