### PR TITLE
Fix pico-build workflow

### DIFF
--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -66,7 +66,7 @@ jobs:
       shell: bash
       working-directory: ./src/platforms/rp2040/tests
       # Unfortunately, rp2040js doesn't support cyw43 and cyw43_arch_init panics
-      if: success() && matrix.board != "pico_w"
+      if: ${{ success() && matrix.board != 'pico_w' }}
       run: |
         set -euo pipefail
         source $HOME/.nvm/nvm.sh


### PR DESCRIPTION
Use ${{ ... }} for expressions and single quotes.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
