### PR TITLE
CI: avoid running all workflows for just one changed

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -9,7 +9,7 @@ name: ESP32 Builds
 on:
   push:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/esp32-build.yaml'
       - 'CMakeLists.txt'
       - 'libs/**'
       - 'src/platforms/esp32/**'
@@ -17,7 +17,7 @@ on:
       - 'tools/packbeam/**'
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/esp32-build.yaml'
       - 'src/platforms/esp32/**'
       - 'src/libAtomVM/**'
 

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -9,7 +9,7 @@ name: esp32-mkimage
 on:
   push:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/esp32-mkimage.yaml'
       - 'CMakeLists.txt'
       - 'libs/**'
       - 'src/platforms/esp32/**'
@@ -19,7 +19,7 @@ on:
       - '*'
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/esp32-mkimage.yaml'
       - 'src/platforms/esp32/**'
       - 'src/libAtomVM/**'
 

--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -9,7 +9,7 @@ name: Pico Build
 on:
   push:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/pico-build.yaml'
       - 'CMakeLists.txt'
       - 'libs/**'
       - 'src/platforms/rp2040/**'
@@ -18,7 +18,7 @@ on:
       - '*'
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/pico-build.yaml'
       - 'CMakeLists.txt'
       - 'libs/**'
       - 'src/platforms/rp2040/**'

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -17,7 +17,7 @@ on:
     branches:
       - 'master'
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/publish-docs.yaml'
       - 'CMakeLists.txt'
       - 'doc/**'
       - 'libs/**'

--- a/.github/workflows/stm32-build.yaml
+++ b/.github/workflows/stm32-build.yaml
@@ -9,13 +9,13 @@ name: STM32 Build
 on:
   push:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/stm32-build.yaml'
       - 'CMakeLists.txt'
       - 'src/platforms/stm32/**'
       - 'src/libAtomVM/**'
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/stm32-build.yaml'
       - 'CMakeLists.txt'
       - 'src/platforms/stm32/**'
       - 'src/libAtomVM/**'

--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -9,7 +9,7 @@ name: Wasm Build
 on:
   push:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/wasm-build.yaml'
       - 'CMakeLists.txt'
       - 'libs/**'
       - 'src/platforms/emscripten/**'
@@ -18,7 +18,7 @@ on:
       - '*'
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/wasm-build.yaml'
       - 'CMakeLists.txt'
       - 'libs/**'
       - 'src/platforms/emscripten/**'


### PR DESCRIPTION
There is no need to run esp32-mkimage when pico-build.yaml is changed and so on.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
