### PR TITLE
generic_unix: exports symbols in order to make plugins work

### DIFF
--- a/src/platforms/generic_unix/CMakeLists.txt
+++ b/src/platforms/generic_unix/CMakeLists.txt
@@ -21,7 +21,7 @@
 cmake_minimum_required (VERSION 3.13)
 
 add_executable(AtomVM main.c)
-set_target_properties(AtomVM PROPERTIES RUNTIME_OUTPUT_DIRECTORY ../../)
+set_target_properties(AtomVM PROPERTIES RUNTIME_OUTPUT_DIRECTORY ../../ ENABLE_EXPORTS ON)
 target_compile_features(AtomVM PUBLIC c_std_11)
 if(CMAKE_COMPILER_IS_GNUCC)
     target_compile_options(AtomVM PUBLIC -Wall -pedantic -Wextra -ggdb)


### PR DESCRIPTION
Enable ENABLE_EXPORTS executable target option which exports all executable symbols, so dlopen doesn't fail when loading a plugin. ENABLE_EXPORTS uses -export-dynamic/-rdynamic.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
