### PR TITLE
Add support for `crypto:hash/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `esp:partition_list/0` function
 - Added `esp:nvs_fetch_binary/2` and `nvs_put_binary/3` functions (`esp:nvs_set_binary` and
 functions that default to `?ATOMVM_NVS_NS` are deprecated now).
+- Added support for `crypto:hash/2` (ESP32 and generic_unix with openssl)
 
 ### Fixed
 - Fixed issue with formatting integers with io:format() on STM32 platform

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -627,11 +627,6 @@ To convert a `datetime()` to convert the number of seconds since midnight Januar
 
 ### Miscellaneous
 
-Use the `erlang:md5/1` function to compute the MD5 hash of an input binary.  The output is a fixed-length binary ()
-
-    %% erlang
-    Hash = erlang:md5(<<foo>>).
-
 Use `atomvm:random/0` to generate a random unsigned 32-bit integer in the range `0..4294967295`:
 
     %% erlang
@@ -800,6 +795,35 @@ The input values for these functions may be `float` or `integer` types.  The ret
 Input values that are out of range for the specific mathematical function or which otherwise are invalid or yield an invalid result (e.g., division by 0) will result in a `badarith` error.
 
 > Note.  If the AtomVM virtual machine is built with floating point arithmetic support disabled, these functions will result in a `badarg` error.
+
+### Cryptographic Operations
+
+You can hash binary date using the `crypto:hash/2` function.
+
+    %% erlang
+    crypto:hash(sha, [<<"Some binary">>, $\s, "data"])
+
+This function takes a hash algorithm, which may be one of:
+
+    -type md_type() :: md5 | sha | sha224 | sha256 | sha384 | sha512.
+
+and an IO list.  The output type is a binary, who's length (in bytes) is dependent on the algorithm chosen:
+
+| Algorithm | Hash Length (bytes) |
+|-----------|-------------|
+| `md5` | 16 |
+| `sha` | 20 |
+| `sha224` | 32 |
+| `sha256` | 32 |
+| `sha384` | 64 |
+| `sha512` | 64 |
+
+> Note.  The `crypto:hash/2` function is currently only supported on the ESP32 and generic UNIX platforms.
+
+You can also use the legacy `erlang:md5/1` function to compute the MD5 hash of an input binary.  The output is a fixed-length binary (16 bytes)
+
+    %% erlang
+    Hash = erlang:md5(<<foo>>).
 
 ## ESP32-specific APIs
 

--- a/libs/estdlib/src/crypto.erl
+++ b/libs/estdlib/src/crypto.erl
@@ -1,0 +1,39 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License")
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+-module(crypto).
+
+-export([
+    hash/2
+]).
+
+-type hash_algorithm() :: md5 | sha | sha224 | sha256 | sha384 | sha512.
+-type digest() :: binary().
+
+%%-----------------------------------------------------------------------------
+%% @param   Type the hash algorithm
+%% @param   Data the data to hash
+%% @returns Returns the result of hashing the supplied data using the supplied
+%%          hash algorithm.
+%% @doc     Hash data using a specified hash algorithm.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec hash(Type :: hash_algorithm(), Data :: iolist()) -> digest().
+hash(_Type, _Data) ->
+    erlang:nif_error(undefined).

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -250,7 +250,7 @@ system_flag(_Key, _Value) ->
 %%-----------------------------------------------------------------------------
 -spec md5(Data :: binary()) -> binary().
 md5(Data) when is_binary(Data) ->
-    erlang:nif_error(undefined).
+    crypto:hash(md5, Data).
 
 %%-----------------------------------------------------------------------------
 %% @param   Module Name of module

--- a/src/platforms/esp32/components/avm_sys/CMakeLists.txt
+++ b/src/platforms/esp32/components/avm_sys/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 idf_component_register(
     SRCS ${AVM_SYS_COMPONENT_SRCS}
     INCLUDE_DIRS "include"
-    REQUIRES "spi_flash" "soc" "newlib" "pthread" "vfs" ${ADDITIONAL_COMPONENTS}
+    REQUIRES "spi_flash" "soc" "newlib" "pthread" "vfs" "mbedtls" ${ADDITIONAL_COMPONENTS}
     PRIV_REQUIRES "libatomvm" "esp_timer" ${ADDITIONAL_PRIV_REQUIRES}
 )
 

--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -36,25 +36,12 @@
 #include <esp_partition.h>
 #include <esp_sleep.h>
 #include <esp_system.h>
+#include <mbedtls/md5.h>
+#include <mbedtls/sha1.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/sha512.h>
 #include <soc/soc.h>
 #include <stdlib.h>
-#if defined __has_include
-#  if __has_include (<esp_idf_version.h>)
-#    include <esp_idf_version.h>
-#  endif
-#endif
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0) && CONFIG_IDF_TARGET_ESP32
-#include <esp_rom_md5.h>
-#else
-#include <rom/md5_hash.h>
-#endif
-#if CONFIG_IDF_TARGET_ESP32C3
-#include "esp32c3/rom/md5_hash.h"
-#elif CONFIG_IDF_TARGET_ESP32S2
-#include "esp32s2/rom/md5_hash.h"
-#elif CONFIG_IDF_TARGET_ESP32S3
-#include "esp32s3/rom/md5_hash.h"
-#endif
 
 // introduced starting with 4.4
 #if ESP_IDF_VERSION_MAJOR >= 5
@@ -66,7 +53,7 @@
 
 #define TAG "atomvm"
 
-#define MD5_DIGEST_LENGTH 16
+#define MAX_MD_SIZE 64
 
 static const char *const esp_rst_unknown_atom   = "\xF"  "esp_rst_unknown";
 static const char *const esp_rst_poweron        = "\xF"  "esp_rst_poweron";
@@ -92,6 +79,33 @@ static const AtomStringIntPair interface_table[] = {
     { ATOM_STR("\xB", "wifi_softap"), WifiSoftAPInterface },
     SELECT_INT_DEFAULT(InvalidInterface)
 };
+
+enum crypto_algorithm
+{
+    CryptoInvalidAlgorithm = 0,
+    CryptoMd5,
+    CryptoSha1,
+    CryptoSha224,
+    CryptoSha256,
+    CryptoSha384,
+    CryptoSha512
+};
+
+static const AtomStringIntPair crypto_algorithm_table[] = {
+    { ATOM_STR("\x3", "md5"), CryptoMd5 },
+    { ATOM_STR("\x3", "sha"), CryptoSha1 },
+    { ATOM_STR("\x6", "sha224"), CryptoSha224 },
+    { ATOM_STR("\x6", "sha256"), CryptoSha256 },
+    { ATOM_STR("\x6", "sha384"), CryptoSha384 },
+    { ATOM_STR("\x6", "sha512"), CryptoSha512 },
+    SELECT_INT_DEFAULT(CryptoInvalidAlgorithm)
+};
+
+#if defined __has_include
+#if __has_include(<esp_idf_version.h>)
+#include <esp_idf_version.h>
+#endif
+#endif
 
 //
 // NIFs
@@ -435,27 +449,156 @@ static term nif_esp_sleep_enable_ext1_wakeup(Context *ctx, int argc, term argv[]
 
 #endif
 
-static term nif_rom_md5(Context *ctx, int argc, term argv[])
+#define DEFINE_DO_HASH(ALGORITHM, SUFFIX)                                                                      \
+    static InteropFunctionResult ALGORITHM##_hash_fold_fun(term t, void *accum)                                \
+    {                                                                                                          \
+        mbedtls_##ALGORITHM##_context *md_ctx = (mbedtls_##ALGORITHM##_context *) accum;                       \
+        if (term_is_integer(t)) {                                                                              \
+            uint8_t val = term_to_uint8(t);                                                                    \
+            mbedtls_##ALGORITHM##_update##SUFFIX(md_ctx, &val, 1);                                             \
+        } else if (term_is_binary(t)) {                                                                        \
+            mbedtls_##ALGORITHM##_update(md_ctx, (uint8_t *) term_binary_data(t), term_binary_size(t));        \
+        }                                                                                                      \
+        return InteropOk;                                                                                      \
+    }                                                                                                          \
+                                                                                                               \
+    static bool do_##ALGORITHM##_hash(term data, unsigned char *dst)                                           \
+    {                                                                                                          \
+        mbedtls_##ALGORITHM##_context md_ctx;                                                                  \
+                                                                                                               \
+        mbedtls_##ALGORITHM##_init(&md_ctx);                                                                   \
+        mbedtls_##ALGORITHM##_starts##SUFFIX(&md_ctx);                                                         \
+                                                                                                               \
+        InteropFunctionResult result = interop_iolist_fold(data, ALGORITHM##_hash_fold_fun, (void *) &md_ctx); \
+        if (UNLIKELY(result != InteropOk)) {                                                                   \
+            return false;                                                                                      \
+        }                                                                                                      \
+                                                                                                               \
+        if (UNLIKELY(mbedtls_##ALGORITHM##_finish##SUFFIX(&md_ctx, dst) != 0)) {                               \
+            return false;                                                                                      \
+        }                                                                                                      \
+                                                                                                               \
+        return true;                                                                                           \
+    }
+
+#define DEFINE_DO_HASH2(ALGORITHM, SUFFIX, IS_OTHER)                                                           \
+    static InteropFunctionResult ALGORITHM##_hash_fold_fun_##IS_OTHER(term t, void *accum)                     \
+    {                                                                                                          \
+        mbedtls_##ALGORITHM##_context *md_ctx = (mbedtls_##ALGORITHM##_context *) accum;                       \
+        if (term_is_any_integer(t)) {                                                                          \
+            avm_int64_t tmp = term_maybe_unbox_int64(t);                                                       \
+            if (tmp < 0 || tmp > 255) {                                                                        \
+                return InteropBadArg;                                                                          \
+            }                                                                                                  \
+            uint8_t val = (avm_int64_t) tmp;                                                                   \
+            mbedtls_##ALGORITHM##_update##SUFFIX(md_ctx, &val, 1);                                             \
+        } else if (term_is_binary(t)) {                                                                        \
+            mbedtls_##ALGORITHM##_update(md_ctx, (uint8_t *) term_binary_data(t), term_binary_size(t));        \
+        }                                                                                                      \
+        return InteropOk;                                                                                      \
+    }                                                                                                          \
+                                                                                                               \
+    static bool do_##ALGORITHM##_hash_##IS_OTHER(term data, unsigned char *dst)                                \
+    {                                                                                                          \
+        mbedtls_##ALGORITHM##_context md_ctx;                                                                  \
+                                                                                                               \
+        mbedtls_##ALGORITHM##_init(&md_ctx);                                                                   \
+        mbedtls_##ALGORITHM##_starts##SUFFIX(&md_ctx, IS_OTHER);                                               \
+                                                                                                               \
+        InteropFunctionResult result = interop_iolist_fold(data, ALGORITHM##_hash_fold_fun_##IS_OTHER, (void *) &md_ctx); \
+        if (UNLIKELY(result != InteropOk)) {                                                                   \
+            return false;                                                                                      \
+        }                                                                                                      \
+                                                                                                               \
+        if (UNLIKELY(mbedtls_##ALGORITHM##_finish##SUFFIX(&md_ctx, dst) != 0)) {                               \
+            return false;                                                                                      \
+        }                                                                                                      \
+                                                                                                               \
+        return true;                                                                                           \
+    }
+
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+
+DEFINE_DO_HASH(md5, _ret)
+DEFINE_DO_HASH(sha1, _ret)
+DEFINE_DO_HASH2(sha256, _ret, true)
+DEFINE_DO_HASH2(sha256, _ret, false)
+DEFINE_DO_HASH2(sha512, _ret, true)
+DEFINE_DO_HASH2(sha512, _ret, false)
+
+#else
+
+DEFINE_DO_HASH(md5, )
+DEFINE_DO_HASH(sha1, )
+DEFINE_DO_HASH2(sha256, , true)
+DEFINE_DO_HASH2(sha256, , false)
+DEFINE_DO_HASH2(sha512, , true)
+DEFINE_DO_HASH2(sha512, , false)
+
+#endif
+
+static term nif_crypto_hash(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);
-    term data = argv[0];
-    VALIDATE_VALUE(data, term_is_binary);
+    term type = argv[0];
+    VALIDATE_VALUE(type, term_is_atom);
+    term data = argv[1];
 
-    unsigned char digest[MD5_DIGEST_LENGTH];
-    struct MD5Context md5;
-    #if __has_include (<esp_idf_version.h>) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0) && CONFIG_IDF_TARGET_ESP32
-    esp_rom_md5_init(&md5);
-    esp_rom_md5_update(&md5, (const unsigned char *) term_binary_data(data), term_binary_size(data));
-    esp_rom_md5_final(digest, &md5);
-    #else
-    MD5Init(&md5);
-    MD5Update(&md5, (const unsigned char *) term_binary_data(data), term_binary_size(data));
-    MD5Final(digest, &md5);
-    #endif
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(MD5_DIGEST_LENGTH)) != MEMORY_GC_OK)) {
+    unsigned char digest[MAX_MD_SIZE];
+    size_t digest_len = 0;
+
+    enum crypto_algorithm algo = interop_atom_term_select_int(crypto_algorithm_table, type, ctx->global);
+    switch (algo) {
+        case CryptoMd5: {
+            if (UNLIKELY(!do_md5_hash(data, digest))) {
+                RAISE_ERROR(BADARG_ATOM)
+            }
+            digest_len = 16;
+            break;
+        }
+        case CryptoSha1: {
+            if (UNLIKELY(!do_sha1_hash(data, digest))) {
+                RAISE_ERROR(BADARG_ATOM)
+            }
+            digest_len = 20;
+            break;
+        }
+        case CryptoSha224: {
+            if (UNLIKELY(!do_sha256_hash_true(data, digest))) {
+                RAISE_ERROR(BADARG_ATOM)
+            }
+            digest_len = 28;
+            break;
+        }
+        case CryptoSha256: {
+            if (UNLIKELY(!do_sha256_hash_false(data, digest))) {
+                RAISE_ERROR(BADARG_ATOM)
+            }
+            digest_len = 32;
+            break;
+        }
+        case CryptoSha384: {
+            if (UNLIKELY(!do_sha512_hash_true(data, digest))) {
+                RAISE_ERROR(BADARG_ATOM)
+            }
+            digest_len = 48;
+            break;
+        }
+        case CryptoSha512: {
+            if (UNLIKELY(!do_sha512_hash_false(data, digest))) {
+                RAISE_ERROR(BADARG_ATOM)
+            }
+            digest_len = 64;
+            break;
+        }
+        default:
+            RAISE_ERROR(BADARG_ATOM);
+    }
+
+    if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(digest_len)) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
-    return term_from_literal_binary(digest, MD5_DIGEST_LENGTH, &ctx->heap, ctx->global);
+    return term_from_literal_binary(digest, digest_len, &ctx->heap, ctx->global);
 }
 
 static term nif_atomvm_platform(Context *ctx, int argc, term argv[])
@@ -566,10 +709,10 @@ static const struct Nif esp_sleep_enable_ext1_wakeup_nif =
     .nif_ptr = nif_esp_sleep_enable_ext1_wakeup
 };
 #endif
-static const struct Nif rom_md5_nif =
+static const struct Nif crypto_hash_nif =
 {
     .base.type = NIFFunctionType,
-    .nif_ptr = nif_rom_md5
+    .nif_ptr = nif_crypto_hash
 };
 static const struct Nif atomvm_platform_nif =
 {
@@ -638,9 +781,9 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
         return &esp_sleep_enable_ext1_wakeup_nif;
     }
 #endif
-    if (strcmp("erlang:md5/1", nifname) == 0) {
+    if (strcmp("crypto:hash/2", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
-        return &rom_md5_nif;
+        return &crypto_hash_nif;
     }
     if (strcmp("atomvm:platform/0", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);

--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -40,6 +40,7 @@ compile_erlang(test_esp_partition)
 compile_erlang(test_file)
 compile_erlang(test_list_to_binary)
 compile_erlang(test_md5)
+compile_erlang(test_crypto)
 compile_erlang(test_monotonic_time)
 compile_erlang(test_rtc_slow)
 compile_erlang(test_select)
@@ -55,6 +56,7 @@ add_custom_command(
         test_file.beam
         test_list_to_binary.beam
         test_md5.beam
+        test_crypto.beam
         test_monotonic_time.beam
         test_rtc_slow.beam
         test_select.beam
@@ -67,6 +69,7 @@ add_custom_command(
         "${CMAKE_CURRENT_BINARY_DIR}/test_file.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_list_to_binary.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_md5.beam"
+        "${CMAKE_CURRENT_BINARY_DIR}/test_crypto.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_monotonic_time.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_rtc_slow.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_select.beam"

--- a/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
@@ -1,0 +1,93 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+-module(test_crypto).
+
+-export([start/0]).
+
+start() ->
+    ok = test_hash(),
+    ok.
+
+test_hash() ->
+    test_hash(
+        <<56, 88, 246, 34, 48, 172, 60, 145, 95, 48, 12, 102, 67, 18, 198, 63>>,
+        md5,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+    test_hash(
+        <<136, 67, 215, 249, 36, 22, 33, 29, 233, 235, 185, 99, 255, 76, 226, 129, 37, 147, 40,
+            120>>,
+        sha,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+    test_hash(
+        <<222, 118, 195, 229, 103, 252, 169, 210, 70, 245, 248, 211, 178, 231, 4, 163, 140, 60, 94,
+            37, 137, 136, 171, 82, 95, 148, 29, 184>>,
+        sha224,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+    test_hash(
+        <<195, 171, 143, 241, 55, 32, 232, 173, 144, 71, 221, 57, 70, 107, 60, 137, 116, 229, 146,
+            194, 250, 56, 61, 74, 57, 96, 113, 76, 174, 240, 196, 242>>,
+        sha256,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+    test_hash(
+        <<60, 156, 48, 217, 246, 101, 231, 77, 81, 92, 132, 41, 96, 212, 164, 81, 200, 58, 1, 37,
+            253, 61, 231, 57, 45, 123, 55, 35, 26, 241, 12, 114, 234, 88, 174, 223, 205, 248, 154,
+            87, 101, 191, 144, 42, 249, 62, 207, 6>>,
+        sha384,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+    test_hash(
+        <<10, 80, 38, 30, 189, 26, 57, 15, 237, 43, 243, 38, 242, 103, 60, 20, 85, 130, 166, 52, 45,
+            82, 50, 4, 151, 61, 2, 25, 51, 127, 129, 97, 106, 128, 105, 176, 18, 88, 124, 245, 99,
+            95, 105, 37, 241, 181, 108, 54, 2, 48, 193, 155, 39, 53, 0, 238, 1, 62, 3, 6, 1, 191,
+            36, 37>>,
+        sha512,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+
+    ok = expect(badarg, fun() -> crypto:hash(not_a_type, <<"foobar">>) end),
+    ok = expect(badarg, fun() -> crypto:hash(sha, not_a_binary) end),
+    ok = expect(badarg, fun() -> crypto:hash(sha, ["not", "an", [iolist]]) end),
+    ok = expect(badarg, fun() -> crypto:hash(sha, ["not", "a", "byte", -1]) end),
+    ok = expect(badarg, fun() -> crypto:hash(sha, ["not", "a", "byte", 32768]) end),
+    ok = expect(badarg, fun() -> crypto:hash(sha, ["not", "a", "byte", 34359738367]) end),
+
+    ok.
+
+test_hash(Expect, Type, DataList) ->
+    [Expect = crypto:hash(Type, Data) || Data <- DataList].
+
+expect(Error, F) ->
+    try
+        F(),
+        fail
+    catch
+        _:E ->
+            %% NB. Error types vary across OTP implementations
+            case erlang:system_info(machine) of
+                "BEAM" ->
+                    ok;
+                _ when Error == E ->
+                    ok
+            end
+    end.

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -224,6 +224,12 @@ TEST_CASE("test_md5", "[test_run]")
     TEST_ASSERT(ret_value == OK_ATOM);
 }
 
+TEST_CASE("test_crypto", "[test_run]")
+{
+    term ret_value = avm_test_case("test_crypto.beam");
+    TEST_ASSERT(ret_value == OK_ATOM);
+}
+
 TEST_CASE("test_monotonic_time", "[test_run]")
 {
     term ret_value = avm_test_case("test_monotonic_time.beam");

--- a/src/platforms/generic_unix/lib/platform_nifs.c
+++ b/src/platforms/generic_unix/lib/platform_nifs.c
@@ -22,6 +22,7 @@
 
 #include "atom.h"
 #include "defaultatoms.h"
+#include "interop.h"
 #include "memory.h"
 #include "nifs.h"
 #include "platform_defaultatoms.h"
@@ -29,7 +30,7 @@
 #include <stdlib.h>
 
 #if defined ATOMVM_HAS_OPENSSL
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 #include <openssl/rand.h>
 #endif
 
@@ -49,18 +50,118 @@
     return term_invalid_term();
 
 #if defined ATOMVM_HAS_OPENSSL
-static term nif_openssl_md5(Context *ctx, int argc, term argv[])
+
+enum crypto_algorithm
+{
+    CryptoInvalidAlgorithm = 0,
+    CryptoMd5,
+    CryptoSha1,
+    CryptoSha224,
+    CryptoSha256,
+    CryptoSha384,
+    CryptoSha512
+};
+
+static const AtomStringIntPair crypto_algorithm_table[] = {
+    { ATOM_STR("\x3", "md5"), CryptoMd5 },
+    { ATOM_STR("\x3", "sha"), CryptoSha1 },
+    { ATOM_STR("\x6", "sha224"), CryptoSha224 },
+    { ATOM_STR("\x6", "sha256"), CryptoSha256 },
+    { ATOM_STR("\x6", "sha384"), CryptoSha384 },
+    { ATOM_STR("\x6", "sha512"), CryptoSha512 },
+    SELECT_INT_DEFAULT(CryptoInvalidAlgorithm)
+};
+
+const char *get_crypto_algorithm(GlobalContext *global, term type)
+{
+    enum crypto_algorithm algo = interop_atom_term_select_int(crypto_algorithm_table, type, global);
+    switch (algo) {
+        case CryptoMd5:
+            return "MD5";
+        case CryptoSha1:
+            return "SHA1";
+        case CryptoSha224:
+            return "SHA224";
+        case CryptoSha256:
+            return "SHA256";
+        case CryptoSha384:
+            return "SHA384";
+        case CryptoSha512:
+            return "SHA512";
+        default:
+            return NULL;
+    }
+}
+
+static InteropFunctionResult hash_fold_fun(term t, void *accum)
+{
+    EVP_MD_CTX *md_ctx = (EVP_MD_CTX *) accum;
+    if (term_is_any_integer(t)) {
+        avm_int64_t tmp = term_maybe_unbox_int64(t);
+        if (tmp < 0 || tmp > 255) {
+            return InteropBadArg;
+        }
+        uint8_t val = (avm_int64_t) tmp;
+        if (!EVP_DigestUpdate(md_ctx, &val, 1)) {
+            return InteropBadArg;
+        }
+    } else if (term_is_binary(t)) {
+        if (!EVP_DigestUpdate(md_ctx, (uint8_t *) term_binary_data(t), term_binary_size(t))) {
+            return InteropBadArg;
+        }
+    }
+    return InteropOk;
+}
+
+static term nif_crypto_hash(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);
-    term data = argv[0];
-    VALIDATE_VALUE(data, term_is_binary);
+    term type = argv[0];
+    term data = argv[1];
+    VALIDATE_VALUE(type, term_is_atom);
 
-    unsigned char digest[MD5_DIGEST_LENGTH];
-    MD5((const unsigned char *) term_binary_data(data), term_binary_size(data), digest);
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(MD5_DIGEST_LENGTH)) != MEMORY_GC_OK)) {
+    const char *algorithm = get_crypto_algorithm(ctx->global, type);
+    if (IS_NULL_PTR(algorithm)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    const EVP_MD *md = EVP_get_digestbyname(algorithm);
+    if (IS_NULL_PTR(md)) {
+        fprintf(stderr, "Could not find digest by name: %s\n", algorithm);
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
+    if (IS_NULL_PTR(md_ctx)) {
+        fprintf(stderr, "Could not allocate MD context\n");
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
-    return term_from_literal_binary(digest, MD5_DIGEST_LENGTH, &ctx->heap, ctx->global);
+
+    if (UNLIKELY(!EVP_DigestInit_ex(md_ctx, md, NULL))) {
+        fprintf(stderr, "Digest init failed for algorithm: %s\n", algorithm);
+        EVP_MD_CTX_free(md_ctx);
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    InteropFunctionResult result = interop_iolist_fold(data, hash_fold_fun, (void *) md_ctx);
+    if (result != InteropOk) {
+        fprintf(stderr, "Failed hashing input for algorithm: %s\n", algorithm);
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int md_len;
+    if (!EVP_DigestFinal_ex(md_ctx, digest, &md_len)) {
+        fprintf(stderr, "Failed finishing hash for algorithm: %s\n", algorithm);
+        EVP_MD_CTX_free(md_ctx);
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    EVP_MD_CTX_free(md_ctx);
+    if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(md_len)) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    return term_from_literal_binary(digest, md_len, &ctx->heap, ctx->global);
 }
 
 static term nif_openssl_rand_bytes(Context *ctx, int argc, term argv[])
@@ -107,10 +208,10 @@ static term nif_openssl_random(Context *ctx, int argc, term argv[])
     return term_make_boxed_int(value, &ctx->heap);
 }
 
-static const struct Nif openssl_md5_nif =
+static const struct Nif crypto_hash_nif =
 {
     .base.type = NIFFunctionType,
-    .nif_ptr = nif_openssl_md5
+    .nif_ptr = nif_crypto_hash
 };
 static const struct Nif openssl_rand_bytes_nif =
 {
@@ -142,9 +243,9 @@ static const struct Nif atomvm_platform_nif =
 const struct Nif *platform_nifs_get_nif(const char *nifname)
 {
 #if defined ATOMVM_HAS_OPENSSL
-    if (strcmp("erlang:md5/1", nifname) == 0) {
+    if (strcmp("crypto:hash/2", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
-        return &openssl_md5_nif;
+        return &crypto_hash_nif;
     }
     if (strcmp("atomvm:rand_bytes/1", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -466,6 +466,7 @@ compile_erlang(trap_exit_flag)
 
 compile_erlang(test_stacktrace)
 compile_erlang(small_big_ext)
+compile_erlang(test_crypto)
 
 compile_erlang(test_code_load_binary)
 compile_erlang(test_code_load_abs)
@@ -904,8 +905,9 @@ add_custom_target(erlang_test_modules DEPENDS
     trap_exit_flag.beam
 
     test_stacktrace.beam
-    
+
     small_big_ext.beam
+    test_crypto.beam
 
     test_code_load_binary.beam
     test_code_load_abs.beam

--- a/tests/erlang_tests/test_crypto.erl
+++ b/tests/erlang_tests/test_crypto.erl
@@ -1,0 +1,93 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+-module(test_crypto).
+
+-export([start/0]).
+
+start() ->
+    ok = test_hash(),
+    0.
+
+test_hash() ->
+    test_hash(
+        <<56, 88, 246, 34, 48, 172, 60, 145, 95, 48, 12, 102, 67, 18, 198, 63>>,
+        md5,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+    test_hash(
+        <<136, 67, 215, 249, 36, 22, 33, 29, 233, 235, 185, 99, 255, 76, 226, 129, 37, 147, 40,
+            120>>,
+        sha,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+    test_hash(
+        <<222, 118, 195, 229, 103, 252, 169, 210, 70, 245, 248, 211, 178, 231, 4, 163, 140, 60, 94,
+            37, 137, 136, 171, 82, 95, 148, 29, 184>>,
+        sha224,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+    test_hash(
+        <<195, 171, 143, 241, 55, 32, 232, 173, 144, 71, 221, 57, 70, 107, 60, 137, 116, 229, 146,
+            194, 250, 56, 61, 74, 57, 96, 113, 76, 174, 240, 196, 242>>,
+        sha256,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+    test_hash(
+        <<60, 156, 48, 217, 246, 101, 231, 77, 81, 92, 132, 41, 96, 212, 164, 81, 200, 58, 1, 37,
+            253, 61, 231, 57, 45, 123, 55, 35, 26, 241, 12, 114, 234, 88, 174, 223, 205, 248, 154,
+            87, 101, 191, 144, 42, 249, 62, 207, 6>>,
+        sha384,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+    test_hash(
+        <<10, 80, 38, 30, 189, 26, 57, 15, 237, 43, 243, 38, 242, 103, 60, 20, 85, 130, 166, 52, 45,
+            82, 50, 4, 151, 61, 2, 25, 51, 127, 129, 97, 106, 128, 105, 176, 18, 88, 124, 245, 99,
+            95, 105, 37, 241, 181, 108, 54, 2, 48, 193, 155, 39, 53, 0, 238, 1, 62, 3, 6, 1, 191,
+            36, 37>>,
+        sha512,
+        [<<"foobar">>, "foobar", [<<"foo">>, <<"bar">>]]
+    ),
+
+    ok = expect(badarg, fun() -> crypto:hash(not_a_type, <<"foobar">>) end),
+    ok = expect(badarg, fun() -> crypto:hash(sha, not_a_binary) end),
+    ok = expect(badarg, fun() -> crypto:hash(sha, ["not", "an", [iolist]]) end),
+    ok = expect(badarg, fun() -> crypto:hash(sha, ["not", "a", "byte", -1]) end),
+    ok = expect(badarg, fun() -> crypto:hash(sha, ["not", "a", "byte", 32768]) end),
+    ok = expect(badarg, fun() -> crypto:hash(sha, ["not", "a", "byte", 34359738367]) end),
+
+    ok.
+
+test_hash(Expect, Type, DataList) ->
+    [Expect = crypto:hash(Type, Data) || Data <- DataList].
+
+expect(Error, F) ->
+    try
+        F(),
+        fail
+    catch
+        _:E ->
+            %% NB. Error types vary across OTP implementations
+            case erlang:system_info(machine) of
+                "BEAM" ->
+                    ok;
+                _ when Error == E ->
+                    ok
+            end
+    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -502,6 +502,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(trap_exit_flag, 1),
     TEST_CASE_COND(test_stacktrace, 0, SKIP_STACKTRACES),
     TEST_CASE(small_big_ext),
+    TEST_CASE(test_crypto),
 
     TEST_CASE(test_min_max_guard),
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
