### PR TITLE
Fix compiler warnings around unicode functions

### DIFF
--- a/libs/estdlib/src/unicode.erl
+++ b/libs/estdlib/src/unicode.erl
@@ -74,6 +74,9 @@ characters_to_list(_Data) ->
     erlang:nif_error(undefined).
 
 %% @doc Convert UTF-8 or Latin1 data to a list of Unicode characters.
+%% Following Erlang/OTP, if input encoding is latin1, this function returns
+%% an error tuple if a character > 255 is passed (in a list). Otherwise, it
+%% will accept any character within Unicode range (0-0x10FFFF).
 %% @see characters_to_list/1
 %% @param Data data to convert
 %% @param Encoding encoding of data to convert

--- a/src/libAtomVM/bitstring.c
+++ b/src/libAtomVM/bitstring.c
@@ -101,7 +101,7 @@ static bool is_invalid_codepoint(int32_t v)
 // +----------+----------+----------+----------+----------+
 //
 
-bool bitstring_utf8_encode(avm_int_t c, uint8_t *buf, size_t *out_size)
+bool bitstring_utf8_encode(uint32_t c, uint8_t *buf, size_t *out_size)
 {
     size_t sz = 0;
     if (is_invalid_codepoint(c)) {
@@ -207,7 +207,7 @@ enum UnicodeTransformDecodeResult bitstring_utf8_decode(const uint8_t *buf, size
 //  W1 = 110110yyyyyyyyyy      // 0xD800 + yyyyyyyyyy
 //  W2 = 110111xxxxxxxxxx      // 0xDC00 + xxxxxxxxxx
 
-bool bitstring_utf16_encode(avm_int_t c, uint8_t *buf, enum BitstringFlags bs_flags, size_t *out_size)
+bool bitstring_utf16_encode(uint32_t c, uint8_t *buf, enum BitstringFlags bs_flags, size_t *out_size)
 {
     size_t sz = 0;
     if (is_invalid_codepoint(c)) {
@@ -302,7 +302,7 @@ bool bitstring_utf16_decode(const uint8_t *buf, size_t len, int32_t *c, size_t *
     return false;
 }
 
-bool bitstring_utf32_encode(avm_int_t c, uint8_t *buf, enum BitstringFlags bs_flags)
+bool bitstring_utf32_encode(uint32_t c, uint8_t *buf, enum BitstringFlags bs_flags)
 {
     UNUSED(bs_flags);
     if (is_invalid_codepoint(c)) {

--- a/src/libAtomVM/bitstring.h
+++ b/src/libAtomVM/bitstring.h
@@ -318,7 +318,7 @@ static inline bool bitstring_insert_integer(term dst_bin, size_t offset, avm_int
  * @return \c true if encoding was successful, \c false if c is not a valid
  * unicode character
  */
-bool bitstring_utf8_encode(avm_int_t c, uint8_t *buf, size_t *out_size);
+bool bitstring_utf8_encode(uint32_t c, uint8_t *buf, size_t *out_size);
 
 /**
  * @brief Decode a character from UTF-8.
@@ -345,7 +345,7 @@ enum UnicodeTransformDecodeResult bitstring_utf8_decode(const uint8_t *buf, size
  * @return \c true if encoding was successful, \c false if c is not a valid
  * unicode character
  */
-bool bitstring_utf16_encode(avm_int_t c, uint8_t *buf, enum BitstringFlags bs_flags, size_t *out_size);
+bool bitstring_utf16_encode(uint32_t c, uint8_t *buf, enum BitstringFlags bs_flags, size_t *out_size);
 
 /**
  * @brief Decode a character from UTF-16.
@@ -370,7 +370,7 @@ bool bitstring_utf16_decode(const uint8_t *buf, size_t len, int32_t *c, size_t *
  * @return \c true if encoding was successful, \c false if c is not a valid
  * unicode character
  */
-bool bitstring_utf32_encode(avm_int_t c, uint8_t *buf, enum BitstringFlags bs_flags);
+bool bitstring_utf32_encode(uint32_t c, uint8_t *buf, enum BitstringFlags bs_flags);
 
 /**
  * @brief Decode a character from UTF-32.
@@ -393,7 +393,7 @@ bool bitstring_utf32_decode(const uint8_t *buf, size_t len, int32_t *c, enum Bit
  * @return \c true if encoding was successful, \c false if c is not a valid
  * unicode character
  */
-static inline bool bitstring_utf8_size(avm_int_t c, size_t *out_size)
+static inline bool bitstring_utf8_size(uint32_t c, size_t *out_size)
 {
     return bitstring_utf8_encode(c, NULL, out_size);
 }
@@ -406,7 +406,7 @@ static inline bool bitstring_utf8_size(avm_int_t c, size_t *out_size)
  * @return \c true if encoding was successful, \c false if c is not a valid
  * unicode character
  */
-static inline bool bitstring_utf16_size(avm_int_t c, size_t *out_size) {
+static inline bool bitstring_utf16_size(uint32_t c, size_t *out_size) {
     return bitstring_utf16_encode(c, NULL, 0, out_size);
 }
 
@@ -420,7 +420,7 @@ static inline bool bitstring_utf16_size(avm_int_t c, size_t *out_size) {
  * @return \c true if encoding was successful, \c false if c is not a valid
  * unicode character
  */
-static inline bool bitstring_insert_utf8(term dst_bin, size_t offset, avm_int_t c, size_t *out_size)
+static inline bool bitstring_insert_utf8(term dst_bin, size_t offset, uint32_t c, size_t *out_size)
 {
     // size was verified by a bs_utf8_size instruction call
     uint8_t *dst = (uint8_t *) term_binary_data(dst_bin) + (offset >> 3);
@@ -455,7 +455,7 @@ static inline bool bitstring_match_utf8(term src_bin, size_t offset, uint32_t *c
  * @return \c true if encoding was successful, \c false if c is not a valid
  * unicode character
  */
-static inline bool bitstring_insert_utf16(term dst_bin, size_t offset, avm_int_t c, enum BitstringFlags bs_flags, size_t *out_size)
+static inline bool bitstring_insert_utf16(term dst_bin, size_t offset, uint32_t c, enum BitstringFlags bs_flags, size_t *out_size)
 {
     // size was verified by a bs_utf8_size instruction call
     uint8_t *dst = (uint8_t *) term_binary_data(dst_bin) + (offset >> 3);
@@ -490,7 +490,7 @@ static inline bool bitstring_match_utf16(term src_bin, size_t offset, int32_t *c
  * @return \c true if encoding was successful, \c false if c is not a valid
  * unicode character
  */
-static inline bool bitstring_insert_utf32(term dst_bin, size_t offset, avm_int_t c, enum BitstringFlags bs_flags)
+static inline bool bitstring_insert_utf32(term dst_bin, size_t offset, uint32_t c, enum BitstringFlags bs_flags)
 {
     uint8_t *dst = (uint8_t *) term_binary_data(dst_bin) + (offset >> 3);
     return bitstring_utf32_encode(c, dst, bs_flags);

--- a/src/libAtomVM/term_typedef.h
+++ b/src/libAtomVM/term_typedef.h
@@ -85,6 +85,8 @@ typedef uint64_t avm_uint64_t;
     #error "term size must be either 32 bit or 64 bit."
 #endif
 
+#define UNICODE_CHAR_MAX 0x10FFFF
+
 #define MIN_NOT_BOXED_INT (AVM_INT_MIN >> 4)
 #define MAX_NOT_BOXED_INT (AVM_INT_MAX >> 4)
 


### PR DESCRIPTION
Also fix implementation of unicode:characters_to_list/2 with latin1 encoding and non-latin1 characters

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
