### PR TITLE
Fix `monotonic_time/1` and `system_time/1` with pico (fix #786)

### DIFF
--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: "Install deps"
-      run: sudo apt install -y cmake gperf ninja-build gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+      run: sudo apt install -y cmake gperf ninja-build gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib erlang-base erlang-dialyzer
 
     - name: Build
       shell: bash
@@ -58,4 +58,4 @@ jobs:
         source $HOME/.nvm/nvm.sh
         nvm use node
         npm install
-        npx tsx run-tests.ts ../build/tests/rp2040_tests.uf2
+        npx tsx run-tests.ts ../build/tests/rp2040_tests.uf2 ../build/tests/test_erl_sources/rp2040_test_modules.uf2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `esp:nvs_set_binary` functions.
+- Fixed `monotonic_time/1` and `system_time/1` functions for Raspberry Pi Pico
 
 ## [0.6.0-alpha.0] - 2023-08-13
 

--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -597,7 +597,7 @@ Install the emulator and required Javascript dependencies:
 
 We are assuming tests were built as part of regular build of AtomVM. Run them with the commands:
 
-	shell$ npx tsx run-tests.ts ../build/tests/rp2040_tests.uf2
+	shell$ npx tsx run-tests.ts ../build/tests/rp2040_tests.uf2 ../build/tests/test_erl_sources/rp2040_test_modules.uf2
 
 ## Building for NodeJS/Web
 

--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(esp32_test_modules)
 
 ExternalProject_Add(HostAtomVM
     SOURCE_DIR ../../../../../../../../
+    INSTALL_COMMAND cmake -E echo "Skipping install step."
 )
 
 function(compile_erlang module_name)

--- a/src/platforms/rp2040/src/lib/smp.c
+++ b/src/platforms/rp2040/src/lib/smp.c
@@ -35,6 +35,7 @@
 
 #pragma GCC diagnostic pop
 
+#include <scheduler.h>
 #include <utils.h>
 
 struct Mutex
@@ -56,7 +57,8 @@ static void scheduler_core1_entry_point(void)
 {
     _Static_assert(sizeof(uintptr_t) == sizeof(uint32_t), "Expected pointers to be 32 bits");
     uint32_t ctx_int = multicore_fifo_pop_blocking();
-    return scheduler_entry_point((GlobalContext *) ctx_int);
+    int result = scheduler_entry_point((GlobalContext *) ctx_int);
+    UNUSED(result);
 }
 
 void smp_scheduler_start(GlobalContext *ctx)

--- a/src/platforms/rp2040/src/main.c
+++ b/src/platforms/rp2040/src/main.c
@@ -101,21 +101,23 @@ static int app_main()
         AVM_ABORT();
     }
 
+    avmpack_data_init(&avmpack_data->base, &const_avm_pack_info);
     avmpack_data->base.data = MAIN_AVM;
     avmpack_data->base.in_use = true;
 
-    synclist_append(&glb->avmpack_data, (struct ListHead *) avmpack_data);
+    synclist_append(&glb->avmpack_data, &avmpack_data->base.avmpack_head);
 
     if (avmpack_is_valid(LIB_AVM, (uintptr_t) MAIN_AVM - (uintptr_t) LIB_AVM)) {
-        avmpack_data = malloc(sizeof(struct AVMPackData));
+        avmpack_data = malloc(sizeof(struct ConstAVMPack));
         if (IS_NULL_PTR(avmpack_data)) {
             sleep_ms(5000);
             fprintf(stderr, "Memory error: Cannot allocate AVMPackData for lib.avm.");
             AVM_ABORT();
         }
+        avmpack_data_init(&avmpack_data->base, &const_avm_pack_info);
         avmpack_data->base.data = LIB_AVM;
         avmpack_data->base.in_use = true;
-        synclist_append(&glb->avmpack_data, (struct ListHead *) avmpack_data);
+        synclist_append(&glb->avmpack_data, &avmpack_data->base.avmpack_head);
     } else {
         fprintf(stderr, "Warning: invalid lib.avm packbeam\n");
     }

--- a/src/platforms/rp2040/tests/CMakeLists.txt
+++ b/src/platforms/rp2040/tests/CMakeLists.txt
@@ -52,3 +52,6 @@ pico_enable_stdio_uart(AtomVM 1)
 
 # create map/bin/hex/uf2 file in addition to ELF.
 pico_add_extra_outputs(rp2040_tests)
+
+add_subdirectory(test_erl_sources)
+add_dependencies(rp2040_tests rp2040_test_modules)

