### PR TITLE
Fix memory leak in esp32 network driver

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -456,6 +456,7 @@ static wifi_config_t *get_ap_wifi_config(term ap_config, GlobalContext *global)
         int ok = 0;
         psk = interop_term_to_string(pass_term, &ok);
         if (strlen(psk) < 8) {
+            free(ssid);
             ESP_LOGE(TAG, "get_ap_wifi_config: AP PSK must be length 8 or more");
             return NULL;
         }


### PR DESCRIPTION
Fix a leak that only happened when provided PSK was too short.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
