### PR TITLE
ESP32: add support for `crypto:crypto_one_time/4,5` (using mbedtls)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added configurable logging macros to stm32 platform
 - Added support for ULP wakeup on ESP32
 - Added heap growth strategies as a fine-tuning option to `spawn_opt/2,4`
+- Added `crypto:crypto_one_time/5` on ESP32
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added configurable logging macros to stm32 platform
 - Added support for ULP wakeup on ESP32
 - Added heap growth strategies as a fine-tuning option to `spawn_opt/2,4`
-- Added `crypto:crypto_one_time/5` on ESP32
+- Added `crypto:crypto_one_time/4,5` on ESP32
 
 ### Fixed
 

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -825,6 +825,39 @@ You can also use the legacy `erlang:md5/1` function to compute the MD5 hash of a
     %% erlang
     Hash = erlang:md5(<<foo>>).
 
+On ESP32, you can perform symetric encryption and decryption of any iodata data using
+`crypto_one_time/4,5` function.
+
+Following ciphers are supported:
+
+Without IV (using `crypto_one_time/4`):
+
+- `aes_128_ecb`
+- `aes_192_ecb`
+- `aes_256_ecb`
+
+With IV (using `crypto_one_time/5`):
+
+- `aes_128_cbc`
+- `aes_192_cbc`
+- `aes_256_cbc`
+- `aes_128_cfb128`
+- `aes_192_cfb128`
+- `aes_256_cfb128`
+- `aes_128_ctr`
+- `aes_192_ctr`
+- `aes_256_ctr`
+
+The function is implemented using [mbedTLS](https://github.com/Mbed-TLS/mbedtls), so please to its
+documentation for further details.
+
+Please refer to
+[Erlang crypto documentation](https://www.erlang.org/doc/man/crypto#crypto_one_time-4) for
+additional details about these two functions.
+
+> Note: mbedTLS doesn't support padding for ciphers other than CCB, so block size must be accounted
+> otherwise output will be truncated.
+
 ## ESP32-specific APIs
 
 Certain APIs are specific to and only supported on the ESP32 platform.  This section describes these APIs.

--- a/libs/estdlib/src/crypto.erl
+++ b/libs/estdlib/src/crypto.erl
@@ -26,6 +26,22 @@
 -type hash_algorithm() :: md5 | sha | sha224 | sha256 | sha384 | sha512.
 -type digest() :: binary().
 
+-type cipher_iv() ::
+    aes_128_cbc
+    | aes_192_cbc
+    | aes_256_cbc
+    | aes_128_cfb128
+    | aes_192_cfb128
+    | aes_256_cfb128
+    | aes_128_ctr
+    | aes_192_ctr
+    | aes_256_ctr.
+
+-type padding() :: none | pkcs_padding.
+
+-type crypto_opt() :: {encrypt, boolean()} | {padding, padding()}.
+-type crypto_opts() :: [crypto_opt()].
+
 %%-----------------------------------------------------------------------------
 %% @param   Type the hash algorithm
 %% @param   Data the data to hash
@@ -36,4 +52,25 @@
 %%-----------------------------------------------------------------------------
 -spec hash(Type :: hash_algorithm(), Data :: iolist()) -> digest().
 hash(_Type, _Data) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Cipher a supported cipher that makes use of IV
+%% @param   Key the encryption / decryption key
+%% @param   IV an initialization vector
+%% @param   Data to be crypted or encrypted
+%% @param   FlagOrOptions either just true for encryption (or false for decryption), or a proplist
+%%          for any additional option such as padding.
+%% @returns Returns crypted or encrypted data.
+%% @doc     Encrypted/decrypt data using given cipher, key, IV.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec crypto_one_time(
+    Cipher :: cipher_iv(),
+    Key :: iodata(),
+    IV :: iodata(),
+    Data :: iodata(),
+    FlagOrOptions :: crypto_opts()
+) -> binary().
+crypto_one_time(Cipher, Key, IV, Data, FlagOrOptions) ->
     erlang:nif_error(undefined).

--- a/libs/estdlib/src/crypto.erl
+++ b/libs/estdlib/src/crypto.erl
@@ -26,6 +26,11 @@
 -type hash_algorithm() :: md5 | sha | sha224 | sha256 | sha384 | sha512.
 -type digest() :: binary().
 
+-type cipher_no_iv() ::
+    aes_128_ecb
+    | aes_192_ecb
+    | aes_256_ecb.
+
 -type cipher_iv() ::
     aes_128_cbc
     | aes_192_cbc
@@ -52,6 +57,25 @@
 %%-----------------------------------------------------------------------------
 -spec hash(Type :: hash_algorithm(), Data :: iolist()) -> digest().
 hash(_Type, _Data) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Cipher a supported cipher
+%% @param   Key the encryption / decryption key
+%% @param   Data to be crypted or encrypted
+%% @param   FlagOrOptions either just true for encryption (or false for decryption), or a proplist
+%%          for any additional option
+%% @returns Returns crypted or encrypted data.
+%% @doc     Encrypted/decrypt data using given cipher and key
+%% @end
+%%-----------------------------------------------------------------------------
+-spec crypto_one_time(
+    Cipher :: cipher_no_iv(),
+    Key :: iodata(),
+    Data :: iodata(),
+    FlagOrOptions :: crypto_opts()
+) -> binary().
+crypto_one_time(Cipher, Key, Data, FlagOrOptions) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -131,6 +131,18 @@ static inline term interop_kv_get_value(term kv, AtomString key, GlobalContext *
     return interop_kv_get_value_default(kv, key, term_invalid_term(), glb);
 }
 
+static inline term interop_bytes_to_list(const void *bytes, int len, Heap *heap)
+{
+    const uint8_t *bytes_u8 = bytes;
+
+    term l = term_nil();
+    for (int i = len - 1; i >= 0; i--) {
+        l = term_list_prepend(term_from_int11(bytes_u8[i]), l, heap);
+    }
+
+    return l;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -36,6 +36,7 @@
 #include <esp_partition.h>
 #include <esp_sleep.h>
 #include <esp_system.h>
+#include <mbedtls/cipher.h>
 #include <mbedtls/md5.h>
 #include <mbedtls/sha1.h>
 #include <mbedtls/sha256.h>
@@ -628,6 +629,263 @@ static term nif_crypto_hash(Context *ctx, int argc, term argv[])
     return term_from_literal_binary(digest, digest_len, &ctx->heap, ctx->global);
 }
 
+static const AtomStringIntPair cipher_iv_table[] = {
+    { ATOM_STR("\xB", "aes_128_cbc"), MBEDTLS_CIPHER_AES_128_CBC },
+    { ATOM_STR("\xB", "aes_192_cbc"), MBEDTLS_CIPHER_AES_192_CBC },
+    { ATOM_STR("\xB", "aes_256_cbc"), MBEDTLS_CIPHER_AES_256_CBC },
+    { ATOM_STR("\xE", "aes_128_cfb128"), MBEDTLS_CIPHER_AES_128_CFB128 },
+    { ATOM_STR("\xE", "aes_192_cfb128"), MBEDTLS_CIPHER_AES_192_CFB128 },
+    { ATOM_STR("\xE", "aes_256_cfb128"), MBEDTLS_CIPHER_AES_256_CFB128 },
+    { ATOM_STR("\xB", "aes_128_ctr"), MBEDTLS_CIPHER_AES_128_CTR },
+    { ATOM_STR("\xB", "aes_192_ctr"), MBEDTLS_CIPHER_AES_192_CTR },
+    { ATOM_STR("\xB", "aes_256_ctr"), MBEDTLS_CIPHER_AES_256_CTR },
+    SELECT_INT_DEFAULT(MBEDTLS_CIPHER_NONE)
+};
+
+static const AtomStringIntPair padding_table[] = {
+    { ATOM_STR("\x4", "none"), MBEDTLS_PADDING_NONE },
+    { ATOM_STR("\xC", "pkcs_padding"), MBEDTLS_PADDING_PKCS7 },
+    SELECT_INT_DEFAULT(-1)
+};
+
+static term handle_iodata(term iodata, const void **data, size_t *len, void **allocated_ptr)
+{
+    *allocated_ptr = NULL;
+
+    if (term_is_binary(iodata)) {
+        *data = term_binary_data(iodata);
+        *len = term_binary_size(iodata);
+        return OK_ATOM;
+    } else if (term_is_list(iodata)) {
+        InteropFunctionResult result = interop_iolist_size(iodata, len);
+        switch (result) {
+            case InteropOk:
+                break;
+            case InteropMemoryAllocFail:
+                return OUT_OF_MEMORY_ATOM;
+            case InteropBadArg:
+                return BADARG_ATOM;
+        }
+        void *allocated_buf = malloc(*len);
+        if (IS_NULL_PTR(allocated_buf)) {
+            return OUT_OF_MEMORY_ATOM;
+        }
+        result = interop_write_iolist(iodata, allocated_buf);
+        switch (result) {
+            case InteropOk:
+                break;
+            case InteropMemoryAllocFail:
+                free(allocated_buf);
+                return OUT_OF_MEMORY_ATOM;
+            case InteropBadArg:
+                free(allocated_buf);
+                return BADARG_ATOM;
+        }
+        *data = allocated_buf;
+        *allocated_ptr = allocated_buf;
+        return OK_ATOM;
+    } else {
+        return BADARG_ATOM;
+    }
+}
+
+static bool bool_to_mbedtls_operation(term encrypt_flag, mbedtls_operation_t *operation)
+{
+    switch (encrypt_flag) {
+        case TRUE_ATOM:
+            *operation = MBEDTLS_ENCRYPT;
+            return true;
+        case FALSE_ATOM:
+            *operation = MBEDTLS_DECRYPT;
+            return true;
+        default:
+            return false;
+    }
+}
+
+static term make_crypto_error(const char *file, int line, const char *message, Context *ctx)
+{
+    int err_needed_mem = (strlen(file) * CONS_SIZE) + TUPLE_SIZE(2) + (strlen(message) * CONS_SIZE)
+        + TUPLE_SIZE(3);
+
+    if (UNLIKELY(memory_ensure_free(ctx, err_needed_mem) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    term file_t = interop_bytes_to_list(file, strlen(file), &ctx->heap);
+    term file_line_t = term_alloc_tuple(2, &ctx->heap);
+    term_put_tuple_element(file_line_t, 0, file_t);
+    term_put_tuple_element(file_line_t, 1, term_from_int(line));
+
+    term message_t = interop_bytes_to_list(message, strlen(message), &ctx->heap);
+
+    term err_t = term_alloc_tuple(3, &ctx->heap);
+    term_put_tuple_element(err_t, 0, BADARG_ATOM);
+    term_put_tuple_element(err_t, 1, file_line_t);
+    term_put_tuple_element(err_t, 2, message_t);
+
+    return err_t;
+}
+
+static term nif_crypto_crypto_one_time(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+
+    term cipher_term = argv[0];
+    mbedtls_cipher_type_t cipher
+        = interop_atom_term_select_int(cipher_iv_table, cipher_term, ctx->global);
+    if (UNLIKELY(cipher == MBEDTLS_CIPHER_NONE)) {
+        RAISE_ERROR(make_crypto_error(__FILE__, __LINE__, "Unknown cipher", ctx));
+    }
+
+    // from this point onward use `goto raise_error` in order to raise and free all buffers
+    term error_atom = UNDEFINED_ATOM;
+
+    void *allocated_key_data = NULL;
+    void *allocated_iv_data = NULL;
+    void *allocated_data_data = NULL;
+
+    term key = argv[1];
+    const void *key_data;
+    size_t key_len;
+    term result_t = handle_iodata(key, &key_data, &key_len, &allocated_key_data);
+    if (UNLIKELY(result_t != OK_ATOM)) {
+        error_atom = result_t;
+        goto raise_error;
+    }
+
+    term iv = argv[2];
+    const void *iv_data;
+    size_t iv_len;
+    result_t = handle_iodata(iv, &iv_data, &iv_len, &allocated_iv_data);
+    if (UNLIKELY(result_t != OK_ATOM)) {
+        error_atom = result_t;
+        goto raise_error;
+    }
+
+    term data = argv[3];
+    const void *data_data;
+    size_t data_size;
+    result_t = handle_iodata(data, &data_data, &data_size, &allocated_data_data);
+    if (UNLIKELY(result_t != OK_ATOM)) {
+        error_atom = result_t;
+        goto raise_error;
+    }
+
+    term flag_or_options = argv[4];
+    mbedtls_operation_t operation;
+    mbedtls_cipher_padding_t padding = MBEDTLS_PADDING_NONE;
+    bool padding_has_been_set = false;
+
+    if (term_is_list(flag_or_options)) {
+        term encrypt_flag = interop_kv_get_value_default(
+            flag_or_options, ATOM_STR("\x7", "encrypt"), UNDEFINED_ATOM, ctx->global);
+        if (UNLIKELY(!bool_to_mbedtls_operation(encrypt_flag, &operation))) {
+            error_atom = BADARG_ATOM;
+            goto raise_error;
+        }
+
+        term padding_term = interop_kv_get_value_default(
+            flag_or_options, ATOM_STR("\x7", "padding"), UNDEFINED_ATOM, ctx->global);
+
+        if (padding_term != UNDEFINED_ATOM) {
+            padding_has_been_set = true;
+
+            padding = interop_atom_term_select_int(padding_table, padding_term, ctx->global);
+            if (UNLIKELY(padding < 0)) {
+                error_atom = BADARG_ATOM;
+                goto raise_error;
+            }
+        }
+
+    } else {
+        if (UNLIKELY(!bool_to_mbedtls_operation(flag_or_options, &operation))) {
+            error_atom = BADARG_ATOM;
+            goto raise_error;
+        }
+    }
+
+    const mbedtls_cipher_info_t *cipher_info = mbedtls_cipher_info_from_type(cipher);
+
+    mbedtls_cipher_context_t cipher_ctx;
+
+    void *temp_buf = NULL;
+
+    int source_line;
+    int result = mbedtls_cipher_setup(&cipher_ctx, cipher_info);
+    if (UNLIKELY(result != 0)) {
+        source_line = __LINE__;
+        goto mbed_error;
+    }
+
+    result = mbedtls_cipher_setkey(&cipher_ctx, key_data, key_len * 8, operation);
+    if (UNLIKELY(result != 0)) {
+        source_line = __LINE__;
+        goto mbed_error;
+    }
+
+    // we know that mbedtls supports padding just for CBC, so it makes sense to change to OTP
+    // default (none) just for it. However in case a padding is set for other modes let mbedtls
+    // decide which error should be raised.
+    if (mbedtls_cipher_get_cipher_mode(&cipher_ctx) == MBEDTLS_MODE_CBC || padding_has_been_set) {
+        result = mbedtls_cipher_set_padding_mode(&cipher_ctx, padding);
+        if (UNLIKELY(result != 0)) {
+            source_line = __LINE__;
+            goto mbed_error;
+        }
+    }
+
+    unsigned int block_size = mbedtls_cipher_get_block_size(&cipher_ctx);
+
+    size_t temp_buf_size = data_size + block_size;
+    temp_buf = malloc(temp_buf_size);
+    if (IS_NULL_PTR(temp_buf)) {
+        error_atom = OUT_OF_MEMORY_ATOM;
+        goto raise_error;
+    }
+
+    // from this point onward use `mbed_error` in order to raise and free all buffers
+
+    result = mbedtls_cipher_crypt(
+        &cipher_ctx, iv_data, iv_len, data_data, data_size, temp_buf, &temp_buf_size);
+    if (result != 0 && result != MBEDTLS_ERR_CIPHER_FULL_BLOCK_EXPECTED) {
+        source_line = __LINE__;
+        goto mbed_error;
+    }
+    mbedtls_cipher_free(&cipher_ctx);
+
+    free(allocated_key_data);
+    free(allocated_iv_data);
+    free(allocated_data_data);
+
+    if (UNLIKELY(memory_ensure_free(ctx, temp_buf_size) != MEMORY_GC_OK)) {
+        free(temp_buf);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    term out = term_from_literal_binary(temp_buf, temp_buf_size, &ctx->heap, ctx->global);
+
+    free(temp_buf);
+
+    return out;
+
+raise_error:
+    free(allocated_key_data);
+    free(allocated_iv_data);
+    free(allocated_data_data);
+    RAISE_ERROR(error_atom);
+
+mbed_error:
+    free(temp_buf);
+    free(allocated_key_data);
+    free(allocated_iv_data);
+    free(allocated_data_data);
+
+    char err_msg[24];
+    snprintf(err_msg, sizeof(err_msg), "Error %x", -result);
+    RAISE_ERROR(make_crypto_error(__FILE__, source_line, err_msg, ctx));
+}
+
 static term nif_atomvm_platform(Context *ctx, int argc, term argv[])
 {
     UNUSED(ctx);
@@ -748,6 +1006,11 @@ static const struct Nif crypto_hash_nif =
     .base.type = NIFFunctionType,
     .nif_ptr = nif_crypto_hash
 };
+static const struct Nif crypto_crypto_one_time_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_crypto_crypto_one_time
+};
 static const struct Nif atomvm_platform_nif =
 {
     .base.type = NIFFunctionType,
@@ -828,6 +1091,10 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
     if (strcmp("crypto:hash/2", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &crypto_hash_nif;
+    }
+    if (strcmp("crypto:crypto_one_time/5", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &crypto_crypto_one_time_nif;
     }
     if (strcmp("atomvm:platform/0", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);

--- a/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
@@ -122,6 +122,10 @@ test_crypto_one_time() ->
         ]
     ),
 
+    <<218, 189, 18, 174, 31, 123, 37, 254, 119, 34, 71, 35, 219, 0, 185, 153>> = crypto:crypto_one_time(
+        aes_256_ecb, <<5, 1:240, 7>>, <<"Test1234567890ab">>, [{encrypt, true}]
+    ),
+
     {badarg, {File, Line}, Message} = get_error(fun() ->
         crypto:crypto_one_time(bad, <<1:128>>, <<0:128>>, <<"Test">>, true)
     end),

--- a/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
@@ -23,6 +23,7 @@
 
 start() ->
     ok = test_hash(),
+    ok = test_crypto_one_time(),
     ok.
 
 test_hash() ->
@@ -90,4 +91,89 @@ expect(Error, F) ->
                 _ when Error == E ->
                     ok
             end
+    end.
+
+test_crypto_one_time() ->
+    <<50, 136, 204, 108, 55>> = crypto:crypto_one_time(
+        aes_128_ctr,
+        <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>>,
+        <<1:120, 5:8>>,
+        <<"Hello">>,
+        true
+    ),
+
+    % No padding is used so output will be truncated
+    <<231, 108, 83, 104, 188, 131, 182, 65, 2, 128, 78, 162, 210, 149, 128, 248>> = crypto:crypto_one_time(
+        aes_128_cbc, <<1:128>>, <<0:128>>, <<"First bytesSecond bytes">>, true
+    ),
+
+    % Previous test, but with iolist
+    <<231, 108, 83, 104, 188, 131, 182, 65, 2, 128, 78, 162, 210, 149, 128, 248>> = crypto:crypto_one_time(
+        aes_128_cbc,
+        <<1:128>>,
+        <<0:128>>,
+        [<<"First ">>, $b, $y, <<"tes">>, [<<"Second ">>, <<"bytes">>]],
+        true
+    ),
+
+    <<117, 16, 152, 235, 154, 151, 58, 120, 64, 65, 33, 201, 242, 240, 41, 177>> = crypto:crypto_one_time(
+        aes_256_cbc, <<5, 1:240, 7>>, <<1:120, 7:8>>, <<"Test">>, [
+            {encrypt, true}, {padding, pkcs_padding}
+        ]
+    ),
+
+    {badarg, {File, Line}, Message} = get_error(fun() ->
+        crypto:crypto_one_time(bad, <<1:128>>, <<0:128>>, <<"Test">>, true)
+    end),
+    true = is_list(File),
+    true = is_integer(Line),
+    true = is_list(Message),
+
+    % Invalid key
+    {badarg, {File1, Line1}, Message1} = get_error(fun() ->
+        crypto:crypto_one_time(
+            aes_128_ctr,
+            <<>>,
+            <<1:120, 5:8>>,
+            <<"Hello">>,
+            true
+        )
+    end),
+    true = is_list(File1),
+    true = is_integer(Line1),
+    true = is_list(Message1),
+
+    % Invalid IV
+    {badarg, {File2, Line2}, Message2} = get_error(fun() ->
+        crypto:crypto_one_time(
+            aes_128_ctr,
+            <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>>,
+            <<5>>,
+            <<"Hello">>,
+            true
+        )
+    end),
+    true = is_list(File2),
+    true = is_integer(Line2),
+    true = is_list(Message2),
+
+    % Invalid opts
+    badarg = get_error(fun() ->
+        crypto:crypto_one_time(
+            aes_128_ctr,
+            <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>>,
+            <<1:120, 5:8>>,
+            <<"Hello">>,
+            {bad}
+        )
+    end),
+
+    ok.
+
+get_error(F) ->
+    try
+        F(),
+        fail
+    catch
+        _:E -> E
     end.


### PR DESCRIPTION
This PR introduce `crypto:crypto_one_time/4,5` for handling AES with ECB/CBC/CTR/CFB.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
