### PR TITLE
ESP32: add `esp:partition_list/0` function

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -31,8 +31,6 @@ jobs:
 
       matrix:
         idf-version:
-        - 4.2.4
-        - 4.3.5
         - 4.4.4
         - 5.0.2
         - 5.1-rc1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for Raspberry Pi Pico
 - Added support for nodejs with Wasm
 - Added support for a subset of the OTP logger interface
+- Added `esp:partition_list/0` function
 
 ### Fixed
 - Fixed issue with formatting integers with io:format() on STM32 platform

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -951,6 +951,23 @@ The `freq_hz` function can be used to retrieve the clock frequency of the chip.
 
 * `esp:freq_hz/0`
 
+The `esp:partition_list/0` function can be used to retrieve information about the paritions on an ESP32 flash.
+
+The return type is a list of tuples, each of which contains the partition id (as a binary), partition type and sub-type (both of which are represented as integers), the start of the partition as an address along with its size, as well as a list of properties about the partition, as a properties list.
+
+    %% erlang
+    PartitionList = esp:partition_list(),
+    lists:foreach(
+        fun({PartitionId, PartitionType, PartitionSubtype, PartitionAddress, PartitionSize, PartitionProperties}) ->
+            %% ...
+        end,
+        PartitionList
+    )
+
+> Note.  The partition properties are currently empty (`[]`).
+
+For information about the encoding of partition types and sub-types, see the IDF SDK partition [type definitions](https://docs.espressif.com/projects/esp-idf/en/v4.4.5/esp32/api-reference/storage/spi_flash.html?highlight=esp_partition_get#id13).
+
 ## Peripherals
 
 The AtomVM virtual machine and libraries support APIs for interfacing with peripheral devices connected to the ESP32.  This section provides information about these APIs.

--- a/libs/eavmlib/src/esp.erl
+++ b/libs/eavmlib/src/esp.erl
@@ -37,6 +37,7 @@
     nvs_erase_key/1, nvs_erase_key/2,
     nvs_erase_all/0, nvs_erase_all/1,
     nvs_reformat/0,
+    partition_list/0,
     rtc_slow_get_binary/0,
     rtc_slow_set_binary/1,
     freq_hz/0
@@ -67,6 +68,21 @@
     | sleep_wakeup_cocpu
     | sleep_wakeup_cocpu_trap_trig
     | sleep_wakeup_bt.
+
+-type esp_partition_type() :: 0..254.
+-type esp_partition_subtype() :: 0..254.
+-type esp_partition_address() :: 0..134217728.
+-type esp_partition_size() :: 0..134217728.
+-type esp_partition_props() :: [].
+
+-type esp_partition() :: {
+    binary(),
+    esp_partition_type(),
+    esp_partition_subtype(),
+    esp_partition_address(),
+    esp_partition_size(),
+    esp_partition_props()
+}.
 
 -define(ATOMVM_NVS_NS, atomvm).
 
@@ -227,6 +243,17 @@ nvs_erase_all(Namespace) when is_atom(Namespace) ->
 %%-----------------------------------------------------------------------------
 -spec nvs_reformat() -> ok.
 nvs_reformat() ->
+    throw(nif_error).
+
+%%-----------------------------------------------------------------------------
+%% @returns List of partitions
+%% @doc     Gets the list of partitions as tuples, such as {name, type, subtype,
+%%          offset, size, props}. Type and subtype are integers as described in
+%%          esp-idf documentation.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec partition_list() -> [esp_partition()].
+partition_list() ->
     throw(nif_error).
 
 %%-----------------------------------------------------------------------------

--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -36,6 +36,7 @@ function(compile_erlang module_name)
     set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.beam")
 endfunction()
 
+compile_erlang(test_esp_partition)
 compile_erlang(test_file)
 compile_erlang(test_md5)
 compile_erlang(test_monotonic_time)
@@ -48,6 +49,7 @@ add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/esp32_test_modules.avm"
     COMMAND HostAtomVM-prefix/src/HostAtomVM-build/tools/packbeam/PackBEAM -i esp32_test_modules.avm
         HostAtomVM-prefix/src/HostAtomVM-build/libs/atomvmlib.avm
+        test_esp_partition.beam
         test_file.beam
         test_md5.beam
         test_monotonic_time.beam
@@ -57,6 +59,7 @@ add_custom_command(
         test_tz.beam
     DEPENDS
         HostAtomVM
+        "${CMAKE_CURRENT_BINARY_DIR}/test_esp_partition.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_file.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_md5.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_monotonic_time.beam"

--- a/src/platforms/esp32/test/main/test_erl_sources/test_esp_partition.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_esp_partition.erl
@@ -1,0 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_esp_partition).
+-export([start/0]).
+
+start() ->
+    [
+        {<<"nvs">>, 1, 2, 16#9000, 16#6000, []},
+        {<<"phy_init">>, 1, 1, 16#f000, 16#1000, []},
+        {<<"factory">>, 0, 0, 16#10000, 16#1C0000, []},
+        {<<"lib.avm">>, 1, 1, 16#1D0000, 16#40000, []},
+        {<<"main.avm">>, 1, 1, 16#210000, 16#100000, []}
+    ] = esp:partition_list(),
+    0.

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -167,6 +167,12 @@ term avm_test_case(const char *test_module)
     return ret_value;
 }
 
+TEST_CASE("test_esp_partition", "[test_run]")
+{
+    term ret_value = avm_test_case("test_esp_partition.beam");
+    TEST_ASSERT(term_to_int(ret_value) == 0);
+}
+
 TEST_CASE("test_file", "[test_run]")
 {
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {

--- a/src/platforms/esp32/test/partitions.csv
+++ b/src/platforms/esp32/test/partitions.csv
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 
+# UPDATE ALSO "test_erl_sources/test_esp_partition.erl" WHEN UPDATING THIS FILE
+# OTHERWISE "test_esp_partition.erl" TEST WILL ALWAYS FAIL.
+
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you change the phy_init or app partition offset, make sure to change the offset in Kconfig.projbuild
 nvs,      data, nvs,       0x9000,     0x6000,


### PR DESCRIPTION
Add function for listing all available partitions.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
