### PR TITLE
Fix documentation

### DIFF
--- a/libs/estdlib/src/io_lib.erl
+++ b/libs/estdlib/src/io_lib.erl
@@ -54,7 +54,6 @@ format(Format, Args) ->
 %% internal operations
 %%
 
-%% @private
 -record(format, {
     field_width = undefined :: number() | undefined,
     precision = undefined :: number() | undefined,

--- a/libs/estdlib/src/timer.erl
+++ b/libs/estdlib/src/timer.erl
@@ -30,7 +30,7 @@
 -export([sleep/1]).
 
 %%-----------------------------------------------------------------------------
-%% @parm Timeout number of milliseconds to sleep or `infinity'
+%% @param Timeout number of milliseconds to sleep or `infinity'
 %% @returns `ok'
 %%
 %% @doc Pauses the execution of the current process for a given number of

--- a/src/libAtomVM/bitstring.h
+++ b/src/libAtomVM/bitstring.h
@@ -316,10 +316,9 @@ bool bitstring_utf8_encode(avm_int_t c, uint8_t *buf, size_t *out_size);
 /**
  * @brief Decode a character from UTF-8.
  *
- * @param c int value to decode to
- * @param buf the buffer froom which to decode the sring to or NULL to only compute the
- * size.
+ * @param buf the buffer from which to decode the string
  * @param len the length (in bytes) of the bytes in buf
+ * @param c int value to decode to or NULL to only compute the size.
  * @param out_size the size in bytes, on output (if not NULL)
  * @return \c true if decoding was successful, \c false if character starting at buf is not a valid
  * unicode character


### PR DESCRIPTION
Fix compilation of documentation after 032a912
Fix warning in src/timer.erl
Fix content of documentation related to `bitstring_utf8_encode`

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
