### PR TITLE
SPI: API renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `esp:get_default_mac/0` for retrieving the default MAC address on ESP32.
 
+### Changed
+
+- Shorten SPI config options, such as `sclk_io_num` -> `sclk`
+
 ## [0.6.0-alpha.2] - 2023-12-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `esp:get_default_mac/0` for retrieving the default MAC address on ESP32.
+- Added support for `pico` and `poci` as an alternative to `mosi` and `miso` for SPI
 
 ### Changed
 

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -1220,11 +1220,11 @@ The AtomVM SPI implementation uses the AtomVM Port mechanism and must be initial
 
 The `bus_config` properties list contains the following entries:
 
-| Key | Value Type | Required | Description |
-|-----|------------|----------|---|
-| `miso` | `integer()` | yes | SPI leader-in, follower-out pin (MOSI) |
-| `mosi` | `integer()` | yes | SPI leader-out, follower-in pin (MISO) |
-| `sclk` | `integer()` | yes | SPI clock pin (SCLK) |
+| Key              | Value Type  | Required    | Description                                  |
+|------------------|-------------|-------------|----------------------------------------------|
+| `poci` (`miso`)  | `integer()` | yes         | SPI peripheral-out, controller-in pin (MOSI) |
+| `pico` (`mosi`)  | `integer()` | yes         | SPI peripheral-in, controller-out pin (MISO) |
+| `sclk`           | `integer()` | yes         | SPI clock pin (SCLK)                         |
 
 The `device_config` entry is a properties list containing entries for each device attached to the SPI Bus.  Each entry in this list contains the user-selected name (as an atom) of the device, followed by configuration for the named device.
 

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -1222,9 +1222,9 @@ The `bus_config` properties list contains the following entries:
 
 | Key | Value Type | Required | Description |
 |-----|------------|----------|---|
-| `miso_io_num` | `integer()` | yes | SPI leader-in, follower-out pin (MOSI) |
-| `mosi_io_num` | `integer()` | yes | SPI leader-out, follower-in pin (MISO) |
-| `sclk_io_num` | `integer()` | yes | SPI clock pin (SCLK) |
+| `miso` | `integer()` | yes | SPI leader-in, follower-out pin (MOSI) |
+| `mosi` | `integer()` | yes | SPI leader-out, follower-in pin (MISO) |
+| `sclk` | `integer()` | yes | SPI clock pin (SCLK) |
 
 The `device_config` entry is a properties list containing entries for each device attached to the SPI Bus.  Each entry in this list contains the user-selected name (as an atom) of the device, followed by configuration for the named device.
 
@@ -1232,9 +1232,9 @@ Each device configuration is a properties list containing the following entries:
 
 | Key | Value Type | Required | Description |
 |-----|------------|----------|---|
-| `spi_clock_hz` | `integer()` | yes | SPI clock frequency (in hertz) |
+| `clock_speed_hz` | `integer()` | yes | SPI clock frequency (in hertz) |
 | `mode` | `0..3` | yes | SPI mode, indicating clock polarity (`CPOL`) and clock phase (`CPHA`).  Consult the SPI specification and data sheet for your device, for more information about how to control the behavior of the SPI clock. |
-| `spi_cs_io_num` | `integer()` | yes | SPI chip select pin (CS) |
+| `cs` | `integer()` | yes | SPI chip select pin (CS) |
 | `address_len_bits` | `0..64` | yes | number of bits in the address field of a read/write operation (for example, 8, if the transaction address field is a single byte) |
 | `command_len_bits` | `0..16` | default: 0 | number of bits in the command field of a read/write operation (for example, 8, if the transaction command field is a single byte) |
 
