### PR TITLE
Add debug info in beams for Dialyzer

### DIFF
--- a/CMakeModules/BuildErlang.cmake
+++ b/CMakeModules/BuildErlang.cmake
@@ -23,7 +23,7 @@ macro(pack_archive avm_name)
     foreach(module_name ${ARGN})
         add_custom_command(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/beams/${module_name}.beam
-            COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/beams && erlc -o ${CMAKE_CURRENT_BINARY_DIR}/beams -I ${CMAKE_SOURCE_DIR}/libs/include ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl
+            COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/beams && erlc +debug_info -o ${CMAKE_CURRENT_BINARY_DIR}/beams -I ${CMAKE_SOURCE_DIR}/libs/include ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl
             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl
             COMMENT "Compiling ${module_name}.erl"
             VERBATIM
@@ -98,7 +98,7 @@ macro(pack_runnable avm_name main)
 
     add_custom_command(
         OUTPUT ${main}.beam
-        COMMAND erlc -I ${CMAKE_SOURCE_DIR}/libs/include ${CMAKE_CURRENT_SOURCE_DIR}/${main}.erl
+        COMMAND erlc +debug_info -I ${CMAKE_SOURCE_DIR}/libs/include ${CMAKE_CURRENT_SOURCE_DIR}/${main}.erl
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${main}.erl
         COMMENT "Compiling ${main}.erl"
         VERBATIM
@@ -152,7 +152,7 @@ macro(pack_test test_avm_name)
 
     add_custom_target(
         ${test_avm_name} ALL
-        COMMAND erlc -I ${CMAKE_SOURCE_DIR}/libs/include ${CMAKE_CURRENT_SOURCE_DIR}/tests.erl
+        COMMAND erlc +debug_info -I ${CMAKE_SOURCE_DIR}/libs/include ${CMAKE_CURRENT_SOURCE_DIR}/tests.erl
         COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${INCLUDE_LINES} ${CMAKE_CURRENT_BINARY_DIR}/${test_avm_name}.avm ${CMAKE_CURRENT_BINARY_DIR}/tests.beam ${ARCHIVES}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tests.erl
         COMMENT "Packing runnable ${test_avm_name}.avm"
@@ -166,7 +166,7 @@ macro(pack_uf2 avm_name main)
 
     add_custom_command(
         OUTPUT ${main}.beam
-        COMMAND erlc -I ${CMAKE_SOURCE_DIR}/libs/include ${CMAKE_CURRENT_SOURCE_DIR}/${main}.erl
+        COMMAND erlc +debug_info -I ${CMAKE_SOURCE_DIR}/libs/include ${CMAKE_CURRENT_SOURCE_DIR}/${main}.erl
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${main}.erl
         COMMENT "Compiling ${main}.erl"
         VERBATIM


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
