### PR TITLE
Dialyzer-related fixes and improvements

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -65,6 +65,12 @@ jobs:
         export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
         ninja
 
+    - name: "Build: run dialyzer"
+      working-directory: build
+      run: |
+        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
+        ninja dialyzer
+
     # Test
     - name: "Test: test-erlang"
       timeout-minutes: 10

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -235,6 +235,10 @@ jobs:
       working-directory: build
       run: make
 
+    - name: "Build: run dialyzer"
+      working-directory: build
+      run: make dialyzer
+
     # Test
     - name: "Test: test-erlang"
       timeout-minutes: 10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
 option(AVM_RELEASE "Build an AtomVM release" ON)
 option(AVM_CREATE_STACKTRACES "Create stacktraces" ON)
 option(COVERAGE "Build for code coverage" OFF)
-option(RUN_DIALYZER "Run dialyzer on BEAM modules" ON)
 
 if((${CMAKE_SYSTEM_NAME} STREQUAL "Darwin") OR
    (${CMAKE_SYSTEM_NAME} STREQUAL "Linux") OR
@@ -48,6 +47,7 @@ add_subdirectory(tools/packbeam)
 add_subdirectory(tools/uf2tool)
 
 if (NOT "${CMAKE_GENERATOR}" MATCHES "Xcode")
+    add_custom_target(dialyzer COMMENT "Run dialyzer")
     add_subdirectory(libs)
     add_subdirectory(examples)
     add_subdirectory(doc)

--- a/examples/emscripten/wasm_webserver.erl
+++ b/examples/emscripten/wasm_webserver.erl
@@ -24,6 +24,7 @@
 
 -export([start/0, handle_req/3]).
 
+-spec start() -> no_return().
 start() ->
     Router = [
         {"*", ?MODULE, []}

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
     pack_lib(atomvmlib eavmlib estdlib alisp)
 endif()
 
-if (Dialyzer_FOUND AND RUN_DIALYZER)
+if (Dialyzer_FOUND)
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/atomvmlib.plt
         DEPENDS atomvmlib
@@ -49,12 +49,11 @@ if (Dialyzer_FOUND AND RUN_DIALYZER)
             -r ${CMAKE_CURRENT_BINARY_DIR}/eavmlib/src/beams
             -r ${CMAKE_CURRENT_BINARY_DIR}/alisp/src/beams
     )
-
-    add_custom_target(atomvmlib_plt ALL
+    add_custom_target(atomvmlib_plt
         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/atomvmlib.plt
     )
 else()
-    message("Dialyzer is not enabled -- skipping PLT build")
+    message("Dialyzer was not found -- skipping PLT build")
 endif()
 
 install(

--- a/libs/eavmlib/src/atomvm.erl
+++ b/libs/eavmlib/src/atomvm.erl
@@ -33,7 +33,18 @@
     read_priv/2,
     add_avm_pack_binary/2,
     add_avm_pack_file/2,
-    close_avm_pack/2
+    close_avm_pack/2,
+    get_start_beam/1,
+    posix_open/2,
+    posix_open/3,
+    posix_close/1,
+    posix_read/2,
+    posix_write/2
+]).
+
+-export_type([
+    posix_fd/0,
+    posix_open_flag/0
 ]).
 
 -type platform_name() ::
@@ -43,7 +54,30 @@
     | pico
     | stm32.
 
--type avm_path() :: string() | binary().
+-type avm_path() :: iodata().
+
+-opaque posix_fd() :: binary().
+-type posix_open_flag() ::
+    o_exec
+    | o_rdonly
+    | o_rdwr
+    | o_search
+    | o_wronly
+    | o_append
+    | o_cloexec
+    | o_creat
+    | o_directory
+    | o_dsync
+    | o_excl
+    | o_noctty
+    | o_nofollow
+    | o_rsync
+    | o_sync
+    | o_trunc
+    | o_tty_atom.
+-type posix_error() ::
+    atom()
+    | integer().
 
 %%-----------------------------------------------------------------------------
 %% @returns The platform name.
@@ -104,7 +138,8 @@ read_priv(_App, _Path) ->
 %%          Failure to properly load AVM data is result in a runtime `error'
 %% @end
 %%-----------------------------------------------------------------------------
--spec add_avm_pack_binary(AVMData :: binary(), Options :: [{name, Name :: atom()}]) -> ok.
+-spec add_avm_pack_binary(AVMData :: binary(), Options :: [{name, Name :: atom()}]) ->
+    ok | {error, any()}.
 add_avm_pack_binary(_AVMData, _Options) ->
     erlang:nif_error(undefined).
 
@@ -131,7 +166,8 @@ add_avm_pack_binary(_AVMData, _Options) ->
 %%          Failure to properly load AVM path is result in a runtime `error'
 %% @end
 %%-----------------------------------------------------------------------------
--spec add_avm_pack_file(AVMPath :: avm_path(), Options :: []) -> ok.
+-spec add_avm_pack_file(AVMPath :: avm_path(), Options :: [{name, Name :: atom()}]) ->
+    ok | {error, any()}.
 add_avm_pack_file(_AVMPath, _Options) ->
     erlang:nif_error(undefined).
 
@@ -150,4 +186,84 @@ add_avm_pack_file(_AVMPath, _Options) ->
 %%-----------------------------------------------------------------------------
 -spec close_avm_pack(Name :: atom(), Options :: []) -> ok | error.
 close_avm_pack(_Name, _Options) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   AVM     Name of avm (atom)
+%% @returns the name of the start module (with suffix)
+%% @doc     Get the start beam for a given avm
+%% @end
+%%-----------------------------------------------------------------------------
+-spec get_start_beam(AVM :: atom()) -> {ok, binary()} | {error, not_found}.
+get_start_beam(_AVM) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Path    Path to the file to open
+%% @param   Flags   List of flags passed to `open(3)'.
+%% @returns A tuple with a file descriptor or an error tuple.
+%% @doc     Open a file (on platforms that have `open(3)').
+%% The file is automatically closed when the file descriptor is garbage
+%% collected.
+%%
+%% Files are automatically opened with `O_NONBLOCK'. Other flags can be passed.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec posix_open(Path :: iodata(), Flags :: [posix_open_flag()]) ->
+    {ok, posix_fd()} | {error, posix_error()}.
+posix_open(_Path, _Flags) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Path    Path to the file to open
+%% @param   Flags   List of flags passed to `open(3)'.
+%% @param   Mode    Mode passed to `open(3)' for created file.
+%% @returns A tuple with a file descriptor or an error tuple.
+%% @doc     Open a file (on platforms that have `open(3)').
+%% This variant can be used to specify the mode for new file.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec posix_open(Path :: iodata(), Flags :: [posix_open_flag()], Mode :: non_neg_integer()) ->
+    {ok, posix_fd()} | {error, posix_error()}.
+posix_open(_Path, _Flags, _Mode) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   File    Descriptor to a file to close
+%% @returns `ok' or an error tuple
+%% @doc     Close a file that was opened with `posix_open/2,3'
+%% @end
+%%-----------------------------------------------------------------------------
+-spec posix_close(File :: posix_fd()) -> ok | {error, posix_error()}.
+posix_close(_File) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   File    Descriptor to an open file
+%% @param   Count   Maximum number of bytes to read
+%% @returns a tuple with read bytes, `eof' or an error tuple
+%% @doc     Read at most `Count' bytes from a file.
+%% Files are open non-blocking. ˋatomvm:posix_select_read/3' can be used to
+%% determine if the file can be read.
+%% `eof' is returned if no more data can be read because the file cursor
+%% reached the end.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec posix_read(File :: posix_fd(), Count :: non_neg_integer()) ->
+    {ok, binary()} | eof | {error, posix_error()}.
+posix_read(_File, _Count) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   File    Descriptor to an open file
+%% @param   Data    Data to write
+%% @returns a tuple with the number of written bytes or an error tuple
+%% @doc     Write data to a file.
+%% Files are open non-blocking. ˋatomvm:posix_select_write/3' can be used to
+%% determine if the file can be written.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec posix_write(File :: posix_fd(), Data :: binary()) ->
+    {ok, non_neg_integer()} | {error, posix_error()}.
+posix_write(_File, _Data) ->
     erlang:nif_error(undefined).

--- a/libs/eavmlib/src/console.erl
+++ b/libs/eavmlib/src/console.erl
@@ -27,7 +27,7 @@
 -export([start/0, puts/1, puts/2, flush/0, flush/1, print/1]).
 
 %%-----------------------------------------------------------------------------
-%% @param   String the string data to write to the console
+%% @param   Text the string data to write to the console
 %% @returns ok if the data was written, or {error, Reason}, if there was
 %%          an error.
 %% @see     erlang:display/1
@@ -38,14 +38,14 @@
 %%          To print an erlang term, use erlang:display/1.</em>
 %% @end
 %%-----------------------------------------------------------------------------
--spec puts(string()) -> ok | {error, term()}.
-puts(String) ->
-    puts(get_pid(), String).
+-spec puts(iodata()) -> ok | {error, term()}.
+puts(Text) ->
+    puts(get_pid(), Text).
 
 %% @hidden
--spec puts(pid(), string()) -> ok.
-puts(Console, String) ->
-    port:call(Console, {puts, String}).
+-spec puts(pid(), iodata()) -> ok.
+puts(Console, Text) ->
+    port:call(Console, {puts, Text}).
 
 %%-----------------------------------------------------------------------------
 %% @returns ok if the data was written, or {error, Reason}, if there was
@@ -63,15 +63,15 @@ flush(Console) ->
     port:call(Console, flush).
 
 %%-----------------------------------------------------------------------------
-%% @param   String the string data to write to the console
+%% @param   Text the data to write to the console
 %% @returns ok if the data was written, or {error, Reason}, if there was
 %%          an error.
 %% @see     erlang:display/1
 %% @doc     Write a string to the console.
 %% @end
 %%-----------------------------------------------------------------------------
--spec print(string()) -> ok | {error, term()}.
-print(_String) ->
+-spec print(Text :: iodata()) -> ok | {error, term()}.
+print(_Text) ->
     erlang:nif_error(undefined).
 
 %% Internal operations

--- a/libs/esp32boot/esp32init.erl
+++ b/libs/esp32boot/esp32init.erl
@@ -35,9 +35,7 @@ is_dev_mode_enabled(SystemStatus) ->
         {ok, undefined} ->
             false;
         {app_exit, undefined} ->
-            false;
-        {app_fail, undefined} ->
-            true
+            false
     end.
 
 maybe_start_dev_mode(SystemStatus) ->
@@ -92,7 +90,7 @@ get_start_module() ->
     case esp:nvs_get_binary(atomvm, start_module) of
         undefined ->
             case atomvm:get_start_beam(app) of
-                error ->
+                {error, not_found} ->
                     main;
                 {ok, ModuleNameWithExt} when is_binary(ModuleNameWithExt) ->
                     Len = byte_size(ModuleNameWithExt) - byte_size(<<".beam">>),

--- a/libs/estdlib/src/binary.erl
+++ b/libs/estdlib/src/binary.erl
@@ -24,7 +24,7 @@
 %%-----------------------------------------------------------------------------
 -module(binary).
 
--export([at/2]).
+-export([at/2, part/3]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Binary binary to get a byte from
@@ -35,4 +35,17 @@
 %%-----------------------------------------------------------------------------
 -spec at(Binary :: binary(), Index :: non_neg_integer()) -> byte().
 at(_Binary, _Index) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Binary binary to extract a subbinary from
+%% @param   Pos    0-based index of the subbinary to extract
+%% @param   Len    length, in bytes, of the subbinary to extract.
+%% @return a subbinary from Binary
+%% @doc Get the part of a given binary.
+%% A negative length can be passed to count bytes backwards.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec part(Binary :: binary(), Pos :: non_neg_integer(), Len :: integer()) -> binary().
+part(_Binary, _Pos, _Len) ->
     erlang:nif_error(undefined).

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -52,6 +52,8 @@
     list_to_integer/1,
     list_to_tuple/1,
     iolist_to_binary/1,
+    binary_to_atom/2,
+    binary_to_integer/1,
     binary_to_list/1,
     atom_to_binary/2,
     atom_to_list/1,
@@ -488,14 +490,14 @@ list_to_atom(_String) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
-%% @param   List    list to convert to binary
-%% @returns a binary composed of bytes from the list
-%% @doc     Convert a list of bytes into a binary.
-%% Errors with `badarg' if the list is not a list of bytes.
+%% @param   IOList   iolist to convert to binary
+%% @returns a binary composed of bytes and binaries from the list
+%% @doc     Convert a list into a binary.
+%% Errors with `badarg' if the list is not an iolist.
 %% @end
 %%-----------------------------------------------------------------------------
--spec list_to_binary(List :: [byte()]) -> binary().
-list_to_binary(_String) ->
+-spec list_to_binary(IOList :: iolist()) -> binary().
+list_to_binary(_IOList) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
@@ -527,6 +529,28 @@ list_to_tuple(_List) ->
 %%-----------------------------------------------------------------------------
 -spec iolist_to_binary(IOList :: iolist()) -> binary().
 iolist_to_binary(_IOList) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Binary  Binary to convert to atom
+%% @param   Encoding encoding for conversion
+%% @returns an atom from passed binary
+%% @doc     Convert a binary to atom.
+%% Only latin1 encoded is supported.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec binary_to_atom(Binary :: binary(), Encoding :: latin1) -> atom().
+binary_to_atom(_Binary, _Encoding) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Binary  Binary to parse for integer
+%% @returns the integer represented by the binary
+%% @doc     Parse the text in a given binary as an integer.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec binary_to_integer(Binary :: binary()) -> integer().
+binary_to_integer(_Binary) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -401,7 +401,7 @@ filter(Pred, [H | T], Accum) ->
 %% @doc     Inserts Sep between every element of List.
 %% @end
 %%-----------------------------------------------------------------------------
--spec join(Sep :: list(), List :: list()) -> list().
+-spec join(Sep :: any(), List :: list()) -> list().
 join(Sep, L) ->
     join(L, Sep, []).
 


### PR DESCRIPTION
Document the following functions:
- atomvm:get_start_beam/1
- atomvm:posix_open/2
- atomvm:posix_open/3
- atomvm:posix_close/1
- atomvm:posix_read/2
- atomvm:posix_write/2
- binary:part/3
- erlang:binary_to_atom/2
- erlang:binary_to_integer/1

Also fix specifications of the following functions:
- wasm_webserver:start/0
- atomvm:add_avm_pack_binary/2
- atomvm:add_avm_pack_file/2
- console:puts/1
- console:puts/2
- console:print/1
- erlang:list_to_binary/1
- lists:join/2

Also fix esp32init
Also make dialyzer a separate target and build plt of libs if dialyzer is found and the plt is needed
Also run dialyzer on runnables if target is built
Also fix rules in BuildErlang.cmake

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
