### PR TITLE
Prepare v0.6.0-alpha.1 dev cycle

### DIFF
--- a/version.cmake
+++ b/version.cmake
@@ -18,5 +18,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-set(ATOMVM_BASE_VERSION "0.6.0-alpha.0")
-set(ATOMVM_DEV FALSE)
+set(ATOMVM_BASE_VERSION "0.6.0-alpha.1")
+set(ATOMVM_DEV TRUE)


### PR DESCRIPTION

Bump version to v0.6.0-alpha.1, and set dev to true.
Version number will be something like `v0.6.0-alpha.1+git.abcdef12`.

This is the first maintenance operation just after the tagging.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