@@ -1243,21 +1243,21 @@ For example,
     %% erlang
     SPIConfig = [
         {bus_config, [
-            {miso_io_num, 19},
-            {mosi_io_num, 27},
-            {sclk_io_num, 5}
+            {miso, 19},
+            {mosi, 27},
+            {sclk, 5}
         ]},
         {device_config, [
             {my_device_1, [
-                {spi_clock_hz, 1000000},
+                {clock_speed_hz, 1000000},
                 {mode, 0},
-                {spi_cs_io_num, 18},
+                {cs, 18},
                 {address_len_bits, 8}
             ]}
             {my_device_2, [
-                {spi_clock_hz, 1000000},
+                {clock_speed_hz, 1000000},
                 {mode, 0},
-                {spi_cs_io_num, 15},
+                {cs, 15},
                 {address_len_bits, 8}
             ]}
         ]}

--- a/examples/erlang/esp32/sx127x.erl
+++ b/examples/erlang/esp32/sx127x.erl
@@ -67,15 +67,15 @@
 
 -define(SPISettings, [
     {bus_config, [
-        {miso_io_num, 19},
-        {mosi_io_num, 27},
-        {sclk_io_num, 5}
+        {miso, 19},
+        {mosi, 27},
+        {sclk, 5}
     ]},
     {device_config, [
         {my_device, [
-            {spi_clock_hz, 1000000},
+            {clock_speed_hz, 1000000},
             {mode, 0},
-            {spi_cs_io_num, 18},
+            {cs, 18},
             {address_len_bits, 8}
         ]}
     ]}

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -162,10 +162,10 @@ static void debug_buscfg(spi_bus_config_t *buscfg)
 {
     TRACE("Bus Config\n");
     TRACE("==========\n");
-    TRACE("    miso_io_num: %i\n", buscfg->miso_io_num);
-    TRACE("    mosi_io_num: %i\n", buscfg->mosi_io_num);
-    TRACE("    sclk_io_num: %i\n", buscfg->sclk_io_num);
-    TRACE("    miso_io_num: %i\n", buscfg->miso_io_num);
+    TRACE("    miso: %i\n", buscfg->miso_io_num);
+    TRACE("    mosi: %i\n", buscfg->mosi_io_num);
+    TRACE("    sclk: %i\n", buscfg->sclk_io_num);
+    TRACE("    miso: %i\n", buscfg->miso_io_num);
     TRACE("    quadwp_io_num: %i\n", buscfg->quadwp_io_num);
     TRACE("    quadhd_io_num: %i\n", buscfg->quadhd_io_num);
 }
@@ -176,7 +176,7 @@ static void debug_devcfg(spi_device_interface_config_t *devcfg)
     TRACE("==========\n");
     TRACE("    clock_speed_hz: %i\n", devcfg->clock_speed_hz);
     TRACE("    mode: %i\n", devcfg->mode);
-    TRACE("    spics_io_num: %i\n", devcfg->spics_io_num);
+    TRACE("    cs: %i\n", devcfg->spics_io_num);
     TRACE("    queue_size: %i\n", devcfg->queue_size);
     TRACE("    address_bits: %i\n", devcfg->address_bits);
 }
@@ -195,16 +195,16 @@ Context *spi_driver_create_port(GlobalContext *global, term opts)
     term hspi_atom = globalcontext_make_atom(global, ATOM_STR("\x4", "hspi"));
 
     term bus_config = interop_kv_get_value(opts, ATOM_STR("\xA", "bus_config"), global);
-    term miso_io_num_term = interop_kv_get_value(bus_config, ATOM_STR("\xB", "miso_io_num"), global);
-    term mosi_io_num_term = interop_kv_get_value(bus_config, ATOM_STR("\xB", "mosi_io_num"), global);
-    term sclk_io_num_term = interop_kv_get_value(bus_config, ATOM_STR("\xB", "sclk_io_num"), global);
-    term spi_peripheral_term = interop_kv_get_value_default(bus_config, ATOM_STR("\xB", "spi_peripheral"), hspi_atom, global);
-    spi_host_device_t host_device = get_spi_host_device(spi_peripheral_term, global);
+    term miso_term = interop_kv_get_value(bus_config, ATOM_STR("\x4", "miso"), global);
+    term mosi_term = interop_kv_get_value(bus_config, ATOM_STR("\x4", "mosi"), global);
+    term sclk_term = interop_kv_get_value(bus_config, ATOM_STR("\x4", "sclk"), global);
+    term peripheral_term = interop_kv_get_value_default(bus_config, ATOM_STR("\xA", "peripheral"), hspi_atom, global);
+    spi_host_device_t host_device = get_spi_host_device(peripheral_term, global);
 
     spi_bus_config_t buscfg = { 0 };
-    buscfg.miso_io_num = term_to_int32(miso_io_num_term);
-    buscfg.mosi_io_num = term_to_int32(mosi_io_num_term);
-    buscfg.sclk_io_num = term_to_int32(sclk_io_num_term);
+    buscfg.miso_io_num = term_to_int32(miso_term);
+    buscfg.mosi_io_num = term_to_int32(mosi_term);
+    buscfg.sclk_io_num = term_to_int32(sclk_term);
     buscfg.quadwp_io_num = -1;
     buscfg.quadhd_io_num = -1;
 
@@ -237,16 +237,16 @@ Context *spi_driver_create_port(GlobalContext *global, term opts)
         term device_name = term_get_tuple_element(device_names, i);
         term device_config = term_get_map_assoc(device_map, device_name, ctx->global);
 
-        term clock_speed_hz_term = interop_kv_get_value(device_config, ATOM_STR("\xC", "spi_clock_hz"), global);
+        term clock_speed_hz_term = interop_kv_get_value(device_config, ATOM_STR("\xE", "clock_speed_hz"), global);
         term mode_term = interop_kv_get_value(device_config, ATOM_STR("\x4", "mode"), global);
-        term spics_io_num_term = interop_kv_get_value(device_config, ATOM_STR("\xD", "spi_cs_io_num"), global);
+        term cs_term = interop_kv_get_value(device_config, ATOM_STR("\x2", "cs"), global);
         term address_bits_term = interop_kv_get_value(device_config, ATOM_STR("\x10", "address_len_bits"), global);
         term command_bits_term = interop_kv_get_value(device_config, ATOM_STR("\x10", "command_len_bits"), global);
 
         spi_device_interface_config_t devcfg = { 0 };
         devcfg.clock_speed_hz = term_to_int32(clock_speed_hz_term);
         devcfg.mode = term_to_int32(mode_term);
-        devcfg.spics_io_num = term_to_int32(spics_io_num_term);
+        devcfg.spics_io_num = term_to_int32(cs_term);
         devcfg.queue_size = 4;
         devcfg.address_bits = term_to_int32(address_bits_term);
         devcfg.command_bits = term_to_int32(command_bits_term);


### PR DESCRIPTION
Make names shorter and clearer, with no additional clutter.

Closes #651 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
