### PR TITLE
Fix and factorize spawn functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ functions that default to `?ATOMVM_NVS_NS` are deprecated now).
 - Added most format possibilities to `io:format/2` and `io_lib:format/2`
 - Added `unicode` module with `characters_to_list/1,2` and `characters_to_binary/1,2,3` functions
 - Added support for `crypto:hash/2` (ESP32 and generic_unix with openssl)
+- Added erlang:spawn_link/1,3
 - Added links to process_info/2
 
 ### Fixed

--- a/examples/emscripten/CMakeLists.txt
+++ b/examples/emscripten/CMakeLists.txt
@@ -22,7 +22,7 @@ project(examples_emscripten)
 
 include(BuildErlang)
 
-pack_runnable(run_script run_script eavmlib)
+pack_runnable(run_script run_script estdlib eavmlib)
 pack_runnable(call_cast call_cast eavmlib)
 pack_runnable(html5_events html5_events estdlib eavmlib)
 pack_runnable(wasm_webserver wasm_webserver estdlib eavmlib)

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -74,6 +74,8 @@
     whereis/1,
     spawn/1,
     spawn/3,
+    spawn_link/1,
+    spawn_link/3,
     spawn_opt/2,
     spawn_opt/4,
     link/1,
@@ -118,6 +120,19 @@
 -type timestamp() :: {
     MegaSecs :: non_neg_integer(), Secs :: non_neg_integer(), MicroSecs :: non_neg_integer
 }.
+
+-type float_format_option() ::
+    {decimals, Decimals :: 0..57}
+    | {scientific, Decimals :: 0..57}
+    | compact.
+
+-type demonitor_option() :: flush | {flush, boolean()} | info | {info, boolean()}.
+
+-type spawn_option() ::
+    {min_heap_size, pos_integer()}
+    | {max_heap_size, pos_integer()}
+    | link
+    | monitor.
 
 %%-----------------------------------------------------------------------------
 %% @param   Time time in milliseconds after which to send the timeout message.
@@ -612,11 +627,6 @@ atom_to_binary(_Atom, _Encoding) ->
 atom_to_list(_Atom) ->
     erlang:nif_error(undefined).
 
--type float_format_option() ::
-    {decimals, Decimals :: 0..57}
-    | {scientific, Decimals :: 0..57}
-    | compact.
-
 %%-----------------------------------------------------------------------------
 %% @param   Float   Float to convert
 %% @returns a binary with a text representation of the float
@@ -774,8 +784,8 @@ whereis(_Name) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec spawn(Function :: function()) -> pid().
-spawn(_Name) ->
-    erlang:nif_error(undefined).
+spawn(Function) ->
+    erlang:spawn_opt(Function, []).
 
 %%-----------------------------------------------------------------------------
 %% @param   Module      module of the function to create a process from
@@ -786,14 +796,31 @@ spawn(_Name) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec spawn(Module :: module(), Function :: atom(), Args :: [any()]) -> pid().
-spawn(_Module, _Function, _Args) ->
-    erlang:nif_error(undefined).
+spawn(Module, Function, Args) ->
+    erlang:spawn_opt(Module, Function, Args, []).
 
--type spawn_option() ::
-    {min_heap_size, pos_integer()}
-    | {max_heap_size, pos_integer()}
-    | link
-    | monitor.
+%%-----------------------------------------------------------------------------
+%% @param   Function    function to create a process from
+%% @returns pid of the new process
+%% @doc     Create a new process and link it.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec spawn_link(Function :: function()) -> pid().
+spawn_link(Function) ->
+    erlang:spawn_opt(Function, [link]).
+
+%%-----------------------------------------------------------------------------
+%% @param   Module      module of the function to create a process from
+%% @param   Function    name of the function to create a process from
+%% @param   Args        arguments to pass to the function to create a process from
+%% @returns pid of the new process
+%% @doc     Create a new process by calling exported Function from Module with Args
+%% and link it.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec spawn_link(Module :: module(), Function :: atom(), Args :: [any()]) -> pid().
+spawn_link(Module, Function, Args) ->
+    erlang:spawn_opt(Module, Function, Args, [link]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Function    function to create a process from
@@ -802,7 +829,7 @@ spawn(_Module, _Function, _Args) ->
 %% @doc     Create a new process.
 %% @end
 %%-----------------------------------------------------------------------------
--spec spawn_opt(Function :: function(), Options :: [{max_heap_size, integer()}]) ->
+-spec spawn_opt(Function :: function(), Options :: [spawn_option()]) ->
     pid() | {pid(), reference()}.
 spawn_opt(_Name, _Options) ->
     erlang:nif_error(undefined).
@@ -888,8 +915,6 @@ monitor(_Type, _Pid) ->
 -spec demonitor(Monitor :: reference()) -> true.
 demonitor(_Monitor) ->
     erlang:nif_error(undefined).
-
--type demonitor_option() :: flush | {flush, boolean()} | info | {info, boolean()}.
 
 %%-----------------------------------------------------------------------------
 %% @param   Monitor reference of monitor to remove

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -81,8 +81,6 @@ erlang:register/2, &register_nif
 erlang:unregister/1, &unregister_nif
 erlang:send/2, &send_nif
 erlang:setelement/3, &setelement_nif
-erlang:spawn/1, &spawn_fun_nif
-erlang:spawn/3, &spawn_nif
 erlang:spawn_opt/2, &spawn_fun_opt_nif
 erlang:spawn_opt/4, &spawn_opt_nif
 erlang:system_info/1, &system_info_nif

--- a/tests/erlang_tests/call_with_ref_test.erl
+++ b/tests/erlang_tests/call_with_ref_test.erl
@@ -23,7 +23,7 @@
 -export([start/0, loop/1]).
 
 start() ->
-    Pid = spawn(call_with_ref_test, loop, [initial_state()]),
+    Pid = spawn_opt(call_with_ref_test, loop, [initial_state()], []),
     send_integer(Pid, 1),
     send_integer(Pid, 2),
     send_integer(Pid, 3),

--- a/tests/erlang_tests/copy_terms0.erl
+++ b/tests/erlang_tests/copy_terms0.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms0).
 
