### PR TITLE
Initial support for wasm

### DIFF
--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -1,0 +1,99 @@
+#
+#  Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+name: Wasm Build
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'libs/**'
+      - 'src/platforms/emscripten/**'
+      - 'src/libAtomVM/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'CMakeLists.txt'
+      - 'libs/**'
+      - 'src/platforms/emscripten/**'
+      - 'src/libAtomVM/**'
+
+env:
+  otp_version: 24
+  elixir_version: 1.14
+
+jobs:
+  compile_tests:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ env.otp_version }}
+        elixir-version: ${{ env.elixir_version }}
+
+    - name: apt update
+      run: sudo apt update
+
+    - name: Install required packages
+      run: sudo apt install -y gperf
+
+    - name: Compile test modules
+      run: |
+        set -e
+        mkdir build_tests
+        cd build_tests
+        cmake ..
+        make test_eavmlib
+        make test_alisp
+
+    - name: Upload test modules
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-modules
+        path: |
+            build_tests/**/*.avm
+            build_tests/**/*.beam
+            build_tests/**/*.hrl
+        retention-days: 1
+
+  wasm:
+    needs: compile_tests
+    runs-on: ubuntu-latest
+    container: emscripten/emsdk
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: "Install deps"
+      run: sudo apt update -y && sudo apt install -y cmake gperf
+
+    - name: Build
+      shell: bash
+      working-directory: ./src/platforms/emscripten/
+      run: |
+        set -euo pipefail
+        mkdir build
+        cd build
+        emcmake cmake ..
+        emmake make -j
+
+    - name: Download test modules
+      uses: actions/download-artifact@v3
+      with:
+        name: test-modules
+        path: build_tests
+
+    - name: Test
+      shell: bash
+      working-directory: ./src/platforms/emscripten/build
+      run: |
+        set -euo pipefail
+        node src/AtomVM.js ../../../../build_tests/tests/libs/alisp/test_alisp.avm
+        node src/AtomVM.js ../../../../build_tests/tests/libs/eavmlib/test_eavmlib.avm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for code:load_abs/1, code:load_binary/3
 - Added support for loading / closing AVMPacks at runtime
 - Added support for ESP-IDF v5.x
+- Added support for Raspberry Pi Pico
+- Added support for nodejs with Wasm
 
 ### Fixed
 - Fixed issue with formatting integers with io:format() on STM32 platform

--- a/README.Md
+++ b/README.Md
@@ -19,6 +19,7 @@ Supported Platforms
 * ESP32 SoC (with IDF/FreeRTOS, see [README.ESP32.Md](README.ESP32.Md))
 * STM32 MCUs (with LibOpenCM3, see [README.STM32.Md](README.STM32.Md))
 * Raspberry Pi Pico (see [README.PICO.Md](README.PICO.Md))
+* nodejs with Wasm (see [README.Wasm.Md](README.Wasm.Md))
 
 AtomVM aims to be easily portable to new platforms with a minimum effort, so additional platforms
 might be supported in a near future.

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -118,7 +118,7 @@ check_c_source_compiles("
          #pragma STDC FENV_ACCESS ON
         return 0;
      }
- " HAVE_PRAGMA_STDC_FENV_ACCESS)
+ " HAVE_PRAGMA_STDC_FENV_ACCESS FAIL_REGEX FENV_ACCESS)
 if (HAVE_PRAGMA_STDC_FENV_ACCESS)
     target_compile_definitions(libAtomVM PUBLIC HAVE_PRAGMA_STDC_FENV_ACCESS)
 endif()

--- a/src/platforms/emscripten/.gitignore
+++ b/src/platforms/emscripten/.gitignore
@@ -1,0 +1,5 @@
+# Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+
+build

--- a/src/platforms/emscripten/CMakeLists.txt
+++ b/src/platforms/emscripten/CMakeLists.txt
@@ -1,0 +1,41 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 202" Paul Guyot <pguyot@kallisys.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+cmake_minimum_required(VERSION 3.13)
+
+project(AtomVM)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules")
+
+# Include an error in case the user forgets to specify emscripten toolchain
+if (NOT CMAKE_TOOLCHAIN_FILE)
+    message(FATAL_ERROR "Cross compiling only. Please use emcmake cmake or use -DCMAKE_TOOLCHAIN_FILE")
+endif ()
+
+# Options that make sense for this platform
+set(AVM_DISABLE_SMP ON FORCE)
+option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
+option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
+
+set(
+    PLATFORM_LIB_SUFFIX
+    ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
+)
+
+add_subdirectory(src)

