### PR TITLE
ESP32 init: fix devmode

### DIFF
--- a/libs/esp32boot/esp32init.erl
+++ b/libs/esp32boot/esp32init.erl
@@ -35,7 +35,9 @@ is_dev_mode_enabled(SystemStatus) ->
         {ok, undefined} ->
             false;
         {app_exit, undefined} ->
-            false
+            false;
+        {app_fail, undefined} ->
+            true
     end.
 
 maybe_start_dev_mode(SystemStatus) ->


### PR DESCRIPTION
Fix handling of application loading failure.

It was failing due to a missing case clause for `{app_fail,_}`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
