### PR TITLE
Add more missing function stubs

### DIFF
--- a/libs/eavmlib/src/esp.erl
+++ b/libs/eavmlib/src/esp.erl
@@ -29,9 +29,10 @@
 -export([
     restart/0,
     reset_reason/0,
-    wakeup_cause/0,
+    sleep_get_wakeup_cause/0,
     sleep_enable_ext0_wakeup/2,
     sleep_enable_ext1_wakeup/2,
+    deep_sleep/1,
     nvs_fetch_binary/2,
     nvs_get_binary/1, nvs_get_binary/2, nvs_get_binary/3,
     nvs_set_binary/2, nvs_set_binary/3,
@@ -122,8 +123,8 @@ reset_reason() ->
 %% @doc     Returns the cause for the wakeup
 %% @end
 %%-----------------------------------------------------------------------------
--spec wakeup_cause() -> undefined | esp_wakeup_cause() | error.
-wakeup_cause() ->
+-spec sleep_get_wakeup_cause() -> undefined | esp_wakeup_cause() | error.
+sleep_get_wakeup_cause() ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
@@ -140,6 +141,18 @@ sleep_enable_ext0_wakeup(_Pin, _Level) ->
 %%-----------------------------------------------------------------------------
 -spec sleep_enable_ext1_wakeup(Mask :: non_neg_integer(), Mode :: 0..1) -> ok | error.
 sleep_enable_ext1_wakeup(_Mask, _Mode) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   SleepMS time to deep sleep in milliseconds
+%% @doc Put the esp32 into deep sleep.
+%% This function never returns. Program is restarted and wake up reason can be
+%% inspected to determine if the esp32 was woken by the timeout or by another
+%% cause.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec deep_sleep(SleepMS :: non_neg_integer()) -> no_return().
+deep_sleep(_SleepMS) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/libs/estdlib/src/CMakeLists.txt
+++ b/libs/estdlib/src/CMakeLists.txt
@@ -24,6 +24,7 @@ include(BuildErlang)
 
 set(ERLANG_MODULES
     base64
+    binary
     calendar
     crypto
     gen_event

--- a/libs/estdlib/src/binary.erl
+++ b/libs/estdlib/src/binary.erl
@@ -1,0 +1,38 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%%-----------------------------------------------------------------------------
+%% @doc An implementation of a subset of the Erlang/OTP binary interface.
+%% @end
+%%-----------------------------------------------------------------------------
+-module(binary).
+
+-export([at/2]).
+
+%%-----------------------------------------------------------------------------
+%% @param   Binary binary to get a byte from
+%% @param   Index  0-based index of the byte to return
+%% @returns value of the byte from the binary
+%% @doc     Get a byte from a binary by index.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec at(Binary :: binary(), Index :: non_neg_integer()) -> byte().
+at(_Binary, _Index) ->
+    erlang:nif_error(undefined).

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -79,16 +79,21 @@
     open_port/2,
     system_time/1,
     group_leader/0,
+    group_leader/2,
     process_flag/2,
     get_module_info/1,
     get_module_info/2,
     processes/0,
     binary_to_term/1,
-    term_to_binary/1
+    term_to_binary/1,
+    timestamp/0,
+    universaltime/0,
+    localtime/0
 ]).
 
 -export_type([
-    time_unit/0
+    time_unit/0,
+    timestamp/0
 ]).
 
 %%
@@ -100,6 +105,9 @@
 
 -type mem_type() :: binary().
 -type time_unit() :: second | millisecond | microsecond.
+-type timestamp() :: {
+    MegaSecs :: non_neg_integer(), Secs :: non_neg_integer(), MicroSecs :: non_neg_integer
+}.
 
 %%-----------------------------------------------------------------------------
 %% @param   Time time in milliseconds after which to send the timeout message.
@@ -834,6 +842,17 @@ group_leader() ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
+%% @param   Leader  pid of process to set as leader
+%% @param   Pid     pid of process to set a Leader
+%% @returns `true'
+%% @doc Set the group leader for a given process.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec group_leader(Leader :: pid(), Pid :: pid()) -> true.
+group_leader(_Leader, _Pid) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
 %% @param   Flag    flag to change
 %% @param   Value   new value of the flag
 %% @returns Previous value of the flag
@@ -912,4 +931,37 @@ binary_to_term(_Binary) ->
 %%-----------------------------------------------------------------------------
 -spec term_to_binary(Term :: any()) -> binary().
 term_to_binary(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns A tuple representing the current timestamp.
+%% @see monotonic_time/1
+%% @see system_time/1
+%% @doc Return the timestamp in `{MegaSec, Sec, MicroSec}' format.
+%% This the old format returned by `erlang:now/0'. Please note that the latter
+%% which is deprecated in Erlang/OTP is not implemented by AtomVM.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec timestamp() -> erlang:timestamp().
+timestamp() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns A tuple representing the current universal time.
+%% @see localtime/0
+%% @doc Return the current time and day for UTC.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec universaltime() -> calendar:datetime().
+universaltime() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns A tuple representing the current local time.
+%% @see universaltime/0
+%% @doc Return the current time and day for system local timezone.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec localtime() -> calendar:datetime().
+localtime() ->
     erlang:nif_error(undefined).


### PR DESCRIPTION
Add functions used by examples and more.
Also fix name of `esp:sleep_get_wakeup_cause/0`

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