--export([start/0, loop/0, count_nestings/1]).
+-export([start/0, count_nestings/1]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), {}},
     Count =
         receive

--- a/tests/erlang_tests/copy_terms1.erl
+++ b/tests/erlang_tests/copy_terms1.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms1).
 
--export([start/0, loop/0, count_nestings/1]).
+-export([start/0, count_nestings/1]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), {{}}},
     Count =
         receive

--- a/tests/erlang_tests/copy_terms10.erl
+++ b/tests/erlang_tests/copy_terms10.erl
@@ -22,7 +22,6 @@
 
 -export([
     start/0,
-    loop/0,
     compute/1,
     compute_tree/1,
     a/0,
@@ -52,7 +51,7 @@
 ]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), z()},
     Res =
         receive

--- a/tests/erlang_tests/copy_terms11.erl
+++ b/tests/erlang_tests/copy_terms11.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms11).
 
--export([start/0, loop/0]).
+-export([start/0]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid !
         {
             self(),

--- a/tests/erlang_tests/copy_terms12.erl
+++ b/tests/erlang_tests/copy_terms12.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms12).
 
--export([start/0, loop/0]).
+-export([start/0]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Ref = make_ref(),
     Pid !
         {compute, Ref, self(),

--- a/tests/erlang_tests/copy_terms13.erl
+++ b/tests/erlang_tests/copy_terms13.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms13).
 
--export([start/0, loop/0]).
+-export([start/0]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Ref = make_ref(),
     Pid !
         {compute, Ref, self(),

--- a/tests/erlang_tests/copy_terms14.erl
+++ b/tests/erlang_tests/copy_terms14.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms14).
 
--export([start/0, loop/0]).
+-export([start/0]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Ref = make_ref(),
     Pid ! {det, Ref, self(), {{2, 2, 3, 9}, {1, 1, 3, 4}, {2, 0, 1, 7}, {11, 3, 4, 8}}},
     Res =

--- a/tests/erlang_tests/copy_terms15.erl
+++ b/tests/erlang_tests/copy_terms15.erl
@@ -20,11 +20,11 @@
 
 -module(copy_terms15).
 
--export([start/0, sort/1, insert/2, check/1, loop/0]).
+-export([start/0, sort/1, insert/2, check/1]).
 
 %% erlfmt-ignore
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Ref = make_ref(),
     Pid ! {sort, Ref, self(), [5, 7, 9, 15, 18, 22, 4, 11, 89, 94, 1, 0, 5, 8, 9, 3, 4, 5, 35, 12, 93, 29, 39, 29,
           22, 93, 23, 28, 98, 32, 32, 42, 91, 83, 38, 18, 98, 10, 12, 39, 14, 12, 93, 32, 23,

--- a/tests/erlang_tests/copy_terms16.erl
+++ b/tests/erlang_tests/copy_terms16.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms16).
 
--export([start/0, find/2, loop/0]).
+-export([start/0, find/2]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Ref = make_ref(),
     Pid ! {find, Ref, self(), [<<"Hello">>, <<"Ciao">>, <<"Hola">>, <<"Hi">>, <<"Bonjur">>]},
     Res =

--- a/tests/erlang_tests/copy_terms17.erl
+++ b/tests/erlang_tests/copy_terms17.erl
@@ -23,7 +23,7 @@
 -export([start/0, sort/1, insert/2, loop/0]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Ref = make_ref(),
     Ref2 = make_ref(),
     Pid !

--- a/tests/erlang_tests/copy_terms18.erl
+++ b/tests/erlang_tests/copy_terms18.erl
@@ -22,7 +22,6 @@
 
 -export([
     start/0,
-    loop/0,
     compute/1,
     compute_tree/1,
     a/0,
@@ -51,7 +50,7 @@
 ]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), t()},
     Res =
         receive

--- a/tests/erlang_tests/copy_terms2.erl
+++ b/tests/erlang_tests/copy_terms2.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms2).
 
--export([start/0, loop/0, count_nestings/1]).
+-export([start/0, count_nestings/1]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), {{{}}}},
     Count =
         receive

--- a/tests/erlang_tests/copy_terms3.erl
+++ b/tests/erlang_tests/copy_terms3.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms3).
 
--export([start/0, loop/0, count_nestings/1]).
+-export([start/0, count_nestings/1]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), {{{{{{}}}}}}},
     Count =
         receive

--- a/tests/erlang_tests/copy_terms4.erl
+++ b/tests/erlang_tests/copy_terms4.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms4).
 
--export([start/0, loop/0]).
+-export([start/0]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), {[{1, 0}, {2, 1}, {3, 4}], [{4, 2}, {5, 5}, {6, 1}]}},
     Res =
         receive

