### PR TITLE
Improve esp32 `flash.sh` tool

### DIFF
--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -395,6 +395,38 @@ Applications can be flashed using the `flash.sh` script in the esp32 build direc
 
 > Note.  Since the Erlang core libraries are flashed to the ESP32 device, it is not necessary to include core libraries in your application AVM files.  Users may be interested in using downstream development tools, such as the Elixir <a href="https://github.com/atomvm/ExAtomVM">ExAtomVM Mix task</a>, or the Erlang <a href="https://github.com/atomvm/atomvm_rebar3_plugin">AtomVM Rebar3 Plugin</a> for doing day-to-day development of applications for the AtomVM platform.
 
+#### Flashing the core libraries
+
+If you are doing development work on the core Erlang/Elixir libraries and wish to test changes that do not involve the `C` code in the core VM you may flash `atomvmlib.avm` to the avm.lib partition (offset 0x1D0000) by using the `flash.sh` script in the esp32 build directory as follows:
+
+    shell$ build/flash.sh -l ../../../build/libs/atomvmlib.avm
+    %%
+    %% Flashing ../../../build/libs/atomvmlib.avm (size=116k)
+    %%
+    esptool.py v4.5.1
+    Serial port /dev/ttyUSB0
+    Connecting.....
+    Detecting chip type... Unsupported detection protocol, switching and trying again...
+    Connecting.....
+    Detecting chip type... ESP32
+    Chip is ESP32-D0WD (revision v1.0)
+    Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
+    Crystal is 40MHz
+    MAC: 1a:57:c5:7f:ac:5b
+    Uploading stub...
+    Running stub...
+    Stub running...
+    Changing baud rate to 921600
+    Changed.
+    Configuring flash size...
+    Auto-detected Flash size: 8MB
+    Flash will be erased from 0x001d0000 to 0x001ecfff...
+    Wrote 131072 bytes at 0x001d0000 in 1.8 seconds (582.1 kbit/s)...
+    Hash of data verified.
+    
+    Leaving...
+    Hard resetting via RTS pin...
+
 ### Adding custom Nifs, Ports, and third-party components
 
 While AtomVM is a functional implementation of the Erlang virtual machine, it is nonetheless designed to allow developers to extend the VM to support additional integrations with peripherals and protocols that are not otherwise supported in the core virtual machine.

--- a/tools/dev/flash.sh
+++ b/tools/dev/flash.sh
@@ -25,13 +25,24 @@ set -e
 : "${FLASH_SERIAL_PORT:=/dev/ttyUSB0}"
 : "${FLASH_OFFSET:=0x210000}"
 
-if [ -z "${IDF_PATH}" ]; then
-    echo "ERROR!  IDF_PATH must be set to root of IDF-SDK to pick up esptool."
+ESP_TOOL=`which esptool.py`
+if [ -z ${ESP_TOOL} ]; then
+    echo "ERROR!  esptool.py not found! IDF_PATH must be set to root of IDF-SDK to pick up esptool. Or install the standalone tool."
     exit -1
 fi
 
 usage() {
-    echo "Usage: $0 [-p <port>] [-b <baud>] <avm_file>"
+    echo "Usage: $ ${0} [-p <port>] [-b <baud>] [-o <offset>] [-l] [-h] <avm_file>"
+    echo "Options:"
+    echo "    -p <port> is the port connected to the device (default: /dev/ttyUSB0)"
+    echo "    -b <baud> is the baud rate (default: 115200)"
+    echo "    -o <offset> is the offset into flash to start writing the AVM file"
+    echo "    -l (without offset) may be used to flash the AtomVM core libraries (<avm_file>)."
+    echo "    -h print this help"
+    echo "    <avm-file> is the path to the AVM file"
+    echo ""
+    echo "Note: '-o' and '-l' should not be used together, both options take precidence over FLASH_OFFSET environment variable."
+    echo "      The '-l' option uses the lib.avm partition offset of 0x1D0000"
 }
 
 if [[ $# -lt 1 ]]; then
@@ -39,13 +50,19 @@ if [[ $# -lt 1 ]]; then
     exit -1
 fi
 
-while getopts 'p:b:h' arg; do
+while getopts 'p:b:o:lh' arg; do
     case ${arg} in
         p)
             FLASH_SERIAL_PORT=${OPTARG}
             ;;
         b)
             FLASH_BAUD_RATE=${OPTARG}
+            ;;
+        o)
+            FLASH_OFFSET=${OPTARG}
+            ;;
+        l)
+            FLASH_OFFSET="0x1D0000"
             ;;
         h)
             usage


### PR DESCRIPTION
Enhances the `flash.sh` tool to accept `-o` option to set the flash offset from option arguments, overriding any environment variable. Also adds the `-l` option to allow flashing `atomvmlib.avm` to the default `lib.avm` partition offset of `0x1D0000`. Allows for the use of independently installed `esptool.py`, either from OS packages, with `pip install esptool`, or from Espressif's [esptool github repo](https://github.com/espressif/esptool). Note: by default, if the ESP-IDF has been activated in the users environment, the esp-idf included version of the tool will appear first in the users environment PATH.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
