### PR TITLE
Further Wasm support

### DIFF
--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -42,28 +42,44 @@ jobs:
       run: sudo apt update
 
     - name: Install required packages
-      run: sudo apt install -y gperf
+      run: sudo apt install -y gperf zlib1g-dev ninja-build
 
-    - name: Compile test modules
+    - name: Compile AtomVM and test modules
       run: |
         set -e
-        mkdir build_tests
-        cd build_tests
-        cmake ..
-        make test_eavmlib
-        make test_alisp
+        mkdir build
+        cd build
+        cmake .. -G Ninja
+        ninja AtomVM atomvmlib test_eavmlib test_alisp hello_world run_script call_cast wasm_webserver
 
-    - name: Upload test modules
+    - name: Upload AtomVM and test modules
       uses: actions/upload-artifact@v3
       with:
-        name: test-modules
+        name: atomvm-and-test-modules
         path: |
-            build_tests/**/*.avm
-            build_tests/**/*.beam
-            build_tests/**/*.hrl
+            build/**/*.avm
+            build/**/*.beam
+            build/src/AtomVM
         retention-days: 1
 
-  wasm:
+    - name: Compile emscripten test modules
+      run: |
+        set -e
+        cd src/platforms/emscripten
+        mkdir -p build/tests/src/
+        cd build/tests/src
+        cmake ../../../tests/src -G Ninja
+        ninja emscripten_erlang_test_modules
+
+    - name: Upload emscripten test modules
+      uses: actions/upload-artifact@v3
+      with:
+        name: emscripten-test-modules
+        path: |
+            src/platforms/emscripten/build/**/*.beam
+        retention-days: 1
+
+  wasm_build_and_test_node:
     needs: compile_tests
     runs-on: ubuntu-latest
     container: emscripten/emsdk
@@ -84,16 +100,84 @@ jobs:
         emcmake cmake ..
         emmake make -j
 
-    - name: Download test modules
+    - name: Download AtomVM and test modules
       uses: actions/download-artifact@v3
       with:
-        name: test-modules
-        path: build_tests
+        name: atomvm-and-test-modules
+        path: build
 
     - name: Test
       shell: bash
       working-directory: ./src/platforms/emscripten/build
       run: |
+        set -euxo pipefail
+        # Test compressed beams
+        node src/AtomVM.js ../../../../build/examples/erlang/hello_world.beam  ../../../../build/libs/eavmlib/src/eavmlib.avm
+        # Run tests that pass
+        node src/AtomVM.js ../../../../build/tests/libs/alisp/test_alisp.avm
+        node src/AtomVM.js ../../../../build/tests/libs/eavmlib/test_eavmlib.avm
+
+  wasm_build_web:
+    runs-on: ubuntu-latest
+    container: emscripten/emsdk
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: "Install deps"
+      run: sudo apt update -y && sudo apt install -y cmake gperf
+
+    - name: Build wasm build for web
+      shell: bash
+      working-directory: ./src/platforms/emscripten/
+      run: |
         set -euo pipefail
-        node src/AtomVM.js ../../../../build_tests/tests/libs/alisp/test_alisp.avm
-        node src/AtomVM.js ../../../../build_tests/tests/libs/eavmlib/test_eavmlib.avm
+        mkdir build
+        cd build
+        emcmake cmake .. -DAVM_EMSCRIPTEN_ENV=web
+        emmake make -j
+
+    - name: Upload wasm build for web
+      uses: actions/upload-artifact@v3
+      with:
+        name: atomvm-js-web
+        path: |
+            src/platforms/emscripten/build/**/*.wasm
+            src/platforms/emscripten/build/**/*.js
+        retention-days: 1
+
+  wasm_test_web:
+    needs: [compile_tests, wasm_build_web]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Download AtomVM and test modules
+      uses: actions/download-artifact@v3
+      with:
+        name: atomvm-and-test-modules
+        path: build
+
+    - name: Download wasm build for web
+      uses: actions/download-artifact@v3
+      with:
+        name: atomvm-js-web
+        path: src/platforms/emscripten/build
+
+    - name: Download emscripten test modules
+      uses: actions/download-artifact@v3
+      with:
+        name: emscripten-test-modules
+        path: src/platforms/emscripten/build
+
+    - name: Test using cypress
+      shell: bash
+      run: |
+        set -euxo pipefail
+        cd build
+        chmod +x ./src/AtomVM
+        ./src/AtomVM examples/emscripten/wasm_webserver.avm &
+        cd ../src/platforms/emscripten/tests/
+        docker run --network host -v $PWD:/mnt -w /mnt cypress/included:12.17.1 --browser chrome
+        killall AtomVM

--- a/README.WASM.Md
+++ b/README.WASM.Md
@@ -1,0 +1,76 @@
+<!--
+ Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+
+ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+
+Building AtomVM for wasm (emscripten)
+=====================================
+
+* requirements:
+
+Install emscripten and cmake
+
+* build:
+
+```
+cd src/platforms/emscripten/
+mkdir build
+cd build
+emcmake cmake ..
+emmake make -j
+```
+
+Running AtomVM with nodejs
+==========================
+
+By default, AtomVM is compiled for node.
+
+It can be passed avm and beam files on the command line.
+
+Provided that you built examples, you can run:
+
+```
+cd src/platforms/emscripten/build
+node src/AtomVM.js ../../../../build/examples/erlang/hello_world.avm
+```
+
+You can also load beam files with:
+
+```
+cd src/platforms/emscripten/build
+node src/AtomVM.js ../../../../build/examples/erlang/hello_world.beam ../../../../build/libs/atomvmlib.avm
+```
+
+Running AtomVM in the browser
+=============================
+
+AtomVM can also be run in the browser. For this, you need to build it with
+```
+AVM_EMSCRIPTEN_ENV=web
+```
+
+as follows:
+```
+cd src/platforms/emscripten/
+mkdir build
+cd build
+emcmake cmake .. -DAVM_EMSCRIPTEN_ENV=web
+emmake make -j
+```
+
+Please note that running emscripten code in the browser requires a server that
+sends the proper headers, especially considering that AtomVM uses SharedArrayBuffer,
+a feature that browsers restrict for security reasons.
+
+Fortunately, AtomVM comes with a simple HTTP server that provides these headers.
+
+Provided that you built AtomVM for Unix, you can run:
+
+```
+cd build
+./src/AtomVM examples/emscripten/wasm_webserver.avm
+```
+
+Then you can visit http://localhost:8080/ with your browser, it will list
+various examples. Make sure to check the HTML and Erlang source code of these.

--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -544,7 +544,7 @@ is 8N1 with no flow control.
 * `Erlang/OTP`
 * `Elixir` (optional)
 
-## AtomVM build steps
+### AtomVM build steps
 
     cd src/platforms/rp2040/
     mkdir build
@@ -554,7 +554,7 @@ is 8N1 with no flow control.
 
 > You may want to build with option `AVM_REBOOT_ON_NOT_OK` so Pico restarts on error.
 
