### PR TITLE
Prepend AVM files that are loaded via add_avm_pack_file

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -45,6 +45,7 @@
 #include "posix_nifs.h"
 #include "scheduler.h"
 #include "smp.h"
+#include "synclist.h"
 #include "sys.h"
 #include "term.h"
 #include "utils.h"
@@ -3590,7 +3591,7 @@ static term nif_atomvm_add_avm_pack_file(Context *ctx, int argc, term argv[])
     if (name != UNDEFINED_ATOM) {
         avmpack_data->name_atom_id = term_to_atom_index(name);
     }
-    synclist_append(&ctx->global->avmpack_data, &avmpack_data->avmpack_head);
+    synclist_prepend(&ctx->global->avmpack_data, &avmpack_data->avmpack_head);
 
     return OK_ATOM;
 }

--- a/src/libAtomVM/synclist.h
+++ b/src/libAtomVM/synclist.h
@@ -72,6 +72,13 @@ static inline void synclist_unlock(struct SyncList *synclist)
     smp_rwlock_unlock(synclist->lock);
 }
 
+static inline void synclist_prepend(struct SyncList *synclist, struct ListHead *new_item)
+{
+    struct ListHead *head = synclist_wrlock(synclist);
+    list_prepend(head, new_item);
+    synclist_unlock(synclist);
+}
+
 static inline void synclist_append(struct SyncList *synclist, struct ListHead *new_item)
 {
     struct ListHead *head = synclist_wrlock(synclist);
@@ -104,6 +111,7 @@ static inline int synclist_is_empty(struct SyncList *synclist)
 #define synclist_nolock(list) list
 #define synclist_unlock(list) UNUSED(list)
 #define synclist_destroy(list) UNUSED(list)
+#define synclist_prepend(list, new_item) list_prepend(list, new_item)
 #define synclist_append(list, new_item) list_append(list, new_item)
 #define synclist_remove(list, new_item) list_remove(new_item)
 #define synclist_is_empty(list) list_is_empty(list)


### PR DESCRIPTION
This PR prepends the AVM data to the list of AVMs when using the `atomvm: add_avm_pack_file` function.  In so doing, modules in AVM files that are so added are searched first when loading, allowing users to over-ride module definitions in applications (for testing/debugging)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
