### PR TITLE
Fix more types and few examples

### DIFF
--- a/examples/erlang/esp32/ap_sta_network.erl
+++ b/examples/erlang/esp32/ap_sta_network.erl
@@ -36,7 +36,7 @@ start() ->
             {sta_connected, fun sta_connected/1},
             {sta_ip_assigned, fun sta_ip_assigned/1},
             {sta_disconnected, fun sta_disconnected/1},
-            {ap_sta_ip_assigned, fun ap_sta_ip_assigned/1}
+            {sta_ip_assigned, fun ap_sta_ip_assigned/1}
         ]},
         {sta, [
             {ssid, <<"myssid">>},

--- a/examples/erlang/hello_world_server.erl
+++ b/examples/erlang/hello_world_server.erl
@@ -33,8 +33,8 @@ start() ->
             {disconnected, fun() -> Self ! disconnected end}
         ]}
     ],
-    case network_fsm:start(Config) of
-        ok ->
+    case network:start(Config) of
+        {ok, _Pid} ->
             wait_for_message();
         Error ->
             io:format("An error occurred starting network: ~p~n", [Error])

--- a/examples/erlang/system_info_server.erl
+++ b/examples/erlang/system_info_server.erl
@@ -33,8 +33,8 @@ start() ->
             {disconnected, fun() -> Self ! disconnected end}
         ]}
     ],
-    case network_fsm:start(Config) of
-        ok ->
+    case network:start(Config) of
+        {ok, _Pid} ->
             wait_for_message();
         Error ->
             io:format("An error occurred starting network: ~p~n", [Error])

--- a/libs/eavmlib/src/atomvm.erl
+++ b/libs/eavmlib/src/atomvm.erl
@@ -38,7 +38,9 @@
 
 -type platform_name() ::
     generic_unix
+    | emscripten
     | esp32
+    | pico
     | stm32.
 
 -type avm_path() :: string() | binary().
@@ -52,7 +54,7 @@
 %%-----------------------------------------------------------------------------
 -spec platform() -> platform_name().
 platform() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns random 32-bit integer.
@@ -63,7 +65,7 @@ platform() ->
 %%-----------------------------------------------------------------------------
 -spec random() -> integer().
 random() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Len non-negative integer
@@ -76,7 +78,7 @@ random() ->
 %%-----------------------------------------------------------------------------
 -spec rand_bytes(Len :: non_neg_integer()) -> binary().
 rand_bytes(_Len) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   App application name.
@@ -87,7 +89,7 @@ rand_bytes(_Len) ->
 %%-----------------------------------------------------------------------------
 -spec read_priv(App :: atom(), Path :: list()) -> binary().
 read_priv(_App, _Path) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   AVMData AVM data.
