### PR TITLE
SPI: fix `mode` that wasn't working

### DIFF
--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -1108,7 +1108,7 @@ Each device configuration is a properties list containing the following entries:
 | Key | Value Type | Required | Description |
 |-----|------------|----------|---|
 | `spi_clock_hz` | `integer()` | yes | SPI clock frequency (in hertz) |
-| `spi_mode` | `0..3` | yes | SPI mode, indicating clock polarity (`CPOL`) and clock phase (`CPHA`).  Consult the SPI specification and data sheet for your device, for more information about how to control the behavior of the SPI clock. |
+| `mode` | `0..3` | yes | SPI mode, indicating clock polarity (`CPOL`) and clock phase (`CPHA`).  Consult the SPI specification and data sheet for your device, for more information about how to control the behavior of the SPI clock. |
 | `spi_cs_io_num` | `integer()` | yes | SPI chip select pin (CS) |
 | `address_len_bits` | `0..64` | yes | number of bits in the address field of a read/write operation (for example, 8, if the transaction address field is a single byte) |
 | `command_len_bits` | `0..16` | default: 0 | number of bits in the command field of a read/write operation (for example, 8, if the transaction command field is a single byte) |
@@ -1125,13 +1125,13 @@ For example,
         {device_config, [
             {my_device_1, [
                 {spi_clock_hz, 1000000},
-                {spi_mode, 0},
+                {mode, 0},
                 {spi_cs_io_num, 18},
                 {address_len_bits, 8}
             ]}
             {my_device_2, [
                 {spi_clock_hz, 1000000},
-                {spi_mode, 0},
+                {mode, 0},
                 {spi_cs_io_num, 15},
                 {address_len_bits, 8}
             ]}

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -219,7 +219,7 @@ Context *spi_driver_create_port(GlobalContext *global, term opts)
         term device_config = term_get_map_assoc(device_map, device_name, ctx->global);
 
         term clock_speed_hz_term = interop_kv_get_value(device_config, ATOM_STR("\xC", "spi_clock_hz"), global);
-        term mode_term = interop_kv_get_value(device_config, ATOM_STR("\x8", "spi_mode"), global);
+        term mode_term = interop_kv_get_value(device_config, ATOM_STR("\x4", "mode"), global);
         term spics_io_num_term = interop_kv_get_value(device_config, ATOM_STR("\xD", "spi_cs_io_num"), global);
         term address_bits_term = interop_kv_get_value(device_config, ATOM_STR("\x10", "address_len_bits"), global);
         term command_bits_term = interop_kv_get_value(device_config, ATOM_STR("\x10", "command_len_bits"), global);


### PR DESCRIPTION
Erlang `spi` module was using `mode` as key, but the driver was looking for `spi_mode`, hence it wasn't working (and default value was used).

Also update documentation that was still mentioning `spi_mode`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
