### PR TITLE
Fix hello_world and "Install and smoke test"

### DIFF
--- a/examples/erlang/hello_world.erl
+++ b/examples/erlang/hello_world.erl
@@ -22,4 +22,5 @@
 -export([start/0]).
 
 start() ->
-    erlang:display(hello_world).
+    erlang:display(hello_world),
+    ok.


### PR DESCRIPTION
Explicitly return ok, so atomvm exits with success.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
