### PR TITLE
Fix esp32 CI by installing dialyzer

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -59,7 +59,7 @@ jobs:
         set -eu
         apt update
         DEBIAN_FRONTEND=noninteractive apt install -y -q \
-            doxygen erlang-base \
+            doxygen erlang-base erlang-dialyzer \
             libglib2.0-0 libpixman-1-0 \
             gcc g++ zlib1g-dev
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