--- a/src/platforms/emscripten/src/CMakeLists.txt
+++ b/src/platforms/emscripten/src/CMakeLists.txt
@@ -1,0 +1,40 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+cmake_minimum_required (VERSION 3.13)
+
+add_executable(AtomVM main.c)
+
+target_compile_features(AtomVM PUBLIC c_std_11)
+target_compile_options(AtomVM PUBLIC -Oz)
+
+add_subdirectory(../../../libAtomVM libAtomVM)
+target_link_libraries(AtomVM PUBLIC libAtomVM)
+target_compile_options(libAtomVM PUBLIC -Oz)
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -sNODERAWFS")
+
+set(
+    PLATFORM_LIB_SUFFIX
+    ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
+)
+
+add_subdirectory(lib)
+target_link_libraries(AtomVM PRIVATE libAtomVM${PLATFORM_LIB_SUFFIX})

--- a/src/platforms/emscripten/src/lib/CMakeLists.txt
+++ b/src/platforms/emscripten/src/lib/CMakeLists.txt
@@ -1,0 +1,41 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+cmake_minimum_required (VERSION 3.13)
+project (libAtomVMPlatformSTM32)
+
+set(HEADER_FILES
+)
+
+set(SOURCE_FILES
+    platform_defaultatoms.c
+    platform_nifs.c
+    sys.c
+)
+
+set(
+    PLATFORM_LIB_SUFFIX
+    ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
+)
+
+add_library(libAtomVM${PLATFORM_LIB_SUFFIX} ${SOURCE_FILES} ${HEADER_FILES})
+target_compile_features(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC c_std_11)
+
+target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC libAtomVM)

--- a/src/platforms/emscripten/src/lib/platform_defaultatoms.c
+++ b/src/platforms/emscripten/src/lib/platform_defaultatoms.c
@@ -1,0 +1,34 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include "platform_defaultatoms.h"
+
+static const char *const emscripten_atom = ATOM_STR("\xA", "emscripten");
+
+void platform_defaultatoms_init(GlobalContext *glb)
+{
+    int ok = 1;
+
+    ok &= globalcontext_insert_atom(glb, emscripten_atom) == EMSCRIPTEN_ATOM_INDEX;
+
+    if (!ok) {
+        AVM_ABORT();
+    }
+}

