### PR TITLE
Fix a memory allocation bug in erlang:get_module_info/1

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3394,7 +3394,7 @@ static term nif_erlang_get_module_info(Context *ctx, int argc, term argv[])
     }
     size_t info_size = module_get_exported_functions_list_size(target_module);
     if (argc == 1) {
-        info_size += TUPLE_SIZE(2) + 3 * (TUPLE_SIZE(2) + CONS_SIZE);
+        info_size += 4 * (TUPLE_SIZE(2) + CONS_SIZE);
     }
     if (UNLIKELY(memory_ensure_free(ctx, info_size) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
