### PR TITLE
ESP32/NVS: fix nvs_set_binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0-alpha.1] - Unreleased
 
+### Fixed
+
+- Fixed `esp:nvs_set_binary` functions.
+
 ## [0.6.0-alpha.0] - 2023-08-13
 
 ### Added

--- a/libs/eavmlib/src/esp.erl
+++ b/libs/eavmlib/src/esp.erl
@@ -213,7 +213,7 @@ nvs_get_binary(Namespace, Key, Default) when
 %%-----------------------------------------------------------------------------
 -spec nvs_set_binary(Key :: atom(), Value :: binary()) -> ok.
 nvs_set_binary(Key, Value) when is_atom(Key) andalso is_binary(Value) ->
-    esp:nvs_set_binary(?ATOMVM_NVS_NS, Key, Value).
+    nvs_set_binary(?ATOMVM_NVS_NS, Key, Value).
 
 %%-----------------------------------------------------------------------------
 %% @param   Namespace NVS namespace
@@ -229,7 +229,7 @@ nvs_set_binary(Key, Value) when is_atom(Key) andalso is_binary(Value) ->
 nvs_set_binary(Namespace, Key, Value) when
     is_atom(Namespace) andalso is_atom(Key) andalso is_binary(Value)
 ->
-    nvs_put_binary(Namespace, Key, Value).
+    esp:nvs_put_binary(Namespace, Key, Value).
 
 %%-----------------------------------------------------------------------------
 %% @param   Namespace NVS namespace

--- a/version.cmake
+++ b/version.cmake
@@ -18,5 +18,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-set(ATOMVM_BASE_VERSION "0.6.0-alpha.0")
-set(ATOMVM_DEV FALSE)
+set(ATOMVM_BASE_VERSION "0.6.0-alpha.1")
+set(ATOMVM_DEV TRUE)


### PR DESCRIPTION
In order to execute the NIF, an extern call must be done.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
