### PR TITLE
Fix unregistration

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -114,13 +114,14 @@ void context_destroy(Context *ctx)
 
     list_remove(&ctx->processes_table_head);
 
-    // When monitor message is sent, process is no longer in the table.
+    // Ensure process is not registered
+    globalcontext_maybe_unregister_process_id(ctx->global, ctx->process_id);
+
+    // When monitor message is sent, process is no longer in the table
+    // and is no longer registered either.
     context_monitors_handle_terminate(ctx);
 
     synclist_unlock(&ctx->global->processes_table);
-
-    // Ensure process is not registered
-    globalcontext_maybe_unregister_process_id(ctx->global, ctx->process_id);
 
     // Any other process released our mailbox, so we can clear it.
     mailbox_destroy(&ctx->mailbox, &ctx->heap);

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -358,21 +358,19 @@ bool globalcontext_unregister_process(GlobalContext *glb, int atom_index)
     return false;
 }
 
-bool globalcontext_maybe_unregister_process_id(GlobalContext *glb, int target_process_id)
+void globalcontext_maybe_unregister_process_id(GlobalContext *glb, int target_process_id)
 {
     struct ListHead *registered_processes_list = synclist_wrlock(&glb->registered_processes);
     struct ListHead *item;
-    LIST_FOR_EACH (item, registered_processes_list) {
+    struct ListHead *tmp;
+    MUTABLE_LIST_FOR_EACH (item, tmp, registered_processes_list) {
         struct RegisteredProcess *registered_process = GET_LIST_ENTRY(item, struct RegisteredProcess, registered_processes_list_head);
         if (registered_process->local_process_id == target_process_id) {
             list_remove(item);
             free(registered_process);
-            synclist_unlock(&glb->registered_processes);
-            return true;
         }
     }
     synclist_unlock(&glb->registered_processes);
-    return false;
 }
 
 int globalcontext_get_registered_process(GlobalContext *glb, int atom_index)

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -247,7 +247,7 @@ bool globalcontext_register_process(GlobalContext *glb, int atom_index, int loca
 int globalcontext_get_registered_process(GlobalContext *glb, int atom_index);
 
 /**
- * @brief Unregister a process
+ * @brief Unregister a process by name
  *
  * @details Unregister a process with a certain name (atom).
  * @param glb the global context, each registered process will be globally available for that context.
@@ -257,15 +257,14 @@ int globalcontext_get_registered_process(GlobalContext *glb, int atom_index);
 bool globalcontext_unregister_process(GlobalContext *glb, int atom_index);
 
 /**
- * @brief Remove entry from registered atoms by process id
+ * @brief Remove entry(ies) from registered atoms by process id
  *
  * @details Unregister a process with a certain process id. This is used when a process dies to ensure
  * the process is not registered and remove it from the registered atoms table if it is.
  * @param glb the global context, each registered process will be globally available for that context.
  * @param process_id the process id of the entry to remove.
- * @returns \c true if the process was unregistered, \c false otherwise
  */
-bool globalcontext_maybe_unregister_process_id(GlobalContext *glb, int process_id);
+void globalcontext_maybe_unregister_process_id(GlobalContext *glb, int process_id);
 
 /**
  * @brief equivalent to globalcontext_insert_atom_maybe_copy(glb, atom_string, 0);


### PR DESCRIPTION
- Unregister before sending DOWN messages
- Unregister all names

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
