### PR TITLE
Compile crypto module

### DIFF
--- a/libs/estdlib/src/CMakeLists.txt
+++ b/libs/estdlib/src/CMakeLists.txt
@@ -25,6 +25,7 @@ include(BuildErlang)
 set(ERLANG_MODULES
     base64
     calendar
+    crypto
     gen_event
     gen_server
     gen_statem


### PR DESCRIPTION
We need it for dialyzer :-)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
