### PR TITLE
Fix esp32 default socket opts

### DIFF
--- a/.github/workflows/esp32-test.yaml
+++ b/.github/workflows/esp32-test.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
   esp32-test:
     runs-on: ubuntu-latest
-    container: espressif/idf:v4.4.4
+    container: espressif/idf:v4.4.5
 
     strategy:
       fail-fast: false

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -791,8 +791,8 @@ static void do_connect(Context *ctx, term msg)
 
     term address_term = interop_proplist_get_value(params, ADDRESS_ATOM);
     term port_term = interop_proplist_get_value(params, PORT_ATOM);
-    term binary_term = interop_proplist_get_value(params, BINARY_ATOM);
-    term active_term = interop_proplist_get_value(params, ACTIVE_ATOM);
+    term binary_term = interop_proplist_get_value_default(params, BINARY_ATOM, FALSE_ATOM);
+    term active_term = interop_proplist_get_value_default(params, ACTIVE_ATOM, TRUE_ATOM);
     term controlling_process_term = interop_proplist_get_value(params, CONTROLLING_PROCESS_ATOM);
 
     bool ok = term_is_pid(controlling_process_term);
@@ -878,8 +878,8 @@ static void do_listen(Context *ctx, term msg)
 
     term port_term = interop_proplist_get_value(params, PORT_ATOM);
     term backlog_term = interop_proplist_get_value(params, BACKLOG_ATOM);
-    term binary_term = interop_proplist_get_value(params, BINARY_ATOM);
-    term active_term = interop_proplist_get_value(params, ACTIVE_ATOM);
+    term binary_term = interop_proplist_get_value_default(params, BINARY_ATOM, FALSE_ATOM);
+    term active_term = interop_proplist_get_value_default(params, ACTIVE_ATOM, TRUE_ATOM);
     term buffer_term = interop_proplist_get_value(params, BUFFER_ATOM);
 
     avm_int_t port = term_to_int(port_term);
@@ -949,8 +949,8 @@ void do_udp_open(Context *ctx, term msg)
     term params = term_get_tuple_element(cmd, 1);
 
     term port_term = interop_proplist_get_value(params, PORT_ATOM);
-    term binary_term = interop_proplist_get_value(params, BINARY_ATOM);
-    term active_term = interop_proplist_get_value(params, ACTIVE_ATOM);
+    term binary_term = interop_proplist_get_value_default(params, BINARY_ATOM, FALSE_ATOM);
+    term active_term = interop_proplist_get_value_default(params, ACTIVE_ATOM, TRUE_ATOM);
     term controlling_process_term = interop_proplist_get_value(params, CONTROLLING_PROCESS_ATOM);
 
     bool ok = term_is_pid(controlling_process_term);

--- a/src/platforms/esp32/test/test_atomvm.py
+++ b/src/platforms/esp32/test/test_atomvm.py
@@ -38,7 +38,7 @@ def create_sd_image():
     indirect=True,
 )
 def test_atomvm(dut, redirect):
-     dut.expect_unity_test_output()
+     dut.expect_unity_test_output(timeout=120)
      assert len(dut.testsuite.testcases) > 0
      assert dut.testsuite.attrs['failures'] == 0
      assert dut.testsuite.attrs['errors'] == 0


### PR DESCRIPTION
Also fix CI for esp32 test by bumping timeout to 120 secs

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
