### PR TITLE
Add `-h` and `-v` flags to generic_unix AtomVM command

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -124,3 +124,5 @@ jobs:
         export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
         sudo ninja install
         atomvm examples/erlang/hello_world.avm
+        atomvm -v
+        atomvm -h

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -298,3 +298,5 @@ jobs:
       run: |
         sudo PATH=${PATH} make install
         atomvm examples/erlang/hello_world.avm
+        atomvm -v
+        atomvm -h

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved nif and port support on STM32
 - Added support for `atomvm:posix_clock_settime/2`
 - Added support for creations of binaries with unaligned strings
+- Added `-h` and `-v` flags to generic_unix AtomVM command
 
 ### Fixed
 

--- a/doc/src/getting-started-guide.md
+++ b/doc/src/getting-started-guide.md
@@ -318,9 +318,33 @@ standard libraries (`atomvmlib.uf2`).
 
 AtomVM may be run on UNIX-like platforms using the `atomvm` command.
 
-You may specify one or more AVM files on the command line when running the `atom` command.  BEAM modules defined in earlier AVM modules on the command line take higher precedence that BEAM modules included in AVM files later in the argument list.
+You may specify one or more AVM files on the command line when running the `atomvm` command.  BEAM modules defined in earlier AVM modules on the command line take higher precedence that BEAM modules included in AVM files later in the argument list.
 
     shell$ atomvm /path/to/myapp.avm
+
+To get the current version of AtomVM, use the `-v` option, e.g.:
+
+    shell$ atomvm -v
+    0.6.1
+
+Use the `-h` option to get command line help:
+
+    shell$ atomvm -h
+
+    Syntax:
+
+        /usr/local/lib/atomvm/AtomVM [-h] [-v] <path-to-avm-file>+
+
+    Options:
+
+        -h         Print this help and exit.
+        -v         Print the AtomVM version and exit.
+
+    Supply one or more AtomVM packbeam (.avm) files to start your application.
+
+    Example:
+
+        $ /usr/local/lib/atomvm/AtomVM /path/to/my/application.avm /path/to/atomvmlib.avm
 
 Currently, the `atomvm` command and libraries must be built and installed from source.
 

--- a/src/platforms/generic_unix/atomvm
+++ b/src/platforms/generic_unix/atomvm
@@ -25,9 +25,7 @@ avm_lib="${avm_root}/lib"
 nargs=$#
 if [ "${nargs}" -eq "0" ]
 then
-    echo "%%"
-    echo "%% Error!  Syntax: ${0} [<avm-file>]+"
-    echo "%%"
+    "${avm_lib}/atomvm/AtomVM" -h
     exit 1
 fi
 

--- a/src/platforms/generic_unix/main.c
+++ b/src/platforms/generic_unix/main.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "atom.h"
 #include "avmpack.h"
@@ -37,11 +38,51 @@
 #include "sys.h"
 #include "term.h"
 #include "utils.h"
+#include "version.h"
+
+void print_help(const char *program_name)
+{
+    printf(
+        "\n"
+        "Syntax:\n"
+        "\n"
+        "    %s [-h] [-v] <path-to-avm-file>+\n"
+        "\n"
+        "Options:\n"
+        "\n"
+        "    -h         Print this help and exit.\n"
+        "    -v         Print the AtomVM version and exit.\n"
+        "\n"
+        "Supply one or more AtomVM packbeam (.avm) files to start your application.\n"
+        "\n"
+        "Example:\n"
+        "\n"
+        "    $ %s /path/to/my/application.avm /path/to/atomvmlib.avm\n"
+        "\n",
+        program_name, program_name);
+}
 
 int main(int argc, char **argv)
 {
+    int c;
+    while ((c = getopt(argc, argv, "hv")) != -1) {
+        switch (c) {
+            case 'h':
+                print_help(argv[0]);
+                return EXIT_SUCCESS;
+
+            case 'v':
+                printf(ATOMVM_VERSION "\n");
+                return EXIT_SUCCESS;
+
+            default:
+                break;
+        }
+    }
+
     if (argc < 2) {
-        printf("Need .beam or .avm files\n");
+        printf("Syntax Error!  Missing .beam or .avm files.\n");
+        print_help(argv[0]);
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
This PR adds help and version support for the AtomVM command on the generic unix platform.

This PR addresses Issue #842 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
