### PR TITLE
Fix bug where guards would raise exceptions (fix #779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0-alpha.2] - Unreleased
 
+### Fixed
+
+- Fixed a bug where guards would raise exceptions instead of just being false
+
 ## [0.6.0-alpha.1] - 2023-10-09
 
 ### Added

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1920,7 +1920,6 @@ schedule_in:
                 break;
             }
 
-            //TODO: implement me
             case OP_BIF1: {
                 uint32_t fail_label;
                 DECODE_LABEL(fail_label, pc);
@@ -1945,7 +1944,12 @@ schedule_in:
                     DEBUG_FAIL_NULL(func);
                     term ret = func(ctx, arg1);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
-                        HANDLE_ERROR();
+                        if (fail_label) {
+                            pc = mod->labels[fail_label];
+                            break;
+                        } else {
+                            HANDLE_ERROR();
+                        }
                     }
 
                     WRITE_REGISTER(dreg, ret);
@@ -1953,7 +1957,6 @@ schedule_in:
                 break;
             }
 
-            //TODO: implement me
             case OP_BIF2: {
                 uint32_t fail_label;
                 DECODE_LABEL(fail_label, pc);
@@ -1981,7 +1984,12 @@ schedule_in:
                     DEBUG_FAIL_NULL(func);
                     term ret = func(ctx, arg1, arg2);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
-                        HANDLE_ERROR();
+                        if (fail_label) {
+                            pc = mod->labels[fail_label];
+                            break;
+                        } else {
+                            HANDLE_ERROR();
+                        }
                     }
 
                     WRITE_REGISTER(dreg, ret);
@@ -5026,8 +5034,8 @@ wait_timeout_trap_handler:
             }
 
             case OP_GC_BIF1: {
-                uint32_t f_label;
-                DECODE_LABEL(f_label, pc);
+                uint32_t fail_label;
+                DECODE_LABEL(fail_label, pc);
                 uint32_t live;
                 DECODE_LITERAL(live, pc);
                 uint32_t bif;
@@ -5040,7 +5048,12 @@ wait_timeout_trap_handler:
                     GCBifImpl1 func = EXPORTED_FUNCTION_TO_GCBIF(exported_bif)->gcbif1_ptr;
                     term ret = func(ctx, live, arg1);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
-                        HANDLE_ERROR();
+                        if (fail_label) {
+                            pc = mod->labels[fail_label];
+                            break;
+                        } else {
+                            HANDLE_ERROR();
+                        }
                     }
                 #endif
 
@@ -5048,27 +5061,25 @@ wait_timeout_trap_handler:
                 DECODE_DEST_REGISTER(dreg, pc);
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    TRACE("gc_bif1/5 fail_lbl=%i, live=%i, bif=%i, arg1=0x%lx, dest=%c%i\n", f_label, live, bif, arg1, T_DEST_REG(dreg));
+                    TRACE("gc_bif1/5 fail_lbl=%i, live=%i, bif=%i, arg1=0x%lx, dest=%c%i\n", fail_label, live, bif, arg1, T_DEST_REG(dreg));
                     WRITE_REGISTER(dreg, ret);
                 #endif
 
                 #ifdef IMPL_CODE_LOADER
                     TRACE("gc_bif1/5\n");
 
-                    UNUSED(f_label)
+                    UNUSED(fail_label)
                     UNUSED(live)
                     UNUSED(bif)
                     UNUSED(arg1)
                     UNUSED(dreg)
                 #endif
-
-                UNUSED(f_label)
                 break;
             }
 
             case OP_GC_BIF2: {
-                uint32_t f_label;
-                DECODE_LABEL(f_label, pc);
+                uint32_t fail_label;
+                DECODE_LABEL(fail_label, pc);
                 uint32_t live;
                 DECODE_LITERAL(live, pc);
                 uint32_t bif;
@@ -5083,7 +5094,12 @@ wait_timeout_trap_handler:
                     GCBifImpl2 func = EXPORTED_FUNCTION_TO_GCBIF(exported_bif)->gcbif2_ptr;
                     term ret = func(ctx, live, arg1, arg2);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
-                        HANDLE_ERROR();
+                        if (fail_label) {
+                            pc = mod->labels[fail_label];
+                            break;
+                        } else {
+                            HANDLE_ERROR();
+                        }
                     }
                 #endif
 
