### PR TITLE
Bump actions versions

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
     # Setup
     - name: "Checkout repo"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -177,7 +177,7 @@ jobs:
     steps:
     # Setup
     - name: "Checkout repo"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
@@ -217,7 +217,7 @@ jobs:
     - name: "Build: create build dir"
       run: mkdir build
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: cache
       with:
         path: 'build/tests/**/*.beam'

--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -26,7 +26,7 @@ jobs:
   clang-format-check:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: erlef/setup-beam@v1
       with:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -46,7 +46,7 @@ jobs:
       run: sudo apt install -y cmake gperf zlib1g-dev ninja-build erlang
 
     - name: "Checkout repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: "Initialize CodeQL"
       uses: github/codeql-action/init@v2

--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build with idf.py
       shell: bash

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - uses: erlef/setup-beam@v1
       with:

--- a/.github/workflows/reuse-lint.yaml
+++ b/.github/workflows/reuse-lint.yaml
@@ -10,6 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1


### PR DESCRIPTION
v2 versions are deprecated and GH CI warns about it

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
