### PR TITLE
Implement `lists:reverse/1,2` as nif

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -166,6 +166,7 @@ static term nif_base64_encode_to_string(Context *ctx, int argc, term argv[]);
 static term nif_base64_decode_to_string(Context *ctx, int argc, term argv[]);
 static term nif_code_load_abs(Context *ctx, int argc, term argv[]);
 static term nif_code_load_binary(Context *ctx, int argc, term argv[]);
+static term nif_lists_reverse(Context *ctx, int argc, term argv[]);
 static term nif_maps_next(Context *ctx, int argc, term argv[]);
 static term nif_unicode_characters_to_list(Context *ctx, int argc, term argv[]);
 static term nif_unicode_characters_to_binary(Context *ctx, int argc, term argv[]);
@@ -693,6 +694,11 @@ static const struct Nif code_load_binary_nif =
 {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_code_load_binary
+};
+static const struct Nif lists_reverse_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_lists_reverse
 };
 static const struct Nif maps_next_nif =
 {
@@ -4239,6 +4245,34 @@ static term nif_code_load_binary(Context *ctx, int argc, term argv[])
     term_put_tuple_element(result, 0, MODULE_ATOM);
     term_put_tuple_element(result, 1, module_name);
 
+    return result;
+}
+
+static term nif_lists_reverse(Context *ctx, int argc, term argv[])
+{
+    // Compared to erlang version, compute the length of the list and allocate
+    // at once the space for the reverse.
+    int proper;
+    size_t len = term_list_length(argv[0], &proper);
+    if (UNLIKELY(!proper)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, len * CONS_SIZE, 2, argv, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    term result = term_nil();
+    if (argc == 2) {
+        result = argv[1];
+    }
+    term list_crsr = argv[0];
+    while (!term_is_nil(list_crsr)) {
+        // term is a proper list as verified above
+        term *list_ptr = term_get_list_ptr(list_crsr);
+        result = term_list_prepend(list_ptr[LIST_HEAD_INDEX], result, &ctx->heap);
+        list_crsr = list_ptr[LIST_TAIL_INDEX];
+    }
     return result;
 }
 

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -141,6 +141,8 @@ base64:encode/1, &base64_encode_nif
 base64:decode/1, &base64_decode_nif
 base64:encode_to_string/1, &base64_encode_to_string_nif
 base64:decode_to_string/1, &base64_decode_to_string_nif
+lists:reverse/1, &lists_reverse_nif
+lists:reverse/2, &lists_reverse_nif
 maps:next/1, &maps_next_nif
 unicode:characters_to_list/1, &unicode_characters_to_list_nif
 unicode:characters_to_list/2, &unicode_characters_to_list_nif

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -3040,11 +3040,10 @@ wait_timeout_trap_handler:
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("get_list/3 %lx, %c%i, %c%i\n", src_value, T_DEST_REG(head_dreg), T_DEST_REG(tail_dreg));
 
-                    term head = term_get_list_head(src_value);
-                    term tail = term_get_list_tail(src_value);
+                    term *list_ptr = term_get_list_ptr(src_value);
 
-                    WRITE_REGISTER(head_dreg, head);
-                    WRITE_REGISTER(tail_dreg, tail);
+                    WRITE_REGISTER(head_dreg, list_ptr[LIST_HEAD_INDEX]);
+                    WRITE_REGISTER(tail_dreg, list_ptr[LIST_TAIL_INDEX]);
                 #endif
 
                 #ifdef IMPL_CODE_LOADER

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -88,6 +88,9 @@ extern "C" {
 #define CONS_SIZE 2
 #define REFC_BINARY_CONS_OFFSET 4
 
+#define LIST_HEAD_INDEX 1
+#define LIST_TAIL_INDEX 0
+
 #define TERM_BINARY_SIZE_IS_HEAP(size) ((size) < REFC_BINARY_MIN)
 
 #if TERM_BYTES == 4
@@ -1288,7 +1291,7 @@ static inline term term_list_from_list_ptr(term *list_elem)
 static inline term term_get_list_head(term t)
 {
     term *list_ptr = term_get_list_ptr(t);
-    return list_ptr[1];
+    return list_ptr[LIST_HEAD_INDEX];
 }
 
 /**
@@ -1300,7 +1303,7 @@ static inline term term_get_list_head(term t)
 static inline term term_get_list_tail(term t)
 {
     term *list_ptr = term_get_list_ptr(t);
-    return *list_ptr;
+    return list_ptr[LIST_TAIL_INDEX];
 }
 
 /**
@@ -1312,7 +1315,7 @@ static inline term term_get_list_tail(term t)
  */
 MALLOC_LIKE static inline term *term_list_alloc(Heap *heap)
 {
-    return memory_heap_alloc(heap, 2);
+    return memory_heap_alloc(heap, CONS_SIZE);
 }
 
 /**

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -132,6 +132,7 @@ compile_erlang(test_list_processes)
 compile_erlang(test_tl)
 compile_erlang(test_list_to_atom)
 compile_erlang(test_list_to_existing_atom)
+compile_erlang(test_lists_reverse)
 compile_erlang(test_binary_to_atom)
 compile_erlang(test_binary_to_existing_atom)
 compile_erlang(test_atom_to_list)
@@ -577,6 +578,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_tl.beam
     test_list_to_atom.beam
     test_list_to_existing_atom.beam
+    test_lists_reverse.beam
     test_binary_to_atom.beam
     test_binary_to_existing_atom.beam
     test_atom_to_list.beam

--- a/tests/erlang_tests/test_lists_reverse.erl
+++ b/tests/erlang_tests/test_lists_reverse.erl
@@ -1,0 +1,75 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_lists_reverse).
+
+-export([start/0]).
+
+start() ->
+    ok = test_lists_reverse_1(),
+    ok = test_lists_reverse_2(),
+    0.
+
+test_lists_reverse_1() ->
+    [] = lists:reverse([]),
+    [a, b, c] = lists:reverse([c, b, a]),
+    ok =
+        try
+            lists:reverse([a, b | improper]),
+            fail
+        catch
+            error:badarg -> ok
+        end,
+    ok =
+        try
+            lists:reverse(not_a_list),
+            fail
+        catch
+            % AtomVM
+            error:badarg -> ok;
+            % BEAM
+            error:function_clause -> ok
+        end,
+    ok.
+
+test_lists_reverse_2() ->
+    [] = lists:reverse([], []),
+    [a, b, c, d, e, f] = lists:reverse([c, b, a], [d, e, f]),
+    ok =
+        try
+            lists:reverse([a, b | improper], [a]),
+            fail
+        catch
+            % AtomVM
+            error:badarg -> ok;
+            % BEAM
+            T:V -> {T, V}
+        end,
+    [b, a, c, d | improper] = lists:reverse([a, b], [c, d | improper]),
+    ok =
+        try
+            lists:reverse(not_a_list, []),
+            fail
+        catch
+            error:badarg -> ok
+        end,
+    not_a_list = lists:reverse([], not_a_list),
+    [c, b, a | not_a_list] = lists:reverse([a, b, c], not_a_list),
+    ok.

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -27,7 +27,6 @@
 test() ->
     ok = test_nth(),
     ok = test_member(),
-    ok = test_reverse(),
     ok = test_delete(),
     ok = test_keyfind(),
     ok = test_keydelete(),
@@ -49,18 +48,7 @@ test_nth() ->
     ?ASSERT_MATCH(lists:nth(1, [a, b, c]), a),
     ?ASSERT_MATCH(lists:nth(2, [a, b, c]), b),
     ?ASSERT_MATCH(lists:nth(3, [a, b, c]), c),
-    % try
-    %     lists:nth(-1, [a,b,c]),
-    %     throw(failure)
-    % catch
-    %     _:_ -> ok
-    % end,
-    ok.
-
-test_reverse() ->
-    ?ASSERT_MATCH(lists:reverse([]), []),
-    ?ASSERT_MATCH(lists:reverse([a]), [a]),
-    ?ASSERT_MATCH(lists:reverse([a, b]), [b, a]),
+    ?ASSERT_FAILURE(lists:nth(-1, [a, b, c]), function_clause),
     ok.
 
 test_member() ->
@@ -193,6 +181,7 @@ test_seq() ->
     ?ASSERT_MATCH(lists:seq(-1, 2, 3), [-1, 2]),
     ?ASSERT_MATCH(lists:seq(5, 1, -1), [5, 4, 3, 2, 1]),
     ?ASSERT_MATCH(lists:seq(1, 1, 0), [1]),
+    ?ASSERT_MATCH(lists:seq(1, 1), [1]),
 
     ?ASSERT_FAILURE(lists:seq(foo, 1)),
     ?ASSERT_FAILURE(lists:seq(1, bar)),

--- a/tests/test.c
+++ b/tests/test.c
@@ -155,6 +155,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(test_tl, 5),
     TEST_CASE_EXPECTED(test_list_to_atom, 9),
     TEST_CASE_EXPECTED(test_list_to_existing_atom, 9),
+    TEST_CASE(test_lists_reverse),
     TEST_CASE_EXPECTED(test_binary_to_atom, 9),
     TEST_CASE_EXPECTED(test_binary_to_existing_atom, 9),
     TEST_CASE_EXPECTED(test_atom_to_list, 1),


### PR DESCRIPTION
This nif does not need to be updated after #795 is merged.

Also rewrite several lists module functions to not use this nif, either because
it was not necessary (`lists:seq/2,3`) or because a non-tail recursive loop
is more efficient memory-wise. 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
