### PR TITLE
Fix flappiness of tests with esp-idf 5.1

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -84,12 +84,21 @@ jobs:
             pytest-embedded-idf==1.2.5 \
             pytest-embedded-qemu==1.2.5
 
-    - name: Patch esp-idf to fix race condition that affects qemu under heavy load
+    - name: Patch esp-idf 4.4.5 to fix race condition that affects qemu under heavy load
       working-directory: ./src/platforms/esp32/test/
       if: matrix.idf-version == '4.4.5'
       run: |
         set -e
         PATCH=$PWD/esp_ipc_isr.patch
+        cd $IDF_PATH
+        patch -p1 < $PATCH
+
+    - name: Patch esp-idf 5.1 to fix race condition that affects qemu under heavy load
+      working-directory: ./src/platforms/esp32/test/
+      if: matrix.idf-version == '5.1'
+      run: |
+        set -e
+        PATCH=$PWD/esp_ipc_isr_5.1.patch
         cd $IDF_PATH
         patch -p1 < $PATCH
 

--- a/src/platforms/esp32/test/esp_ipc_isr_5.1.patch
+++ b/src/platforms/esp32/test/esp_ipc_isr_5.1.patch
@@ -1,0 +1,65 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+diff --git a/components/esp_system/port/arch/xtensa/esp_ipc_isr.c b/components/esp_system/port/arch/xtensa/esp_ipc_isr.c
+index 70fb1a9f1fd..5ffcb76e21b 100644
+--- a/components/esp_system/port/arch/xtensa/esp_ipc_isr.c
++++ b/components/esp_system/port/arch/xtensa/esp_ipc_isr.c
+@@ -142,6 +142,8 @@ void IRAM_ATTR esp_ipc_isr_release_other_cpu(void)
+         const uint32_t cpu_id = xPortGetCoreID();
+         if (--s_count_of_nested_calls[cpu_id] == 0) {
+             esp_ipc_isr_finish_cmd = 1;
++            // Make sure end flag is cleared and esp_ipc_isr_waiting_for_finish_cmd is done.
++            while (!esp_ipc_isr_end_fl) {};
+             IPC_ISR_EXIT_CRITICAL();
+ #if CONFIG_FREERTOS_SMP
+             portRESTORE_INTERRUPTS(s_stored_interrupt_level);
+diff --git a/components/esp_system/port/arch/xtensa/esp_ipc_isr_handler.S b/components/esp_system/port/arch/xtensa/esp_ipc_isr_handler.S
+index 0fb4ae676a9..20638a68956 100644
+--- a/components/esp_system/port/arch/xtensa/esp_ipc_isr_handler.S
++++ b/components/esp_system/port/arch/xtensa/esp_ipc_isr_handler.S
+@@ -96,6 +96,7 @@ esp_ipc_isr_handler:
+ 
+     /* set the start flag */
+     movi    a0, esp_ipc_isr_start_fl
++    memw
+     s32i    a0, a0, 0
+ 
+     /* Call the esp_ipc_function(void* arg) */
+@@ -113,6 +114,7 @@ esp_ipc_isr_handler:
+ 
+     /* set the end flag */
+     movi    a0, esp_ipc_isr_end_fl
++    memw
+     s32i    a0, a0, 0
+ 
+     /* restore a0 */
+diff --git a/components/esp_system/port/arch/xtensa/esp_ipc_isr_routines.S b/components/esp_system/port/arch/xtensa/esp_ipc_isr_routines.S
+index 01ddf8b5280..e947c3ed2f3 100644
+--- a/components/esp_system/port/arch/xtensa/esp_ipc_isr_routines.S
++++ b/components/esp_system/port/arch/xtensa/esp_ipc_isr_routines.S
+@@ -23,6 +23,7 @@
+ esp_ipc_isr_waiting_for_finish_cmd:
+     /* waiting for the finish command */
+ .check_finish_cmd:
++    memw
+     l32i    a3, a2, 0
+     beqz    a3, .check_finish_cmd
+     ret


### PR DESCRIPTION
Fix of bug
https://github.com/espressif/esp-idf/issues/11433 is in v5.0.3 but not in v5.1.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
