### PR TITLE
Build and test on macos with OTP24-26

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-11"]
-        otp: ["23", "24", "25"]
+        otp: ["24", "25", "26"]
 
     steps:
     # Setup


### PR DESCRIPTION
Linux builds rely on setup-beam which is broken for OTP26.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
