### PR TITLE
Fix warning introduced in 007d3786c

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -111,6 +111,7 @@ void context_destroy(Context *ctx)
 {
     // Another process can get an access to our mailbox until this point.
     struct ListHead *processes_table_list = synclist_wrlock(&ctx->global->processes_table);
+    UNUSED(processes_table_list);
 
     list_remove(&ctx->processes_table_head);
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
