### PR TITLE
Fix handling of exception class

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2927,7 +2927,11 @@ static term nif_erlang_raise(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);
 
-    ctx->x[0] = argv[0];
+    term ex_class = argv[0];
+    if (UNLIKELY(ex_class != ERROR_ATOM && ex_class != LOWERCASE_EXIT_ATOM && ex_class != THROW_ATOM)) {
+        return BADARG_ATOM;
+    }
+    ctx->x[0] = ex_class;
     ctx->x[1] = argv[1];
     ctx->x[2] = term_nil();
     return term_invalid_term();

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -92,7 +92,7 @@ typedef union
 #define SET_ERROR(error_type_atom)   \
     ctx->x[0] = ERROR_ATOM;                                        \
     ctx->x[1] = error_type_atom;                                   \
-    ctx->x[2] = stacktrace_create_raw(ctx, mod, i);                \
+    ctx->x[2] = stacktrace_create_raw(ctx, mod, i, ERROR_ATOM);    \
 
 // Override nifs.h RAISE_ERROR macro
 #ifdef RAISE_ERROR
@@ -812,8 +812,8 @@ typedef union
 #define POINTER_TO_II(instruction_pointer) \
     (((uint8_t *) (instruction_pointer)) - code)
 
-#define HANDLE_ERROR()                                     \
-    ctx->x[2] = stacktrace_create_raw(ctx, mod, i);        \
+#define HANDLE_ERROR()                                         \
+    ctx->x[2] = stacktrace_create_raw(ctx, mod, i, ctx->x[0]); \
     goto handle_error;
 
 #define VERIFY_IS_INTEGER(t, opcode_name)                  \
@@ -3645,22 +3645,24 @@ wait_timeout_trap_handler:
                 int next_off = 1;
                 term stacktrace;
                 DECODE_COMPACT_TERM(stacktrace, code, i, next_off);
-                UNUSED(stacktrace);
                 term exc_value;
                 DECODE_COMPACT_TERM(exc_value, code, i, next_off);
 
                 #ifdef IMPL_CODE_LOADER
                     TRACE("raise/2\n");
+                    UNUSED(stacktrace);
                     UNUSED(exc_value);
+                    NEXT_INSTRUCTION(next_off);
                 #endif
 
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("raise/2 stacktrace=0x%lx exc_value=0x%lx\n", stacktrace, exc_value);
-
-                    RAISE_ERROR(exc_value);
+                    ctx->x[0] = stacktrace_exception_class(stacktrace);
+                    ctx->x[1] = exc_value;
+                    ctx->x[2] = stacktrace_create_raw(ctx, mod, i, ctx->x[0]);
+                    goto handle_error;
                 #endif
 
-                NEXT_INSTRUCTION(next_off);
                 break;
             }
 

--- a/src/libAtomVM/stacktrace.h
+++ b/src/libAtomVM/stacktrace.h
@@ -29,8 +29,9 @@ extern "C" {
 #include "module.h"
 #include "term.h"
 
-term stacktrace_create_raw(Context *ctx, Module *mod, int current_offset);
+term stacktrace_create_raw(Context *ctx, Module *mod, int current_offset, term exception_class);
 term stacktrace_build(Context *ctx, term *stack_info);
+term stacktrace_exception_class(term stack_info);
 
 #ifdef __cplusplus
 }

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -162,6 +162,7 @@ compile_erlang(pingpong)
 compile_erlang(prime_ext)
 compile_erlang(prime_smp)
 compile_erlang(test_try_case_end)
+compile_erlang(test_exception_classes)
 compile_erlang(test_recursion_and_try_catch)
 compile_erlang(test_func_info)
 compile_erlang(test_func_info2)
@@ -596,6 +597,7 @@ add_custom_target(erlang_test_modules DEPENDS
     prime_ext.beam
     prime_smp.beam
     test_try_case_end.beam
+    test_exception_classes.beam
     test_recursion_and_try_catch.beam
     test_func_info.beam
     test_func_info2.beam

--- a/tests/erlang_tests/test_exception_classes.erl
+++ b/tests/erlang_tests/test_exception_classes.erl
@@ -1,0 +1,123 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_exception_classes).
+
+-export([start/0]).
+
+start() ->
+    ok = test_exit(),
+    ok = test_throw(),
+    ok = test_error(),
+    ok = test_inner_exit(),
+    ok = test_after_catch_throw(),
+    ok = test_after_throw(),
+    ok = test_raise_error(),
+    ok = test_raise_exit(),
+    ok = test_raise_badarg(),
+    0.
+
+test_exit() ->
+    try
+        exit(foo)
+    catch
+        exit:foo -> ok;
+        C:V -> {unexpected, ?LINE, C, V}
+    end.
+
+test_throw() ->
+    try
+        throw(foo)
+    catch
+        throw:foo -> ok;
+        C:V -> {unexpected, ?LINE, C, V}
+    end.
+
+test_error() ->
+    try
+        error(foo)
+    catch
+        error:foo -> ok;
+        C:V -> {unexpected, ?LINE, C, V}
+    end.
+
+test_inner_exit() ->
+    try
+        try
+            exit(foo)
+        catch
+            error:foo -> {unexpected, ?LINE}
+        end
+    catch
+        exit:foo -> ok;
+        C:V -> {unexpected, ?LINE, C, V}
+    end.
+
+test_after_catch_throw() ->
+    try
+        try
+            exit(foo)
+        after
+            try
+                throw(foo)
+            catch
+                throw:foo -> ok
+            end
+        end
+    catch
+        exit:foo -> ok;
+        C:V -> {unexpected, ?LINE, C, V}
+    end.
+
+test_after_throw() ->
+    try
+        try
+            exit(foo)
+        after
+            throw(foo)
+        end
+    catch
+        throw:foo -> ok;
+        C:V -> {unexpected, ?LINE, C, V}
+    end.
+
+test_raise_error() ->
+    try
+        erlang:raise(error, foo, [])
+    catch
+        error:foo -> ok;
+        C:V -> {unexpected, ?LINE, C, V}
+    end.
+
+test_raise_exit() ->
+    try
+        erlang:raise(exit, foo, [])
+    catch
+        exit:foo -> ok;
+        C:V -> {unexpected, ?LINE, C, V}
+    end.
+
+test_raise_badarg() ->
+    try
+        badarg = erlang:raise(bar, foo, []),
+        ok
+    catch
+        C:V -> {unexpected, ?LINE, C, V}
+    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -178,6 +178,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(test_open_port_badargs, -21),
     TEST_CASE_EXPECTED(prime_ext, 1999),
     TEST_CASE_EXPECTED(test_try_case_end, 256),
+    TEST_CASE(test_exception_classes),
     TEST_CASE_EXPECTED(test_recursion_and_try_catch, 3628800),
     TEST_CASE_EXPECTED(test_func_info, 89),
     TEST_CASE_EXPECTED(test_func_info2, 1),


### PR DESCRIPTION
* Fix lost class issue when exception is rethrown (fix #713)
* Fix semantic of first parameter of `erlang:raise/3`

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