--- a/tests/erlang_tests/copy_terms5.erl
+++ b/tests/erlang_tests/copy_terms5.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms5).
 
--export([start/0, loop/0]).
+-export([start/0]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), {[1, 2, 3], [4, 5, 6]}},
     Res =
         receive

--- a/tests/erlang_tests/copy_terms6.erl
+++ b/tests/erlang_tests/copy_terms6.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms6).
 
--export([start/0, loop/0]).
+-export([start/0]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), [1, 2, 3]},
     Res =
         receive

--- a/tests/erlang_tests/copy_terms7.erl
+++ b/tests/erlang_tests/copy_terms7.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms7).
 
--export([start/0, loop/0]).
+-export([start/0]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), test, 5},
     Res =
         receive

--- a/tests/erlang_tests/copy_terms8.erl
+++ b/tests/erlang_tests/copy_terms8.erl
@@ -20,10 +20,10 @@
 
 -module(copy_terms8).
 
--export([start/0, loop/0]).
+-export([start/0]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {test, self(), 2},
     Res =
         receive

--- a/tests/erlang_tests/copy_terms9.erl
+++ b/tests/erlang_tests/copy_terms9.erl
@@ -22,7 +22,6 @@
 
 -export([
     start/0,
-    loop/0,
     compute/1,
     compute_tree/1,
     a/0,
@@ -51,7 +50,7 @@
 ]).
 
 start() ->
-    Pid = spawn(?MODULE, loop, []),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), t()},
     Res =
         receive

--- a/tests/erlang_tests/gen_server_like_test.erl
+++ b/tests/erlang_tests/gen_server_like_test.erl
@@ -76,7 +76,7 @@ start_link() ->
 
 fake_start() ->
     {ok, InitialState} = init(initial_state()),
-    spawn(?MODULE, loop, [InitialState]).
+    spawn_opt(?MODULE, loop, [InitialState], []).
 
 init(Initial) ->
     {ok, Initial}.

--- a/tests/erlang_tests/guards3.erl
+++ b/tests/erlang_tests/guards3.erl
@@ -24,7 +24,7 @@
 
 start() ->
     Port = do_open_port("echo", []),
-    Pid = spawn(guards3, loop, [initial_state()]),
+    Pid = spawn_opt(guards3, loop, [initial_state()], []),
     do_something(Port) + do_something(Pid) * 3 + do_something(2) * 100.
 
 do_open_port(PortName, Param) ->

--- a/tests/erlang_tests/is_type.erl
+++ b/tests/erlang_tests/is_type.erl
@@ -20,10 +20,10 @@
 
 -module(is_type).
 
--export([start/0, test_is_type/8, all_true/8, quick_exit/0]).
+-export([start/0, test_is_type/8, all_true/8]).
 
 start() ->
-    Pid = spawn(?MODULE, quick_exit, []),
+    Pid = self(),
     test_is_type(hello, <<"hello">>, 10, [1, 2, 3], 5, Pid, make_ref(), {1, 2}).
 
 test_is_type(A, B, I, L, N, P, R, T) ->
@@ -44,6 +44,3 @@ all_true(false, false, false, false, false, false, false, false) ->
     0;
 all_true(_, _, _, _, _, _, _, _) ->
     -1.
-
-quick_exit() ->
-    ok.

--- a/tests/erlang_tests/link_kill_parent.erl
+++ b/tests/erlang_tests/link_kill_parent.erl
@@ -20,10 +20,10 @@
 
 -module(link_kill_parent).
 
--export([start/0, start2/0, sum/1, proc/1]).
+-export([start/0, sum/1, proc/1]).
 
 start() ->
-    Pid = spawn(?MODULE, start2, []),
+    Pid = spawn_opt(fun start2/0, []),
     Pid ! {monitor, self()},
     CP =
         receive

--- a/tests/erlang_tests/link_throw.erl
+++ b/tests/erlang_tests/link_throw.erl
@@ -20,10 +20,10 @@
 
 -module(link_throw).
 
--export([start/0, start2/0, sum/1, proc/1]).
+-export([start/0, sum/1, proc/1]).
 
 start() ->
-    {Pid, Ref} = spawn_opt(?MODULE, start2, [], [monitor]),
+    {Pid, Ref} = spawn_opt(fun start2/0, [monitor]),
     Pid ! {self(), sum},
     CM =
         receive
@@ -52,7 +52,7 @@ start2() ->
         receive
             {ParentPid, sum} -> ParentPid
         end,
-    Pid = spawn(?MODULE, proc, [L]),
+    Pid = spawn_opt(?MODULE, proc, [L], []),
     erlang:link(Pid),
     Pid ! {self(), sum},
     receive

