### PR TITLE
Remove check for lib.avm in esp32 main

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -14,3 +14,6 @@
 binaries need to be rebuilt with the proper offset using `uf2tool`.
 - On ESP32, SSID and PSK stored in NVS are no longer read by network module. Applications
 must fetch the values and pass them to `network:start/1` or `network:start_link/1`.
+- The `lib.avm` partition is no longer supported on ESP32.  If you have been using a
+spacialized partitioning of your ESP32 flash (uncommon), AtomVM will no longer try to load
+code off this partition name.

--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -99,20 +99,6 @@ void app_main()
     avmpack_data->base.data = startup_avm;
     synclist_append(&glb->avmpack_data, &avmpack_data->base.avmpack_head);
 
-    const void *lib_avm = esp32_sys_mmap_partition("lib.avm", &handle, &size);
-    if (!IS_NULL_PTR(lib_avm) && avmpack_is_valid(lib_avm, size)) {
-        avmpack_data = malloc(sizeof(struct ConstAVMPack));
-        if (IS_NULL_PTR(avmpack_data)) {
-            ESP_LOGE(TAG, "Memory error: Cannot allocate AVMPackData for lib.avm.");
-            AVM_ABORT();
-        }
-        avmpack_data_init(&avmpack_data->base, &const_avm_pack_info);
-        avmpack_data->base.data = lib_avm;
-        synclist_append(&glb->avmpack_data, &avmpack_data->base.avmpack_head);
-    } else {
-        ESP_LOGI(TAG, "Unable to mount lib.avm partition. Hopefully the AtomVM core libraries are included in your application.");
-    }
-
     Module *mod = module_new_from_iff_binary(glb, startup_beam, startup_beam_size);
     if (IS_NULL_PTR(mod)) {
         ESP_LOGE(TAG, "Error!  Unable to load startup module %s", startup_module_name);


### PR DESCRIPTION

This PR removes the check for the `lib.avm` partition on the ESP32.  The `lib.avm` partition no longer exists, so there is no need for this check.  Moreover, without this fix, potentially misleading information is printed to the console, e.g.,

```
W (894) sys: AVM partition not found for lib.avm
I (894) AtomVM: Unable to mount lib.avm partition. Hopefully the AtomVM core libraries are included in your application.
```

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
