### PR TITLE
CI ESP32 build: update esp-idf versions

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -31,9 +31,9 @@ jobs:
 
       matrix:
         idf-version:
-        - 4.4.4
-        - 5.0.2
-        - 5.1-rc1
+        - '4.4.5'
+        - '5.0.3'
+        - '5.1'
 
     steps:
     - name: Checkout repo


### PR DESCRIPTION
Use latest released versions.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
