### PR TITLE
Prevent certain workflows when top level markdown is changed

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -13,12 +13,14 @@ on:
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
+      - '*.Md'
   pull_request:
     paths-ignore:
       - 'src/platforms/esp32/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
+      - '*.Md'
 
 jobs:
   build-and-test:

--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -13,12 +13,14 @@ on:
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
+      - '*.Md'
   pull_request:
     paths-ignore:
       - 'src/platforms/esp32/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
+      - '*.Md'
 
 env:
   otp_version: 24

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,12 +13,14 @@ on:
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
+      - '*.Md'
   pull_request:
     paths-ignore:
       - 'src/platforms/esp32/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
+      - '*.Md'
 
 jobs:
   build-and-test:

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -13,12 +13,14 @@ on:
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
+      - '*.Md'
   pull_request:
     paths-ignore:
       - 'src/platforms/esp32/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
+      - '*.Md'
 
 jobs:
   run-tests:


### PR DESCRIPTION
Certain build and test workflows are triggered by changes to top level markdown files, like `CHANGELOG.Md` that do not need to run when a feture for another platform is added to the change log, or a README is edited. These changes reduce the number of unnecessary workflow runs.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
