### PR TITLE
Improve nif and port support for stm32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for ULP wakeup on ESP32
 - Added heap growth strategies as a fine-tuning option to `spawn_opt/2,4`
 - Added `crypto:crypto_one_time/4,5` on ESP32
+- Improved nif and port support on STM32
 
 ### Fixed
 

--- a/src/platforms/stm32/src/lib/CMakeLists.txt
+++ b/src/platforms/stm32/src/lib/CMakeLists.txt
@@ -22,9 +22,11 @@ cmake_minimum_required (VERSION 3.13)
 project (libAtomVMPlatformSTM32)
 
 set(HEADER_FILES
+    avm_log.h
     gpiodriver.h
     platform_defaultatoms.h
-    avm_log.h
+    stm_sys.h
+    ../../../../libAtomVM/platform_nifs.h
     ../../../../libAtomVM/sys.h
 )
 
@@ -47,6 +49,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif()
 
 target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC libAtomVM)
+target_link_options(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC ${LINK_OPTIONS} -Wl,--whole-archive ${CMAKE_CURRENT_BINARY_DIR}/liblibAtomVMGeneric-arm.a -Wl,--no-whole-archive)
 
 target_include_directories(libAtomVM${PLATFORM_LIB_SUFFIX} SYSTEM PUBLIC ${OPENCM3_INCLUDE})
 target_link_directories(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC ${OPENCM3_LIB})

--- a/src/platforms/stm32/src/lib/platform_nifs.c
+++ b/src/platforms/stm32/src/lib/platform_nifs.c
@@ -18,14 +18,16 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
-#include "platform_nifs.h"
-#include "defaultatoms.h"
-#include "nifs.h"
-#include "platform_defaultatoms.h"
-#include "term.h"
+#include <defaultatoms.h>
+#include <nifs.h>
+#include <platform_nifs.h>
+#include <term.h>
 
 //#define ENABLE_TRACE
-#include "trace.h"
+#include <trace.h>
+
+#include "platform_defaultatoms.h"
+#include "stm_sys.h"
 
 static term nif_atomvm_platform(Context *ctx, int argc, term argv[])
 {
@@ -46,6 +48,10 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
     if (strcmp("atomvm:platform/0", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &atomvm_platform_nif;
+    }
+    const struct Nif *nif = nif_collection_resolve_nif(nifname);
+    if (nif) {
+        return nif;
     }
     return NULL;
 }

--- a/src/platforms/stm32/src/lib/stm_sys.h
+++ b/src/platforms/stm32/src/lib/stm_sys.h
@@ -1,0 +1,107 @@
+/* This file is part of AtomVM.
+ *
+ * Copyright 2023 Winford (Uncle Grumpy) <winford@object.stream>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _STM_SYS_H_
+#define _STM_SYS_H_
+
+#include <interop.h>
+#include <sys.h>
+
+#define REGISTER_PORT_DRIVER(NAME, INIT_CB, DESTROY_CB, CREATE_CB)    \
+    struct PortDriverDef NAME##_port_driver_def = {                   \
+        .port_driver_name = #NAME,                                    \
+        .port_driver_init_cb = INIT_CB,                               \
+        .port_driver_destroy_cb = DESTROY_CB,                         \
+        .port_driver_create_port_cb = CREATE_CB                       \
+    };                                                                \
+                                                                      \
+    struct PortDriverDefListItem NAME##_port_driver_def_list_item = { \
+        .def = &NAME##_port_driver_def                                \
+    };                                                                \
+                                                                      \
+    __attribute__((constructor)) void NAME##register_port_driver()    \
+    {                                                                 \
+        NAME##_port_driver_def_list_item.next = port_driver_list;     \
+        port_driver_list = &NAME##_port_driver_def_list_item;         \
+    }
+
+#define REGISTER_NIF_COLLECTION(NAME, INIT_CB, DESTROY_CB, RESOLVE_NIF_CB)  \
+    struct NifCollectionDef NAME##_nif_collection_def = {                   \
+        .nif_collection_init_cb = INIT_CB,                                  \
+        .nif_collection_destroy_cb = DESTROY_CB,                            \
+        .nif_collection_resove_nif_cb = RESOLVE_NIF_CB                      \
+    };                                                                      \
+                                                                            \
+    struct NifCollectionDefListItem NAME##_nif_collection_def_list_item = { \
+        .def = &NAME##_nif_collection_def                                   \
+    };                                                                      \
+                                                                            \
+    __attribute__((constructor)) void NAME##register_nif_collection()       \
+    {                                                                       \
+        NAME##_nif_collection_def_list_item.next = nif_collection_list;     \
+        nif_collection_list = &NAME##_nif_collection_def_list_item;         \
+    }
+
+typedef void (*port_driver_init_t)(GlobalContext *global);
+typedef void (*port_driver_destroy_t)(GlobalContext *global);
+typedef Context *(*port_driver_create_port_t)(GlobalContext *global, term opts);
+
+struct PortDriverDef
+{
+    const char *port_driver_name;
+    const port_driver_init_t port_driver_init_cb;
+    const port_driver_destroy_t port_driver_destroy_cb;
+    const port_driver_create_port_t port_driver_create_port_cb;
+};
+
+struct PortDriverDefListItem
+{
+    struct PortDriverDefListItem *next;
+    const struct PortDriverDef *const def;
+};
+
+typedef void (*nif_collection_init_t)(GlobalContext *global);
+typedef void (*nif_collection_destroy_t)(GlobalContext *global);
+typedef const struct Nif *(*nif_collection_resolve_nif_t)(const char *name);
+
+struct NifCollectionDef
+{
+    const nif_collection_init_t nif_collection_init_cb;
+    const nif_collection_destroy_t nif_collection_destroy_cb;
+    const nif_collection_resolve_nif_t nif_collection_resove_nif_cb;
+};
+
+struct NifCollectionDefListItem
+{
+    struct NifCollectionDefListItem *next;
+    const struct NifCollectionDef *const def;
+};
+
+extern struct PortDriverDefListItem *port_driver_list;
+extern struct NifCollectionDefListItem *nif_collection_list;
+
+static Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts);
+void port_driver_init_all(GlobalContext *global);
+void port_driver_destroy_all(GlobalContext *global);
+
+const struct Nif *nif_collection_resolve_nif(const char *name);
+void nif_collection_init_all(GlobalContext *global);
+void nif_collection_destroy_all(GlobalContext *global);
+
+#endif /* _STM_SYS_H_ */

--- a/src/platforms/stm32/src/main.c
+++ b/src/platforms/stm32/src/main.c
@@ -36,6 +36,7 @@
 #include <version.h>
 
 #include "lib/avm_log.h"
+#include "lib/stm_sys.h"
 
 #define USART_CONSOLE USART2
 #define AVM_ADDRESS (0x8080000)
@@ -143,6 +144,8 @@ int main()
     AVM_LOGD(TAG, "Maximum application size: %lu", size);
 
     GlobalContext *glb = globalcontext_new();
+    port_driver_init_all(glb);
+    nif_collection_init_all(glb);
 
     if (!avmpack_is_valid(flashed_avm, size) || !avmpack_find_section_by_flag(flashed_avm, BEAM_START_FLAG, &startup_beam, &startup_beam_size, &startup_module_name)) {
         AVM_LOGE(TAG, "Invalid AVM Pack");


### PR DESCRIPTION
Adds support for `REGISTER_PORT_DRIVER` and `REGISTER_NIF_COLLECTION` macros to stm32 platform.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
