### PR TITLE
Fixed a bug in list_to_binary

### DIFF
--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -37,6 +37,7 @@ function(compile_erlang module_name)
 endfunction()
 
 compile_erlang(test_file)
+compile_erlang(test_list_to_binary)
 compile_erlang(test_md5)
 compile_erlang(test_monotonic_time)
 compile_erlang(test_rtc_slow)
@@ -49,6 +50,7 @@ add_custom_command(
     COMMAND HostAtomVM-prefix/src/HostAtomVM-build/tools/packbeam/PackBEAM -i esp32_test_modules.avm
         HostAtomVM-prefix/src/HostAtomVM-build/libs/atomvmlib.avm
         test_file.beam
+        test_list_to_binary.beam
         test_md5.beam
         test_monotonic_time.beam
         test_rtc_slow.beam
@@ -58,6 +60,7 @@ add_custom_command(
     DEPENDS
         HostAtomVM
         "${CMAKE_CURRENT_BINARY_DIR}/test_file.beam"
+        "${CMAKE_CURRENT_BINARY_DIR}/test_list_to_binary.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_md5.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_monotonic_time.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_rtc_slow.beam"

--- a/src/platforms/esp32/test/main/test_erl_sources/test_list_to_binary.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_list_to_binary.erl
@@ -1,0 +1,34 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_list_to_binary).
+
+-export([start/0]).
+
+start() ->
+    ok = test_empty_list_to_binary(),
+    ok.
+
+test_empty_list_to_binary() ->
+    <<"">> = erlang:list_to_binary(id([])),
+    ok.
+
+id(X) ->
+    X.

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -204,6 +204,12 @@ TEST_CASE("test_file", "[test_run]")
     ESP_LOGI(TAG, "Card unmounted");
 }
 
+TEST_CASE("test_list_to_binary", "[test_run]")
+{
+    term ret_value = avm_test_case("test_list_to_binary.beam");
+    TEST_ASSERT(ret_value == OK_ATOM);
+}
+
 TEST_CASE("test_md5", "[test_run]")
 {
     term ret_value = avm_test_case("test_md5.beam");

--- a/tests/erlang_tests/test_list_to_binary.erl
+++ b/tests/erlang_tests/test_list_to_binary.erl
@@ -26,6 +26,7 @@ start() ->
     ok = test_concat(),
     ok = test_iolist(),
     ok = test_iolist_to_binary(),
+    ok = test_empty_list_to_binary(),
     0.
 
 test_concat() ->
@@ -57,6 +58,10 @@ test_iolist_to_binary() ->
             error:badarg ->
                 fail
         end,
+    ok.
+
+test_empty_list_to_binary() ->
+    <<"">> = erlang:list_to_binary([]),
     ok.
 
 concat(A, B) ->


### PR DESCRIPTION
malloc(0) returns NULL on ESP32, which results in an OUT_OF_MEMORY error.  This PR checks handles the case where the size of the input list is 0 specially.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