--- a/src/platforms/emscripten/src/lib/platform_defaultatoms.h
+++ b/src/platforms/emscripten/src/lib/platform_defaultatoms.h
@@ -1,0 +1,30 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _PLATFORM_DEFAULTATOMS_H_
+#define _PLATFORM_DEFAULTATOMS_H_
+
+#include "defaultatoms.h"
+
+#define EMSCRIPTEN_ATOM_INDEX (PLATFORM_ATOMS_BASE_INDEX + 0)
+
+#define EMSCRIPTEN_ATOM term_from_atom_index(EMSCRIPTEN_ATOM_INDEX)
+
+#endif

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -1,0 +1,50 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include "platform_nifs.h"
+#include "defaultatoms.h"
+#include "nifs.h"
+#include "platform_defaultatoms.h"
+#include "term.h"
+
+//#define ENABLE_TRACE
+#include "trace.h"
+
+static term nif_atomvm_platform(Context *ctx, int argc, term argv[])
+{
+    UNUSED(ctx);
+    UNUSED(argc);
+    UNUSED(argv);
+    return EMSCRIPTEN_ATOM;
+}
+
+static const struct Nif atomvm_platform_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_atomvm_platform
+};
+
+const struct Nif *platform_nifs_get_nif(const char *nifname)
+{
+    if (strcmp("atomvm:platform/0", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &atomvm_platform_nif;
+    }
+    return NULL;
+}

--- a/src/platforms/emscripten/src/lib/sys.c
+++ b/src/platforms/emscripten/src/lib/sys.c
@@ -1,0 +1,163 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include <sys.h>
+
+#include <avmpack.h>
+#include <defaultatoms.h>
+#include <scheduler.h>
+
+#include <fcntl.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "trace.h"
+
+void sys_init_platform(GlobalContext *glb)
+{
+    UNUSED(glb);
+}
+
+void sys_free_platform(GlobalContext *glb)
+{
+    UNUSED(glb);
+}
+
+void sys_poll_events(GlobalContext *glb, int timeout_ms)
+{
+    UNUSED(glb);
+    UNUSED(timeout_ms);
+}
+
+void sys_listener_destroy(struct ListHead *item)
+{
+    UNUSED(item);
+}
+
+void sys_time(struct timespec *t)
+{
+    if (UNLIKELY(clock_gettime(CLOCK_REALTIME, t))) {
+        fprintf(stderr, "Failed clock_gettime.\n");
+        AVM_ABORT();
+    }
+}
+
+void sys_monotonic_time(struct timespec *t)
+{
+    if (UNLIKELY(clock_gettime(CLOCK_MONOTONIC, t))) {
+        fprintf(stderr, "Failed clock_gettime.\n");
+        AVM_ABORT();
+    }
+}
+
+uint64_t sys_monotonic_millis()
+{
+    struct timespec ts;
+    sys_monotonic_time(&ts);
+    return (ts.tv_nsec / 1000000UL) + (ts.tv_sec * 1000UL);
+}
+
+struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *path)
+{
+    TRACE("sys_open_avm_from_file: Going to open: %s\n", path);
+
+    UNUSED(global);
+
+    int fd = open(path, O_RDONLY);
+    if (UNLIKELY(fd < 0)) {
+        return NULL;
+    }
+
+    off_t fsize = lseek(fd, 0, SEEK_END);
+    lseek(fd, 0, SEEK_SET);
+    void *data = malloc(fsize);
+    if (IS_NULL_PTR(data)) {
+        close(fd);
+        return NULL;
+    }
+
+    size_t r = read(fd, data, fsize);
+    if (UNLIKELY(r != fsize)) {
+        free(data);
+        close(fd);
+        return NULL;
+    }
+
+    struct ConstAVMPack *const_avm = malloc(sizeof(struct ConstAVMPack));
+    if (IS_NULL_PTR(const_avm)) {
+        return NULL;
+    }
+    avmpack_data_init(&const_avm->base, &const_avm_pack_info);
+    const_avm->base.data = (const uint8_t *) data;
+
+    return &const_avm->base;
+}
+
+Module *sys_load_module_from_file(GlobalContext *global, const char *path)
+{
+    UNUSED(global);
+    UNUSED(path);
+
+    // TODO
+    return NULL;
+}
+
+Module *sys_load_module(GlobalContext *global, const char *module_name)
+{
+    const void *beam_module = NULL;
+    uint32_t beam_module_size = 0;
+
+    struct ListHead *avmpack_data_list = synclist_rdlock(&global->avmpack_data);
+    struct ListHead *item;
+    LIST_FOR_EACH (item, avmpack_data_list) {
+        struct AVMPackData *avmpack_data = GET_LIST_ENTRY(item, struct AVMPackData, avmpack_head);
+        avmpack_data->in_use = true;
+        if (avmpack_find_section_by_name(avmpack_data->data, module_name, &beam_module, &beam_module_size)) {
+            break;
+        }
+    }
+    synclist_unlock(&global->avmpack_data);
+
+    if (IS_NULL_PTR(beam_module)) {
+        fprintf(stderr, "Failed to open module: %s\n", module_name);
+        return NULL;
+    }
+
+    Module *new_module = module_new_from_iff_binary(global, beam_module, beam_module_size);
+    new_module->module_platform_data = NULL;
+
+    return new_module;
+}
+
+Context *sys_create_port(GlobalContext *glb, const char *driver_name, term opts)
+{
+    UNUSED(glb);
+    UNUSED(driver_name);
+    UNUSED(opts);
+    return NULL;
+}
+
+term sys_get_info(Context *ctx, term key)
+{
+    UNUSED(ctx);
+    UNUSED(key);
+    return UNDEFINED_ATOM;
+}