@@ -5091,22 +5107,20 @@ wait_timeout_trap_handler:
                 DECODE_DEST_REGISTER(dreg, pc);
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    TRACE("gc_bif2/6 fail_lbl=%i, live=%i, bif=%i, arg1=0x%lx, arg2=0x%lx, dest=%c%i\n", f_label, live, bif, arg1, arg2, T_DEST_REG(dreg));
+                    TRACE("gc_bif2/6 fail_lbl=%i, live=%i, bif=%i, arg1=0x%lx, arg2=0x%lx, dest=%c%i\n", fail_label, live, bif, arg1, arg2, T_DEST_REG(dreg));
                     WRITE_REGISTER(dreg, ret);
                 #endif
 
                 #ifdef IMPL_CODE_LOADER
                     TRACE("gc_bif2/6\n");
 
-                    UNUSED(f_label)
+                    UNUSED(fail_label)
                     UNUSED(live)
                     UNUSED(bif)
                     UNUSED(arg1)
                     UNUSED(arg2)
                     UNUSED(dreg)
                 #endif
-
-                UNUSED(f_label)
                 break;
             }
 
@@ -5131,9 +5145,11 @@ wait_timeout_trap_handler:
                 break;
             }
 
+            // TODO: This opcode is currently uncovered by tests.
+            // We need to implement GC bifs with arity 3, e.g. binary_part/3.
             case OP_GC_BIF3: {
-                uint32_t f_label;
-                DECODE_LABEL(f_label, pc);
+                uint32_t fail_label;
+                DECODE_LABEL(fail_label, pc);
                 uint32_t live;
                 DECODE_LITERAL(live, pc);
                 uint32_t bif;
@@ -5150,7 +5166,12 @@ wait_timeout_trap_handler:
                     GCBifImpl3 func = EXPORTED_FUNCTION_TO_GCBIF(exported_bif)->gcbif3_ptr;
                     term ret = func(ctx, live, arg1, arg2, arg3);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
-                        HANDLE_ERROR();
+                        if (fail_label) {
+                            pc = mod->labels[fail_label];
+                            break;
+                        } else {
+                            HANDLE_ERROR();
+                        }
                     }
                 #endif
 
@@ -5158,14 +5179,14 @@ wait_timeout_trap_handler:
                 DECODE_DEST_REGISTER(dreg, pc);
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    TRACE("gc_bif3/7 fail_lbl=%i, live=%i, bif=%i, arg1=0x%lx, arg2=0x%lx, arg3=0x%lx, dest=%c%i\n", f_label, live, bif, arg1, arg2, arg3, T_DEST_REG(dreg));
+                    TRACE("gc_bif3/7 fail_lbl=%i, live=%i, bif=%i, arg1=0x%lx, arg2=0x%lx, arg3=0x%lx, dest=%c%i\n", fail_label, live, bif, arg1, arg2, arg3, T_DEST_REG(dreg));
                     WRITE_REGISTER(dreg, ret);
                 #endif
 
                 #ifdef IMPL_CODE_LOADER
                     TRACE("gc_bif2/6\n");
 
-                    UNUSED(f_label)
+                    UNUSED(fail_label)
                     UNUSED(live)
                     UNUSED(bif)
                     UNUSED(arg1)
@@ -5173,8 +5194,6 @@ wait_timeout_trap_handler:
                     UNUSED(arg3)
                     UNUSED(dreg)
                 #endif
-
-                UNUSED(f_label)
                 break;
             }
 
@@ -5648,11 +5667,21 @@ wait_timeout_trap_handler:
                     ctx->fr[freg3] = ctx->fr[freg1] + ctx->fr[freg2];
                     #ifdef HAVE_PRAGMA_STDC_FENV_ACCESS
                         if (fetestexcept(FE_OVERFLOW)) {
-                            RAISE_ERROR(BADARITH_ATOM);
+                            if (fail_label) {
+                                // Not sure this can happen, float operations
+                                // in guards are translated to gc_bif calls
+                                pc = mod->labels[fail_label];
+                            } else {
+                                RAISE_ERROR(BADARITH_ATOM);
+                            }
                         }
                     #else
                         if (!isfinite(ctx->fr[freg3])) {
-                            RAISE_ERROR(BADARITH_ATOM);
+                            if (fail_label) {
+                                pc = mod->labels[fail_label];
+                            } else {
+                                RAISE_ERROR(BADARITH_ATOM);
+                            }
                         }
                     #endif
                 #endif