--- a/tests/erlang_tests/pingpong.erl
+++ b/tests/erlang_tests/pingpong.erl
@@ -24,8 +24,8 @@
 
 start() ->
     Echo = echo:start(),
-    Pong = spawn(?MODULE, pong, [Echo, self()]),
-    spawn(?MODULE, ping, [Echo, Pong]),
+    Pong = spawn_opt(?MODULE, pong, [Echo, self()], []),
+    spawn_opt(?MODULE, ping, [Echo, Pong], []),
     receive
         exit -> 1;
         _Any -> 0

--- a/tests/erlang_tests/prime.erl
+++ b/tests/erlang_tests/prime.erl
@@ -23,9 +23,9 @@
 -export([start/0, is_prime/1, calculate_list/2]).
 
 start() ->
-    spawn(prime, calculate_list, num_range(2, 100)),
-    spawn(prime, calculate_list, num_range(100, 400)),
-    spawn(prime, calculate_list, num_range(500, 1500)),
+    spawn_opt(prime, calculate_list, num_range(2, 100), []),
+    spawn_opt(prime, calculate_list, num_range(100, 400), []),
+    spawn_opt(prime, calculate_list, num_range(500, 1500), []),
     all_primes_test(2000) -
         all_primes_test(2000) +
         all_primes_test(2000) -

--- a/tests/erlang_tests/prime_ext.erl
+++ b/tests/erlang_tests/prime_ext.erl
@@ -30,9 +30,9 @@
 ]).
 
 start() ->
-    spawn(?MODULE, calculate_list, num_range(2, 100)),
-    spawn(?MODULE, calculate_list, num_range(100, 400)),
-    spawn(?MODULE, calculate_list, num_range(500, 1500)),
+    spawn_opt(?MODULE, calculate_list, num_range(2, 100), []),
+    spawn_opt(?MODULE, calculate_list, num_range(100, 400), []),
+    spawn_opt(?MODULE, calculate_list, num_range(500, 1500), []),
     ?MODULE:all_primes_test(2000) -
         ?MODULE:all_primes_test(2000) +
         ?MODULE:all_primes_test(2000) -

--- a/tests/erlang_tests/send_to_dead_process.erl
+++ b/tests/erlang_tests/send_to_dead_process.erl
@@ -20,10 +20,10 @@
 
 -module(send_to_dead_process).
 
--export([start/0, double_and_terminate/0]).
+-export([start/0]).
 
 start() ->
-    Pid = spawn(?MODULE, double_and_terminate, []),
+    Pid = spawn_opt(fun double_and_terminate/0, []),
     Pid ! {self(), 10},
     Result =
         receive

--- a/tests/erlang_tests/sleep.erl
+++ b/tests/erlang_tests/sleep.erl
@@ -42,10 +42,13 @@ spawn_sleeping_processes([], Pids) ->
     Pids;
 spawn_sleeping_processes([Timeout | T], Acc) ->
     Parent = self(),
-    Pid = spawn(fun() ->
-        ok = sub_sleep(Timeout),
-        Parent ! {self(), ok}
-    end),
+    Pid = spawn_opt(
+        fun() ->
+            ok = sub_sleep(Timeout),
+            Parent ! {self(), ok}
+        end,
+        []
+    ),
     spawn_sleeping_processes(T, [Pid | Acc]).
 
 wait_for_sleeping_processes([]) ->

--- a/tests/erlang_tests/spawn_fun1.erl
+++ b/tests/erlang_tests/spawn_fun1.erl
@@ -23,7 +23,7 @@
 -export([start/0, loop/0]).
 
 start() ->
-    Pid = spawn(fun loop/0),
+    Pid = spawn_opt(fun loop/0, []),
     Pid ! {self(), 21},
     Double =
         receive

--- a/tests/erlang_tests/spawn_fun2.erl
+++ b/tests/erlang_tests/spawn_fun2.erl
@@ -25,7 +25,7 @@
 start() ->
     Father = self(),
     Fun = fun() -> Father ! 33 end,
-    spawn(Fun),
+    spawn_opt(Fun, []),
     Result =
         receive
             Any -> Any

--- a/tests/erlang_tests/spawn_fun3.erl
+++ b/tests/erlang_tests/spawn_fun3.erl
@@ -30,7 +30,7 @@ start() ->
                 Pid ! sum(L)
         end
     end,
-    Pid = spawn(Fun),
+    Pid = spawn_opt(Fun, []),
     Pid ! {self(), sum},
     receive
         N -> N

--- a/tests/erlang_tests/spawn_opt_link_normal.erl
+++ b/tests/erlang_tests/spawn_opt_link_normal.erl
@@ -20,10 +20,10 @@
 
 -module(spawn_opt_link_normal).
 
--export([start/0, start2/0, sum/1, proc/1]).
+-export([start/0, sum/1, proc/1]).
 
 start() ->
-    {Pid, Ref} = spawn_opt(?MODULE, start2, [], [monitor]),
+    {Pid, Ref} = spawn_opt(fun start2/0, [monitor]),
     CM =
         receive
             N2 -> N2

--- a/tests/erlang_tests/state_test.erl
+++ b/tests/erlang_tests/state_test.erl
@@ -23,7 +23,7 @@
 -export([start/0, loop/1]).
 
 start() ->