--- a/src/platforms/emscripten/src/main.c
+++ b/src/platforms/emscripten/src/main.c
@@ -1,0 +1,122 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include <signal.h>
+#include <stdio.h>
+
+#include <avmpack.h>
+#include <context.h>
+#include <defaultatoms.h>
+#include <globalcontext.h>
+#include <iff.h>
+#include <module.h>
+#include <sys.h>
+#include <version.h>
+
+#define ATOMVM_BANNER                                                   \
+    "\n"                                                                \
+    "    ###########################################################\n" \
+    "\n"                                                                \
+    "       ###    ########  #######  ##     ## ##     ## ##     ## \n" \
+    "      ## ##      ##    ##     ## ###   ### ##     ## ###   ### \n" \
+    "     ##   ##     ##    ##     ## #### #### ##     ## #### #### \n" \
+    "    ##     ##    ##    ##     ## ## ### ## ##     ## ## ### ## \n" \
+    "    #########    ##    ##     ## ##     ##  ##   ##  ##     ## \n" \
+    "    ##     ##    ##    ##     ## ##     ##   ## ##   ##     ## \n" \
+    "    ##     ##    ##     #######  ##     ##    ###    ##     ## \n" \
+    "\n"                                                                \
+    "    ###########################################################\n" \
+    "\n"
+
+int main(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("Need .avm files\n");
+        return EXIT_FAILURE;
+    }
+
+    fprintf(stderr, "%s", ATOMVM_BANNER);
+    fprintf(stderr, "Starting AtomVM revision " ATOMVM_VERSION "\n");
+
+    GlobalContext *glb = globalcontext_new();
+
+    const void *startup_beam = NULL;
+    uint32_t startup_beam_size;
+    const char *startup_module_name;
+
+    for (int i = 1; i < argc; ++i) {
+        const char *ext = strrchr(argv[i], '.');
+        if (ext && strcmp(ext, ".avm") == 0) {
+            struct AVMPackData *avmpack_data = sys_open_avm_from_file(glb, argv[i]);
+            if (IS_NULL_PTR(avmpack_data)) {
+                fprintf(stderr, "Failed opening %s.\n", argv[i]);
+                return EXIT_FAILURE;
+            }
+            synclist_append(&glb->avmpack_data, &avmpack_data->avmpack_head);
+
+            if (IS_NULL_PTR(startup_beam)) {
+                avmpack_find_section_by_flag(avmpack_data->data, 1, &startup_beam, &startup_beam_size, &startup_module_name);
+
+                if (startup_beam) {
+                    avmpack_data->in_use = true;
+                }
+            }
+
+        } else {
+            fprintf(stderr, "%s is not an AVM file.\n", argv[i]);
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (IS_NULL_PTR(startup_beam)) {
+        fprintf(stderr, "Unable to locate entrypoint.\n");
+        return EXIT_FAILURE;
+    }
+
+    Module *mod = module_new_from_iff_binary(glb, startup_beam, startup_beam_size);
+    if (IS_NULL_PTR(mod)) {
+        fprintf(stderr, "Cannot load startup module: %s\n", startup_module_name);
+        return EXIT_FAILURE;
+    }
+    globalcontext_insert_module(glb, mod);
+    mod->module_platform_data = NULL;
+    Context *ctx = context_new(glb);
+    ctx->leader = 1;
+
+    context_execute_loop(ctx, mod, "start", 0);
+
+    term ret_value = ctx->x[0];
+    fprintf(stderr, "Return value: ");
+    term_display(stderr, ret_value, ctx);
+    fprintf(stderr, "\n");
+
+    int status;
+    if (ret_value == OK_ATOM) {
+        status = EXIT_SUCCESS;
+    } else {
+        status = EXIT_FAILURE;
+    }
+
+    context_destroy(ctx);
+    globalcontext_destroy(glb);
+    module_destroy(mod);
+
+    return status;
+}


### PR DESCRIPTION
Also improve detection of support of pragma STDC_FENV_ACCESS

This is a different approach than #30 : emscripten is created as a separate platform instead of patching generic_unix files.
Also, SMP is disabled on this platform (for now) as using pthreads create some serious constraint in browsers.

This PR is only for creating the platform, with tests using nodejs.
A continuation PR shall include adding an option to not use nodejs raw file system and adding a script to bundle avm files (mostly calling emscripten's file_package.py), so this can be used in the browser.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
