### PR TITLE
Added support for `calendar:datetime_to_gregorian_seconds/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for loading / closing AVMPacks at runtime
 - Added support for ESP-IDF v5.x
 - Added support for `calendar:system_time_to_universal_time/2`
+- Added support for `calendar:datetime_to_gregorian_seconds/1`
 
 ### Fixed
 - Fixed issue with formatting integers with io:format() on STM32 platform

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -438,7 +438,42 @@ To convert a time (in seconds, milliseconds, or microseconds from the UNIX epoch
     Milliseconds = ... %% get milliseconds from the UNIX epoch
     {{Year, Month, Day}, {Hour, Minute, Second}} = calendar:system_time_to_universal_time(Milliseconds, millisecond).
 
-As above, valid time units are `second`, `millisecond`, and `microsecond`.
+Valid time units are `second`, `millisecond`, and `microsecond`.
+
+### Date and Time
+
+A `datetime()` is a tuple containing a date and time, where a date is a tuple containing the year, month, and day (in the [Gregorian](https://en.wikipedia.org/wiki/Gregorian_calendar) calendar), expressed as integers, and a time is an hour, minute, and second, also expressed in integers.
+
+The following Erlang type specification enumerates this type:
+
+    %% erlang
+    -type year() :: integer().
+    -type month() :: 1..12.
+    -type day() :: 1..31.
+    -type date() :: {year(), month(), day()}.
+    -type gregorian_days() :: integer().
+    -type day_of_week() :: 1..7.
+    -type hour() :: 0..23.
+    -type minute() :: 0..59.
+    -type second() :: 0..59.
+    -type time() :: {hour(), minute(), second()}.
+    -type datetime() :: {date(), time()}.
+
+Erlang/OTP uses the Christian epoch to count time units from year 0 in the Gregorian calendar.  The, for example, the value 0 in Gregorian seconds represents the date Jan 1, year 0, and midnight (UTC), or in Erlang terms, `{{0, 1, 1}, {0, 0, 0}}`.
+
+> Note.  AtomVM is currently limited to representing integers in at most 64 bits, with one bit representing the sign bit.  However, even with this limitation, AtomVM is able to resolve microsecond values in the Gregorian calendar for over 292,000 years, likely well past the likely lifetime of an AtomVM application (unless perhaps launched on a deep space probe).
+
+The `calendar` module provides useful functions for converting dates to Gregorian days, and date-times to Gregorian seconds.
+
+To convert a `date()` to the number of days since January 1, year 0, use the `calendar:date_to_gregorian_days/1` function, e.g.,
+
+    GregorianDays = calendar:date_to_gregorian_days({2023, 7, 23})
+
+To convert a `datetime()` to convert the number of seconds since midnight January 1, year 0, use the `calendar:datetime_to_gregorian_seconds/1` function, e.g.,
+
+    GregorianSeconds = calendar:datetime_to_gregorian_seconds({{2023, 7, 23}, {13, 31, 7}})
+
+> Note.  The `calendar` module does not support year values before year `0`.
 
 ### Miscellaneous
 

--- a/libs/estdlib/src/calendar.erl
+++ b/libs/estdlib/src/calendar.erl
@@ -39,14 +39,11 @@
 -export([
     date_to_gregorian_days/1,
     date_to_gregorian_days/3,
+    datetime_to_gregorian_seconds/1,
     day_of_the_week/1,
     day_of_the_week/3,
     system_time_to_universal_time/2
 ]).
-
--type date() :: {year(), month(), day()}.
--type time() :: {hour(), minute(), second()}.
--type datetime() :: {date(), time()}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Year cannot be abbreviated.
@@ -56,8 +53,8 @@
 %%
 %% @end
 %%-----------------------------------------------------------------------------
--type year() :: non_neg_integer().
 
+-type year() :: integer().
 -type month() :: 1..12.
 -type day() :: 1..31.
 -type hour() :: 0..23.
@@ -65,6 +62,9 @@
 -type second() :: 0..59.
 -type gregorian_days() :: integer().
 -type day_of_week() :: 1..7.
+-type date() :: {year(), month(), day()}.
+-type time() :: {hour(), minute(), second()}.
+-type datetime() :: {date(), time()}.
 -type time_unit() :: second | millisecond | microsecond.
 
 %%-----------------------------------------------------------------------------
@@ -86,7 +86,11 @@ date_to_gregorian_days({Y, M, D}) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec date_to_gregorian_days(Year :: year(), M :: month(), D :: day()) -> gregorian_days().
-date_to_gregorian_days(Year, M, D) when M =< 12 andalso D =< 31 ->
+date_to_gregorian_days(Year, M, D) when
+    is_integer(Year) andalso Year >= 0 andalso
+        is_integer(M) andalso M > 0 andalso M =< 12 andalso
+        is_integer(D) andalso D > 0 andalso D =< 31
+->
     Y =
         if
             M =< 2 -> Year - 1;
@@ -106,6 +110,21 @@ date_to_gregorian_days(Year, M, D) when M =< 12 andalso D =< 31 ->
     DoY = (153 * (M + MO) + 2) div 5 + D - 1,
     DoE = YoE * 365 + YoE div 4 - YoE div 100 + DoY,
     Era * 146097 + DoE + 60.
+
+%%-----------------------------------------------------------------------------
+%% @param   DateTime
+%% @returns Days    number of days
+%% @doc     Computes the number of gregorian days starting with year 0 and ending at the specified date.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec datetime_to_gregorian_seconds(DateTime :: datetime()) -> integer().
+datetime_to_gregorian_seconds({Date, {Hour, Minute, Second}}) when
+    is_integer(Hour) andalso Hour >= 0 andalso Hour =< 23 andalso
+        is_integer(Minute) andalso Minute >= 0 andalso Minute =< 59 andalso
+        is_integer(Second) andalso Second >= 0 andalso Second =< 59
+->
+    DateSeconds = date_to_gregorian_days(Date) * 24 * 60 * 60,
+    DateSeconds + Hour * 60 * 60 + Minute * 60 + Second.
 
 %%-----------------------------------------------------------------------------
 %% @equiv day_of_the_week(Y, M, D)

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -23,6 +23,7 @@ project(test_estdlib)
 include(BuildErlang)
 
 set(ERLANG_MODULES
+    test_calendar
     test_gen_event
     test_gen_server
     test_gen_statem

--- a/tests/libs/estdlib/test_calendar.erl
+++ b/tests/libs/estdlib/test_calendar.erl
@@ -1,0 +1,76 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_calendar).
+
+-export([test/0]).
+
+test() ->
+    ok = test_gregorian_days(),
+    ok = test_gregorian_seconds(),
+    ok.
+
+test_gregorian_days() ->
+    0 = calendar:date_to_gregorian_days({0, 1, 1}),
+    739089 = calendar:date_to_gregorian_days({2023, 7, 23}),
+
+    expect_exception(fun() -> calendar:date_to_gregorian_days(not_a_date) end),
+    expect_exception(fun() -> calendar:date_to_gregorian_days({not_a_year, 1, 1}) end),
+    expect_exception(fun() -> calendar:date_to_gregorian_days({0, not_a_month, 1}) end),
+    expect_exception(fun() -> calendar:date_to_gregorian_days({0, -1, 1}) end),
+    expect_exception(fun() -> calendar:date_to_gregorian_days({0, 13, 1}) end),
+    expect_exception(fun() -> calendar:date_to_gregorian_days({0, 1, not_a_day}) end),
+    expect_exception(fun() -> calendar:date_to_gregorian_days({0, 1, -1}) end),
+    expect_exception(fun() -> calendar:date_to_gregorian_days({0, 1, 32}) end),
+    expect_exception(fun() -> calendar:date_to_gregorian_days({-1, 12, 31}) end),
+
+    ok.
+
+test_gregorian_seconds() ->
+    0 = calendar:datetime_to_gregorian_seconds({{0, 1, 1}, {0, 0, 0}}),
+    1 = calendar:datetime_to_gregorian_seconds({{0, 1, 1}, {0, 0, 1}}),
+    61 = calendar:datetime_to_gregorian_seconds({{0, 1, 1}, {0, 1, 1}}),
+    63857338267 = calendar:datetime_to_gregorian_seconds({{2023, 7, 23}, {13, 31, 7}}),
+
+    expect_exception(fun() -> calendar:datetime_to_gregorian_seconds(not_a_datetime) end),
+    expect_exception(fun() -> calendar:datetime_to_gregorian_seconds({{0, 1, 1}, not_a_time}) end),
+    expect_exception(fun() ->
+        calendar:datetime_to_gregorian_seconds({{0, 1, 1}, {not_an_hour, 0, 0}})
+    end),
+    expect_exception(fun() -> calendar:datetime_to_gregorian_seconds({{0, 1, 1}, {-1, 0, 0}}) end),
+    expect_exception(fun() -> calendar:datetime_to_gregorian_seconds({{0, 1, 1}, {-24, 0, 0}}) end),
+    expect_exception(fun() ->
+        calendar:datetime_to_gregorian_seconds({{0, 1, 1}, {0, not_a_minute, 0}})
+    end),
+    expect_exception(fun() -> calendar:datetime_to_gregorian_seconds({{0, 1, 1}, {0, -1, 0}}) end),
+    expect_exception(fun() -> calendar:datetime_to_gregorian_seconds({{0, 1, 1}, {0, 60, 0}}) end),
+    expect_exception(fun() -> calendar:datetime_to_gregorian_seconds({{0, 1, 1}, {0, 0, -1}}) end),
+    expect_exception(fun() -> calendar:datetime_to_gregorian_seconds({{0, 1, 1}, {0, 0, 60}}) end),
+
+    ok.
+
+expect_exception(F) ->
+    try
+        F(),
+        fail
+    catch
+        _:_ ->
+            ok
+    end.

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -25,6 +25,7 @@
 start() ->
     ok = etest:test([
         test_lists,
+        test_calendar,
         test_gen_event,
         test_gen_server,
         test_gen_statem,


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
