### PR TITLE
Fix publish-docs.yaml

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -94,11 +94,6 @@ jobs:
         shell: bash
         run: |
           . /home/runner/python-env/sphinx/bin/activate
-          if [ ${GITHUB_REPOSITORY} == 'atomvm/AtomVM' ]; then {
-            for remote in `git tag -l | grep -v "/HEAD\|${{ github.ref_name }}"`; do git checkout --track $remote; done
-            git checkout ${{ github.ref_name }}
-          };
-          fi
           mkdir build
           cd build
           cmake ..


### PR DESCRIPTION
There was an unnecessary step left in the build process from the branch based documentation builds that casued a build failure when run in the AtomVM repo CI workflow.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
