### PR TITLE
Bump OTP and Elixir versions in documentation workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -60,8 +60,8 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "24"
-          elixir-version: "1.14"
+          otp-version: "25"
+          elixir-version: "1.15"
 
       - name: Install rebar3
         working-directory: /tmp
@@ -69,11 +69,6 @@ jobs:
           wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
           ./rebar3 local install
           echo "/home/runner/.cache/rebar3/bin" >> ${GITHUB_PATH}
-
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: "24"
-          elixir-version: "1.14"
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Also remove useless second installation of Erlang/OTP in documentation workflow

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
