### PR TITLE
Add entries to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ src/platforms/esp32/sdkconfig
 !src/platforms/esp32/components/libatomvm/**
 .idea/**
 .vscode/**
+.DS_Store
+.cache
+.clang-tidy


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
