### PR TITLE
Fix bug in bs_create_bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `monotonic_time/1` and `system_time/1` functions for Raspberry Pi Pico
 - Fixed race conditions in atoms table.
 - Fixed a bug in the STM32 port that caused the final result to never be returned.
+- Fix bug when building a binary using a 64-bit integer on a 32-bit CPU.
 
 ## [0.6.0-alpha.0] - 2023-08-13
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -6720,7 +6720,7 @@ wait_timeout_trap_handler:
                         DECODE_COMPACT_TERM(size, code, i, list_off);
                         size_t segment_size;
                         avm_int_t flags_value = 0;
-                        avm_int_t src_value = 0;
+                        avm_int64_t src_value = 0;
                         size_t size_value = 0;
                         switch (atom_type) {
                             case UTF16_ATOM:

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -482,6 +482,8 @@ compile_erlang(test_close_avm_pack)
 compile_erlang(test_min_max_guard)
 compile_erlang(test_module_info)
 
+compile_erlang(int64_build_binary)
+
 add_custom_target(erlang_test_modules DEPENDS
     code_load_files
 
@@ -927,4 +929,6 @@ add_custom_target(erlang_test_modules DEPENDS
 
     test_min_max_guard.beam
     test_module_info.beam
+
+    int64_build_binary.beam
 )

--- a/tests/erlang_tests/int64_build_binary.erl
+++ b/tests/erlang_tests/int64_build_binary.erl
@@ -1,0 +1,37 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(int64_build_binary).
+-export([start/0, build/1]).
+
+start() ->
+    Bin = make_map(3940753902, 3186666752, 7),
+    sum_all(binary_to_list(Bin), 1, 0) - 8559.
+
+sum_all([], _N, Acc) ->
+    Acc;
+sum_all([H | T], N, Acc) ->
+    sum_all(T, N + 1, Acc + N * H).
+
+make_map(A, B, C) ->
+    ?MODULE:build(#{a64 => A, b32 => B, c => C, d => 0}).
+
+build(#{a64 := A64, b32 := B32}) ->
+    <<A64:64/little-unsigned, B32:32/little-unsigned, 0:32>>.

--- a/tests/test.c
+++ b/tests/test.c
@@ -512,6 +512,8 @@ struct Test tests[] = {
 
     TEST_CASE(test_min_max_guard),
 
+    TEST_CASE(int64_build_binary),
+
     // TEST CRASHES HERE: TEST_CASE(memlimit),
 
     { NULL, 0, false, false }


### PR DESCRIPTION
Just replace `avm_int_t` with `avm_int64_t` which is always a 64-bit integer.

Fixes #827 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
