### PR TITLE
Add `gpio:set_int/4` for ESP32 and STM32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `esp:get_default_mac/0` for retrieving the default MAC address on ESP32.
 - Added support for `pico` and `poci` as an alternative to `mosi` and `miso` for SPI
 - ESP32: Added support to SPI peripherals other than hspi and vspi
+- Added `gpio:set_int/4`, with the 4th parameter being the pid() or registered name of the process to receive interrupt messages
 
 ### Changed
 

--- a/libs/eavmlib/src/gpio.erl
+++ b/libs/eavmlib/src/gpio.erl
@@ -36,7 +36,7 @@
     read/2,
     set_direction/3,
     set_level/3,
-    set_int/3,
+    set_int/3, set_int/4,
     remove_int/2,
     stop/0,
     close/1
@@ -250,6 +250,31 @@ set_level(GPIO, Pin, Level) ->
     ok | {error, Reason :: atom()} | error.
 set_int(GPIO, Pin, Trigger) ->
     port:call(GPIO, {set_int, Pin, Trigger}).
+
+%%-----------------------------------------------------------------------------
+%% @param   GPIO pid that was returned from `gpio:start/0'
+%% @param   Pin number of the pin to set the interrupt on
+%% @param   Trigger is the state that will trigger an interrupt
+%% @param   Pid is the process that will receive the interrupt message
+%% @returns ok | error | {error, Reason}
+%% @doc     Set a GPIO interrupt
+%%
+%%          Available triggers are `none' (which is the same as disabling an
+%%          interrupt), `rising', `falling', `both' (rising or falling), `low', and
+%%          `high'. When the interrupt is triggered it will send a tuple:
+%%            `{gpio_interrupt, Pin}'
+%%          to the process that set the interrupt. Pin will be the number
+%%          of the pin that triggered the interrupt.
+%%
+%%          The STM32 port only supports `rising', `falling', or `both'.
+%%
+%%          The rp2040 (Pico) port does not support gpio interrupts at this time.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec set_int(GPIO :: gpio(), Pin :: pin(), Trigger :: trigger(), Pid :: pid()) ->
+    ok | {error, Reason :: atom()} | error.
+set_int(GPIO, Pin, Trigger, Pid) ->
+    port:call(GPIO, {set_int, Pin, Trigger, Pid}).
 
 %%-----------------------------------------------------------------------------
 %% @param   GPIO pid that was returned from `gpio:start/0'


### PR DESCRIPTION
Allows setting the `pid()` or registered name of the process to receive `gpio_interrupt` messages as the fourth parameter of `gpio:set_int/4`, with both ESP32 and STM32 GPIO port drivers.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
