### PR TITLE
Fix issue with http_server introduced in 474dea9

### DIFF
--- a/libs/eavmlib/src/http_server.erl
+++ b/libs/eavmlib/src/http_server.erl
@@ -73,7 +73,13 @@ find_route(Method, Path, [{Target, Mod, _Opts} | T]) ->
     end.
 
 reply(StatusCode, ReplyBody, Conn) ->
-    reply(StatusCode, ReplyBody, [<<"Content-Type: text/html\r\nConnection: close\r\n">>], Conn).
+    {ok, Conn} = reply(
+        StatusCode, ReplyBody, [<<"Content-Type: text/html\r\nConnection: close\r\n">>], Conn
+    ),
+    Socket = proplists:get_value(socket, Conn),
+    gen_tcp:close(Socket),
+    ClosedConn = [{closed, true} | Conn],
+    {ok, ClosedConn}.
 
 reply(StatusCode, ReplyBody, ReplyHeaders, Conn) ->
     Socket = proplists:get_value(socket, Conn),


### PR DESCRIPTION
Close TCP connection from http_server when reply/3 is used (as it used to do). Connection is not closed by users of reply/4 as they may pass a Content-Length header and let the client close the connection. This actually is a workaround for an issue in the gen_tcp implementation where the socket is closed before all data is sent.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
