### PR TITLE
Fix demonitor flush #716

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1107,6 +1107,9 @@ COLD_FUNC static void dump(Context *ctx)
     mailbox_crashdump(ctx);
 
     fprintf(stderr, "\n\nMonitors\n--------\n");
+    // Lock processes table to make sure any dying process will not modify monitors
+    struct ListHead *processes_table = synclist_rdlock(&ctx->global->processes_table);
+    UNUSED(processes_table);
     struct ListHead *item;
     LIST_FOR_EACH (item, &ctx->monitors_head) {
         struct Monitor *monitor = GET_LIST_ENTRY(item, struct Monitor, monitor_list_head);
@@ -1123,7 +1126,7 @@ COLD_FUNC static void dump(Context *ctx)
         term_display(stderr, term_from_local_process_id(ctx->process_id), ctx);
         fprintf(stderr, "\n");
     }
-
+    synclist_unlock(&ctx->global->processes_table);
     fprintf(stderr, "\n\n**End Of Crash Report**\n");
 }
 


### PR DESCRIPTION
Keep lock on processes table when sending monitor messages.

Also acquire lock when printing crash dump, fixing random segfaults.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