@@ -5685,11 +5714,21 @@ wait_timeout_trap_handler:
                     ctx->fr[freg3] = ctx->fr[freg1] - ctx->fr[freg2];
                     #ifdef HAVE_PRAGMA_STDC_FENV_ACCESS
                         if (fetestexcept(FE_OVERFLOW)) {
-                            RAISE_ERROR(BADARITH_ATOM);
+                            if (fail_label) {
+                                // Not sure this can happen, float operations
+                                // in guards are translated to gc_bif calls
+                                pc = mod->labels[fail_label];
+                            } else {
+                                RAISE_ERROR(BADARITH_ATOM);
+                            }
                         }
                     #else
                         if (!isfinite(ctx->fr[freg3])) {
-                            RAISE_ERROR(BADARITH_ATOM);
+                            if (fail_label) {
+                                pc = mod->labels[fail_label];
+                            } else {
+                                RAISE_ERROR(BADARITH_ATOM);
+                            }
                         }
                     #endif
                 #endif
@@ -5722,11 +5761,21 @@ wait_timeout_trap_handler:
                     ctx->fr[freg3] = ctx->fr[freg1] * ctx->fr[freg2];
                     #ifdef HAVE_PRAGMA_STDC_FENV_ACCESS
                         if (fetestexcept(FE_OVERFLOW)) {
-                            RAISE_ERROR(BADARITH_ATOM);
+                            if (fail_label) {
+                                // Not sure this can happen, float operations
+                                // in guards are translated to gc_bif calls
+                                pc = mod->labels[fail_label];
+                            } else {
+                                RAISE_ERROR(BADARITH_ATOM);
+                            }
                         }
                     #else
                         if (!isfinite(ctx->fr[freg3])) {
-                            RAISE_ERROR(BADARITH_ATOM);
+                            if (fail_label) {
+                                pc = mod->labels[fail_label];
+                            } else {
+                                RAISE_ERROR(BADARITH_ATOM);
+                            }
                         }
                     #endif
                 #endif
@@ -5759,11 +5808,21 @@ wait_timeout_trap_handler:
                     ctx->fr[freg3] = ctx->fr[freg1] / ctx->fr[freg2];
                     #ifdef HAVE_PRAGMA_STDC_FENV_ACCESS
                         if (fetestexcept(FE_OVERFLOW | FE_DIVBYZERO)) {
-                            RAISE_ERROR(BADARITH_ATOM);
+                            if (fail_label) {
+                                // Not sure this can happen, float operations
+                                // in guards are translated to gc_bif calls
+                                pc = mod->labels[fail_label];
+                            } else {
+                                RAISE_ERROR(BADARITH_ATOM);
+                            }
                         }
                     #else
                         if (!isfinite(ctx->fr[freg3])) {
-                            RAISE_ERROR(BADARITH_ATOM);
+                            if (fail_label) {
+                                pc = mod->labels[fail_label];
+                            } else {
+                                RAISE_ERROR(BADARITH_ATOM);
+                            }
                         }
                     #endif
                 #endif
