### PR TITLE
Completely remove idf < 4.4

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -48,10 +48,6 @@ jobs:
         idf.py build
         idf.py size
     - name: Print component size info with idf.py
-      # size-components doesn't work with a .noinit section on 4.2.x branch.
-      # The bug was fixed on later versions and didn't occur on 4.0.x & 3.x
-      # https://github.com/espressif/esp-idf/issues/8428
-      if: matrix.build-system == 'idf' && matrix.idf-version != '4.2.3'
       shell: bash
       working-directory: ./src/platforms/esp32/
       run: |

--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -47,10 +47,9 @@ AtomVM currently supports the following versions of ESP-IDF:
 
 | Espressif supported versions | AtomVM support |
 |------------------------------|----------------|
-| ESP-IDF v4.2 | ✅ |
-| ESP-IDF v4.3 | ✅ |
 | ESP-IDF v4.4 | ✅ |
 | ESP-IDF v5.0 | ✅ |
+| ESP-IDF v5.1 | ✅ |
 
 Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the ([AtomVM repositories](https://github.com/atomvm)) you will need a compatible version of ([Espressif's](https:/espressif.com)) ESP-IDF.  Espressif provides excellent [installation documentation](https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/get-started/index.html).
 

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -413,14 +413,7 @@ static wifi_config_t *get_sta_wifi_config(term sta_config, GlobalContext *global
 static char *get_default_device_name(esp_mac_type_t interface)
 {
     uint8_t mac[6];
-// Support actually begins with IDF v4.3
-#if ESP_IDF_VERSION_MAJOR == 5
     esp_read_mac(mac, interface);
-// TODO: remove this conditional when IDF 4.2 is dropped.
-#else
-    UNUSED(interface);
-    esp_efuse_mac_get_default(mac);
-#endif
 
     size_t buf_size = strlen("atomvm-") + 12 + 1;
     char *buf = malloc(buf_size);


### PR DESCRIPTION
ESP-IDF < v4.4 wasn't already supported since #679, however it was still mentioned in documentation, and previous releases were mentioned in few other places.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
