### PR TITLE
Add build-time option for Pico to wait for a USB connection

### DIFF
--- a/src/platforms/rp2040/CMakeLists.txt
+++ b/src/platforms/rp2040/CMakeLists.txt
@@ -48,7 +48,7 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
 option(AVM_DISABLE_SMP "Disable SMP support." OFF)
 option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
-
+option(AVM_WAIT_FOR_USB_CONNECT "Wait for USB connection before starting" OFF)
 option(AVM_REBOOT_ON_NOT_OK "Reboot Pico if result is not ok" OFF)
 
 set(

--- a/src/platforms/rp2040/src/CMakeLists.txt
+++ b/src/platforms/rp2040/src/CMakeLists.txt
@@ -41,6 +41,10 @@ if (AVM_REBOOT_ON_NOT_OK)
     target_compile_definitions(AtomVM PRIVATE CONFIG_REBOOT_ON_NOT_OK)
 endif()
 
+if (AVM_WAIT_FOR_USB_CONNECT)
+    target_compile_definitions(AtomVM PRIVATE PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS=-1)
+endif()
+
 set(
     PLATFORM_LIB_SUFFIX
     ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}


### PR DESCRIPTION
Pico SDK doesn't have idf.py monitor which allows to be connected from the boot. Instead, it has an option that waits for an USB serial connection before starting. Add a built-time setting to enable this feature.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
