### PR TITLE
Optimize by registering labels to the instruction that follows the label

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1594,9 +1594,6 @@ schedule_in:
 
         switch (*pc++) {
             case OP_LABEL: {
-                #ifdef IMPL_CODE_LOADER
-                    const uint8_t* saved_pc = pc - 1;
-                #endif
                 uint32_t label;
                 DECODE_LITERAL(label, pc)
 
@@ -1604,8 +1601,8 @@ schedule_in:
                 USED_BY_TRACE(label);
 
                 #ifdef IMPL_CODE_LOADER
-                    TRACE("Mark label %i here at %" PRIuPTR "\n", label, saved_pc - code);
-                    module_add_label(mod, label, saved_pc);
+                    TRACE("Mark label %i here at %" PRIuPTR "\n", label, pc - code);
+                    module_add_label(mod, label, pc);
                 #endif
                 break;
             }


### PR DESCRIPTION
It brings a significant speed improvement by avoiding processing label opcodes during execution.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
