### PR TITLE
Implement `min/2` and `max/2` as bifs

### DIFF
--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -316,22 +316,22 @@ map_is_key(_Key, _Map) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec min(A :: any(), B :: any()) -> any().
-min(A, B) when A < B -> A;
-min(_A, B) -> B.
+min(_A, _B) ->
+    throw(bif_error).
 
 %%-----------------------------------------------------------------------------
 %% @param   A   any term
 %% @param   B   any term
 %% @returns `A' if `A > B'; `B', otherwise.
-%% @doc     Return the minimum value of two terms
+%% @doc     Return the maximum value of two terms
 %%
 %% Terms are compared using `>' and follow the ordering principles defined in
 %% https://www.erlang.org/doc/reference_manual/expressions.html#term-comparisons
 %% @end
 %%-----------------------------------------------------------------------------
 -spec max(A :: any(), B :: any()) -> any().
-max(A, B) when A > B -> A;
-max(_A, B) -> B.
+max(_A, _B) ->
+    throw(bif_error).
 
 %%-----------------------------------------------------------------------------
 %% @param   Type the type of memory to request

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -39,8 +39,7 @@ extern "C" {
 
 #define MAX_BIF_NAME_LEN 260
 
-BifImpl bif_registry_get_handler(AtomString module, AtomString function, int arity);
-bool bif_registry_is_gc_bif(AtomString module, AtomString function, int arity);
+const struct ExportedFunction *bif_registry_get_handler(AtomString module, AtomString function, int arity);
 
 term bif_erlang_self_0(Context *ctx);
 term bif_erlang_byte_size_1(Context *ctx, int live, term arg1);
@@ -107,6 +106,9 @@ term bif_erlang_less_than_or_equal_2(Context *ctx, term arg1, term arg2);
 term bif_erlang_greater_than_or_equal_2(Context *ctx, term arg1, term arg2);
 
 term bif_erlang_get_1(Context *ctx, term arg1);
+
+term bif_erlang_min_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_max_2(Context *ctx, term arg1, term arg2);
 
 #ifdef __cplusplus
 }

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -28,60 +28,65 @@ typedef struct BifNameAndPtr BifNameAndPtr;
 struct BifNameAndPtr
 {
   const char *name;
-  BifImpl function;
-  bool gc_bif : 1;
+  union
+  {
+    struct Bif bif;
+    struct GCBif gcbif;
+  };
 };
 %%
-erlang:self/0, bif_erlang_self_0, false
-erlang:length/1, bif_erlang_length_1, true
-erlang:byte_size/1, bif_erlang_byte_size_1, true
-erlang:bit_size/1, bif_erlang_bit_size_1, true
-erlang:get/1, bif_erlang_get_1, false
-erlang:is_atom/1, bif_erlang_is_atom_1, false
-erlang:is_binary/1, bif_erlang_is_binary_1, false
-erlang:is_boolean/1, bif_erlang_is_boolean_1, false
-erlang:is_float/1, bif_erlang_is_float_1, false
-erlang:is_function/1, bif_erlang_is_function_1, false
-erlang:is_integer/1, bif_erlang_is_integer_1, false
-erlang:is_list/1, bif_erlang_is_list_1, false
-erlang:is_number/1, bif_erlang_is_number_1, false
-erlang:is_pid/1, bif_erlang_is_pid_1, false
-erlang:is_reference/1, bif_erlang_is_reference_1, false
-erlang:is_tuple/1, bif_erlang_is_tuple_1, false
-erlang:is_map/1, bif_erlang_is_map_1, false
-erlang:is_map_key/2, bif_erlang_is_map_key_2, false
-erlang:not/1, bif_erlang_not_1, false
-erlang:and/2, bif_erlang_and_2, false
-erlang:or/2, bif_erlang_or_2, false
-erlang:xor/2, bif_erlang_xor_2, false
-erlang:==/2, bif_erlang_equal_to_2, false
-erlang:/=/2, bif_erlang_not_equal_to_2, false
-erlang:=:=/2, bif_erlang_exactly_equal_to_2, false
-erlang:=/=/2, bif_erlang_exactly_not_equal_to_2, false
-erlang:>/2, bif_erlang_greater_than_2, false
-erlang:</2, bif_erlang_less_than_2, false
-erlang:=</2, bif_erlang_less_than_or_equal_2, false
-erlang:>=/2, bif_erlang_greater_than_or_equal_2, false
-erlang:+/2, bif_erlang_add_2, true
-erlang:-/2, bif_erlang_sub_2, true
-erlang:*/2, bif_erlang_mul_2, true
-erlang:div/2, bif_erlang_div_2, true
-erlang:rem/2, bif_erlang_rem_2, true
-erlang:-/1, bif_erlang_neg_1, true
-erlang:abs/1, bif_erlang_abs_1, true
-erlang:ceil/1, bif_erlang_ceil_1, true
-erlang:floor/1, bif_erlang_floor_1, true
-erlang:round/1, bif_erlang_round_1, true
-erlang:trunc/1, bif_erlang_trunc_1, true
-erlang:bor/2, bif_erlang_bor_2, true
-erlang:band/2, bif_erlang_band_2, true
-erlang:bxor/2, bif_erlang_bxor_2, true
-erlang:bsl/2, bif_erlang_bsl_2, true
-erlang:bsr/2, bif_erlang_bsr_2, true
-erlang:bnot/1, bif_erlang_bnot_1, true
-erlang:hd/1, bif_erlang_hd_1, false
-erlang:tl/1, bif_erlang_tl_1, false
-erlang:element/2, bif_erlang_element_2, false
-erlang:tuple_size/1, bif_erlang_tuple_size_1, false
-erlang:map_size/1, bif_erlang_map_size_1, true
-erlang:map_get/2, bif_erlang_map_get_2, false
+erlang:self/0, {.bif.base.type = BIFFunctionType, .bif.bif0_ptr = bif_erlang_self_0}
+erlang:length/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_length_1}
+erlang:byte_size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_byte_size_1}
+erlang:bit_size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_bit_size_1}
+erlang:get/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_get_1}
+erlang:is_atom/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_atom_1}
+erlang:is_binary/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_binary_1}
+erlang:is_boolean/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_boolean_1}
+erlang:is_float/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_float_1}
+erlang:is_function/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_function_1}
+erlang:is_integer/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_integer_1}
+erlang:is_list/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_list_1}
+erlang:is_number/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_number_1}
+erlang:is_pid/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_pid_1}
+erlang:is_reference/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_reference_1}
+erlang:is_tuple/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_tuple_1}
+erlang:is_map/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_map_1}
+erlang:is_map_key/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_is_map_key_2}
+erlang:not/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_not_1}
+erlang:and/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_and_2}
+erlang:or/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_or_2}
+erlang:xor/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_xor_2}
+erlang:==/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_equal_to_2}
+erlang:/=/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_not_equal_to_2}
+erlang:=:=/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_exactly_equal_to_2}
+erlang:=/=/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_exactly_not_equal_to_2}
+erlang:>/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_greater_than_2}
+erlang:</2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_less_than_2}
+erlang:=</2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_less_than_or_equal_2}
+erlang:>=/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_greater_than_or_equal_2}
+erlang:+/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_add_2}
+erlang:-/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_sub_2}
+erlang:*/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_mul_2}
+erlang:div/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_div_2}
+erlang:rem/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_rem_2}
+erlang:-/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_neg_1}
+erlang:abs/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_abs_1}
+erlang:ceil/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_ceil_1}
+erlang:floor/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_floor_1}
+erlang:round/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_round_1}
+erlang:trunc/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_trunc_1}
+erlang:bor/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_bor_2}
+erlang:band/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_band_2}
+erlang:bxor/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_bxor_2}
+erlang:bsl/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_bsl_2}
+erlang:bsr/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_bsr_2}
+erlang:bnot/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_bnot_1}
+erlang:hd/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_hd_1}
+erlang:tl/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_tl_1}
+erlang:element/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_element_2}
+erlang:tuple_size/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_tuple_size_1}
+erlang:map_size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_map_size_1}
+erlang:map_get/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_map_get_2}
+erlang:min/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_min_2}
+erlang:max/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_max_2}

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -113,7 +113,7 @@ struct Module
     struct ModuleFilename *filenames;
     struct ListHead line_ref_offsets;
 
-    union imported_func *imported_funcs;
+    const struct ExportedFunction **imported_funcs;
 
     void **labels;
 
@@ -254,7 +254,7 @@ static inline const struct ExportedFunction *module_resolve_function(Module *mod
     // We cannot optimistically read the unresolved function call.
     // While reads of imported_funcs can happen outside the lock, read of the func
     // pointer itself cannot, as UnresolvedFunctionCall pointers are freed.
-    struct ExportedFunction *func = (struct ExportedFunction *) mod->imported_funcs[import_table_index].func;
+    const struct ExportedFunction *func = mod->imported_funcs[import_table_index];
     if (func->type != UnresolvedFunctionCall) {
         SMP_MODULE_UNLOCK(mod);
         return func;

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3052,7 +3052,7 @@ static term nif_erlang_function_exported(Context *ctx, int argc, term argv[])
     AtomString function_name = globalcontext_atomstring_from_term(ctx->global, function);
     avm_int_t arity = term_to_int(arity_term);
 
-    BifImpl bif = bif_registry_get_handler(module_name, function_name, arity);
+    const struct ExportedFunction *bif = bif_registry_get_handler(module_name, function_name, arity);
     if (bif) {
         return TRUE_ATOM;
     }

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1259,41 +1259,37 @@ term make_fun(Context *ctx, const Module *mod, int fun_index)
 static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString function_name, int arity,
     term *return_value)
 {
-    BifImpl bif = bif_registry_get_handler(module_name, function_name, arity);
-    if (bif) {
-        if (bif_registry_is_gc_bif(module_name, function_name, arity)) {
+    const struct ExportedFunction *exported_bif = bif_registry_get_handler(module_name, function_name, arity);
+    if (exported_bif) {
+        if (exported_bif->type == GCBIFFunctionType) {
+            const struct GCBif *gcbif = EXPORTED_FUNCTION_TO_GCBIF(exported_bif);
             switch (arity) {
                 case 1: {
-                    GCBifImpl1 gcbif1 = (GCBifImpl1) bif;
-                    *return_value = gcbif1(ctx, 0, ctx->x[0]);
+                    *return_value = gcbif->gcbif1_ptr(ctx, 0, ctx->x[0]);
                     return true;
                 }
                 case 2: {
-                    GCBifImpl2 gcbif2 = (GCBifImpl2) bif;
-                    *return_value = gcbif2(ctx, 0, ctx->x[0], ctx->x[1]);
+                    *return_value = gcbif->gcbif2_ptr(ctx, 0, ctx->x[0], ctx->x[1]);
                     return true;
                 }
                 case 3: {
-                    GCBifImpl3 gcbif3 = (GCBifImpl3) bif;
-                    *return_value = gcbif3(ctx, 0, ctx->x[0], ctx->x[1], ctx->x[2]);
+                    *return_value = gcbif->gcbif3_ptr(ctx, 0, ctx->x[0], ctx->x[1], ctx->x[2]);
                     return true;
                 }
             }
         } else {
+            const struct Bif *bif = EXPORTED_FUNCTION_TO_BIF(exported_bif);
             switch (arity) {
                 case 0: {
-                    BifImpl0 bif0 = (BifImpl0) bif;
-                    *return_value = bif0(ctx);
+                    *return_value = bif->bif0_ptr(ctx);
                     return true;
                 }
                 case 1: {
-                    BifImpl1 bif1 = (BifImpl1) bif;
-                    *return_value = bif1(ctx, ctx->x[0]);
+                    *return_value = bif->bif1_ptr(ctx, ctx->x[0]);
                     return true;
                 }
                 case 2: {
-                    BifImpl2 bif2 = (BifImpl2) bif;
-                    *return_value = bif2(ctx, ctx->x[0], ctx->x[1]);
+                    *return_value = bif->bif2_ptr(ctx, ctx->x[0], ctx->x[1]);
                     return true;
                 }
             }
@@ -1724,6 +1720,26 @@ schedule_in:
 
                             break;
                         }
+                        case BIFFunctionType: {
+                            // Support compilers < OTP26 that generate CALL_EXT
+                            // for min/2 and max/2
+                            const struct Bif *bif = EXPORTED_FUNCTION_TO_BIF(func);
+                            switch (arity) {
+                                case 0:
+                                    ctx->x[0] = bif->bif0_ptr(ctx);
+                                    break;
+                                case 1:
+                                    ctx->x[0] = bif->bif1_ptr(ctx, ctx->x[0]);
+                                    break;
+                                case 2:
+                                    ctx->x[0] = bif->bif2_ptr(ctx, ctx->x[0], ctx->x[1]);
+                                    break;
+                                default:
+                                    fprintf(stderr, "Invalid arity %" PRIu32 " for bif\n", arity);
+                            }
+
+                            break;
+                        }
                         default: {
                             fprintf(stderr, "Invalid function type %i at index: %" PRIu32 "\n", func->type, index);
                             AVM_ABORT();
@@ -1800,6 +1816,32 @@ schedule_in:
 
                             break;
                         }
+                        case BIFFunctionType: {
+                            // Support compilers < OTP26 that generate CALL_EXT_LAST
+                            // for min/2 and max/2
+                            // These are safe regarding otp issue #7152
+                            ctx->cp = ctx->e[n_words];
+                            ctx->e += (n_words + 1);
+
+                            const struct Bif *bif = EXPORTED_FUNCTION_TO_BIF(func);
+                            switch (arity) {
+                                case 0:
+                                    ctx->x[0] = bif->bif0_ptr(ctx);
+                                    break;
+                                case 1:
+                                    ctx->x[0] = bif->bif1_ptr(ctx, ctx->x[0]);
+                                    break;
+                                case 2:
+                                    ctx->x[0] = bif->bif2_ptr(ctx, ctx->x[0], ctx->x[1]);
+                                    break;
+                                default:
+                                    fprintf(stderr, "Invalid arity %" PRIu32 " for bif\n", arity);
+                            }
+
+                            DO_RETURN();
+
+                            break;
+                        }
                         default: {
                             fprintf(stderr, "Invalid function type %i at index: %" PRIu32 "\n", func->type, index);
                             AVM_ABORT();
@@ -1827,7 +1869,8 @@ schedule_in:
                 USED_BY_TRACE(dreg);
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    BifImpl0 func = (BifImpl0) mod->imported_funcs[bif].bif;
+                    const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
+                    BifImpl0 func = EXPORTED_FUNCTION_TO_BIF(exported_bif)->bif0_ptr;
                     DEBUG_FAIL_NULL(func);
                     term ret = func(ctx);
 
@@ -1860,7 +1903,8 @@ schedule_in:
                 #endif
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    BifImpl1 func = (BifImpl1) mod->imported_funcs[bif].bif;
+                    const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
+                    BifImpl1 func = EXPORTED_FUNCTION_TO_BIF(exported_bif)->bif1_ptr;
                     DEBUG_FAIL_NULL(func);
                     term ret = func(ctx, arg1);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
@@ -1899,7 +1943,8 @@ schedule_in:
                 #endif
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    BifImpl2 func = (BifImpl2) mod->imported_funcs[bif].bif;
+                    const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
+                    BifImpl2 func = EXPORTED_FUNCTION_TO_BIF(exported_bif)->bif2_ptr;
                     DEBUG_FAIL_NULL(func);
                     term ret = func(ctx, arg1, arg2);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
@@ -3455,6 +3500,28 @@ wait_timeout_trap_handler:
                             code = mod->code->code;
 
                             JUMP_TO_ADDRESS(mod->labels[jump->label]);
+
+                            break;
+                        }
+                        case BIFFunctionType: {
+                            // Support compilers < OTP26 that generate CALL_EXT_ONLY
+                            // for min/2 and max/2
+                            const struct Bif *bif = EXPORTED_FUNCTION_TO_BIF(func);
+                            switch (arity) {
+                                case 0:
+                                    ctx->x[0] = bif->bif0_ptr(ctx);
+                                    break;
+                                case 1:
+                                    ctx->x[0] = bif->bif1_ptr(ctx, ctx->x[0]);
+                                    break;
+                                case 2:
+                                    ctx->x[0] = bif->bif2_ptr(ctx, ctx->x[0], ctx->x[1]);
+                                    break;
+                                default:
+                                    fprintf(stderr, "Invalid arity %" PRIu32 " for bif\n", arity);
+                            }
+
+                            DO_RETURN();
 
                             break;
                         }
@@ -5298,7 +5365,8 @@ wait_timeout_trap_handler:
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("gc_bif1/5 fail_lbl=%i, live=%i, bif=%i, arg1=0x%lx, dest=%c%i\n", f_label, live, bif, arg1, T_DEST_REG(dreg_type, dreg));
 
-                    GCBifImpl1 func = (GCBifImpl1) mod->imported_funcs[bif].bif;
+                    const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
+                    GCBifImpl1 func = EXPORTED_FUNCTION_TO_GCBIF(exported_bif)->gcbif1_ptr;
                     term ret = func(ctx, live, arg1);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
                         HANDLE_ERROR();
@@ -5342,7 +5410,8 @@ wait_timeout_trap_handler:
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("gc_bif2/6 fail_lbl=%i, live=%i, bif=%i, arg1=0x%lx, arg2=0x%lx, dest=%c%i\n", f_label, live, bif, arg1, arg2, T_DEST_REG(dreg_type, dreg));
 
-                    GCBifImpl2 func = (GCBifImpl2) mod->imported_funcs[bif].bif;
+                    const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
+                    GCBifImpl2 func = EXPORTED_FUNCTION_TO_GCBIF(exported_bif)->gcbif2_ptr;
                     term ret = func(ctx, live, arg1, arg2);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
                         HANDLE_ERROR();
@@ -5416,7 +5485,8 @@ wait_timeout_trap_handler:
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("gc_bif3/7 fail_lbl=%i, live=%i, bif=%i, arg1=0x%lx, arg2=0x%lx, arg3=0x%lx, dest=%c%i\n", f_label, live, bif, arg1, arg2, arg3, T_DEST_REG(dreg_type, dreg));
 
-                    GCBifImpl3 func = (GCBifImpl3) mod->imported_funcs[bif].bif;
+                    const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
+                    GCBifImpl3 func = EXPORTED_FUNCTION_TO_GCBIF(exported_bif)->gcbif3_ptr;
                     term ret = func(ctx, live, arg1, arg2, arg3);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
                         HANDLE_ERROR();

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -472,6 +472,8 @@ compile_erlang(test_add_avm_pack_binary)
 compile_erlang(test_add_avm_pack_file)
 compile_erlang(test_close_avm_pack)
 
+compile_erlang(test_min_max_guard)
+
 add_custom_target(erlang_test_modules DEPENDS
     code_load_files
 
@@ -907,4 +909,6 @@ add_custom_target(erlang_test_modules DEPENDS
     test_add_avm_pack_binary.beam
     test_add_avm_pack_file.beam
     test_close_avm_pack.beam
+
+    test_min_max_guard.beam
 )

--- a/tests/erlang_tests/test_min_max_guard.erl
+++ b/tests/erlang_tests/test_min_max_guard.erl
@@ -1,0 +1,80 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_min_max_guard).
+
+-export([start/0, test_guard/4, test_without_guard/4]).
+
+start() ->
+    ok = test_guard(min, 2, 1, 2),
+    ok = test_guard(max, 2, 1, 1),
+    ok = test_without_guard(min, 2, 1, 2),
+    ok = test_without_guard(max, 2, 1, 1),
+    ok = test_tail(),
+    0.
+
+-ifdef(OTP_RELEASE).
+%% OTP 21 or higher
+-if(?OTP_RELEASE >= 26).
+test_guard(min, X, Y, Z) when min(X, Y) < Z ->
+    ok;
+test_guard(max, X, Y, Z) when max(X, Y) > Z ->
+    ok;
+test_guard(_Op, _X, _Y, _Z) ->
+    fail.
+-else.
+test_guard(_Op, _X, _Y, _Z) ->
+    ok.
+-endif.
+-else.
+test_guard(_Op, _X, _Y, _Z) ->
+    ok.
+-endif.
+
+test_without_guard(min, X, Y, Z) ->
+    case min(X, Y) < Z of
+        true -> ok;
+        false -> fail
+    end;
+test_without_guard(max, X, Y, Z) ->
+    case max(X, Y) > Z of
+        true -> ok;
+        false -> fail
+    end;
+test_without_guard(_Op, _X, _Y, _Z) ->
+    fail.
+
+test_tail() ->
+    1 = tail_min(infinity, [5, 4, 3, 2, 1]),
+    5 = tail_max(0, [1, 2, 3, 4, 5]),
+    ok.
+
+tail_min(X, [Y]) ->
+    % OP_CALL_EXT_ONLY
+    min(X, Y);
+tail_min(X, [H | T]) ->
+    tail_min(min(X, H), T).
+
+tail_max(X, [Y, Z]) ->
+    M1 = max(Y, Z),
+    % OP_CALL_EXT_LAST
+    max(X, M1);
+tail_max(X, [H | T]) ->
+    tail_max(max(X, H), T).

--- a/tests/test.c
+++ b/tests/test.c
@@ -500,6 +500,8 @@ struct Test tests[] = {
     TEST_CASE_COND(test_stacktrace, 0, SKIP_STACKTRACES),
     TEST_CASE(small_big_ext),
 
+    TEST_CASE(test_min_max_guard),
+
     // TEST CRASHES HERE: TEST_CASE(memlimit),
 
     { NULL, 0, false, false }


### PR DESCRIPTION
Fix compatibility with OTP26 (fix #712)
Also change the way BIFs are imported, so min/2 and max/2 BIFs can be called from code compiled with OTP<26

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
