### PR TITLE
Build and install plt

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -40,6 +40,19 @@ else()
     pack_lib(atomvmlib eavmlib estdlib alisp)
 endif()
 
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/atomvmlib.plt
+    DEPENDS atomvmlib
+    COMMAND dialyzer --build_plt --output_plt ${CMAKE_CURRENT_BINARY_DIR}/atomvmlib.plt
+        -r ${CMAKE_CURRENT_BINARY_DIR}/estdlib/src/beams
+        -r ${CMAKE_CURRENT_BINARY_DIR}/eavmlib/src/beams
+        -r ${CMAKE_CURRENT_BINARY_DIR}/alisp/src/beams
+)
+
+add_custom_target(atomvmlib_plt ALL
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/atomvmlib.plt
+)
+
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/atomvmlib.avm
     DESTINATION lib/atomvm


### PR DESCRIPTION
Building plt also checks that current erlang libraries are correct.

The plt is installed but depends on some installed Erlang/OTP beams.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