@@ -104,7 +106,7 @@ read_priv(_App, _Path) ->
 %%-----------------------------------------------------------------------------
 -spec add_avm_pack_binary(AVMData :: binary(), Options :: [{name, Name :: atom()}]) -> ok.
 add_avm_pack_binary(_AVMData, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   AVMPath Path to AVM data.
@@ -131,7 +133,7 @@ add_avm_pack_binary(_AVMData, _Options) ->
 %%-----------------------------------------------------------------------------
 -spec add_avm_pack_file(AVMPath :: avm_path(), Options :: []) -> ok.
 add_avm_pack_file(_AVMPath, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   name the AVM name.
@@ -148,4 +150,4 @@ add_avm_pack_file(_AVMPath, _Options) ->
 %%-----------------------------------------------------------------------------
 -spec close_avm_pack(Name :: atom(), Options :: []) -> ok | error.
 close_avm_pack(_Name, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).

--- a/libs/eavmlib/src/console.erl
+++ b/libs/eavmlib/src/console.erl
@@ -72,7 +72,7 @@ flush(Console) ->
 %%-----------------------------------------------------------------------------
 -spec print(string()) -> ok | {error, term()}.
 print(_String) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% Internal operations
 

--- a/libs/eavmlib/src/emscripten.erl
+++ b/libs/eavmlib/src/emscripten.erl
@@ -286,7 +286,7 @@
 %% @equiv run_script(_Script, [])
 -spec run_script(iodata()) -> ok.
 run_script(_Script) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Run a script.
 %% By default, the script is run in the current worker thread, which arguably
@@ -300,12 +300,12 @@ run_script(_Script) ->
 %% @returns ok
 -spec run_script(iodata(), [run_script_opt()]) -> ok.
 run_script(_Script, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv promise_resolve(_Promise, 0)
 -spec promise_resolve(promise()) -> ok.
 promise_resolve(_Promise) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Successfully resolve a promise with a given result.
 %% A promise is currently only obtained through synchronous calls using
@@ -326,12 +326,12 @@ promise_resolve(_Promise) ->
 %% @param _Value Value to send to Javascript, must be an integer or a string.
 -spec promise_resolve(promise(), integer() | iodata()) -> ok.
 promise_resolve(_Promise, _Value) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv promise_reject(_Promise, 0)
 -spec promise_reject(promise()) -> ok.
 promise_reject(_Promise) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Reject a promise with a given result.
 %% This is similar to `promise_resolve' except the promise is rejected.
@@ -339,12 +339,12 @@ promise_reject(_Promise) ->
 %% @param _Value Value to send to Javascript, must be an integer or a string.
 -spec promise_reject(promise(), integer() | iodata()) -> ok.
 promise_reject(_Promise, _Value) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_keypress_callback(_Target, [])
 -spec register_keypress_callback(html5_target()) -> register_result().
 register_keypress_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for keypress events.
 %% This function registers with no user data and events are sent as:
@@ -354,7 +354,7 @@ register_keypress_callback(_Target) ->
 %% @see register_keypress_callback/3
 -spec register_keypress_callback(html5_target(), register_options()) -> register_result().
 register_keypress_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for keypress events.
 %% This function registers keypress events on a given target.
@@ -385,7 +385,7 @@ register_keypress_callback(_Target, _Options) ->
 %% @param _UserData user data passed back
 -spec register_keypress_callback(html5_target(), register_options(), any()) -> register_result().
 register_keypress_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a keypress listener.
 %%
@@ -408,60 +408,60 @@ register_keypress_callback(_Target, _Options, _UserData) ->
 -spec unregister_keypress_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_keypress_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_keydown_callback(_Target, [])
 -spec register_keydown_callback(html5_target()) -> register_result().
 register_keydown_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for keydown events.
 %% @see register_keypress_callback/2
 -spec register_keydown_callback(html5_target(), register_options()) -> register_result().
 register_keydown_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for keydown events.
 %% @see register_keypress_callback/2
 -spec register_keydown_callback(html5_target(), register_options(), any()) -> register_result().
 register_keydown_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a keydown event handler.
 %% @see unregister_keypress_callback/1
 -spec unregister_keydown_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_keydown_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_keyup_callback(_Target, [])
 -spec register_keyup_callback(html5_target()) -> register_result().
 register_keyup_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for keyup events.
 %% @see register_keypress_callback/2
 -spec register_keyup_callback(html5_target(), register_options()) -> register_result().
 register_keyup_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for keyup events.
 %% @see register_keypress_callback/2
 -spec register_keyup_callback(html5_target(), register_options(), any()) -> register_result().
 register_keyup_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a keyup event handler.
 %% @see unregister_keypress_callback/1
 -spec unregister_keyup_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_keyup_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_click_callback(_Target, [])
 -spec register_click_callback(html5_target()) -> register_result().
 register_click_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for click events.
 %% Events are sent as:
@@ -471,7 +471,7 @@ register_click_callback(_Target) ->
 %% @see register_keypress_callback/2
 -spec register_click_callback(html5_target(), register_options()) -> register_result().
 register_click_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for click events.
 %% Events are sent as:
@@ -481,211 +481,211 @@ register_click_callback(_Target, _Options) ->
 %% @see register_keypress_callback/2
 -spec register_click_callback(html5_target(), register_options(), any()) -> register_result().
 register_click_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a click event handler.
 %% @see unregister_keypress_callback/1
 -spec unregister_click_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_click_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_mousedown_callback(_Target, [])
 -spec register_mousedown_callback(html5_target()) -> register_result().
 register_mousedown_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mousedown events.
 %% @see register_click_callback/2
 -spec register_mousedown_callback(html5_target(), register_options()) -> register_result().
 register_mousedown_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mousedown events.
 %% @see register_click_callback/2
 -spec register_mousedown_callback(html5_target(), register_options(), any()) -> register_result().
 register_mousedown_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a mousedown event handler.
 %% @see unregister_click_callback/1
 -spec unregister_mousedown_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_mousedown_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_mouseup_callback(_Target, [])
 -spec register_mouseup_callback(html5_target()) -> register_result().
 register_mouseup_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mouseup events.
 %% @see register_click_callback/2
 -spec register_mouseup_callback(html5_target(), register_options()) -> register_result().
 register_mouseup_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mouseup events.
 %% @see register_click_callback/2
 -spec register_mouseup_callback(html5_target(), register_options(), any()) -> register_result().
 register_mouseup_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a mouseup event handler.
 %% @see unregister_click_callback/1
 -spec unregister_mouseup_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_mouseup_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_dblclick_callback(_Target, [])
 -spec register_dblclick_callback(html5_target()) -> register_result().
 register_dblclick_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for dblclick events.
 %% @see register_click_callback/2
 -spec register_dblclick_callback(html5_target(), register_options()) -> register_result().
 register_dblclick_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for dblclick events.
 %% @see register_click_callback/2
 -spec register_dblclick_callback(html5_target(), register_options(), any()) -> register_result().
 register_dblclick_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a dblclick event handler.
 %% @see unregister_click_callback/1
 -spec unregister_dblclick_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_dblclick_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_mousemove_callback(_Target, [])
 -spec register_mousemove_callback(html5_target()) -> register_result().
 register_mousemove_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mousemove events.
 %% @see register_click_callback/2
 -spec register_mousemove_callback(html5_target(), register_options()) -> register_result().
 register_mousemove_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mousemove events.
 %% @see register_click_callback/2
 -spec register_mousemove_callback(html5_target(), register_options(), any()) -> register_result().
 register_mousemove_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a mousemove event handler.
 %% @see unregister_click_callback/1
 -spec unregister_mousemove_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_mousemove_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_mouseenter_callback(_Target, [])
 -spec register_mouseenter_callback(html5_target()) -> register_result().
 register_mouseenter_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mouseenter events.
 %% @see register_click_callback/2
 -spec register_mouseenter_callback(html5_target(), register_options()) -> register_result().
 register_mouseenter_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mouseenter events.
 %% @see register_click_callback/2
 -spec register_mouseenter_callback(html5_target(), register_options(), any()) -> register_result().
 register_mouseenter_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a mouseenter event handler.
 %% @see unregister_click_callback/1
 -spec unregister_mouseenter_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_mouseenter_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_mouseleave_callback(_Target, [])
 -spec register_mouseleave_callback(html5_target()) -> register_result().
 register_mouseleave_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mouseleave events.
 %% @see register_click_callback/2
 -spec register_mouseleave_callback(html5_target(), register_options()) -> register_result().
 register_mouseleave_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mouseleave events.
 %% @see register_click_callback/2
 -spec register_mouseleave_callback(html5_target(), register_options(), any()) -> register_result().
 register_mouseleave_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a mouseleave event handler.
 %% @see unregister_click_callback/1
 -spec unregister_mouseleave_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_mouseleave_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_mouseover_callback(_Target, [])
 -spec register_mouseover_callback(html5_target()) -> register_result().
 register_mouseover_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mouseover events.
 %% @see register_click_callback/2
 -spec register_mouseover_callback(html5_target(), register_options()) -> register_result().
 register_mouseover_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mouseover events.
 %% @see register_click_callback/2
 -spec register_mouseover_callback(html5_target(), register_options(), any()) -> register_result().
 register_mouseover_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a mouseover event handler.
 %% @see unregister_click_callback/1
 -spec unregister_mouseover_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_mouseover_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_mouseout_callback(_Target, [])
 -spec register_mouseout_callback(html5_target()) -> register_result().
 register_mouseout_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mouseout events.
 %% @see register_click_callback/2
 -spec register_mouseout_callback(html5_target(), register_options()) -> register_result().
 register_mouseout_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for mouseout events.
 %% @see register_click_callback/2
 -spec register_mouseout_callback(html5_target(), register_options(), any()) -> register_result().
 register_mouseout_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a mouseout event handler.
 %% @see unregister_click_callback/1
 -spec unregister_mouseout_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_mouseout_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_wheel_callback(_Target, [])
 -spec register_wheel_callback(html5_target()) -> register_result().
 register_wheel_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for wheel events.
 %% Events are sent as:
@@ -695,7 +695,7 @@ register_wheel_callback(_Target) ->
 %% @see register_keypress_callback/2
 -spec register_wheel_callback(html5_target(), register_options()) -> register_result().
 register_wheel_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for wheel events.
 %% Events are sent as:
@@ -705,19 +705,19 @@ register_wheel_callback(_Target, _Options) ->
 %% @see register_keypress_callback/2
 -spec register_wheel_callback(html5_target(), register_options(), any()) -> register_result().
 register_wheel_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a wheel event handler.
 %% @see unregister_keypress_callback/1
 -spec unregister_wheel_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_wheel_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_resize_callback(_Target, [])
 -spec register_resize_callback(html5_target()) -> register_result().
 register_resize_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for resize events.
 %% Events are sent as:
@@ -727,7 +727,7 @@ register_resize_callback(_Target) ->
 %% @see register_keypress_callback/2
 -spec register_resize_callback(html5_target(), register_options()) -> register_result().
 register_resize_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for resize events.
 %% Events are sent as:
@@ -737,43 +737,43 @@ register_resize_callback(_Target, _Options) ->
 %% @see register_keypress_callback/2
 -spec register_resize_callback(html5_target(), register_options(), any()) -> register_result().
 register_resize_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a resize event handler.
 %% @see unregister_keypress_callback/1
 -spec unregister_resize_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_resize_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_scroll_callback(_Target, [])
 -spec register_scroll_callback(html5_target()) -> register_result().
 register_scroll_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for scroll events.
 %% @see register_resize_callback/2
 -spec register_scroll_callback(html5_target(), register_options()) -> register_result().
 register_scroll_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for scroll events.
 %% @see register_resize_callback/2
 -spec register_scroll_callback(html5_target(), register_options(), any()) -> register_result().
 register_scroll_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a scroll event handler.
 %% @see unregister_resize_callback/1
 -spec unregister_scroll_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_scroll_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_blur_callback(_Target, [])
 -spec register_blur_callback(html5_target()) -> register_result().
 register_blur_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for blur events.
 %% Events are sent as:
@@ -783,7 +783,7 @@ register_blur_callback(_Target) ->
 %% @see register_keypress_callback/2
 -spec register_blur_callback(html5_target(), register_options()) -> register_result().
 register_blur_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for blur events.
 %% Events are sent as:
@@ -793,91 +793,91 @@ register_blur_callback(_Target, _Options) ->
 %% @see register_keypress_callback/2
 -spec register_blur_callback(html5_target(), register_options(), any()) -> register_result().
 register_blur_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a blur event handler.
 %% @see unregister_keypress_callback/1
 -spec unregister_blur_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_blur_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_focus_callback(_Target, [])
 -spec register_focus_callback(html5_target()) -> register_result().
 register_focus_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for focus events.
 %% @see register_blur_callback/2
 -spec register_focus_callback(html5_target(), register_options()) -> register_result().
 register_focus_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for focus events.
 %% @see register_blur_callback/2
 -spec register_focus_callback(html5_target(), register_options(), any()) -> register_result().
 register_focus_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a focus event handler.
 %% @see unregister_blur_callback/1
 -spec unregister_focus_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_focus_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_focusin_callback(_Target, [])
 -spec register_focusin_callback(html5_target()) -> register_result().
 register_focusin_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for focusin events.
 %% @see register_blur_callback/2
 -spec register_focusin_callback(html5_target(), register_options()) -> register_result().
 register_focusin_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for focusin events.
 %% @see register_blur_callback/2
 -spec register_focusin_callback(html5_target(), register_options(), any()) -> register_result().
 register_focusin_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a focusin event handler.
 %% @see unregister_blur_callback/1
 -spec unregister_focusin_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_focusin_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_focusout_callback(_Target, [])
 -spec register_focusout_callback(html5_target()) -> register_result().
 register_focusout_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for focusout events.
 %% @see register_blur_callback/2
 -spec register_focusout_callback(html5_target(), register_options()) -> register_result().
 register_focusout_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for focusout events.
 %% @see register_blur_callback/2
 -spec register_focusout_callback(html5_target(), register_options(), any()) -> register_result().
 register_focusout_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a focusout event handler.
 %% @see unregister_blur_callback/1
 -spec unregister_focusout_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_focusout_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_touchstart_callback(_Target, [])
 -spec register_touchstart_callback(html5_target()) -> register_result().
 register_touchstart_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for touchstart events.
 %% Events are sent as:
@@ -887,7 +887,7 @@ register_touchstart_callback(_Target) ->
 %% @see register_keypress_callback/2
 -spec register_touchstart_callback(html5_target(), register_options()) -> register_result().
 register_touchstart_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for touchstart events.
 %% Events are sent as:
@@ -897,83 +897,83 @@ register_touchstart_callback(_Target, _Options) ->
 %% @see register_keypress_callback/2
 -spec register_touchstart_callback(html5_target(), register_options(), any()) -> register_result().
 register_touchstart_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a touchstart event handler.
 %% @see unregister_keypress_callback/1
 -spec unregister_touchstart_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_touchstart_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_touchend_callback(_Target, [])
 -spec register_touchend_callback(html5_target()) -> register_result().
 register_touchend_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for touchend events.
 %% @see register_touchstart_callback/2
 -spec register_touchend_callback(html5_target(), register_options()) -> register_result().
 register_touchend_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for touchend events.
 %% @see register_touchstart_callback/2
 -spec register_touchend_callback(html5_target(), register_options(), any()) -> register_result().
 register_touchend_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a touchend event handler.
 %% @see unregister_touchstart_callback/1
 -spec unregister_touchend_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_touchend_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_touchmove_callback(_Target, [])
 -spec register_touchmove_callback(html5_target()) -> register_result().
 register_touchmove_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for touchmove events.
 %% @see register_touchstart_callback/2
 -spec register_touchmove_callback(html5_target(), register_options()) -> register_result().
 register_touchmove_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for touchmove events.
 %% @see register_touchstart_callback/2
 -spec register_touchmove_callback(html5_target(), register_options(), any()) -> register_result().
 register_touchmove_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a touchmove event handler.
 %% @see unregister_touchstart_callback/1
 -spec unregister_touchmove_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_touchmove_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @equiv register_touchcancel_callback(_Target, [])
 -spec register_touchcancel_callback(html5_target()) -> register_result().
 register_touchcancel_callback(_Target) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for touchcancel events.
 %% @see register_touchstart_callback/2
 -spec register_touchcancel_callback(html5_target(), register_options()) -> register_result().
 register_touchcancel_callback(_Target, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Register for touchcancel events.
 %% @see register_touchstart_callback/2
 -spec register_touchcancel_callback(html5_target(), register_options(), any()) -> register_result().
 register_touchcancel_callback(_Target, _Options, _UserData) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %% @doc Unregister a touchcancel event handler.
 %% @see unregister_touchstart_callback/1
 -spec unregister_touchcancel_callback(html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_touchcancel_callback(_TargetOrHandle) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).

--- a/libs/eavmlib/src/esp.erl
+++ b/libs/eavmlib/src/esp.erl
@@ -92,7 +92,7 @@
 %%-----------------------------------------------------------------------------
 -spec restart() -> ok.
 restart() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns the reason for the restart
@@ -101,7 +101,7 @@ restart() ->
 %%-----------------------------------------------------------------------------
 -spec reset_reason() -> esp_reset_reason().
 reset_reason() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns the cause for the wake up
@@ -110,7 +110,7 @@ reset_reason() ->
 %%-----------------------------------------------------------------------------
 -spec wakeup_cause() -> undefined | esp_wakeup_cause() | error.
 wakeup_cause() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns Configure ext0 wakeup
@@ -118,7 +118,7 @@ wakeup_cause() ->
 %%-----------------------------------------------------------------------------
 -spec sleep_enable_ext0_wakeup(Pin :: pos_integer(), Level :: 0..1) -> ok | error.
 sleep_enable_ext0_wakeup(_Pin, _Level) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns Configure ext1 wakeup
@@ -126,7 +126,7 @@ sleep_enable_ext0_wakeup(_Pin, _Level) ->
 %%-----------------------------------------------------------------------------
 -spec sleep_enable_ext1_wakeup(Mask :: non_neg_integer(), Mode :: 0..1) -> ok | error.
 sleep_enable_ext1_wakeup(_Mask, _Mode) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @doc Equivalent to nvs_get_binary(?ATOMVM_NVS_NS, Key).
@@ -147,7 +147,7 @@ nvs_get_binary(Key) when is_atom(Key) ->
 %%-----------------------------------------------------------------------------
 -spec nvs_get_binary(Namespace :: atom(), Key :: atom()) -> binary() | undefined.
 nvs_get_binary(Namespace, Key) when is_atom(Namespace) andalso is_atom(Key) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Namespace NVS namespace
@@ -192,7 +192,7 @@ nvs_set_binary(Key, Value) when is_atom(Key) andalso is_binary(Value) ->
 nvs_set_binary(Namespace, Key, Value) when
     is_atom(Namespace) andalso is_atom(Key) andalso is_binary(Value)
 ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Key NVS key
@@ -214,7 +214,7 @@ nvs_erase_key(Key) when is_atom(Key) ->
 %%-----------------------------------------------------------------------------
 -spec nvs_erase_key(Namespace :: atom(), Key :: atom()) -> ok.
 nvs_erase_key(Namespace, Key) when is_atom(Namespace) andalso is_atom(Key) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @doc Equivalent to nvs_erase_all(?ATOMVM_NVS_NS).
@@ -232,7 +232,7 @@ nvs_erase_all() ->
 %%-----------------------------------------------------------------------------
 -spec nvs_erase_all(Namespace :: atom()) -> ok.
 nvs_erase_all(Namespace) when is_atom(Namespace) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns ok
@@ -243,7 +243,7 @@ nvs_erase_all(Namespace) when is_atom(Namespace) ->
 %%-----------------------------------------------------------------------------
 -spec nvs_reformat() -> ok.
 nvs_reformat() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns List of partitions
@@ -254,7 +254,7 @@ nvs_reformat() ->
 %%-----------------------------------------------------------------------------
 -spec partition_list() -> [esp_partition()].
 partition_list() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns the currently stored binary in RTC slow memory.
@@ -266,7 +266,7 @@ partition_list() ->
 %%-----------------------------------------------------------------------------
 -spec rtc_slow_get_binary() -> binary().
 rtc_slow_get_binary() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Bin binary to be stored in RTC slow memory
@@ -277,7 +277,7 @@ rtc_slow_get_binary() ->
 %%-----------------------------------------------------------------------------
 -spec rtc_slow_set_binary(Bin :: binary()) -> ok.
 rtc_slow_set_binary(Bin) when is_binary(Bin) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns Clock frequency (in hz)
@@ -286,4 +286,4 @@ rtc_slow_set_binary(Bin) when is_binary(Bin) ->
 %%-----------------------------------------------------------------------------
 -spec freq_hz() -> non_neg_integer().
 freq_hz() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).

--- a/libs/eavmlib/src/gpio.erl
+++ b/libs/eavmlib/src/gpio.erl
@@ -224,7 +224,7 @@ deinit(_Pin) ->
 %%-----------------------------------------------------------------------------
 -spec set_pin_mode(Pin :: pin(), Direction :: direction()) -> ok | error.
 set_pin_mode(_Pin, _Mode) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Pin number to set internal resistor direction
@@ -238,7 +238,7 @@ set_pin_mode(_Pin, _Mode) ->
 %%-----------------------------------------------------------------------------
 -spec set_pin_pull(Pin :: pin(), Pull :: pull()) -> ok | error.
 set_pin_pull(_Pin, _Pull) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Pin number of the pin to be held
@@ -262,7 +262,7 @@ set_pin_pull(_Pin, _Pull) ->
 %%-----------------------------------------------------------------------------
 -spec hold_en(Pin :: pin()) -> ok | error.
 hold_en(_Pin) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Pin number of the pin to be released
@@ -282,7 +282,7 @@ hold_en(_Pin) ->
 %%-----------------------------------------------------------------------------
 -spec hold_dis(Pin :: pin()) -> ok | error.
 hold_dis(_Pin) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns ok
@@ -305,7 +305,7 @@ hold_dis(_Pin) ->
 %%-----------------------------------------------------------------------------
 -spec deep_sleep_hold_en() -> ok.
 deep_sleep_hold_en() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns ok
@@ -314,7 +314,7 @@ deep_sleep_hold_en() ->
 %%-----------------------------------------------------------------------------
 -spec deep_sleep_hold_dis() -> ok.
 deep_sleep_hold_dis() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Pin number of the pin to write
@@ -327,7 +327,7 @@ deep_sleep_hold_dis() ->
 %%-----------------------------------------------------------------------------
 -spec digital_write(Pin :: pin(), Level :: level()) -> ok | error.
 digital_write(_Pin, _Level) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Pin number of the pin to read
@@ -341,7 +341,7 @@ digital_write(_Pin, _Level) ->
 %%-----------------------------------------------------------------------------
 -spec digital_read(Pin :: pin()) -> high | low.
 digital_read(_Pin) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Pin number of the pin to set the interrupt on

--- a/libs/eavmlib/src/ledc.erl
+++ b/libs/eavmlib/src/ledc.erl
@@ -88,7 +88,7 @@
 %%-----------------------------------------------------------------------------
 -spec channel_config(Config :: channel_config()) -> ok | {error, ledc_error_code()}.
 channel_config(_Config) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Config      timer configuration
@@ -100,7 +100,7 @@ channel_config(_Config) ->
 %%-----------------------------------------------------------------------------
 -spec timer_config(Config :: timer_config()) -> ok | {error, ledc_error_code()}.
 timer_config(_Config) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Flags   Flags used to allocate the interrupt. One (or multiple, using
@@ -114,7 +114,7 @@ timer_config(_Config) ->
 %%-----------------------------------------------------------------------------
 -spec fade_func_install(Flags :: non_neg_integer()) -> ok | {error, ledc_error_code()}.
 fade_func_install(_Flags) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns ok
@@ -123,7 +123,7 @@ fade_func_install(_Flags) ->
 %%-----------------------------------------------------------------------------
 -spec fade_func_uninstall() -> ok.
 fade_func_uninstall() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
@@ -146,7 +146,7 @@ fade_func_uninstall() ->
 ) ->
     ok | {error, ledc_error_code()}.
 set_fade_with_time(_SpeedMode, _Channel, _TargetDuty, _MaxFadeTimeMs) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
@@ -170,7 +170,7 @@ set_fade_with_time(_SpeedMode, _Channel, _TargetDuty, _MaxFadeTimeMs) ->
     CycleNum :: non_neg_integer()
 ) -> ok | {error, ledc_error_code()}.
 set_fade_with_step(_SpeedMode, _Channel, _TargetDuty, _Scale, _CycleNum) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
@@ -187,7 +187,7 @@ set_fade_with_step(_SpeedMode, _Channel, _TargetDuty, _Scale, _CycleNum) ->
 -spec fade_start(SpeedMode :: speed_mode(), Channel :: channel(), FadeMode :: fade_mode()) ->
     ok | {error, ledc_error_code()}.
 fade_start(_SpeedMode, _Channel, _FadeMode) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
@@ -199,7 +199,7 @@ fade_start(_SpeedMode, _Channel, _FadeMode) ->
 %%-----------------------------------------------------------------------------
 -spec get_duty(SpeedMode :: speed_mode(), Channel :: channel()) -> ok | {error, ledc_error_code()}.
 get_duty(_SpeedMode, _Channel) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
@@ -213,7 +213,7 @@ get_duty(_SpeedMode, _Channel) ->
 -spec set_duty(SpeedMode :: speed_mode(), Channel :: channel(), Duty :: non_neg_integer()) ->
     ok | {error, ledc_error_code()}.
 set_duty(_SpeedMode, _Channel, _Duty) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
@@ -226,7 +226,7 @@ set_duty(_SpeedMode, _Channel, _Duty) ->
 -spec update_duty(SpeedMode :: speed_mode(), Channel :: channel()) ->
     ok | {error, ledc_error_code()}.
 update_duty(_SpeedMode, _Channel) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
@@ -238,7 +238,7 @@ update_duty(_SpeedMode, _Channel) ->
 -spec get_freq(SpeedMode :: speed_mode(), TimerNum :: timer_num()) ->
     ok | {error, ledc_error_code()}.
 get_freq(_SpeedMode, _TimerNum) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
@@ -251,7 +251,7 @@ get_freq(_SpeedMode, _TimerNum) ->
 -spec set_freq(SpeedMode :: speed_mode(), TimerNum :: timer_num(), FreqHz :: non_neg_integer()) ->
     ok | {error, ledc_error_code()}.
 set_freq(_SpeedMode, _TimerNum, _FreqHz) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   SpeedMode   Select the LEDC channel group with specified speed mode.
@@ -265,4 +265,4 @@ set_freq(_SpeedMode, _TimerNum, _FreqHz) ->
 -spec stop(SpeedMode :: speed_mode(), Channel :: channel(), IdleLevel :: non_neg_integer()) ->
     ok | {error, ledc_error_code()}.
 stop(_SpeedMode, _Channel, _IdleLevel) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).

--- a/libs/eavmlib/src/network.erl
+++ b/libs/eavmlib/src/network.erl
@@ -76,7 +76,7 @@
     | ap_sta_connected_config()
     | ap_sta_disconnected_config()
     | ap_sta_ip_assigned_config().
--type ap_config() :: {sta, [ap_config_property()]}.
+-type ap_config() :: {ap, [ap_config_property()]}.
 
 -type sntp_host_config() :: {host, string() | binary()}.
 -type sntp_synchronized_config() ::
@@ -209,7 +209,7 @@ wait_for_ap(ApConfig, Timeout) ->
 %%          FSM Programming Manual for more information.
 %% @end
 %%-----------------------------------------------------------------------------
--spec start(Config :: network_config()) -> ok | {error, Reason :: term()}.
+-spec start(Config :: network_config()) -> {ok, pid()} | {error, Reason :: term()}.
 start(Config) ->
     case gen_server:start({local, ?MODULE}, ?MODULE, Config, []) of
         {ok, Pid} = R ->
@@ -223,7 +223,7 @@ start(Config) ->
             Error
     end.
 
--spec start_link(Config :: network_config()) -> ok | {error, Reason :: term()}.
+-spec start_link(Config :: network_config()) -> {ok, pid()} | {error, Reason :: term()}.
 start_link(Config) ->
     case gen_server:start_link({local, ?MODULE}, ?MODULE, Config, []) of
         {ok, Pid} = R ->

--- a/libs/eavmlib/src/pico.erl
+++ b/libs/eavmlib/src/pico.erl
@@ -37,4 +37,4 @@
 %%-----------------------------------------------------------------------------
 -spec rtc_set_datetime(calendar:datetime()) -> ok.
 rtc_set_datetime(_Datetime) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).

--- a/libs/estdlib/src/base64.erl
+++ b/libs/estdlib/src/base64.erl
@@ -59,7 +59,7 @@
 %%-----------------------------------------------------------------------------
 -spec encode(binary() | iolist()) -> binary().
 encode(Data) when is_binary(Data) orelse is_list(Data) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Data the data to encode
@@ -69,7 +69,7 @@ encode(Data) when is_binary(Data) orelse is_list(Data) ->
 %%-----------------------------------------------------------------------------
 -spec encode_to_string(binary() | iolist()) -> string().
 encode_to_string(Data) when is_binary(Data) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Data the data to decode
@@ -82,7 +82,7 @@ encode_to_string(Data) when is_binary(Data) ->
 %%-----------------------------------------------------------------------------
 -spec decode(binary() | iolist()) -> binary().
 decode(Data) when is_binary(Data) orelse is_list(Data) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Data the data to decode
@@ -95,4 +95,4 @@ decode(Data) when is_binary(Data) orelse is_list(Data) ->
 %%-----------------------------------------------------------------------------
 -spec decode_to_string(binary() | iolist()) -> string().
 decode_to_string(Data) when is_binary(Data) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).

--- a/libs/estdlib/src/calendar.erl
+++ b/libs/estdlib/src/calendar.erl
@@ -165,4 +165,4 @@ day_of_the_week(Y, M, D) ->
 -spec system_time_to_universal_time(Time :: integer(), TimeUnit :: erlang:time_unit()) ->
     datetime().
 system_time_to_universal_time(_Time, _TimeUnit) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -179,7 +179,7 @@ send_after(Time, Dest, Msg) ->
 %%-----------------------------------------------------------------------------
 -spec process_info(Pid :: pid(), Key :: atom()) -> term().
 process_info(_Pid, _Key) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Key key used to find system information.
@@ -217,7 +217,7 @@ process_info(_Pid, _Key) ->
 %%-----------------------------------------------------------------------------
 -spec system_info(Key :: atom()) -> term().
 system_info(_Key) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Key key used to change system flag.
@@ -239,7 +239,7 @@ system_info(_Key) ->
 %%-----------------------------------------------------------------------------
 -spec system_flag(Key :: atom(), term()) -> term().
 system_flag(_Key, _Value) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Data data to compute hash of, as a binary.
@@ -250,7 +250,7 @@ system_flag(_Key, _Value) ->
 %%-----------------------------------------------------------------------------
 -spec md5(Data :: binary()) -> binary().
 md5(Data) when is_binary(Data) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Module Name of module
@@ -299,7 +299,7 @@ apply(Module, Function, Args) ->
 %%-----------------------------------------------------------------------------
 -spec is_map(Map :: map()) -> boolean().
 is_map(_Map) ->
-    throw(bif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Map the map
@@ -314,7 +314,7 @@ is_map(_Map) ->
 %%-----------------------------------------------------------------------------
 -spec map_size(Map :: map()) -> non_neg_integer().
 map_size(_Map) ->
-    throw(bif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Key     the key to get
@@ -331,7 +331,7 @@ map_size(_Map) ->
 %%-----------------------------------------------------------------------------
 -spec map_get(Key :: term(), Map :: map()) -> Value :: term().
 map_get(_Key, _Map) ->
-    throw(bif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Key     the key
@@ -347,7 +347,7 @@ map_get(_Key, _Map) ->
 %%-----------------------------------------------------------------------------
 -spec map_is_key(Key :: term(), Map :: map()) -> boolean().
 map_is_key(_Key, _Map) ->
-    throw(bif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   A   any term
@@ -361,7 +361,7 @@ map_is_key(_Key, _Map) ->
 %%-----------------------------------------------------------------------------
 -spec min(A :: any(), B :: any()) -> any().
 min(_A, _B) ->
-    throw(bif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   A   any term
@@ -375,7 +375,7 @@ min(_A, _B) ->
 %%-----------------------------------------------------------------------------
 -spec max(A :: any(), B :: any()) -> any().
 max(_A, _B) ->
-    throw(bif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Type the type of memory to request
@@ -386,7 +386,7 @@ max(_A, _B) ->
 %%-----------------------------------------------------------------------------
 -spec memory(Type :: mem_type()) -> non_neg_integer().
 memory(_Type) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Unit    time unit
@@ -407,7 +407,7 @@ memory(_Type) ->
 %%-----------------------------------------------------------------------------
 -spec monotonic_time(Unit :: time_unit()) -> integer().
 monotonic_time(_Unit) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Key     key in the process dictionary
@@ -417,7 +417,7 @@ monotonic_time(_Unit) ->
 %%-----------------------------------------------------------------------------
 -spec get(Key :: any()) -> any().
 get(_Key) ->
-    throw(bif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Key     key to add to the process dictionary
@@ -428,7 +428,7 @@ get(_Key) ->
 %%-----------------------------------------------------------------------------
 -spec put(Key :: any(), Value :: any()) -> any().
 put(_Key, _Value) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Key     key to erase from the process dictionary
@@ -438,7 +438,7 @@ put(_Key, _Value) ->
 %%-----------------------------------------------------------------------------
 -spec erase(Key :: any()) -> any().
 erase(_Key) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Module      module to test
@@ -450,7 +450,7 @@ erase(_Key) ->
 %%-----------------------------------------------------------------------------
 -spec function_exported(Module :: module(), Function :: atom(), Arity :: arity()) -> boolean().
 function_exported(_Module, _Function, _Arity) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Term    term to print
@@ -460,7 +460,7 @@ function_exported(_Module, _Function, _Arity) ->
 %%-----------------------------------------------------------------------------
 -spec display(Term :: any()) -> true.
 display(_Term) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   String  string to convert to an atom
@@ -474,7 +474,7 @@ display(_Term) ->
 %%-----------------------------------------------------------------------------
 -spec list_to_atom(String :: string()) -> atom().
 list_to_atom(_String) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   List    list to convert to binary
@@ -485,7 +485,7 @@ list_to_atom(_String) ->
 %%-----------------------------------------------------------------------------
 -spec list_to_binary(List :: [byte()]) -> binary().
 list_to_binary(_String) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   String  string to convert to integer
@@ -494,9 +494,9 @@ list_to_binary(_String) ->
 %% Errors with `badarg' if the string is not a representation of an integer.
 %% @end
 %%-----------------------------------------------------------------------------
--spec list_to_integer(String :: string()) -> tuple().
+-spec list_to_integer(String :: string()) -> integer().
 list_to_integer(_String) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   List    list to convert to tuple
@@ -506,7 +506,7 @@ list_to_integer(_String) ->
 %%-----------------------------------------------------------------------------
 -spec list_to_tuple(List :: [any()]) -> tuple().
 list_to_tuple(_List) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   IOList  IO list to convert to binary
@@ -516,7 +516,7 @@ list_to_tuple(_List) ->
 %%-----------------------------------------------------------------------------
 -spec iolist_to_binary(IOList :: iolist()) -> binary().
 iolist_to_binary(_IOList) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Binary  Binary to convert to list
@@ -526,7 +526,7 @@ iolist_to_binary(_IOList) ->
 %%-----------------------------------------------------------------------------
 -spec binary_to_list(Binary :: binary()) -> [byte()].
 binary_to_list(_Binary) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Atom        Atom to convert
@@ -538,7 +538,7 @@ binary_to_list(_Binary) ->
 %%-----------------------------------------------------------------------------
 -spec atom_to_binary(Atom :: atom(), Encoding :: latin1) -> binary().
 atom_to_binary(_Atom, _Encoding) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Atom    Atom to convert
@@ -548,7 +548,7 @@ atom_to_binary(_Atom, _Encoding) ->
 %%-----------------------------------------------------------------------------
 -spec atom_to_list(Atom :: atom()) -> string().
 atom_to_list(_Atom) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -type float_format_option() ::
     {decimals, Decimals :: 0..57}
@@ -563,7 +563,7 @@ atom_to_list(_Atom) ->
 %%-----------------------------------------------------------------------------
 -spec float_to_binary(Float :: float()) -> binary().
 float_to_binary(_Float) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Float   Float to convert
@@ -574,7 +574,7 @@ float_to_binary(_Float) ->
 %%-----------------------------------------------------------------------------
 -spec float_to_binary(Float :: float(), Options :: [float_format_option()]) -> binary().
 float_to_binary(_Float, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Float   Float to convert
@@ -584,7 +584,7 @@ float_to_binary(_Float, _Options) ->
 %%-----------------------------------------------------------------------------
 -spec float_to_list(Float :: float()) -> string().
 float_to_list(_Float) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Float   Float to convert
@@ -595,7 +595,7 @@ float_to_list(_Float) ->
 %%-----------------------------------------------------------------------------
 -spec float_to_list(Float :: float(), Options :: [float_format_option()]) -> string().
 float_to_list(_Float, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Integer integer to convert to a binary
@@ -605,7 +605,7 @@ float_to_list(_Float, _Options) ->
 %%-----------------------------------------------------------------------------
 -spec integer_to_binary(Integer :: integer()) -> binary().
 integer_to_binary(_Integer) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Integer integer to convert to a string
@@ -615,7 +615,7 @@ integer_to_binary(_Integer) ->
 %%-----------------------------------------------------------------------------
 -spec integer_to_list(Integer :: integer()) -> string().
 integer_to_list(_Integer) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Integer integer to convert to a string
@@ -626,7 +626,7 @@ integer_to_list(_Integer) ->
 %%-----------------------------------------------------------------------------
 -spec integer_to_list(Integer :: integer(), Base :: 2..36) -> string().
 integer_to_list(_Integer, _Base) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Fun     function to convert to a string
@@ -636,7 +636,7 @@ integer_to_list(_Integer, _Base) ->
 %%-----------------------------------------------------------------------------
 -spec fun_to_list(Fun :: function()) -> string().
 fun_to_list(_Fun) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Pid     pid to convert to a string
@@ -646,7 +646,7 @@ fun_to_list(_Fun) ->
 %%-----------------------------------------------------------------------------
 -spec pid_to_list(Pid :: pid()) -> string().
 pid_to_list(_Pid) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Ref     reference to convert to a string
@@ -656,7 +656,7 @@ pid_to_list(_Pid) ->
 %%-----------------------------------------------------------------------------
 -spec ref_to_list(Ref :: reference()) -> string().
 ref_to_list(_Ref) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Name    name of the process to register
@@ -670,7 +670,7 @@ ref_to_list(_Ref) ->
 %%-----------------------------------------------------------------------------
 -spec register(Name :: atom(), Pid :: pid()) -> true.
 register(_Name, _Pid) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Name    name to unregister
@@ -682,7 +682,7 @@ register(_Name, _Pid) ->
 %%-----------------------------------------------------------------------------
 -spec unregister(Name :: atom()) -> true.
 unregister(_Name) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Name    name of the process to locate
@@ -692,7 +692,7 @@ unregister(_Name) ->
 %%-----------------------------------------------------------------------------
 -spec whereis(Name :: atom()) -> pid() | undefined.
 whereis(_Name) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Function    function to create a process from
@@ -702,7 +702,7 @@ whereis(_Name) ->
 %%-----------------------------------------------------------------------------
 -spec spawn(Function :: function()) -> pid().
 spawn(_Name) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Module      module of the function to create a process from
@@ -714,13 +714,13 @@ spawn(_Name) ->
 %%-----------------------------------------------------------------------------
 -spec spawn(Module :: module(), Function :: atom(), Args :: [any()]) -> pid().
 spawn(_Module, _Function, _Args) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -type spawn_option() ::
     {min_heap_size, pos_integer()}
     | {max_heap_size, pos_integer()}
-    | {link, boolean()}
-    | {monitor, boolean()}.
+    | link
+    | monitor.
 
 %%-----------------------------------------------------------------------------
 %% @param   Function    function to create a process from
@@ -731,7 +731,7 @@ spawn(_Module, _Function, _Args) ->
 %%-----------------------------------------------------------------------------
 -spec spawn_opt(Function :: function(), Options :: [{max_heap_size, integer()}]) -> pid().
 spawn_opt(_Name, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Module      module of the function to create a process from
@@ -746,7 +746,7 @@ spawn_opt(_Name, _Options) ->
     Module :: module(), Function :: atom(), Args :: [any()], Options :: [spawn_option()]
 ) -> pid().
 spawn_opt(_Module, _Function, _Args, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns a new reference
@@ -755,24 +755,24 @@ spawn_opt(_Module, _Function, _Args, _Options) ->
 %%-----------------------------------------------------------------------------
 -spec make_ref() -> reference().
 make_ref() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Type    type of monitor to create
 %% @param   Pid     pid of the object to monitor
 %% @returns a monitor reference
-%% @doc     Create a monitor on a process.
-%% When the process dies, the following message is sent to the caller of this
-%% function:
+%% @doc     Create a monitor on a process or on a port.
+%% When the process or the port terminates, the following message is sent to
+%% the caller of this function:
 %% ```
-%% {'DOWN', MonitorRef, process, Pid, Reason}
+%% {'DOWN', MonitorRef, Type, Pid, Reason}
 %% '''
-%% Unlike Erlang/OTP, monitors are only supported for processes.
+%% Unlike Erlang/OTP, monitors are only supported for processes and ports.
 %% @end
 %%-----------------------------------------------------------------------------
--spec monitor(Type :: process, Pid :: pid()) -> reference().
+-spec monitor(Type :: process | port, Pid :: pid()) -> reference().
 monitor(_Type, _Pid) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Monitor reference of monitor to remove
@@ -782,7 +782,7 @@ monitor(_Type, _Pid) ->
 %%-----------------------------------------------------------------------------
 -spec demonitor(Monitor :: reference()) -> true.
 demonitor(_Monitor) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -type demonitor_option() :: flush | {flush, boolean()} | info | {info, boolean()}.
 
@@ -797,7 +797,7 @@ demonitor(_Monitor) ->
 %%-----------------------------------------------------------------------------
 -spec demonitor(Monitor :: reference(), Options :: [demonitor_option()]) -> boolean().
 demonitor(_Monitor, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   PortName    Tuple {spawn, Name} identifying the port
@@ -809,7 +809,7 @@ demonitor(_Monitor, _Options) ->
 %%-----------------------------------------------------------------------------
 -spec open_port(PortName :: {spawn, iodata()}, Options :: [any()] | map()) -> pid().
 open_port(_PortName, _Options) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Unit    Unit to return system time in
@@ -819,7 +819,7 @@ open_port(_PortName, _Options) ->
 %%-----------------------------------------------------------------------------
 -spec system_time(Unit :: time_unit()) -> non_neg_integer().
 system_time(_Unit) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns Pid of group leader or self() if no group leader is set.
@@ -828,7 +828,7 @@ system_time(_Unit) ->
 %%-----------------------------------------------------------------------------
 -spec group_leader() -> pid().
 group_leader() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Flag    flag to change
@@ -845,7 +845,7 @@ group_leader() ->
 %%-----------------------------------------------------------------------------
 -spec process_flag(Flag :: trap_exit, Value :: boolean()) -> pid().
 process_flag(_Flag, _Value) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Module  module to get info for
@@ -858,7 +858,7 @@ process_flag(_Flag, _Value) ->
 %%-----------------------------------------------------------------------------
 -spec get_module_info(Module :: atom()) -> [{atom(), any()}].
 get_module_info(_Module) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Module  module to get info for
@@ -873,4 +873,4 @@ get_module_info(_Module) ->
 %%-----------------------------------------------------------------------------
 -spec get_module_info(Module :: atom(), InfoKey :: atom()) -> any().
 get_module_info(_Module, _InfoKey) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).

--- a/libs/estdlib/src/gen_server.erl
+++ b/libs/estdlib/src/gen_server.erl
@@ -61,6 +61,40 @@
 -type server_ref() :: atom() | pid().
 -type from() :: any().
 
+-type init_result(StateType) ::
+    {ok, State :: StateType}
+    | {ok, State :: StateType, timeout()}
+    | {stop, Reason :: any()}.
+
+-type handle_call_result(StateType) ::
+    {reply, Reply :: any(), NewState :: StateType}
+    | {reply, Reply :: any(), NewState :: StateType, timeout()}
+    | {noreply, NewState :: StateType}
+    | {noreply, NewState :: StateType, timeout()}
+    | {stop, Reason :: any(), Reply :: any(), NewState :: StateType}
+    | {stop, Reason :: any(), NewState :: StateType}.
+
+-type handle_cast_result(StateType) ::
+    {noreply, NewState :: StateType}
+    | {noreply, NewState :: StateType, timeout()}
+    | {stop, Reason :: any(), NewState :: StateType}.
+
+-type handle_info(StateType) ::
+    {noreply, NewState :: StateType}
+    | {noreply, NewState :: StateType, timeout()}
+    | {stop, Reason :: any(), NewState :: StateType}.
+
+-callback init(Args :: any()) ->
+    init_result(any()).
+-callback handle_call(Request :: any(), From :: {pid(), Tag :: any()}, State :: StateType) ->
+    handle_call_result(StateType).
+-callback handle_cast(Request :: any(), State :: StateType) ->
+    handle_cast_result(StateType).
+-callback handle_info(Info :: timeout() | any(), State :: StateType) ->
+    handle_info(StateType).
+-callback terminate(Reason :: normal | any(), State :: any()) ->
+    any().
+
 %% @private
 do_spawn(Module, Args, Options, SpawnOpts) ->
     Pid = spawn_opt(?MODULE, init_it, [self(), Module, Args, Options], SpawnOpts),
@@ -308,7 +342,7 @@ stop(Pid, Reason, Timeout) when is_pid(Pid) ->
 %% @doc     Send a request to a gen_server instance, and wait for a reply.
 %% @end
 %%-----------------------------------------------------------------------------
--spec call(ServerRef :: server_ref(), Request :: term) ->
+-spec call(ServerRef :: server_ref(), Request :: term()) ->
     Reply :: term() | {error, Reason :: term()}.
 call(ServerRef, Request) ->
     call(ServerRef, Request, 5000).
@@ -385,7 +419,7 @@ cast(Pid, Request) when is_pid(Pid) ->
 %%          function can be safely ignored.
 %% @end
 %%-----------------------------------------------------------------------------
--spec reply(From :: from(), Reply :: term) -> term().
+-spec reply(From :: from(), Reply :: term()) -> term().
 reply({Pid, Ref}, Reply) ->
     Pid ! {Ref, Reply},
     ok.

--- a/libs/estdlib/src/gen_statem.erl
+++ b/libs/estdlib/src/gen_statem.erl
@@ -57,6 +57,19 @@
 -type options() :: list({atom(), term()}).
 -type server_ref() :: atom() | pid().
 
+-type action() ::
+    {reply, From :: pid(), Reply :: any()}
+    | {state_timeout, Timeout :: timeout(), Msg :: any()}.
+
+-type init_result(StateType, DataType) ::
+    {ok, State :: StateType, Data :: DataType}
+    | {ok, State :: StateType, Data :: DataType, Actions :: [action()]}
+    | {stop, Reason :: any()}.
+
+-callback init(Args :: any()) -> init_result(any(), any()).
+-callback terminate(Reason :: normal | any(), State :: any(), Data :: any()) ->
+    any().
+
 %%-----------------------------------------------------------------------------
 %% @param   ServerName the name with which to register the gen_statem
 %% @param   Module the module in which the gen_statem callbacks are defined
@@ -174,7 +187,7 @@ stop(ServerRef, Reason, Timeout) ->
 %% @doc     Send a request to a gen_statem instance, and wait for a reply.
 %% @end
 %%-----------------------------------------------------------------------------
--spec call(ServerRef :: server_ref(), Request :: term) ->
+-spec call(ServerRef :: server_ref(), Request :: term()) ->
     Reply :: term() | {error, Reason :: term()}.
 call(ServerRef, Request) ->
     call(ServerRef, Request, 5000).

--- a/libs/estdlib/src/gen_tcp.erl
+++ b/libs/estdlib/src/gen_tcp.erl
@@ -49,9 +49,10 @@
 -type option() ::
     {active, boolean()}
     | {buffer, pos_integer()}
-    | {timeout, pos_integer() | infinity}
+    | {timeout, timeout()}
     | list
-    | binary.
+    | binary
+    | {binary, boolean()}.
 
 -type listen_option() :: option().
 -type connect_option() :: option().
@@ -84,7 +85,11 @@
 %%          in order to receive data on the socket.
 %% @end
 %%-----------------------------------------------------------------------------
--spec connect(Address :: inet:address(), Port :: inet:port_number(), Options :: [connect_option()]) ->
+-spec connect(
+    Address :: inet:address() | inet:hostname(),
+    Port :: inet:port_number(),
+    Options :: [connect_option()]
+) ->
     {ok, Socket :: inet:socket()} | {error, Reason :: reason()}.
 connect(Address, Port, Params0) ->
     Socket = open_port({spawn, "socket"}, []),
@@ -194,7 +199,7 @@ accept(ListenSocket) ->
 %% @doc     Accept a connection on a listening socket.
 %% @end
 %%-----------------------------------------------------------------------------
--spec accept(ListenSocket :: inet:socket(), Timeout :: non_neg_integer()) ->
+-spec accept(ListenSocket :: inet:socket(), Timeout :: timeout()) ->
     {ok, Socket :: inet:socket()} | {error, Reason :: reason()}.
 accept(ListenSocket, Timeout) ->
     case call(ListenSocket, {accept, Timeout}) of

--- a/libs/estdlib/src/gen_udp.erl
+++ b/libs/estdlib/src/gen_udp.erl
@@ -43,9 +43,16 @@
 
 -export([open/1, open/2, send/4, recv/2, recv/3, close/1, controlling_process/2]).
 
--type proplist() :: [{atom(), any()}].
 -type packet() :: string() | binary().
 -type reason() :: term().
+
+-type option() ::
+    {active, boolean()}
+    | {buffer, pos_integer()}
+    | {timeout, timeout()}
+    | list
+    | binary
+    | {binary, boolean()}.
 
 -define(DEFAULT_PARAMS, [{active, true}, {buffer, 128}, {timeout, infinity}]).
 
@@ -76,7 +83,7 @@ open(PortNum) ->
 %%          <em><b>Note.</b>  The Params argument is currently ignored.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec open(PortNum :: inet:port_number(), Options :: proplist()) ->
+-spec open(PortNum :: inet:port_number(), Options :: [option()]) ->
     {ok, inet:socket()} | {error, Reason :: reason()}.
 open(PortNum, Options) ->
     DriverPid = open_port({spawn, "socket"}, []),
@@ -135,7 +142,7 @@ recv(Socket, Length) ->
 %%          is limited to 128 bytes.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec recv(Socket :: inet:socket(), Length :: non_neg_integer(), Timeout :: non_neg_integer()) ->
+-spec recv(Socket :: inet:socket(), Length :: non_neg_integer(), Timeout :: timeout()) ->
     {ok, {inet:address(), inet:port_number(), packet()}} | {error, reason()}.
 recv(Socket, Length, Timeout) ->
     call(Socket, {recvfrom, Length, Timeout}).

--- a/libs/estdlib/src/inet.erl
+++ b/libs/estdlib/src/inet.erl
@@ -27,8 +27,9 @@
 -type address() :: ipv4_address().
 -type ipv4_address() :: {octet(), octet(), octet(), octet()}.
 -type octet() :: 0..255.
+-type hostname() :: iodata().
 
--export_type([socket/0, port_number/0, address/0, ipv4_address/0, octet/0]).
+-export_type([socket/0, port_number/0, address/0, ipv4_address/0, octet/0, hostname/0]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Socket the socket from which to obtain the port number

--- a/libs/estdlib/src/maps.erl
+++ b/libs/estdlib/src/maps.erl
@@ -171,7 +171,7 @@ iterator(Map) ->
 -spec next(Iterator :: iterator()) ->
     {Key :: key(), Value :: value(), NextIterator :: iterator()} | none.
 next([_Pos | _Map] = _Iterator) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns a new map

--- a/libs/estdlib/src/math.erl
+++ b/libs/estdlib/src/math.erl
@@ -47,91 +47,91 @@
 
 -spec cos(X :: number()) -> float().
 cos(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec acos(X :: number()) -> float().
 acos(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec acosh(X :: number()) -> float().
 acosh(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec asin(X :: number()) -> float().
 asin(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec asinh(X :: number()) -> float().
 asinh(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec atan(X :: number()) -> float().
 atan(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec atan2(Y :: number(), X :: number()) -> float().
 atan2(_Y, _X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec atanh(X :: number()) -> float().
 atanh(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec ceil(X :: number()) -> float().
 ceil(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec cosh(X :: number()) -> float().
 cosh(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec exp(X :: number()) -> float().
 exp(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec floor(X :: number()) -> float().
 floor(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec fmod(X :: number(), Y :: number()) -> float().
 fmod(_X, _Y) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec log(X :: number()) -> float().
 log(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec log10(X :: number()) -> float().
 log10(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec log2(X :: number()) -> float().
 log2(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec pow(X :: number(), Y :: number()) -> float().
 pow(_X, _Y) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec sin(X :: number()) -> float().
 sin(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec sinh(X :: number()) -> float().
 sinh(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec sqrt(X :: number()) -> float().
 sqrt(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec tan(X :: number()) -> float().
 tan(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec tanh(X :: number()) -> float().
 tanh(_X) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 -spec pi() -> float().
 pi() ->

--- a/libs/estdlib/src/timer.erl
+++ b/libs/estdlib/src/timer.erl
@@ -37,7 +37,7 @@
 %%      milliseconds, or forever, using `infinity' as the parameter.
 %% @end
 %%-----------------------------------------------------------------------------
--spec sleep(Timeout :: non_neg_integer() | infinity) -> ok.
+-spec sleep(Timeout :: timeout()) -> ok.
 sleep(Timeout) ->
     receive
     after Timeout ->


### PR DESCRIPTION
Running dialyzer on atomvmlib and examples revealed issues with several types It also revealed bugs in three examples

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
