### PR TITLE
Add function interop_iolist_to_string

### DIFF
--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -27,7 +27,7 @@
 char *interop_term_to_string(term t, int *ok)
 {
     if (term_is_list(t)) {
-        return interop_list_to_string(t, ok);
+        return interop_iolist_to_string(t, ok);
 
     } else if (term_is_binary(t)) {
         char *str = interop_binary_to_string(t);
@@ -53,6 +53,44 @@ char *interop_binary_to_string(term binary)
 
     str[len] = 0;
 
+    return str;
+}
+
+char *interop_iolist_to_string(term list, int *ok)
+{
+    size_t len;
+    switch (interop_iolist_size(list, &len)) {
+        case InteropOk:
+            break;
+        case InteropMemoryAllocFail:
+            *ok = 0;
+            return NULL;
+        case InteropBadArg:
+            *ok = 0;
+            return NULL;
+    }
+
+    char *str = malloc(len + 1);
+    if (IS_NULL_PTR(str)) {
+        return NULL;
+    }
+
+    switch (interop_write_iolist(list, str)) {
+        case InteropOk:
+            break;
+        case InteropMemoryAllocFail:
+            free(str);
+            *ok = 0;
+            return NULL;
+        case InteropBadArg:
+            free(str);
+            *ok = 0;
+            return NULL;
+    }
+
+    str[len] = 0;
+
+    *ok = 1;
     return str;
 }
 

--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -56,6 +56,7 @@ typedef struct
 char *interop_term_to_string(term t, int *ok);
 char *interop_binary_to_string(term binary);
 char *interop_list_to_string(term list, int *ok);
+char *interop_iolist_to_string(term list, int *ok);
 char *interop_atom_to_string(Context *ctx, term atom);
 term interop_proplist_get_value(term list, term key);
 term interop_proplist_get_value_default(term list, term key, term default_value);


### PR DESCRIPTION
Also change semantics of interop_term_to_string to work with iolist.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