-    Pid = spawn(state_test, loop, [initial_state()]),
+    Pid = spawn_opt(state_test, loop, [initial_state()], []),
     send_integer(Pid, 1),
     send_integer(Pid, 2),
     send_integer(Pid, 3),

--- a/tests/erlang_tests/state_test2.erl
+++ b/tests/erlang_tests/state_test2.erl
@@ -23,7 +23,7 @@
 -export([start/0, loop/1]).
 
 start() ->
-    Pid = spawn(state_test2, loop, [initial_state()]),
+    Pid = spawn_opt(state_test2, loop, [initial_state()], []),
     state_test2_sender:send_msgs(Pid).
 
 initial_state() ->

--- a/tests/erlang_tests/state_test3.erl
+++ b/tests/erlang_tests/state_test3.erl
@@ -23,7 +23,7 @@
 -export([start/0]).
 
 start() ->
-    Pid = spawn(state_test3_server, loop, [initial_state()]),
+    Pid = spawn_opt(state_test3_server, loop, [initial_state()], []),
     send_integer(Pid, 1),
     send_integer(Pid, 2),
     send_integer(Pid, 3),

--- a/tests/erlang_tests/test_bs.erl
+++ b/tests/erlang_tests/test_bs.erl
@@ -20,7 +20,7 @@
 
 -module(test_bs).
 
--export([start/0]).
+-export([start/0, id/1]).
 
 start() ->
     test_pack_small_ints({2, 61, 20}, <<23, 180>>),
@@ -368,12 +368,4 @@ test_large() ->
     true = id(X) =:= <<42:1024>>,
     ok.
 
-% Prevent optimization from the compiler
-id(X) ->
-    Self = self(),
-    Pid = spawn(fun() ->
-        Self ! {self(), X}
-    end),
-    receive
-        {Pid, R} -> R
-    end.
+id(X) -> X.

--- a/tests/erlang_tests/test_min_heap_size.erl
+++ b/tests/erlang_tests/test_min_heap_size.erl
@@ -24,7 +24,7 @@
 
 start() ->
     Self = self(),
-    Pid1 = spawn(?MODULE, loop, [Self]),
+    Pid1 = spawn_opt(?MODULE, loop, [Self], []),
     receive
         ok -> ok
     end,

--- a/tests/erlang_tests/test_monitor.erl
+++ b/tests/erlang_tests/test_monitor.erl
@@ -33,7 +33,7 @@ start() ->
     0.
 
 test_monitor_normal() ->
-    Pid = spawn(fun() -> normal_loop() end),
+    Pid = spawn_opt(fun() -> normal_loop() end, []),
     Ref = monitor(process, Pid),
     Pid ! {self(), quit},
     ok =
@@ -51,7 +51,7 @@ test_monitor_normal() ->
     ok.
 
 test_monitor_demonitor() ->
-    Pid = spawn(fun() -> normal_loop() end),
+    Pid = spawn_opt(fun() -> normal_loop() end, []),
     Ref = monitor(process, Pid),
     true = demonitor(Ref),
     Pid ! {self(), quit},
@@ -69,10 +69,12 @@ test_monitor_demonitor() ->
     ok.
 
 test_monitor_noproc() ->
-    Pid = spawn(fun() -> ok end),
-    receive
-    after 100 -> ok
-    end,
+    {Pid, Monitor} = spawn_opt(fun() -> ok end, [monitor]),
+    ok =
+        receive
+            {'DOWN', Monitor, process, Pid, normal} -> ok
+        after 500 -> timeout
+        end,
     Ref = monitor(process, Pid),
     ok =
         receive
@@ -83,7 +85,7 @@ test_monitor_noproc() ->
     ok.
 
 test_monitor_demonitor_flush() ->
-    Pid = spawn(fun() -> normal_loop() end),
+    Pid = spawn_opt(fun() -> normal_loop() end, []),
     Ref = monitor(process, Pid),
     Pid ! {self(), quit},
     receive
@@ -104,7 +106,7 @@ test_monitor_demonitor_flush() ->
     ok.
 
 test_monitor_demonitor_info() ->
-    Pid = spawn(fun() -> normal_loop() end),
+    Pid = spawn_opt(fun() -> normal_loop() end, []),
     Ref = monitor(process, Pid),
     true = demonitor(Ref, [info]),
     Pid ! {self(), quit},
@@ -123,7 +125,7 @@ test_monitor_demonitor_info() ->
     ok.
 
 test_monitor_demonitor_flush_info_true() ->
-    Pid = spawn(fun() -> normal_loop() end),
+    Pid = spawn_opt(fun() -> normal_loop() end, []),
     Ref = monitor(process, Pid),
     Pid ! {self(), quit},
     receive
@@ -144,7 +146,7 @@ test_monitor_demonitor_flush_info_true() ->
     ok.
 
 test_monitor_demonitor_flush_info_false() ->
-    Pid = spawn(fun() -> normal_loop() end),
+    Pid = spawn_opt(fun() -> normal_loop() end, []),
     Ref = monitor(process, Pid),
     true = demonitor(Ref, [flush, info]),
     Pid ! {self(), quit},