@@ -5939,7 +5998,11 @@ wait_timeout_trap_handler:
 
                     if (!(term_is_binary(src) || term_is_match_state(src))) {
                         WRITE_REGISTER(dreg, src);
-                        pc = mod->labels[fail];
+                        if (term_is_integer(fail)) {
+                            pc = mod->labels[term_to_int(fail)];
+                        } else {
+                            RAISE_ERROR(BADARG_ATOM);
+                        }
                     } else {
                         term match_state = term_alloc_bin_match_state(src, 0, &ctx->heap);
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -82,6 +82,8 @@ compile_erlang(guards2)
 compile_erlang(guards3)
 compile_erlang(guards4)
 compile_erlang(guards5)
+compile_erlang(test_guards_do_not_raise)
+compile_erlang(test_min_max_guard)
 compile_erlang(prime)
 compile_erlang(match)
 compile_erlang(if_test)
@@ -479,7 +481,6 @@ compile_erlang(test_add_avm_pack_binary)
 compile_erlang(test_add_avm_pack_file)
 compile_erlang(test_close_avm_pack)
 
-compile_erlang(test_min_max_guard)
 compile_erlang(test_module_info)
 
 compile_erlang(int64_build_binary)
@@ -526,6 +527,8 @@ add_custom_target(erlang_test_modules DEPENDS
     guards3.beam
     guards4.beam
     guards5.beam
+    test_guards_do_not_raise.beam
+    test_min_max_guard.beam
     prime.beam
     match.beam
     if_test.beam
@@ -927,7 +930,6 @@ add_custom_target(erlang_test_modules DEPENDS
     test_add_avm_pack_file.beam
     test_close_avm_pack.beam
 
-    test_min_max_guard.beam
     test_module_info.beam
 
     int64_build_binary.beam

--- a/tests/erlang_tests/test_guards_do_not_raise.erl
+++ b/tests/erlang_tests/test_guards_do_not_raise.erl
@@ -1,0 +1,76 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_guards_do_not_raise).
+
+-export([start/0, id/1]).
+
+start() ->
+    ok = test_gc_bif1(),
+    ok = test_gc_bif2(),
+    ok = test_gc_bif3(),
+    ok = test_bif1(),
+    ok = test_bif2(),
+    0.
+
+test_gc_bif1() ->
+    NotAList = id(not_a_list),
+    if
+        length(NotAList) < 42 -> fail;
+        true -> ok
+    end.
+
+test_gc_bif2() ->
+    NotAnInteger = id(not_an_integer),
+    if
+        NotAnInteger rem 42 < 20 -> fail;
+        true -> ok
+    end.
+
+test_gc_bif3() ->
+    case erlang:function_exported(erlang, binary_part, 3) of
+        true ->
+            NotABin = id(not_a_bin),
+            ok =
+                if
+                    binary_part(NotABin, 0, 2) =:= <<"he">> -> fail;
+                    true -> ok
+                end;
+        false ->
+            erlang:display({warning, erlang, binary_part, 3, unimplemented}),
+            ok
+    end.
+
+test_bif1() ->
+    NotAList = id(not_a_list),
+    if
+        tl(NotAList) > 1 -> fail;
+        true -> ok
+    end.
+
+test_bif2() ->
+    NotAMap = id(not_a_map),
+    if
+        is_map_key(b, NotAMap) -> fail;
+        true -> ok
+    end.
+
+id(X) ->
+    X.

--- a/tests/erlang_tests/test_map.erl
+++ b/tests/erlang_tests/test_map.erl
@@ -95,11 +95,24 @@ test_is_map_key_bif() ->
         end,
     ok =
         try
-            _ = is_map_key(b, id(foo)),
-            fail
+            case is_map_key(b, id(foo)) of
+                true -> fail;
+                false -> fail_as_well
+            end
         catch
             _:{badmap, _} ->
                 ok
+        end,
+    ok =
+        try
+            NotAMap = id(foo),
+            if
+                is_map_key(b, NotAMap) -> fail;
+                true -> ok
+            end
+        catch
+            _:{badmap, _} ->
+                fail
         end.
 
 test_map_get_bif() ->

--- a/tests/test.c
+++ b/tests/test.c
@@ -107,6 +107,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(guards3, 405),
     TEST_CASE_EXPECTED(guards4, 16),
     TEST_CASE_EXPECTED(guards5, 3),
+    TEST_CASE(test_guards_do_not_raise),
     TEST_CASE_EXPECTED(prime, 1999),
     TEST_CASE_COND(prime_smp, 0, SKIP_SMP),
     TEST_CASE_EXPECTED(match, 5),
@@ -509,11 +510,8 @@ struct Test tests[] = {
     TEST_CASE_COND(test_stacktrace, 0, SKIP_STACKTRACES),
     TEST_CASE(small_big_ext),
     TEST_CASE(test_crypto),
-
     TEST_CASE(test_min_max_guard),
-
     TEST_CASE(int64_build_binary),
-
     // TEST CRASHES HERE: TEST_CASE(memlimit),
 
     { NULL, 0, false, false }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
