### PR TITLE
Fix semantic of `list_to_binary/1`

### DIFF
--- a/tests/erlang_tests/test_list_to_binary.erl
+++ b/tests/erlang_tests/test_list_to_binary.erl
@@ -20,13 +20,44 @@
 
 -module(test_list_to_binary).
 
--export([start/0, concat/2, concat2/2, compare_bin/3]).
+-export([start/0, concat/2, concat2/2, compare_bin/3, id/1]).
 
 start() ->
+    ok = test_concat(),
+    ok = test_iolist(),
+    ok = test_iolist_to_binary(),
+    0.
+
+test_concat() ->
     Bin = concat("Hello", "world"),
     Bin2 = concat2("", ""),
     CompRes1 = compare_bin(Bin, <<"Hello world">>) - compare_bin(Bin, <<"HelloXworld">>),
-    CompRes1 + byte_size(Bin2) + invalid(42).
+    1 = CompRes1 + byte_size(Bin2) + invalid(42),
+    ok.
+
+test_iolist() ->
+    <<"Hello world">> = list_to_binary(id([<<"Hello ">>, [<<"wor">>, [$l, $d]]])),
+    ok.
+
+test_iolist_to_binary() ->
+    <<"Hello world">> = iolist_to_binary(id([<<"Hello ">>, [<<"wor">>, [$l, $d]]])),
+    ok =
+        try
+            _ = list_to_binary(id(<<"foo">>)),
+            fail
+        catch
+            error:badarg ->
+                ok
+        end,
+    ok =
+        try
+            <<"foo">> = iolist_to_binary(id(<<"foo">>)),
+            ok
+        catch
+            error:badarg ->
+                fail
+        end,
+    ok.
 
 concat(A, B) ->
     list_to_binary(A ++ " " ++ B).
@@ -55,3 +86,6 @@ compare_bin(Bin1, Bin2, Index) ->
         _Any ->
             0
     end.
+
+id(X) ->
+    X.

--- a/tests/test.c
+++ b/tests/test.c
@@ -277,7 +277,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(binary_last_test, 110),
 
     TEST_CASE(test_integer_to_binary),
-    TEST_CASE_EXPECTED(test_list_to_binary, 1),
+    TEST_CASE(test_list_to_binary),
     TEST_CASE_EXPECTED(test_binary_to_list, 0),
     TEST_CASE_EXPECTED(test_atom_to_binary, 1),
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
