### PR TITLE
Fix small typo in documentation

### DIFF
--- a/libs/eavmlib/src/emscripten.erl
+++ b/libs/eavmlib/src/emscripten.erl
@@ -358,7 +358,7 @@ register_keypress_callback(_Target, _Options) ->
 
 %% @doc Register for keypress events.
 %% This function registers keypress events on a given target.
-%% Target can be specified as special atoms `window' for Javacsript's window,
+%% Target can be specified as special atoms `window' for Javascript's window,
 %% `document' for window.document. `screen' is also supported, but it doesn't
 %% seem to work, see [https://github.com/emscripten-core/emscripten/issues/19865]
 %%


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
