### PR TITLE
Fix README.Md

### DIFF
--- a/README.Md
+++ b/README.Md
@@ -19,7 +19,7 @@ Supported Platforms
 * ESP32 SoC (with IDF/FreeRTOS, see [README.ESP32.Md](README.ESP32.Md))
 * STM32 MCUs (with LibOpenCM3, see [README.STM32.Md](README.STM32.Md))
 * Raspberry Pi Pico (see [README.PICO.Md](README.PICO.Md))
-* nodejs with Wasm (see [README.Wasm.Md](README.Wasm.Md))
+* Browsers and NodeJS with web assembly (see [README.WASM.Md](README.WASM.Md))
 
 AtomVM aims to be easily portable to new platforms with a minimum effort, so additional platforms
 might be supported in a near future.


### PR DESCRIPTION
- Fix link to wasm readme
- Mention AtomVM runs in browsers

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
