### PR TITLE
Remove duplicated dependencies in pico examples

### DIFF
--- a/examples/erlang/rp2040/CMakeLists.txt
+++ b/examples/erlang/rp2040/CMakeLists.txt
@@ -22,7 +22,7 @@ project(examples_erlang_rp2040)
 
 include(BuildErlang)
 
-pack_uf2(hello_pico hello_pico eavmlib estdlib)
-pack_uf2(pico_blink pico_blink eavmlib estdlib)
-pack_uf2(pico_rtc pico_rtc eavmlib estdlib)
-pack_uf2(picow_blink picow_blink eavmlib estdlib)
+pack_uf2(hello_pico hello_pico)
+pack_uf2(pico_blink pico_blink)
+pack_uf2(pico_rtc pico_rtc)
+pack_uf2(picow_blink picow_blink)


### PR DESCRIPTION
The modules are already included in atomvmlib.uf2

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
