### PR TITLE
Add lists:usort/2,3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ functions that default to `?ATOMVM_NVS_NS` are deprecated now).
 - Added `unicode` module with `characters_to_list/1,2` and `characters_to_binary/1,2,3` functions
 - Added support for `crypto:hash/2` (ESP32 and generic_unix with openssl)
 - Added links to process_info/2
+- Added lists:usort/1,2
 
 ### Fixed
 - Fixed issue with formatting integers with io:format() on STM32 platform

--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -48,6 +48,7 @@
     join/2,
     seq/2, seq/3,
     sort/1, sort/2,
+    usort/1, usort/2,
     duplicate/2,
     sublist/2
 ]).
@@ -464,6 +465,7 @@ seq(From, To, Incr, Accum) ->
 %%
 %% @end
 %%-----------------------------------------------------------------------------
+-spec sort(List :: [T]) -> [T].
 sort(List) when is_list(List) ->
     sort(fun lt/2, List).
 
@@ -475,6 +477,7 @@ sort(List) when is_list(List) ->
 %%
 %% @end
 %%-----------------------------------------------------------------------------
+-spec sort(Fun :: fun((T, T) -> boolean()), List :: [T]) -> [T].
 sort(Fun, List) when is_function(Fun), is_list(List) ->
     quick_sort(Fun, List).
 
@@ -489,6 +492,52 @@ quick_sort(_Fun, []) ->
 
 %% @private
 lt(A, B) -> A < B.
+
+%%-----------------------------------------------------------------------------
+%% @param   List a list
+%% @returns Sorted list with duplicates removed, ordered by `<'
+%% @see sort/1
+%% @doc     Returns a unique, sorted list, using `<' operator to determine sort order.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec usort(List :: [T]) -> [T].
+usort(List) ->
+    Sorted = sort(List),
+    unique(Sorted).
+
+%%-----------------------------------------------------------------------------
+%% @param   Fun sort function
+%% @param   List a list
+%% @returns Sorted list with duplicates removed, ordered by Fun.
+%% @see sort/2
+%% @doc     Returns a unique, sorted list.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec usort(Fun :: fun((T, T) -> boolean()), List :: [T]) -> [T].
+usort(Fun, List) ->
+    Sorted = sort(Fun, List),
+    unique(Sorted, Fun).
+
+%% @private
+unique(Sorted) ->
+    unique(Sorted, fun(X, Y) -> X =< Y end).
+
+%% @private
+unique(Sorted, Fun) ->
+    unique(Sorted, Fun, []).
+
+%% @private
+unique([], _Fun, []) ->
+    [];
+unique([X], _Fun, Acc) ->
+    lists:reverse([X | Acc]);
+unique([X, Y | Tail], Fun, Acc) ->
+    case Fun(X, Y) andalso Fun(Y, X) of
+        true ->
+            unique([Y | Tail], Fun, Acc);
+        false ->
+            unique([Y | Tail], Fun, [X | Acc])
+    end.
 
 %%-----------------------------------------------------------------------------
 %% @param   Elem the element to duplicate

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -42,6 +42,7 @@ test() ->
     ok = test_join(),
     ok = test_seq(),
     ok = test_sort(),
+    ok = test_usort(),
     ok.
 
 test_nth() ->
@@ -208,14 +209,31 @@ test_sort() ->
     ?ASSERT_MATCH(lists:sort([]), []),
     ?ASSERT_MATCH(lists:sort([1]), [1]),
     ?ASSERT_MATCH(lists:sort([1, 3, 5, 2, 4]), [1, 2, 3, 4, 5]),
+    ?ASSERT_MATCH(lists:sort([1, 3, 5, 2, 3, 4]), [1, 2, 3, 3, 4, 5]),
     ?ASSERT_MATCH(lists:sort([c, a, b, d]), [a, b, c, d]),
     ?ASSERT_MATCH(lists:sort([#{}, z]), [z, #{}]),
 
-    ?ASSERT_MATCH(lists:sort(fun(A, B) -> A > B end, [1, 2, 3, 4, 5]), [5, 4, 3, 2, 1]),
+    ?ASSERT_MATCH(lists:sort(fun(A, B) -> A > B end, [1, 2, 3, 4, 3, 5]), [5, 4, 3, 3, 2, 1]),
 
     ?ASSERT_FAILURE(lists:sort(1), function_clause),
     ?ASSERT_FAILURE(lists:sort(fun(A, B) -> A > B end, 1), function_clause),
     ?ASSERT_FAILURE(lists:sort(1, [1]), function_clause),
+
+    ok.
+
+test_usort() ->
+    ?ASSERT_MATCH(lists:usort([]), []),
+    ?ASSERT_MATCH(lists:usort([1]), [1]),
+    ?ASSERT_MATCH(lists:usort([1, 3, 5, 2, 3, 4]), [1, 2, 3, 4, 5]),
+    ?ASSERT_MATCH(lists:usort([1, 3, 5, 2, 1, 4]), [1, 2, 3, 4, 5]),
+    ?ASSERT_MATCH(lists:usort([1, 3, 5, 2, 5, 4]), [1, 2, 3, 4, 5]),
+
+    ?ASSERT_MATCH(lists:usort(fun(A, B) -> A > B end, [1, 2, 3, 4, 3, 5]), [5, 4, 3, 3, 2, 1]),
+    ?ASSERT_MATCH(lists:usort(fun(A, B) -> A >= B end, [1, 2, 3, 4, 3, 5]), [5, 4, 3, 2, 1]),
+
+    ?ASSERT_FAILURE(lists:usort(1), function_clause),
+    ?ASSERT_FAILURE(lists:usort(fun(A, B) -> A > B end, 1), function_clause),
+    ?ASSERT_FAILURE(lists:usort(1, [1]), function_clause),
 
     ok.
 


### PR DESCRIPTION
Also add specification for lists:sort/2.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