-## libAtomVM build steps
+### libAtomVM build steps
 
 Build of standard libraries is part of the generic unix build.
 
@@ -564,3 +564,93 @@ From the root of the project:
     cd build
     cmake .. -G Ninja
     ninja
+
+## Building for NodeJS/Web
+
+Two different builds are possible, depending on link options: for NodeJS and
+for the web browser.
+
+### Prerequisites
+
+* [emscripten SDK](https://emscripten.org)
+* `cmake`
+* Erlang/OTP
+* Elixir (optional)
+
+### Building for NodeJS
+
+This is the default. Execute the following commands:
+
+    cd src/platforms/emscripten/
+    mkdir build
+    cd build
+    emcmake cmake ..
+    emmake make -j
+
+AtomVM can then be invoked as on Generic Unix with node:
+
+    node ./src/AtomVM.js
+
+### Running tests with NodeJS
+
+NodeJS build currently does not have dedicated tests. However, you can run
+AtomVM library tests that do not depend on unimplemented APIs.
+
+Build them first by building AtomVM for Generic Unix (see above.)
+Then execute the tests with:
+
+    cd src/platforms/emscripten/build/
+    node ./src/AtomVM.js ../../../../build/tests/libs/eavmlib/test_eavmlib.avm
+    node ./src/AtomVM.js ../../../../build/tests/libs/alisp/test_alisp.avm
+
+### Building for the web
+
+Execute the following commands:
+
+    cd src/platforms/emscripten/
+    mkdir build
+    cd build
+    emcmake cmake .. -DAVM_EMSCRIPTEN_ENV=web
+    emmake make -j
+
+### Running tests with Cypress
+
+AtomVM WebAssembly port on the web uses SharedArrayBuffer feature which is
+restricted by browsers. Tests require an HTTP server that returns the proper
+HTTP headers.
+
+Additionally, tests require [Cypress](https://www.cypress.io). Plus, because of
+a current [bug in Cypress](https://github.com/cypress-io/cypress/issues/19912),
+tests only run with Chrome-based browsers except Electron (Chromium, Chrome or Edge).
+
+Build first AtomVM for Generic Unix (see above). This will include the web
+server.
+
+Then run the web server with:
+
+    cd build
+    ./src/AtomVM examples/emscripten/wasm_webserver.avm
+
+In another terminal, compile specific test modules that are not part of examples.
+
+    cd src/platforms/emscripten/build/
+    make emscripten_erlang_test_modules
+
+Then run tests with Cypress with:
+
+    cd src/platforms/emscripten/tests/
+    npm install cypress
+    npx cypress run --browser chrome
+
+You can alternatvely specify: `chromium` or `edge` depending on what is installed.
+
+Alternatively, on Linux, you can run tests with docker:
+
+    cd src/platforms/emscripten/tests/
+    docker run --network host -v $PWD:/mnt -w /mnt cypress/included:12.17.1 --browser chrome
+
+Or you can open Cypress to interactively run selected test suites.
+
+    cd src/platforms/emscripten/tests/
+    npm install cypress
+    npx cypress open

--- a/doc/src/getting-started-guide.md
+++ b/doc/src/getting-started-guide.md
@@ -332,3 +332,31 @@ The following resources may be useful for understanding how to develop Erlang or
 
 * [Example Programs](./example-programs.md)
 * [Programmers Guide](./programmers-guide.md)
+
+
+## Getting Started with AtomVM WebAssembly port.
+
+AtomVM may be run on platforms with NodeJS from the AtomVM.js file (with its companion AtomVM.wasm file).
+
+Currently, these files must be built and installed from source.
+
+> See the AtomVM [Build Instructions](./build-instructions.md) for instructions about how to build AtomVM WebAssembly port.
+
+AtomVM may also be run in modern browsers (Safari, Chrome and Chrome-based, Firefox) from the AtomVM.js, AtomVM.worker.js and AtomVM.wasm files.
+
+Currently, these files must be built and installed from source. They also need to be installed on a web server that send `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers as explained in [Mozilla's documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements).
+
+AtomVM comes with a toy web server you can use and run with AtomVM built for Generic Unix with:
+
+```
+./src/AtomVM examples/emscripten/wasm_webserver.avm
+```
+
+This web server serves HTML files from `examples/emscripten/` which you can copy to a webserver along with binaries and built files.
+
+## Where to go from here
+
+The following resources may be useful for understanding how to develop Erlang or Elixir applications for the AtomVM platform:
+
+* [Example Programs](./example-programs.md)
+* [Programmers Guide](./programmers-guide.md)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,6 +21,7 @@
 project(libs)
 
 add_subdirectory(erlang)
+add_subdirectory(emscripten)
 if (Elixir_FOUND)
     add_subdirectory(elixir)
 else()

--- a/examples/emscripten/CMakeLists.txt
+++ b/examples/emscripten/CMakeLists.txt
@@ -18,25 +18,10 @@
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-cmake_minimum_required(VERSION 3.13)
+project(examples_emscripten)
 
-project(AtomVM)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules")
+include(BuildErlang)
 
-# Include an error in case the user forgets to specify emscripten toolchain
-if (NOT CMAKE_TOOLCHAIN_FILE)
-    message(FATAL_ERROR "Cross compiling only. Please use emcmake cmake or use -DCMAKE_TOOLCHAIN_FILE")
-endif ()
-
-# Options that make sense for this platform
-set(AVM_DISABLE_SMP ON FORCE)
-option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
-option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
-
-set(
-    PLATFORM_LIB_SUFFIX
-    ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
-)
-
-add_subdirectory(src)
-add_subdirectory(tests/src)
+pack_runnable(run_script run_script eavmlib)
+pack_runnable(call_cast call_cast eavmlib)
+pack_runnable(wasm_webserver wasm_webserver estdlib eavmlib)

--- a/examples/emscripten/call_cast.erl
+++ b/examples/emscripten/call_cast.erl
@@ -1,0 +1,59 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+-module(call_cast).
+-export([start/0]).
+
+start() ->
+    % Register as main
+    register(main, self()),
+    % Add a handler to send a message to self.
+    % For cypress testing, buttons are disabled until the handler is installed
+    % Nevertheless, there seems to be a race condition issue where Cypress
+    % clicks but the handler isn't called. It doesn't happen with the
+    % console.log call in the click handler.
+    emscripten:run_script(
+        [
+            <<"window.document.getElementById('call-button').onclick = async () => { console.log('clicked call'); const result = await Module.call('main', 'click'); window.document.getElementById('call-counter').innerHTML = result; };">>,
+            <<"window.document.getElementById('call-button').disabled = false;">>,
+            <<"window.document.getElementById('cast-button').onclick = () => { console.log('clicked cast'); Module.cast('main', 'click'); };">>,
+            <<"window.document.getElementById('cast-button').disabled = false;">>
+        ],
+        [main_thread, async]
+    ),
+    loop({0, 0}).
+
+loop({CastCounter, CallCounter}) ->
+    NewState =
+        receive
+            {emscripten, {cast, <<"click">>}} ->
+                emscripten:run_script(
+                    [
+                        <<"window.document.getElementById('cast-counter').innerHTML = '">>,
+                        integer_to_list(CastCounter + 1),
+                        <<"';">>
+                    ],
+                    [main_thread, async]
+                ),
+                {CastCounter + 1, CallCounter};
+            {emscripten, {call, Promise, <<"click">>}} ->
+                emscripten:promise_resolve(Promise, CallCounter + 1),
+                {CastCounter, CallCounter + 1}
+        end,
+    loop(NewState).

--- a/examples/emscripten/call_cast.html
+++ b/examples/emscripten/call_cast.html
@@ -1,0 +1,44 @@
+<!--
+This file is part of AtomVM.
+
+Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title>AtomVM call &amp; cast example</title>
+  </head>
+  <body>
+    <h1>Call &amp; cast example</h1>
+    <p>This example demonstrates sending messages to Erlang from Javascript from events in the main thread.</p>
+
+    <button id="call-button" disabled>Call Button</button>
+    <button id="cast-button" disabled>Cast Button</button>
+    <p>Call button was clicked <span id="call-counter">0</span> time(s).</p>
+    <p>Cast button was clicked <span id="cast-counter">0</span> time(s).</p>
+
+    <script>
+    // Arguments are loaded using fetch API.
+    // wasm_webserver serves under /build/ files in build subdirectory.
+    var Module = {
+        arguments: ['/build/examples/emscripten/call_cast.avm'],
+    }
+    </script>
+    <script async src="/AtomVM.js"></script>
+  </body>
+</html>

--- a/examples/emscripten/hello_world_avm.html
+++ b/examples/emscripten/hello_world_avm.html
@@ -1,0 +1,38 @@
+<!--
+This file is part of AtomVM.
+
+Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title>AtomVM hello_world AVM version</title>
+  </head>
+  <body>
+    <h1>Hello world (AVM version)</h1>
+    <p>Please check the console for hello_world output.</p>
+    <script>
+    // Arguments are loaded using fetch API.
+    // wasm_webserver serves under /build/ files in build subdirectory.
+    var Module = {
+        arguments: ['/build/examples/erlang/hello_world.avm']
+    }
+    </script>
+    <script async src="/AtomVM.js"></script>
+  </body>
+</html>

--- a/examples/emscripten/hello_world_beam.html
+++ b/examples/emscripten/hello_world_beam.html
@@ -1,0 +1,40 @@
+<!--
+This file is part of AtomVM.
+
+Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title>AtomVM hello_world Beam version</title>
+  </head>
+  <body>
+    <h1>Hello world (Beam version)</h1>
+    <p>Beam version demonstrates that you can provide beams as well as avm files in arguments,
+    typically loading AtomVM library as a packed avm file.</p>
+    <p>Please check the console for hello_world output.</p>
+    <script>
+    // Arguments are loaded using fetch API.
+    // wasm_webserver serves under /build/ files in build subdirectory.
+    var Module = {
+        arguments: ['/build/examples/erlang/hello_world.beam', '/build/libs/atomvmlib.avm']
+    }
+    </script>
+    <script async src="/AtomVM.js"></script>
+  </body>
+</html>

--- a/examples/emscripten/index.html
+++ b/examples/emscripten/index.html
@@ -1,0 +1,37 @@
+<!--
+This file is part of AtomVM.
+
+Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title>AtomVM emscripten examples</title>
+  </head>
+  <body>
+    <h1>AtomVM emscripten examples</h1>
+    <p>Examples require that you build AtomVM emscripten port with <code>-DAVM_EMSCRIPTEN_ENV=web</code>,
+    as well as AtomVM generic_unix port (to compile libraries and example files).</p>
+    <ul>
+       <li><a href="hello_world_avm.html">Hello world</a> (AVM version)</li>
+       <li><a href="hello_world_beam.html">Hello world</a> (Beam version)</li>
+       <li><a href="run_script.html">Run script</a></li>
+       <li><a href="call_cast.html">Call &amp; cast</a></li>
+    </ul>
+  </body>
+</html>

--- a/examples/emscripten/run_script.erl
+++ b/examples/emscripten/run_script.erl
@@ -1,0 +1,65 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(run_script).
+-export([start/0]).
+
+start() ->
+    CounterPid = spawn(fun() -> counter_loop() end),
+    emscripten:run_script(<<"alert('hello from Erlang in main thread')">>, [main_thread]),
+    CounterPid ! {self(), terminate},
+    receive
+        {CounterPid, CounterValue, DeltaMS} ->
+            emscripten:run_script(
+                [
+                    <<"window.document.getElementById('demo-counter').innerHTML = '">>,
+                    integer_to_list(CounterValue),
+                    <<" and it ran for ">>,
+                    integer_to_list(DeltaMS),
+                    <<" ms.'">>
+                ],
+                [
+                    main_thread, async
+                ]
+            )
+    end,
+    emscripten:run_script(<<"alert('hello from Erlang in main thread async')">>, [
+        main_thread, async
+    ]),
+    emscripten:run_script(<<"alert('hello from Erlang in worker thread')">>),
+    emscripten:run_script(
+        <<"window.document.getElementById('demo-not').style = 'display: none';">>, [
+            main_thread
+        ]
+    ).
+
+counter_loop() ->
+    StartTimeMS = erlang:system_time(millisecond),
+    counter_loop(0, StartTimeMS).
+
+counter_loop(Counter, StartTimeMS) ->
+    receive
+        {Caller, terminate} ->
+            EndTimeMS = erlang:system_time(millisecond),
+            DeltaMS = EndTimeMS - StartTimeMS,
+            Caller ! {self(), Counter, DeltaMS}
+    after 0 ->
+        counter_loop(Counter + 1, StartTimeMS)
+    end.

--- a/examples/emscripten/run_script.html
+++ b/examples/emscripten/run_script.html
@@ -1,0 +1,58 @@
+<!--
+This file is part of AtomVM.
+
+Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title>AtomVM run script example</title>
+  </head>
+  <body>
+    <h1>Run script example</h1>
+    <p>This example demonstrates calling <code>emscripten:run_script/1</code>
+    and <code>emscripten:run_script/2</code> to run Javascript from Erlang.</p>
+
+    <p>It displays three alerts:</p>
+    <ul>
+        <li>An alert in the main thread, synchronously</li>
+        <li>An alert in the main thread, asynchronously</li>
+        <li>An alert in the worker thread</li>
+    </ul>
+    <p>Second alert is likely to appear after third alert.</p>
+
+    <p>On non-SMP builds, it demonstrates the fact that Erlang continues to run
+    when <code>emscripten:run_script/2</code> is called with
+    <code>[main_thread]</code> as a counter is incremented while waiting for
+    first alert to complete. The value is
+    <span id="demo-counter">unset</span.</p>
+
+    <p>Beyond the counter, this example also demonstrates manipulating DOM (in
+    the main thread) using JS function.</p>
+
+    <p>Style of this text was <span id="demo-not">not</span> modified by Erlang.</p>
+    <script>
+    // Arguments are loaded using fetch API.
+    // wasm_webserver serves under /build/ files in build subdirectory.
+    var Module = {
+        arguments: ['/build/examples/emscripten/run_script.avm']
+    }
+    </script>
+    <script async src="/AtomVM.js"></script>
+  </body>
+</html>

--- a/examples/emscripten/wasm_webserver.erl
+++ b/examples/emscripten/wasm_webserver.erl
@@ -1,0 +1,115 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%% @doc Toy web server that serve static files from src/platform/emscripten/build
+%% This is used to demonstrate usage of wasm as a worker in the browser.
+-module(wasm_webserver).
+
+-export([start/0, handle_req/3]).
+
+start() ->
+    Router = [
+        {"*", ?MODULE, []}
+    ],
+    http_server:start_server(8080, Router),
+    io:format("Open http://localhost:8080/\n"),
+    receive
+    after infinity -> ok
+    end.
+
+handle_req(Method, Path, Conn) when Method =:= "GET" orelse Method =:= "HEAD" ->
+    Filename =
+        case Path of
+            [] ->
+                "../examples/emscripten/index.html";
+            ["AtomVM.js"] ->
+                "../src/platforms/emscripten/build/src/AtomVM.js";
+            ["AtomVM.wasm"] ->
+                "../src/platforms/emscripten/build/src/AtomVM.wasm";
+            ["AtomVM.worker.js"] ->
+                "../src/platforms/emscripten/build/src/AtomVM.worker.js";
+            ["tests", "build" | Tail] ->
+                lists:flatten([
+                    "../src/platforms/emscripten/build/tests/src/" | lists:join($/, Tail)
+                ]);
+            ["tests", "src" | Tail] ->
+                lists:flatten(["../src/platforms/emscripten/tests/src/" | lists:join($/, Tail)]);
+            ["build" | _] ->
+                lists:flatten(["../" | lists:join($/, Path)]);
+            _ ->
+                lists:flatten(["../examples/emscripten/" | lists:join($/, Path)])
+        end,
+    MimeType =
+        case lists:reverse(Filename) of
+            "sj." ++ _ -> "text/javascript";
+            "lmth." ++ _ -> "text/html";
+            "msaw." ++ _ -> "application/wasm";
+            "mva." ++ _ -> "application/binary";
+            "maeb." ++ _ -> "application/binary";
+            "pam." ++ _ -> "application/json";
+            _ -> undefined
+        end,
+    case MimeType of
+        undefined ->
+            io:format("Unknown file suffix ~s\n", [Filename]),
+            ErrorBody = <<"<html><body><h1>Forbidden</h1></body></html>">>,
+            http_server:reply(403, ErrorBody, Conn);
+        _ ->
+            case atomvm:posix_open(Filename, [o_rdwr]) of
+                {error, Err} ->
+                    io:format("Could not open file ~s (~p)\n", [Filename, Err]),
+                    ErrorBody = <<"<html><body><h1>Not Found</h1></body></html>">>,
+                    http_server:reply(404, ErrorBody, Conn);
+                {ok, Fd} ->
+                    {Size, Data} = read_file(Fd, 0, []),
+                    ok = atomvm:posix_close(Fd),
+                    Headers = [
+                        <<"Content-Type: ">>,
+                        MimeType,
+                        <<"\r\n">>,
+                        <<"Content-Length: ">>,
+                        integer_to_list(Size),
+                        <<"\r\n">>,
+                        <<"Connection: close\r\n">>,
+                        <<"Server: AtomVM\r\n">>,
+                        % The following are the required headers for wasm to work in worker
+                        <<"Cross-Origin-Opener-Policy: same-origin\r\n">>,
+                        <<"Cross-Origin-Embedder-Policy: require-corp\r\n">>
+                    ],
+                    io:format("~p 200 mime=~s size=~B\n", [Path, MimeType, Size]),
+                    case Method of
+                        "GET" -> http_server:reply(200, Data, Headers, Conn);
+                        "HEAD" -> http_server:reply(200, <<>>, Headers, Conn)
+                    end
+            end
+    end;
+handle_req(Method, Path, Conn) ->
+    io:format("Method: ~p Path: ~p~n", [Method, Path]),
+    Body = <<"<html><body><h1>Not Found</h1></body></html>">>,
+    http_server:reply(404, Body, Conn).
+
+read_file(Fd, Size, Acc) ->
+    case atomvm:posix_read(Fd, 8192) of
+        {ok, Data} ->
+            ChunkSize = byte_size(Data),
+            read_file(Fd, Size + ChunkSize, [Data | Acc]);
+        eof ->
+            {Size, lists:reverse(Acc)}
+    end.

--- a/src/platforms/emscripten/src/CMakeLists.txt
+++ b/src/platforms/emscripten/src/CMakeLists.txt
@@ -23,13 +23,22 @@ cmake_minimum_required (VERSION 3.13)
 add_executable(AtomVM main.c)
 
 target_compile_features(AtomVM PUBLIC c_std_11)
-target_compile_options(AtomVM PUBLIC -Oz)
 
 add_subdirectory(../../../libAtomVM libAtomVM)
 target_link_libraries(AtomVM PUBLIC libAtomVM)
-target_compile_options(libAtomVM PUBLIC -Oz)
+target_compile_options(libAtomVM PUBLIC -O3 -fno-exceptions -fno-rtti -pthread -sINLINING_LIMIT -sUSE_ZLIB=1)
+target_compile_definitions(libAtomVM PRIVATE WITH_ZLIB)
+target_link_options(AtomVM PRIVATE -sEXPORTED_RUNTIME_METHODS=ccall -sUSE_ZLIB=1 -O3 -pthread -sFETCH --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/atomvm.pre.js)
 
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -sNODERAWFS")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_options(AtomVM PRIVATE -sASSERTIONS=2 -sSAFE_HEAP -sSTACK_OVERFLOW_CHECK)
+endif()
+
+if (AVM_EMSCRIPTEN_ENV STREQUAL "web")
+    target_link_options(AtomVM PRIVATE -lworkerfs.js -sENVIRONMENT=web,worker -sPROXY_TO_PTHREAD)
+else()
+    target_link_options(AtomVM PRIVATE -sNODERAWFS -sENVIRONMENT=node)
+endif()
 
 set(
     PLATFORM_LIB_SUFFIX
@@ -38,3 +47,4 @@ set(
 
 add_subdirectory(lib)
 target_link_libraries(AtomVM PRIVATE libAtomVM${PLATFORM_LIB_SUFFIX})
+target_include_directories(AtomVM PRIVATE lib)

--- a/src/platforms/emscripten/src/atomvm.pre.js
+++ b/src/platforms/emscripten/src/atomvm.pre.js
@@ -1,0 +1,26 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+Module['cast'] = function(name, message) {
+    ccall("cast", 'void', ['string', 'string'], [name, message]);
+};
+Module['call'] = async function(name, message) {
+    const promiseId = ccall("call", 'integer', ['string', 'string'], [name, message]);
+    return promiseMap.get(promiseId).promise;
+};

--- a/src/platforms/emscripten/src/lib/emscripten_sys.h
+++ b/src/platforms/emscripten/src/lib/emscripten_sys.h
@@ -1,0 +1,82 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 by Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _EMSCRIPTEN_SYS_H_
+#define _EMSCRIPTEN_SYS_H_
+
+#include <pthread.h>
+#include <time.h>
+
+#include <erl_nif.h>
+#include <list.h>
+#include <sys.h>
+#include <term_typedef.h>
+
+#include <emscripten.h>
+#include <emscripten/fetch.h>
+#include <emscripten/promise.h>
+
+struct PromiseResource
+{
+    em_promise_t promise;
+    bool resolved;
+};
+
+enum EmscriptenMessageType
+{
+    Cast,
+    Call
+};
+
+struct EmscriptenMessageBase
+{
+    struct ListHead message_head;
+    enum EmscriptenMessageType message_type;
+};
+
+struct EmscriptenMessageCast
+{
+    struct EmscriptenMessageBase base;
+    char *target_name;
+    char *message;
+};
+
+struct EmscriptenMessageCall
+{
+    struct EmscriptenMessageBase base;
+    char *target_name;
+    char *message;
+    struct PromiseResource *promise_rsrc;
+};
+
+struct EmscriptenPlatformData
+{
+    pthread_mutex_t poll_mutex;
+    pthread_cond_t poll_cond;
+    struct ListHead messages;
+    ErlNifResourceType *promise_resource_type;
+};
+
+void sys_enqueue_emscripten_cast_message(GlobalContext *glb, const char *target, const char *message);
+em_promise_t sys_enqueue_emscripten_call_message(GlobalContext *glb, const char *target, const char *message);
+void sys_promise_resolve_int_and_destroy(em_promise_t promise, em_promise_result_t result, int value);
+void sys_promise_resolve_str_and_destroy(em_promise_t promise, em_promise_result_t result, int value);
+
+#endif

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -18,14 +18,26 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
-#include "platform_nifs.h"
-#include "defaultatoms.h"
-#include "nifs.h"
-#include "platform_defaultatoms.h"
-#include "term.h"
+#include <defaultatoms.h>
+#include <erl_nif.h>
+#include <erl_nif_priv.h>
+#include <globalcontext.h>
+#include <interop.h>
+#include <nifs.h>
+#include <term.h>
+#include <term_typedef.h>
+
+#include <emscripten.h>
+#include <emscripten/promise.h>
+#include <emscripten/proxying.h>
+#include <emscripten/threading.h>
 
 //#define ENABLE_TRACE
-#include "trace.h"
+#include <trace.h>
+
+#include "emscripten_sys.h"
+#include "platform_defaultatoms.h"
+#include "platform_nifs.h"
 
 static term nif_atomvm_platform(Context *ctx, int argc, term argv[])
 {
@@ -35,9 +47,113 @@ static term nif_atomvm_platform(Context *ctx, int argc, term argv[])
     return EMSCRIPTEN_ATOM;
 }
 
+static void do_run_script(GlobalContext *global, char *script, int sync, int sync_caller_pid)
+{
+    emscripten_run_script(script);
+    if (sync) {
+        Context *target = globalcontext_get_process_lock(global, sync_caller_pid);
+        if (target) {
+            mailbox_send_term_signal(target, TrapAnswerSignal, OK_ATOM);
+            globalcontext_get_process_unlock(global, target);
+        } // else: sender died
+    }
+}
+
+static term nif_emscripten_run_script(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+
+    int ok;
+    char *str = interop_term_to_string(argv[0], &ok);
+    if (UNLIKELY(!ok)) {
+        fprintf(stderr, "bad arg, run_script");
+        term_display(stderr, argv[0], ctx);
+        fprintf(stderr, "\n");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    bool main_thread = false;
+    bool async = false;
+    if (argc == 2) {
+        term main_thread_t = interop_kv_get_value_default(argv[1], ATOM_STR("\xB", "main_thread"), FALSE_ATOM, ctx->global);
+        main_thread = main_thread_t == TRUE_ATOM;
+
+        term async_t = interop_kv_get_value_default(argv[1], ATOM_STR("\x5", "async"), FALSE_ATOM, ctx->global);
+        async = async_t == TRUE_ATOM;
+        if (!main_thread && async) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+    }
+    term ret = OK_ATOM;
+    if (main_thread) {
+        if (async) {
+            // str will be freed as it's passed as satellite
+            emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VIIII, do_run_script, str, ctx->global, str, false, 0);
+        } else {
+            // Trap caller waiting for completion
+            context_update_flags(ctx, ~NoFlags, Trap);
+            ret = term_invalid_term();
+            // str will be freed as it's passed as satellite
+            emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VIIII, do_run_script, str, ctx->global, str, true, ctx->process_id);
+        }
+    } else {
+        emscripten_run_script(str);
+        free(str);
+    }
+    return ret;
+}
+
+static term nif_emscripten_promise_resolve_reject(Context *ctx, int argc, term argv[], em_promise_result_t result)
+{
+    struct EmscriptenPlatformData *platform = ctx->global->platform_data;
+    struct PromiseResource *promise_rsrc;
+    if (UNLIKELY(!enif_get_resource(erl_nif_env_from_context(ctx), argv[0], platform->promise_resource_type, (void **) &promise_rsrc))) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    if (promise_rsrc->resolved) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    if (argc == 0 || term_is_integer(argv[1])) {
+        int value = argc > 0 ? term_to_int(argv[1]) : 0;
+        emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VIII, sys_promise_resolve_int_and_destroy, NULL, promise_rsrc->promise, result, value);
+    } else {
+        int ok;
+        char *str = interop_term_to_string(argv[1], &ok);
+        if (UNLIKELY(!ok || str == NULL)) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        // str will be freed as it's passed as satellite
+        emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VIII, sys_promise_resolve_str_and_destroy, str, promise_rsrc->promise, result, str);
+    }
+    promise_rsrc->resolved = true;
+
+    return OK_ATOM;
+}
+
+static term nif_emscripten_promise_resolve(Context *ctx, int argc, term argv[])
+{
+    return nif_emscripten_promise_resolve_reject(ctx, argc, argv, EM_PROMISE_FULFILL);
+}
+
+static term nif_emscripten_promise_reject(Context *ctx, int argc, term argv[])
+{
+    return nif_emscripten_promise_resolve_reject(ctx, argc, argv, EM_PROMISE_REJECT);
+}
+
 static const struct Nif atomvm_platform_nif = {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_atomvm_platform
+};
+static const struct Nif emscripten_run_script_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_emscripten_run_script
+};
+static const struct Nif emscripten_promise_resolve_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_emscripten_promise_resolve
+};
+static const struct Nif emscripten_promise_reject_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_emscripten_promise_reject
 };
 
 const struct Nif *platform_nifs_get_nif(const char *nifname)
@@ -45,6 +161,30 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
     if (strcmp("atomvm:platform/0", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &atomvm_platform_nif;
+    }
+    if (strcmp("emscripten:run_script/1", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &emscripten_run_script_nif;
+    }
+    if (strcmp("emscripten:run_script/2", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &emscripten_run_script_nif;
+    }
+    if (strcmp("emscripten:promise_resolve/1", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &emscripten_promise_resolve_nif;
+    }
+    if (strcmp("emscripten:promise_resolve/2", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &emscripten_promise_resolve_nif;
+    }
+    if (strcmp("emscripten:promise_reject/1", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &emscripten_promise_reject_nif;
+    }
+    if (strcmp("emscripten:promise_reject/2", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &emscripten_promise_reject_nif;
     }
     return NULL;
 }

--- a/src/platforms/emscripten/src/main.c
+++ b/src/platforms/emscripten/src/main.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of AtomVM.
  *
- * Copyright 2022 Paul Guyot <pguyot@kallisys.net>
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 
 #include <signal.h>
 #include <stdio.h>
+#include <unistd.h>
 
 #include <avmpack.h>
 #include <context.h>
@@ -30,82 +31,77 @@
 #include <sys.h>
 #include <version.h>
 
-#define ATOMVM_BANNER                                                   \
-    "\n"                                                                \
-    "    ###########################################################\n" \
-    "\n"                                                                \
-    "       ###    ########  #######  ##     ## ##     ## ##     ## \n" \
-    "      ## ##      ##    ##     ## ###   ### ##     ## ###   ### \n" \
-    "     ##   ##     ##    ##     ## #### #### ##     ## #### #### \n" \
-    "    ##     ##    ##    ##     ## ## ### ## ##     ## ## ### ## \n" \
-    "    #########    ##    ##     ## ##     ##  ##   ##  ##     ## \n" \
-    "    ##     ##    ##    ##     ## ##     ##   ## ##   ##     ## \n" \
-    "    ##     ##    ##     #######  ##     ##    ###    ##     ## \n" \
-    "\n"                                                                \
-    "    ###########################################################\n" \
-    "\n"
+#include <emscripten.h>
+#include <emscripten/promise.h>
 
-int main(int argc, char **argv)
+#include "emscripten_sys.h"
+
+static GlobalContext *global = NULL;
+static Module *main_module = NULL;
+
+/**
+ * @brief Load a module in .avm or .beam format.
+ * @param path Path or URL to the module or avm package to load.
+ * @return EXIT_SUCESS or EXIT_FAILURE which is then returned by main
+ */
+static int load_module(const char *path)
 {
-    if (argc < 2) {
-        printf("Need .avm files\n");
-        return EXIT_FAILURE;
-    }
-
-    fprintf(stderr, "%s", ATOMVM_BANNER);
-    fprintf(stderr, "Starting AtomVM revision " ATOMVM_VERSION "\n");
-
-    GlobalContext *glb = globalcontext_new();
-
-    const void *startup_beam = NULL;
-    uint32_t startup_beam_size;
-    const char *startup_module_name;
-
-    for (int i = 1; i < argc; ++i) {
-        const char *ext = strrchr(argv[i], '.');
-        if (ext && strcmp(ext, ".avm") == 0) {
-            struct AVMPackData *avmpack_data = sys_open_avm_from_file(glb, argv[i]);
-            if (IS_NULL_PTR(avmpack_data)) {
-                fprintf(stderr, "Failed opening %s.\n", argv[i]);
-                return EXIT_FAILURE;
-            }
-            synclist_append(&glb->avmpack_data, &avmpack_data->avmpack_head);
-
-            if (IS_NULL_PTR(startup_beam)) {
-                avmpack_find_section_by_flag(avmpack_data->data, 1, &startup_beam, &startup_beam_size, &startup_module_name);
-
-                if (startup_beam) {
-                    avmpack_data->in_use = true;
-                }
-            }
-
-        } else {
-            fprintf(stderr, "%s is not an AVM file.\n", argv[i]);
+    const char *ext = strrchr(path, '.');
+    if (ext && strcmp(ext, ".avm") == 0) {
+        struct AVMPackData *avmpack_data = sys_open_avm_from_file(global, path);
+        if (IS_NULL_PTR(avmpack_data)) {
+            fprintf(stderr, "Failed opening %s.\n", path);
             return EXIT_FAILURE;
         }
-    }
+        synclist_append(&global->avmpack_data, &avmpack_data->avmpack_head);
 
-    if (IS_NULL_PTR(startup_beam)) {
-        fprintf(stderr, "Unable to locate entrypoint.\n");
+        if (IS_NULL_PTR(main_module)) {
+            const void *startup_beam = NULL;
+            uint32_t startup_beam_size;
+            const char *startup_module_name;
+            avmpack_find_section_by_flag(avmpack_data->data, 1, &startup_beam, &startup_beam_size, &startup_module_name);
+            if (startup_beam) {
+                avmpack_data->in_use = true;
+                main_module = module_new_from_iff_binary(global, startup_beam, startup_beam_size);
+                if (IS_NULL_PTR(main_module)) {
+                    fprintf(stderr, "Cannot load startup module: %s\n", startup_module_name);
+                    return EXIT_FAILURE;
+                }
+                globalcontext_insert_module(global, main_module);
+                main_module->module_platform_data = NULL;
+            }
+        }
+    } else if (ext && strcmp(ext, ".beam") == 0) {
+        Module *module = sys_load_module_from_file(global, path);
+        globalcontext_insert_module(global, module);
+        if (IS_NULL_PTR(main_module) && module_search_exported_function(module, ATOM_STR("\5", "start"), 0) != 0) {
+            main_module = module;
+        }
+    } else {
+        fprintf(stderr, "%s is not an AVM or BEAM file.\n", path);
         return EXIT_FAILURE;
     }
 
-    Module *mod = module_new_from_iff_binary(glb, startup_beam, startup_beam_size);
-    if (IS_NULL_PTR(mod)) {
-        fprintf(stderr, "Cannot load startup module: %s\n", startup_module_name);
+    return EXIT_SUCCESS;
+}
+
+/**
+ * @brief Create first context and run main module's start function
+ * @return EXIT_SUCESS or EXIT_FAILURE which is then returned by main
+ */
+static int start(void)
+{
+    if (IS_NULL_PTR(main_module)) {
+        fprintf(stderr, "main module not loaded\n");
         return EXIT_FAILURE;
     }
-    globalcontext_insert_module(glb, mod);
-    mod->module_platform_data = NULL;
-    Context *ctx = context_new(glb);
+    Context *ctx = context_new(global);
     ctx->leader = 1;
-
-    context_execute_loop(ctx, mod, "start", 0);
-
+    context_execute_loop(ctx, main_module, "start", 0);
     term ret_value = ctx->x[0];
-    fprintf(stderr, "Return value: ");
-    term_display(stderr, ret_value, ctx);
-    fprintf(stderr, "\n");
+    fprintf(stdout, "Return value: ");
+    term_display(stdout, ret_value, ctx);
+    fprintf(stdout, "\n");
 
     int status;
     if (ret_value == OK_ATOM) {
@@ -115,8 +111,80 @@ int main(int argc, char **argv)
     }
 
     context_destroy(ctx);
-    globalcontext_destroy(glb);
-    module_destroy(mod);
 
     return status;
+}
+
+/**
+ * @brief Send a message to a (registered) erlang process.
+ * @details This function is thread safe and is meant to be executed on the
+ * browser's main thread. It is typically called by `Module.cast` wrapper in
+ * `atomvm.pre.js`.
+ * @param name Name of the process to send a message to
+ * @param message Message to send to the process
+ */
+EMSCRIPTEN_KEEPALIVE
+void cast(const char *name, const char *message)
+{
+    sys_enqueue_emscripten_cast_message(global, name, message);
+}
+
+/**
+ * @brief Send a message to a (registered) erlang process and wait for
+ * the result.
+ * @details This function returns an Emscripten promise handle which needs to
+ * be converted to the actual promise so Javascript can await on it.
+ * This is typically done by using `Module.call` wrapper in `atomvm.pre.js`.
+ * @param name Name of the process to send a message to
+ * @param message Message to send to the process
+ * @return a promise handle
+ */
+EMSCRIPTEN_KEEPALIVE
+em_promise_t call(const char *name, const char *message)
+{
+    return sys_enqueue_emscripten_call_message(global, name, message);
+}
+
+/**
+ * @brief Emscripten entry point
+ * @details For node builds, this function is run in the main thread. For web
+ * builds, this function actually is proxied by Emscripten SDK and runs on a
+ * web worker thread.
+ *
+ * In both cases, the function requires paths to one or more Erlang `.beam` or
+ * AtomVM `.avm` files.
+ *
+ * @param argc number of arguments
+ * @param argv arguments
+ * @return EXIT_SUCCESS or EXIT_FAILURE
+ */
+int main(int argc, char **argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "No .avm or .beam module specified\n");
+        return EXIT_FAILURE;
+    }
+    int result = EXIT_SUCCESS;
+
+    global = globalcontext_new();
+
+    for (int i = 1; i < argc; ++i) {
+        result = load_module(argv[i]);
+        if (UNLIKELY(result != EXIT_SUCCESS)) {
+            break;
+        }
+    }
+    if (result == EXIT_SUCCESS) {
+        result = start();
+    }
+
+    globalcontext_destroy(global);
+    global = NULL;
+
+    if (main_module) {
+        module_destroy(main_module);
+        main_module = NULL;
+    }
+
+    return result;
 }

--- a/src/platforms/emscripten/tests/.gitignore
+++ b/src/platforms/emscripten/tests/.gitignore
@@ -1,7 +1,7 @@
 #
 # This file is part of AtomVM.
 #
-# Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+# Copyright 2022 Paul Guyot <pguyot@kallisys.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,26 +17,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
-
-cmake_minimum_required (VERSION 3.13)
-project (libAtomVMPlatformEmscripten)
-
-set(HEADER_FILES
-    emscripten_sys.h
-)
-
-set(SOURCE_FILES
-    platform_defaultatoms.c
-    platform_nifs.c
-    sys.c
-)
-
-set(
-    PLATFORM_LIB_SUFFIX
-    ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
-)
-
-add_library(libAtomVM${PLATFORM_LIB_SUFFIX} ${SOURCE_FILES} ${HEADER_FILES})
-target_compile_features(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC c_std_11)
-
-target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC libAtomVM)
+node_modules
+package-lock.json
+package.json
+cypress/downloads
+cypress/screenshots
+cypress/videos

--- a/src/platforms/emscripten/tests/cypress.config.js
+++ b/src/platforms/emscripten/tests/cypress.config.js
@@ -1,0 +1,37 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 by Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  e2e: {
+    supportFile: false,
+    baseUrl: 'http://localhost:8080',
+    video: false,
+    setupNodeEvents(on, config) {
+        // https://github.com/cypress-io/cypress/issues/19912
+        on('before:browser:launch', (browser = {}, launchOptions) => {
+            if (browser.family === 'chromium' && browser.name !== 'electron') {
+              launchOptions.args.push('--enable-features=SharedArrayBuffer')
+            }
+            return launchOptions
+          })
+        },
+    },
+})

--- a/src/platforms/emscripten/tests/cypress/e2e/call.spec.cy.js
+++ b/src/platforms/emscripten/tests/cypress/e2e/call.spec.cy.js
@@ -1,0 +1,66 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 by Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+describe('call', () => {
+    beforeEach(() => {
+        cy.visit('/tests/src/test_call.html')
+    })
+
+    it('should resolve an integer', () => {
+        cy.get('#target-input').type('main')
+        cy.get('#message-input').type('resolve-42')
+        cy.get('#call-button').click()
+        cy.get('#result').should('contain', '42')
+    })
+
+    it('should resolve a string', () => {
+        cy.get('#target-input').type('main')
+        cy.get('#message-input').type('resolve-ok')
+        cy.get('#call-button').click()
+        cy.get('#result').should('contain', 'ok')
+    })
+
+    it('should reject an integer', () => {
+        cy.get('#target-input').type('main')
+        cy.get('#message-input').type('reject-42')
+        cy.get('#call-button').click()
+        cy.get('#error').should('contain', '42')
+    })
+
+    it('should reject a string', () => {
+        cy.get('#target-input').type('main')
+        cy.get('#message-input').type('reject-ok')
+        cy.get('#call-button').click()
+        cy.get('#error').should('contain', 'ok')
+    })
+
+    it('should reject an unknown process', () => {
+        cy.get('#target-input').type('unknown')
+        cy.get('#message-input').type('resolve-ok')
+        cy.get('#call-button').click()
+        cy.get('#error').should('contain', 'noproc')
+    })
+
+    it('should reject a garbage collected promise', () => {
+        cy.get('#target-input').type('main')
+        cy.get('#message-input').type('ignore')
+        cy.get('#call-button').click()
+        cy.get('#error').should('contain', 'noproc')
+    })
+});

--- a/src/platforms/emscripten/tests/cypress/e2e/examples.spec.cy.js
+++ b/src/platforms/emscripten/tests/cypress/e2e/examples.spec.cy.js
@@ -1,0 +1,89 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 by Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+describe('emscripten examples homepage', () => {
+    it('should list examples', () => {
+        cy.visit('/')
+        cy.contains('Hello world')
+        cy.contains('Run script')
+        cy.contains('Call & cast')
+    })
+});
+
+describe('emscripten hello world AVM', () => {
+    it('should output to console', () => {
+        cy.visit('/hello_world_avm.html', {
+            onBeforeLoad(win) {
+                cy.stub(win.console, 'log').as('consoleLog')
+                cy.stub(win.console, 'error').as('consoleError')
+            }
+        })
+        cy.get('@consoleLog').should('be.calledWith', 'Hello World')
+        cy.get('@consoleLog').should('be.calledWith', 'Return value: ok')
+        cy.get('@consoleError').should('not.be.called')
+    })
+});
+
+describe('emscripten hello world BEAM', () => {
+    it('should output to console', () => {
+        cy.visit('/hello_world_beam.html', {
+            onBeforeLoad(win) {
+                cy.stub(win.console, 'log').as('consoleLog')
+                cy.stub(win.console, 'error').as('consoleError')
+            }
+        })
+        cy.get('@consoleLog').should('be.calledWith', 'Hello World')
+        cy.get('@consoleLog').should('be.calledWith', 'Return value: ok')
+        cy.get('@consoleError').should('not.be.called')
+    })
+});
+
+describe('emscripten run script', () => {
+    it('should display three alerts and update counter', () => {
+        const alert = cy.stub().as("alert")
+        cy.on('window:alert', alert)
+        cy.visit('/run_script.html')
+        cy.get('#demo-counter').should('contain', 'unset')
+        cy.get("@alert").should("have.been.calledWith", "hello from Erlang in main thread")
+        cy.get("@alert").should("have.been.calledWithMatch", "hello from Erlang in worker thread")
+        cy.get("@alert").should("have.been.calledWith", "hello from Erlang in main thread async")
+        cy.get('#demo-counter').should('contain', 'ms')
+    })
+});
+
+describe('emscripten call & cast', () => {
+    it('should update counters when clicked', () => {
+        cy.visit('/call_cast.html')
+        cy.get('#call-counter').should('contain', '0')
+        cy.get('button#call-button').click()
+        cy.get('#call-counter').should('contain', '1')
+        cy.get('button#call-button').click()
+        cy.get('#call-counter').should('contain', '2')
+        cy.get('button#call-button').click()
+        cy.get('#call-counter').should('contain', '3')
+        cy.get('button#call-button').click()
+        cy.get('#call-counter').should('contain', '4')
+        cy.get('button#call-button').click()
+        cy.get('#call-counter').should('contain', '5')
+        cy.get('#cast-counter').should('contain', '0')
+        cy.get('button#cast-button').click()
+        cy.get('#cast-counter').should('contain', '1')
+        cy.get('#call-counter').should('contain', '5')
+    })
+});

--- a/src/platforms/emscripten/tests/src/CMakeLists.txt
+++ b/src/platforms/emscripten/tests/src/CMakeLists.txt
@@ -18,25 +18,19 @@
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-cmake_minimum_required(VERSION 3.13)
+project(tests_emscripten)
 
-project(AtomVM)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules")
+function(compile_erlang module_name)
+    add_custom_command(
+        OUTPUT ${module_name}.beam
+        COMMAND erlc ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl
+        COMMENT "Compiling ${module_name}.erl"
+    )
+endfunction()
 
-# Include an error in case the user forgets to specify emscripten toolchain
-if (NOT CMAKE_TOOLCHAIN_FILE)
-    message(FATAL_ERROR "Cross compiling only. Please use emcmake cmake or use -DCMAKE_TOOLCHAIN_FILE")
-endif ()
+compile_erlang(test_call)
 
-# Options that make sense for this platform
-set(AVM_DISABLE_SMP ON FORCE)
-option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
-option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
-
-set(
-    PLATFORM_LIB_SUFFIX
-    ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
+add_custom_target(emscripten_erlang_test_modules DEPENDS
+    test_call.beam
 )
-
-add_subdirectory(src)
-add_subdirectory(tests/src)

--- a/src/platforms/emscripten/tests/src/test_call.erl
+++ b/src/platforms/emscripten/tests/src/test_call.erl
@@ -1,0 +1,64 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_call).
+-export([start/0]).
+
+start() ->
+    register(main, self()),
+    emscripten:run_script(
+        [
+            <<
+                "window.document.getElementById('call-button').onclick = async () => {"
+                "const target = window.document.getElementById('target-input').value;"
+                "const message = window.document.getElementById('message-input').value;"
+                "try {"
+                "const result = await Module.call(target, message);"
+                "window.document.getElementById('result').innerHTML = result;"
+                "} catch (error) {"
+                "window.document.getElementById('error').innerHTML = error;"
+                "}"
+                "};"
+            >>,
+            <<"window.document.getElementById('call-button').disabled = false;">>
+        ],
+        [main_thread, async]
+    ),
+    loop().
+
+loop() ->
+    % make sure refc promise is garbage collected
+    erlang:garbage_collect(),
+    receive
+        {emscripten, {call, _Promise, <<"ignore">>}} ->
+            loop();
+        {emscripten, {call, Promise, <<"resolve-42">>}} ->
+            emscripten:promise_resolve(Promise, 42),
+            loop();
+        {emscripten, {call, Promise, <<"resolve-ok">>}} ->
+            emscripten:promise_resolve(Promise, <<"ok">>),
+            loop();
+        {emscripten, {call, Promise, <<"reject-42">>}} ->
+            emscripten:promise_reject(Promise, 42),
+            loop();
+        {emscripten, {call, Promise, <<"reject-ok">>}} ->
+            emscripten:promise_reject(Promise, <<"ok">>),
+            loop()
+    end.

--- a/src/platforms/emscripten/tests/src/test_call.html
+++ b/src/platforms/emscripten/tests/src/test_call.html
@@ -1,0 +1,41 @@
+<!--
+This file is part of AtomVM.
+
+Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <input id="target-input" type="text" />
+    <input id="message-input" type="text" />
+    <button id="call-button" disabled>Call</button>
+    <div id="result"></div>
+    <div id="error"></div>
+    <script>
+    // Arguments are loaded using fetch API.
+    // wasm_webserver serves under /tests/build/ files in src/platform/escripten/build/tests/src subdirectory
+    // and under /build/ files in build/ subdirectory.
+    var Module = {
+        arguments: ['/tests/build/test_call.beam', '/build/libs/eavmlib/src/eavmlib.avm']
+    }
+    </script>
+    <script async src="/AtomVM.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Update Emscripten port so that AtomVM can run in the browser
Add API to run Javascript from Erlang
Add API to call Erlang from Javascript
Add new web server to serve example files with proper headers

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