--- a/src/platforms/rp2040/tests/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/rp2040/tests/test_erl_sources/CMakeLists.txt
@@ -1,0 +1,72 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+ExternalProject_Add(HostAtomVM
+    SOURCE_DIR ../../../../../../
+    INSTALL_COMMAND cmake -E echo "Skipping install step."
+)
+
+function(compile_erlang module_name)
+    add_custom_command(
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.beam"
+        COMMAND erlc ${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl
+        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${module_name}.erl"
+        COMMENT "Compiling ${module_name}.erl"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+    set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.beam")
+endfunction()
+
+compile_erlang(test_clocks)
+compile_erlang(test_smp)
+
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/rp2040_test_modules.avm"
+    COMMAND HostAtomVM-prefix/src/HostAtomVM-build/tools/packbeam/PackBEAM -i rp2040_test_modules.avm
+        HostAtomVM-prefix/src/HostAtomVM-build/libs/atomvmlib.avm
+        test_clocks.beam
+        test_smp.beam
+    DEPENDS
+        HostAtomVM
+        "${CMAKE_CURRENT_BINARY_DIR}/test_clocks.beam"
+        "${CMAKE_CURRENT_BINARY_DIR}/test_smp.beam"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    VERBATIM
+)
+
+set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/rp2040_test_modules.avm")
+
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/rp2040_test_modules.uf2"
+    COMMAND HostAtomVM-prefix/src/HostAtomVM-build/tools/uf2tool/uf2tool
+        create
+        -o rp2040_test_modules.uf2
+        -s 0x100A0000 "${CMAKE_CURRENT_BINARY_DIR}/rp2040_test_modules.avm"
+    DEPENDS
+        HostAtomVM
+        "${CMAKE_CURRENT_BINARY_DIR}/rp2040_test_modules.avm"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    VERBATIM
+)
+
+set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/rp2040_test_modules.uf2")
+
+add_custom_target(rp2040_test_modules DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/rp2040_test_modules.uf2")

--- a/src/platforms/rp2040/tests/test_erl_sources/test_clocks.erl
+++ b/src/platforms/rp2040/tests/test_erl_sources/test_clocks.erl
@@ -1,0 +1,54 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_clocks).
+-export([start/0]).
+
+-define(START_DATE, {{2023, 9, 3}, {21, 30, 00}}).
+
+start() ->
+    test_clock(system_time, fun() -> erlang:system_time(millisecond) end),
+    test_clock(monotonic_time, fun() -> erlang:monotonic_time(millisecond) end),
+    Date = erlang:universaltime(),
+    if
+        Date < ?START_DATE ->
+            pico:rtc_set_datetime(?START_DATE);
+        true ->
+            ok
+    end,
+    test_clock(system_time_after_set_rtc, fun() -> erlang:system_time(millisecond) end),
+    NewDate = erlang:universaltime(),
+    if
+        NewDate >= ?START_DATE -> ok;
+        true -> throw({unexpected_date, NewDate})
+    end,
+    ok.
+
+test_clock(Case, Fun) ->
+    StartTime = Fun(),
+    receive
+    after 100 -> ok
+    end,
+    EndTime = Fun(),
+    Delta = EndTime - StartTime,
+    if
+        Delta >= 100 andalso Delta < 500 -> ok;
+        true -> throw({unexpected_delta, Delta, Case, StartTime, EndTime})
+    end.

--- a/src/platforms/rp2040/tests/test_erl_sources/test_smp.erl
+++ b/src/platforms/rp2040/tests/test_erl_sources/test_smp.erl
@@ -1,0 +1,51 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_smp).
+-export([start/0]).
+
+start() ->
+    {Pid1, Monitor1} = spawn_opt(fun count_loop/0, [monitor]),
+    {Pid2, Monitor2} = spawn_opt(fun count_loop/0, [monitor]),
+    {Pid3, Monitor3} = spawn_opt(fun count_loop/0, [monitor]),
+    {Pid4, Monitor4} = spawn_opt(fun count_loop/0, [monitor]),
+    receive
+        {'DOWN', Monitor1, process, Pid1, normal} -> ok
+    end,
+    receive
+        {'DOWN', Monitor2, process, Pid2, normal} -> ok
+    end,
+    receive
+        {'DOWN', Monitor3, process, Pid3, normal} -> ok
+    end,
+    receive
+        {'DOWN', Monitor4, process, Pid4, normal} -> ok
+    end,
+    ok.
+
+count_loop() ->
+    count_loop(1000).
+
+count_loop(N) when N < 0 -> ok;
+count_loop(X) ->
+    case X rem 2 of
+        0 -> count_loop(X - 1);
+        1 -> count_loop(X - 3)
+    end.


### PR DESCRIPTION
Fix a bug where setting the time with RTC wouldn't set system time.
Also fix a bug with avm_data revealed by new tests.
Also skip unused install step when building host AtomVM for esp32 tests.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
