### PR TITLE
ESP32/NVS: return `namespace_not_found` as `undefined` in get function

### DIFF
--- a/libs/eavmlib/src/esp.erl
+++ b/libs/eavmlib/src/esp.erl
@@ -180,6 +180,7 @@ nvs_get_binary(Namespace, Key) when is_atom(Namespace) andalso is_atom(Key) ->
     case esp:nvs_fetch_binary(Namespace, Key) of
         {ok, Result} -> Result;
         {error, not_found} -> undefined;
+        {error, namespace_not_found} -> undefined;
         {error, OtherError} -> throw(OtherError)
     end.
 


### PR DESCRIPTION
Fixes `nvs_get_binary/2` so it can work on devices with a completely erased NVS area.

namespace not found is quite common in a newly flash device, for consistency reasons it should be returned as undefined.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
