### PR TITLE
Make atomvm:add_avm_pack_file/2 return a meaningful error

### DIFF
--- a/src/libAtomVM/sys.h
+++ b/src/libAtomVM/sys.h
@@ -40,10 +40,22 @@ extern "C" {
 #include <stdint.h>
 #include <time.h>
 
+struct AVMPackData;
+
 enum
 {
     SYS_POLL_EVENTS_DO_NOT_WAIT = 0,
     SYS_POLL_EVENTS_WAIT_FOREVER = -1
+};
+
+enum OpenAVMResult
+{
+    AVM_OPEN_OK = 0,
+    AVM_OPEN_FAILED_ALLOC = 1,
+    AVM_OPEN_INVALID = 2,
+    AVM_OPEN_CANNOT_OPEN = 3,
+    AVM_OPEN_CANNOT_READ = 4,
+    AVM_OPEN_NOT_SUPPORTED = 5
 };
 
 /**
@@ -182,7 +194,8 @@ void sys_signal(GlobalContext *glb);
 
 #endif
 
-struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *path);
+enum OpenAVMResult sys_open_avm_from_file(
+    GlobalContext *global, const char *path, struct AVMPackData **data);
 
 /**
  * @brief gets wall clock time

--- a/src/platforms/emscripten/src/lib/sys.c
+++ b/src/platforms/emscripten/src/lib/sys.c
@@ -412,7 +412,8 @@ static void *load_or_fetch_file(const char *path, emscripten_fetch_t **fetch, si
     return (void *) (*fetch)->data;
 }
 
-struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *path)
+enum OpenAVMResult sys_open_avm_from_file(
+    GlobalContext *global, const char *path, struct AVMPackData **avm_data)
 {
     TRACE("sys_open_avm_from_file: Going to open: %s\n", path);
 
@@ -421,7 +422,7 @@ struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *pa
     emscripten_fetch_t *fetch = NULL;
     void *data = load_or_fetch_file(path, &fetch, NULL);
     if (IS_NULL_PTR(data)) {
-        return NULL;
+        return AVM_OPEN_CANNOT_OPEN;
     }
 
     struct ConstAVMPack *const_avm = malloc(sizeof(struct ConstAVMPack));
@@ -431,12 +432,13 @@ struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *pa
         } else {
             free(data);
         }
-        return NULL;
+        return AVM_OPEN_FAILED_ALLOC;
     }
     avmpack_data_init(&const_avm->base, &const_avm_pack_info);
     const_avm->base.data = (const uint8_t *) data;
 
-    return &const_avm->base;
+    *avm_data = &const_avm->base;
+    return AVM_OPEN_OK;
 }
 
 Module *sys_load_module_from_file(GlobalContext *global, const char *path)

--- a/src/platforms/emscripten/src/main.c
+++ b/src/platforms/emscripten/src/main.c
@@ -48,8 +48,8 @@ static int load_module(const char *path)
 {
     const char *ext = strrchr(path, '.');
     if (ext && strcmp(ext, ".avm") == 0) {
-        struct AVMPackData *avmpack_data = sys_open_avm_from_file(global, path);
-        if (IS_NULL_PTR(avmpack_data)) {
+        struct AVMPackData *avmpack_data;
+        if (sys_open_avm_from_file(global, path, &avmpack_data) != AVM_OPEN_OK) {
             fprintf(stderr, "Failed opening %s.\n", path);
             return EXIT_FAILURE;
         }

--- a/src/platforms/generic_unix/main.c
+++ b/src/platforms/generic_unix/main.c
@@ -54,8 +54,8 @@ int main(int argc, char **argv)
     for (int i = 1; i < argc; ++i) {
         const char *ext = strrchr(argv[i], '.');
         if (ext && strcmp(ext, ".avm") == 0) {
-            struct AVMPackData *avmpack_data = sys_open_avm_from_file(glb, argv[i]);
-            if (IS_NULL_PTR(avmpack_data)) {
+            struct AVMPackData *avmpack_data;
+            if (UNLIKELY(sys_open_avm_from_file(glb, argv[i], &avmpack_data) != AVM_OPEN_OK)) {
                 fprintf(stderr, "Failed opening %s.\n", argv[i]);
                 return EXIT_FAILURE;
             }

--- a/src/platforms/rp2040/src/lib/sys.c
+++ b/src/platforms/rp2040/src/lib/sys.c
@@ -135,13 +135,14 @@ uint64_t sys_monotonic_millis()
     return usec / 1000;
 }
 
-struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *path)
+enum OpenAVMResult sys_open_avm_from_file(
+    GlobalContext *global, const char *path, struct AVMPackData **data)
 {
     UNUSED(global);
     UNUSED(path);
 
-    // No file support on pico.
-    return NULL;
+    // TODO
+    return AVM_OPEN_NOT_SUPPORTED;
 }
 
 Module *sys_load_module_from_file(GlobalContext *global, const char *path)

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -101,12 +101,13 @@ uint64_t sys_monotonic_millis()
     return system_millis;
 }
 
-struct AVMPackData *sys_open_avm_from_file(GlobalContext *global, const char *path)
+enum OpenAVMResult sys_open_avm_from_file(
+    GlobalContext *global, const char *path, struct AVMPackData **data)
 {
     TRACE("sys_open_avm_from_file: Going to open: %s\n", path);
 
     // TODO
-    return NULL;
+    return AVM_OPEN_NOT_SUPPORTED;
 }
 
 Module *sys_load_module_from_file(GlobalContext *global, const char *path)


### PR DESCRIPTION
This change is required for #657.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
