### PR TITLE
Document more nifs

### DIFF
--- a/libs/estdlib/src/CMakeLists.txt
+++ b/libs/estdlib/src/CMakeLists.txt
@@ -26,7 +26,9 @@ set(ERLANG_MODULES
     base64
     binary
     calendar
+    code
     crypto
+    erts_debug
     gen_event
     gen_server
     gen_statem

--- a/libs/estdlib/src/binary.erl
+++ b/libs/estdlib/src/binary.erl
@@ -24,7 +24,7 @@
 %%-----------------------------------------------------------------------------
 -module(binary).
 
--export([at/2, part/3]).
+-export([at/2, part/3, split/2]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Binary binary to get a byte from
@@ -48,4 +48,17 @@ at(_Binary, _Index) ->
 %%-----------------------------------------------------------------------------
 -spec part(Binary :: binary(), Pos :: non_neg_integer(), Len :: integer()) -> binary().
 part(_Binary, _Pos, _Len) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Binary  binary to split
+%% @param   Pattern pattern to perform the split
+%% @return a list composed of one or two binaries
+%% @doc Split a binary according to pattern.
+%% If pattern is not found, returns a singleton list with the passed binary.
+%% Unlike Erlang/OTP, pattern must be a binary.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec split(Binary :: binary(), Pattern :: binary()) -> [binary()].
+split(_Binary, _Pattern) ->
     erlang:nif_error(undefined).

--- a/libs/estdlib/src/code.erl
+++ b/libs/estdlib/src/code.erl
@@ -1,0 +1,54 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%%-----------------------------------------------------------------------------
+%% @doc An implementation of a subset of the Erlang/OTP code interface.
+%% @end
+%%-----------------------------------------------------------------------------
+-module(code).
+
+-export([load_abs/1, load_binary/3]).
+
+%%-----------------------------------------------------------------------------
+%% @param   Filename    path to the beam to open, without .beams suffix
+%% @returns A tuple with the name of the module
+%% @doc     Load a module from a path.
+%% Error return result type is different from Erlang/OTP.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec load_abs(Filename :: string()) -> error | {module, module()}.
+load_abs(_Filename) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Module      name of the module to load
+%% @param   Filename    path to the beam (unused)
+%% @param   Binary      binary of the module to load
+%% @returns A tuple with the name of the module
+%% @doc     Load a module from a binary.
+%% Error return result type is different from Erlang/OTP.
+%% Also unlike Erlang/OTP, no check is performed to verify that `Module'
+%% matches the name of the loaded module.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec load_binary(Module :: module(), Filename :: string(), Binary :: binary()) ->
+    error | {module, module()}.
+load_binary(_Module, _Filename, _Binary) ->
+    erlang:nif_error(undefined).

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -48,6 +48,7 @@
     function_exported/3,
     display/1,
     list_to_atom/1,
+    list_to_existing_atom/1,
     list_to_binary/1,
     list_to_integer/1,
     list_to_tuple/1,
@@ -62,6 +63,7 @@
     float_to_list/1,
     float_to_list/2,
     integer_to_binary/1,
+    integer_to_binary/2,
     integer_to_list/1,
     integer_to_list/2,
     fun_to_list/1,
@@ -74,7 +76,10 @@
     spawn/3,
     spawn_opt/2,
     spawn_opt/4,
+    link/1,
+    unlink/1,
     make_ref/0,
+    send/2,
     monitor/2,
     demonitor/1,
     demonitor/2,
@@ -86,6 +91,9 @@
     get_module_info/1,
     get_module_info/2,
     processes/0,
+    is_process_alive/1,
+    garbage_collect/0,
+    garbage_collect/1,
     binary_to_term/1,
     term_to_binary/1,
     timestamp/0,
@@ -105,7 +113,7 @@
 %% * review API documentation for timer functions in this module
 %%
 
--type mem_type() :: binary().
+-type mem_type() :: binary.
 -type time_unit() :: second | millisecond | microsecond.
 -type timestamp() :: {
     MegaSecs :: non_neg_integer(), Secs :: non_neg_integer(), MicroSecs :: non_neg_integer
@@ -478,6 +486,7 @@ display(_Term) ->
 %%-----------------------------------------------------------------------------
 %% @param   String  string to convert to an atom
 %% @returns an atom from the string
+%% @see     list_to_existing_atom/1
 %% @doc     Convert a string into an atom.
 %% Unlike Erlang/OTP 20+, atoms are limited to ISO-8859-1 characters. The VM
 %% currently aborts if passed unicode characters.
@@ -487,6 +496,18 @@ display(_Term) ->
 %%-----------------------------------------------------------------------------
 -spec list_to_atom(String :: string()) -> atom().
 list_to_atom(_String) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   String  string to convert to an atom
+%% @returns an atom from the string
+%% @see     list_to_atom/1
+%% @doc     Convert a string into an atom.
+%% This function will error with badarg if the atom does not exist
+%% @end
+%%-----------------------------------------------------------------------------
+-spec list_to_existing_atom(String :: string()) -> atom().
+list_to_existing_atom(_String) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
@@ -643,6 +664,17 @@ integer_to_binary(_Integer) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
+%% @param   Integer integer to convert to a binary
+%% @param   Base    base for representation
+%% @returns a binary with a text representation of the integer
+%% @doc     Convert an integer to a binary.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec integer_to_binary(Integer :: integer(), Base :: 2..36) -> binary().
+integer_to_binary(_Integer, _Base) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
 %% @param   Integer integer to convert to a string
 %% @returns a string representation of the integer
 %% @doc     Convert an integer to a string.
@@ -764,7 +796,8 @@ spawn(_Module, _Function, _Args) ->
 %% @doc     Create a new process.
 %% @end
 %%-----------------------------------------------------------------------------
--spec spawn_opt(Function :: function(), Options :: [{max_heap_size, integer()}]) -> pid().
+-spec spawn_opt(Function :: function(), Options :: [{max_heap_size, integer()}]) ->
+    pid() | {pid(), reference()}.
 spawn_opt(_Name, _Options) ->
     erlang:nif_error(undefined).
 
@@ -779,8 +812,28 @@ spawn_opt(_Name, _Options) ->
 %%-----------------------------------------------------------------------------
 -spec spawn_opt(
     Module :: module(), Function :: atom(), Args :: [any()], Options :: [spawn_option()]
-) -> pid().
+) -> pid() | {pid(), reference()}.
 spawn_opt(_Module, _Function, _Args, _Options) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Pid         process to link to
+%% @returns `true'
+%% @doc     Link current process with a given process.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec link(Pid :: pid()) -> true.
+link(_Pid) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Pid         process to unlink from
+%% @returns `true'
+%% @doc     Unlink current process from a given process.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec unlink(Pid :: pid()) -> true.
+unlink(_Pid) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
@@ -790,6 +843,17 @@ spawn_opt(_Module, _Function, _Args, _Options) ->
 %%-----------------------------------------------------------------------------
 -spec make_ref() -> reference().
 make_ref() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Pid     process to send the message to
+%% @param   Message message to send
+%% @returns the sent message
+%% @doc     Send a message to a given process
+%% @end
+%%-----------------------------------------------------------------------------
+-spec send(Pid :: pid(), Message :: Message) -> Message.
+send(_Pid, _Message) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
@@ -929,6 +993,36 @@ get_module_info(_Module, _InfoKey) ->
 %%-----------------------------------------------------------------------------
 -spec processes() -> [pid()].
 processes() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns `true' if the process is alive, `false' otherwise
+%% @param   Pid     pid of the process to test
+%% @doc     Determine if a process is alive
+%% @end
+%%-----------------------------------------------------------------------------
+-spec is_process_alive(Pid :: pid()) -> boolean().
+is_process_alive(_Pid) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns `true'
+%% @doc     Run a garbage collect in current process
+%% @end
+%%-----------------------------------------------------------------------------
+-spec garbage_collect() -> true.
+garbage_collect() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns `true' or `false' if the process no longer exists
+%% @param   Pid     pid of the process to garbage collect
+%% @doc     Run a garbage collect in a given process.
+%% The function returns before the garbage collect actually happens.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec garbage_collect(Pid :: pid()) -> boolean().
+garbage_collect(_Pid) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/libs/estdlib/src/erts_debug.erl
+++ b/libs/estdlib/src/erts_debug.erl
@@ -1,0 +1,37 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%%-----------------------------------------------------------------------------
+%% @doc An implementation of a subset of the Erlang/OTP erts_debug interface.
+%% @end
+%%-----------------------------------------------------------------------------
+-module(erts_debug).
+
+-export([flat_size/1]).
+
+%%-----------------------------------------------------------------------------
+%% @param   Term        term to get the size of
+%% @returns A size
+%% @doc     Return the size, in terms, of a given term.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec flat_size(Term :: any()) -> non_neg_integer().
+flat_size(_Term) ->
+    erlang:nif_error(undefined).

--- a/libs/estdlib/src/unicode.erl
+++ b/libs/estdlib/src/unicode.erl
@@ -67,7 +67,9 @@
 %% @param Data data to convert to Unicode
 %% @return a list of characters or a tuple if conversion failed.
 -spec characters_to_list(Data :: chardata() | latin1_chardata()) ->
-    list() | {error, list(), chardata() | latin1_chardata()} | {incomplete, list(), binary()}.
+    list()
+    | {error, list(), chardata() | latin1_chardata() | list()}
+    | {incomplete, list(), chardata() | latin1_chardata()}.
 characters_to_list(_Data) ->
     erlang:nif_error(undefined).
 
@@ -78,7 +80,7 @@ characters_to_list(_Data) ->
 %% @return a list of characters or a tuple if conversion failed.
 -spec characters_to_list(Data :: chardata() | latin1_chardata(), Encoding :: encoding()) ->
     list()
-    | {error, list(), chardata() | latin1_chardata()}
+    | {error, list(), chardata() | latin1_chardata() | list()}
     | {incomplete, list(), chardata() | latin1_chardata()}.
 characters_to_list(_Data, _Encoding) ->
     erlang:nif_error(undefined).
@@ -89,7 +91,7 @@ characters_to_list(_Data, _Encoding) ->
 %% @return an utf8 binary or a tuple if conversion failed.
 -spec characters_to_binary(Data :: chardata() | latin1_chardata()) ->
     unicode_binary()
-    | {error, list(), chardata() | latin1_chardata()}
+    | {error, list(), chardata() | latin1_chardata() | list()}
     | {incomplete, unicode_binary(), chardata() | latin1_chardata()}.
 characters_to_binary(_Data) ->
     erlang:nif_error(undefined).
@@ -101,7 +103,7 @@ characters_to_binary(_Data) ->
 %% @return an utf8 binary or a tuple if conversion failed.
 -spec characters_to_binary(Data :: chardata() | latin1_chardata(), InEncoding :: encoding()) ->
     unicode_binary()
-    | {error, list(), chardata() | latin1_chardata()}
+    | {error, list(), chardata() | latin1_chardata() | list()}
     | {incomplete, unicode_binary(), chardata() | latin1_chardata()}.
 characters_to_binary(_Data, _InEncoding) ->
     erlang:nif_error(undefined).
@@ -123,7 +125,7 @@ characters_to_binary(_Data, _InEncoding) ->
     Data :: chardata() | latin1_chardata(), InEncoding :: encoding(), OutEncoding :: encoding()
 ) ->
     unicode_binary()
-    | {error, list(), chardata() | latin1_chardata()}
+    | {error, list(), chardata() | latin1_chardata() | list()}
     | {incomplete, unicode_binary(), chardata() | latin1_chardata()}.
 characters_to_binary(_Data, _InEncoding, _OutEncoding) ->
     erlang:nif_error(undefined).


### PR DESCRIPTION
Add documentation for:
- code:load_abs/1
- code:load_binary/3
- erlang:is_process_alive/1
- erlang:garbage_collect/0
- erlang:garbage_collect/1
- erlang:link/1
- erlang:unlink/1

Fix specifications for:
- erlang:spawn_opt/2
- erlang:spawn_opt/3
- unicode:characters_to_list/1
- unicode:characters_to_list/2
- unicode:characters_to_binary/1
- unicode:characters_to_binary/2
- unicode:characters_to_binary/3

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
