### PR TITLE
ESP32: fix SPI on all other ESP32 models, such as ESP32S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed race conditions in atoms table.
 - Fixed a bug in the STM32 port that caused the final result to never be returned.
 - Fix bug when building a binary using a 64-bit integer on a 32-bit CPU.
+- Fix (using 'auto' option)  SPI on ESP32 models other than ESP32, such as ESP32S2, ESP32C3, ...
 
 ## [0.6.0-alpha.0] - 2023-08-13
 

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -196,7 +196,12 @@ Context *spi_driver_create_port(GlobalContext *global, term opts)
 
     debug_buscfg(&buscfg);
 
-    esp_err_t err = spi_bus_initialize(host_device, &buscfg, 1);
+    // TODO: workaround until a proper semantic is investigated
+    #ifdef CONFIG_IDF_TARGET_ESP32
+        esp_err_t err = spi_bus_initialize(host_device, &buscfg, 1);
+    #else
+        esp_err_t err = spi_bus_initialize(host_device, &buscfg, SPI_DMA_CH_AUTO);
+    #endif
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "SPI Bus initialization failed with error=%i", err);
         context_destroy(ctx);


### PR DESCRIPTION
Use SPI_DMA_CH_AUTO instead of 1 if model != ESP32. This might be a temporary workaround and a proper fix should be investigated.

Fixes #831 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