--- a/tests/erlang_tests/test_pids_ordering.erl
+++ b/tests/erlang_tests/test_pids_ordering.erl
@@ -23,12 +23,12 @@
 -export([start/0, sort/1, insert/2, check/2]).
 
 start() ->
-    P1 = spawn(?MODULE, sort, [[]]),
-    P2 = spawn(?MODULE, sort, [[1]]),
-    P3 = spawn(?MODULE, sort, [[2, 1]]),
-    P4 = spawn(?MODULE, sort, [[3]]),
-    P5 = spawn(?MODULE, sort, [[4, 1]]),
-    P6 = spawn(?MODULE, sort, [[]]),
+    P1 = spawn_opt(?MODULE, sort, [[]], []),
+    P2 = spawn_opt(?MODULE, sort, [[1]], []),
+    P3 = spawn_opt(?MODULE, sort, [[2, 1]], []),
+    P4 = spawn_opt(?MODULE, sort, [[3]], []),
+    P5 = spawn_opt(?MODULE, sort, [[4, 1]], []),
+    P6 = spawn_opt(?MODULE, sort, [[]], []),
     Sorted = sort([P3, P4, P1, P5, P2]),
     check(Sorted, [P1, P2, P3, P4, P5]) +
         bool_to_n(Sorted < [P6]) * 2 +

--- a/tests/erlang_tests/test_raise.erl
+++ b/tests/erlang_tests/test_raise.erl
@@ -23,7 +23,7 @@
 -export([start/0]).
 
 start() ->
-    Pid = spawn(fun() -> loop(0) end),
+    Pid = spawn_opt(fun() -> loop(0) end, []),
     Tick = fun() -> Pid ! tick end,
     foo = tryit(
         fun() -> foo end,

--- a/tests/erlang_tests/test_refc_binaries.erl
+++ b/tests/erlang_tests/test_refc_binaries.erl
@@ -106,7 +106,7 @@ test_send() ->
     Bin = create_binary(1024),
     ?VERIFY(MemoryBinarySize + 1024 =< erlang:memory(binary)),
 
-    Pid = erlang:spawn(fun() -> loop(#state{}) end),
+    Pid = spawn_opt(fun() -> loop(#state{}) end, []),
     PidHeapSize0 = get_heap_size(Pid),
     %%
     %% Send the process a refc binary, and check heap size
@@ -134,7 +134,7 @@ test_spawn() ->
     %%
     %% Spawn a function, passing a refc binary through the args
     %%
-    Pid = erlang:spawn(?MODULE, loop, [#state{bin = Bin}]),
+    Pid = spawn_opt(?MODULE, loop, [#state{bin = Bin}], []),
     PidHeapSize0 = get_heap_size(Pid),
     %%
     %% Make sure we can get what we spawned
@@ -154,7 +154,7 @@ test_spawn_fun() ->
     %%
     %% Spawn a function, passing a refc binary through the args
     %%
-    Pid = erlang:spawn(fun() -> loop(#state{bin = Bin}) end),
+    Pid = spawn_opt(fun() -> loop(#state{bin = Bin}) end, []),
     PidHeapSize0 = get_heap_size(Pid),
     %%
     %% Make sure we can get what we spawned
@@ -227,7 +227,7 @@ create_string(N, Accum) ->
 
 run_test(Fun) ->
     Self = self(),
-    _Pid = spawn(fun() -> execute(Self, Fun) end),
+    _Pid = spawn_opt(fun() -> execute(Self, Fun) end, []),
     receive
         ok ->
             ok;

--- a/tests/erlang_tests/test_selective_receive.erl
+++ b/tests/erlang_tests/test_selective_receive.erl
@@ -29,21 +29,30 @@ start() ->
 
 test_selective_receive() ->
     Self = self(),
-    spawn(fun() ->
-        Self ! three
-    end),
-    spawn(fun() ->
-        receive
-        after 250 -> ok
+    spawn_opt(
+        fun() ->
+            Self ! three
         end,
-        Self ! two
-    end),
-    spawn(fun() ->
-        receive
-        after 500 -> ok
+        []
+    ),
+    spawn_opt(
+        fun() ->
+            receive
+            after 250 -> ok
+            end,
+            Self ! two
         end,
-        Self ! one
-    end),
+        []
+    ),
+    spawn_opt(
+        fun() ->
+            receive
+            after 500 -> ok
+            end,
+            Self ! one
+        end,
+        []
+    ),
     receive
         one ->
             ok
@@ -59,15 +68,21 @@ test_selective_receive() ->
 
 test_selective_receive_with_timeout() ->
     Self = self(),
-    spawn(fun() ->
-        Self ! two
-    end),
-    spawn(fun() ->
-        receive
-        after 500 -> ok
+    spawn_opt(
+        fun() ->
+            Self ! two
         end,
-        Self ! one
-    end),
+        []
+    ),
+    spawn_opt(
+        fun() ->
+            receive
+            after 500 -> ok
+            end,
+            Self ! one
+        end,
+        []
+    ),
     ok =
         receive
             one ->

--- a/tests/erlang_tests/test_send.erl
+++ b/tests/erlang_tests/test_send.erl
@@ -23,7 +23,12 @@
 -export([start/0]).
 
 start() ->
-    Dead = spawn(fun() -> ok end),
+    {Dead, DeadMonitor} = spawn_opt(fun() -> ok end, [monitor]),
+    ok =
+        receive
+            {'DOWN', DeadMonitor, process, Dead, normal} -> ok
+        after 500 -> timeout
+        end,
     Sent = send(self(), 32),
     receive
         Sent ->

--- a/tests/erlang_tests/test_stacktrace.erl
+++ b/tests/erlang_tests/test_stacktrace.erl
@@ -190,7 +190,7 @@ test_body_recursive_throw() ->
 
 test_spawned_throw() ->
     Self = self(),
-    spawn(
+    spawn_opt(
         fun() ->
             try
                 do_some_stuff(blah),
@@ -208,7 +208,8 @@ test_spawned_throw() ->
                     ),
                     Self ! Result
             end
-        end
+        end,
+        []
     ),
     receive
         Result ->

--- a/tests/erlang_tests/test_sub_binaries.erl
+++ b/tests/erlang_tests/test_sub_binaries.erl
@@ -137,7 +137,7 @@ test_send_sub_binary() ->
     Bin = create_binary(1024),
     BinarySize = erlang:byte_size(Bin),
     ?VERIFY(MemoryBinarySize + 1024 == erlang:memory(binary)),
-    Pid = erlang:spawn(fun() -> loop(#state{}) end),
+    Pid = spawn_opt(fun() -> loop(#state{}) end, []),
     PidHeapSize0 = get_heap_size(Pid),
     %%
     %% Send the process a refc binary, and check heap size
@@ -170,7 +170,7 @@ test_spawn_sub_binary() ->
     %% Spawn a function, passing a refc binary through the args
     %%
     LargeSubBin = binary:part(Bin, 1, BinarySize - 1),
-    Pid = erlang:spawn(?MODULE, loop, [#state{bin = LargeSubBin}]),
+    Pid = spawn_opt(?MODULE, loop, [#state{bin = LargeSubBin}], []),
     PidHeapSize0 = get_heap_size(Pid),
     %%
     %% Make sure we can get what we spawned
@@ -195,7 +195,7 @@ test_spawn_fun_sub_binary() ->
     %% Spawn a function, passing a refc binary through the args
     %%
     LargeSubBin = binary:part(Bin, 1, BinarySize - 1),
-    Pid = erlang:spawn(fun() -> loop(#state{bin = LargeSubBin}) end),
+    Pid = spawn_opt(fun() -> loop(#state{bin = LargeSubBin}) end, []),
     PidHeapSize0 = get_heap_size(Pid),
     ?VERIFY(MemoryBinarySize + 1024 == erlang:memory(binary)),
     %%
@@ -338,7 +338,7 @@ create_string(N, Accum) ->
 
 run_test(Fun) ->
     Self = self(),
-    _Pid = spawn(fun() -> execute(Self, Fun) end),
+    _Pid = spawn_opt(fun() -> execute(Self, Fun) end, []),
     receive
         ok ->
             ok;

--- a/tests/erlang_tests/test_system_info.erl
+++ b/tests/erlang_tests/test_system_info.erl
@@ -80,7 +80,7 @@ test_process_count(_) ->
 test_process_count() ->
     Count = erlang:system_info(process_count),
     Self = self(),
-    Pid = spawn(?MODULE, loop, [Self]),
+    Pid = spawn_opt(?MODULE, loop, [Self], []),
     receive
         ok -> ok
     end,

--- a/tests/erlang_tests/test_throw_call_ext_last.erl
+++ b/tests/erlang_tests/test_throw_call_ext_last.erl
@@ -38,7 +38,7 @@ test_spawn_fun_sub_binary() ->
     %% Spawn a function, passing a refc binary through the args
     %%
     LargeSubBin = binary:part(Bin, 1, BinarySize - 1),
-    Pid = erlang:spawn(fun() -> loop(#state{bin = LargeSubBin}) end),
+    Pid = spawn_opt(fun() -> loop(#state{bin = LargeSubBin}) end, []),
     PidHeapSize0 = get_heap_size(Pid),
     %%
     %% Make sure we can get what we spawned
@@ -113,7 +113,7 @@ create_string(N, Accum) ->
 
 run_test(Fun) ->
     Self = self(),
-    _Pid = spawn(fun() -> execute(Self, Fun) end),
+    _Pid = spawn_opt(fun() -> execute(Self, Fun) end, []),
     receive
         ok ->
             ok;

--- a/tests/erlang_tests/test_timeout_not_integer.erl
+++ b/tests/erlang_tests/test_timeout_not_integer.erl
@@ -27,8 +27,8 @@ start() ->
 
 test_infinity() ->
     Parent = self(),
-    _Pid1 = spawn(fun() -> waiter1(Parent) end),
-    _Pid2 = spawn(fun() -> waiter2(Parent) end),
+    _Pid1 = spawn_opt(fun() -> waiter1(Parent) end, []),
+    _Pid2 = spawn_opt(fun() -> waiter2(Parent) end, []),
     receive
         _ -> 1
         % wait 2 secs as with bug we waited few ms

--- a/tests/erlang_tests/unlink_error.erl
+++ b/tests/erlang_tests/unlink_error.erl
@@ -51,7 +51,7 @@ start() ->
 
 start2() ->
     L = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-    Pid = spawn(?MODULE, proc, [L]),
+    Pid = spawn_opt(?MODULE, proc, [L], []),
     erlang:link(Pid),
     erlang:unlink(Pid),
     Pid ! {self(), sum},

--- a/tests/erlang_tests/whereis_dead_process.erl
+++ b/tests/erlang_tests/whereis_dead_process.erl
@@ -34,7 +34,7 @@ test_two_names() ->
     test_names([foo, bar]).
 
 test_names(Names) ->
-    Pid = spawn(fun() -> do_register(Names) end),
+    Pid = spawn_opt(fun() -> do_register(Names) end, []),
     Monitor = monitor(process, Pid),
     ok =
         receive

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -33,6 +33,7 @@ set(ERLANG_MODULES
     test_lists
     test_logger
     test_maps
+    test_spawn
     test_string
     test_proplists
     test_timer

--- a/tests/libs/estdlib/test_gen_server.erl
+++ b/tests/libs/estdlib/test_gen_server.erl
@@ -67,12 +67,15 @@ test_start_link() ->
 
     pong = gen_server:call(Pid, ping),
     pong = gen_server:call(Pid, reply_ping),
-    erlang:process_flag(trap_exit, true),
+    false = erlang:process_flag(trap_exit, true),
     ok = gen_server:cast(Pid, crash),
-    receive
-        {'EXIT', Pid, _Reason} -> ok
-    after 30000 -> timeout
-    end.
+    ok =
+        receive
+            {'EXIT', Pid, _Reason} -> ok
+        after 30000 -> timeout
+        end,
+    true = erlang:process_flag(trap_exit, false),
+    ok.
 
 test_cast() ->
     {ok, Pid} = gen_server:start(?MODULE, [], []),

--- a/tests/libs/estdlib/test_gen_statem.erl
+++ b/tests/libs/estdlib/test_gen_statem.erl
@@ -93,12 +93,15 @@ test_start_link() ->
 
     pong = gen_statem:call(Pid, ping),
 
-    erlang:process_flag(trap_exit, true),
+    false = erlang:process_flag(trap_exit, true),
     ok = gen_statem:cast(Pid, crash),
-    receive
-        {'EXIT', Pid, _Reason} -> ok
-    after 30000 -> timeout
-    end.
+    ok =
+        receive
+            {'EXIT', Pid, _Reason} -> ok
+        after 30000 -> timeout
+        end,
+    true = erlang:process_flag(trap_exit, false),
+    ok.
 
 %%
 %% callbacks

--- a/tests/libs/estdlib/test_spawn.erl
+++ b/tests/libs/estdlib/test_spawn.erl
@@ -1,0 +1,68 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_spawn).
+
+-export([test/0, f/1]).
+
+-include("etest.hrl").
+
+test() ->
+    ok = test_spawn(),
+    ok = test_spawn_link(),
+    ok.
+
+%% spawn/1, spawn/3, spawn_link/1, spawn_link/3 are not nifs but implemented
+%% in erlang module.
+
+test_spawn() ->
+    Parent = self(),
+    Pid1 = spawn(fun() -> f(Parent) end),
+    ok =
+        receive
+            {Pid1, {links, []}} -> ok
+        after 500 -> timeout
+        end,
+    Pid2 = spawn(?MODULE, f, [Parent]),
+    ok =
+        receive
+            {Pid2, {links, []}} -> ok
+        after 500 -> timeout
+        end,
+    ok.
+
+test_spawn_link() ->
+    Parent = self(),
+    Pid1 = spawn_link(fun() -> f(Parent) end),
+    ok =
+        receive
+            {Pid1, {links, [Parent]}} -> ok
+        after 500 -> timeout
+        end,
+    Pid2 = spawn_link(?MODULE, f, [Parent]),
+    ok =
+        receive
+            {Pid2, {links, [Parent]}} -> ok
+        after 500 -> timeout
+        end,
+    ok.
+
+f(Parent) ->
+    Parent ! {self(), erlang:process_info(self(), links)}.

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -36,5 +36,6 @@ start() ->
         test_maps,
         test_proplists,
         test_timer,
+        test_spawn,
         test_supervisor
     ]).

--- a/tests/test.c
+++ b/tests/test.c
@@ -502,7 +502,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(link_kill_parent, 1),
     TEST_CASE_EXPECTED(link_throw, 1),
     TEST_CASE_EXPECTED(unlink_error, 1),
-    TEST_CASE_EXPECTED(trap_exit_flag, 1),
+    TEST_CASE(trap_exit_flag),
     TEST_CASE_COND(test_stacktrace, 0, SKIP_STACKTRACES),
     TEST_CASE(small_big_ext),
     TEST_CASE(test_crypto),


### PR DESCRIPTION
Implement `erlang:spawn_link/1,3`
Fix options of `spawn_opt/2` by factorizing it with `spawn_opt/4`
Also rewrite `spawn/1` and `spawn/3` in Erlang and update tests accordingly
Also isolate libs tests

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
