### PR TITLE
Add DHCP server to Pico-W in AP mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for creations of binaries with unaligned strings
 - Added `-h` and `-v` flags to generic_unix AtomVM command
 - Removed support to ESP32 NVS from network module in order to make it generic. See also [UPDATING.md].
-- Added initial support for Pico-W: on-board LED, connection to wifi network.
+- Added initial support for Pico-W: on-board LED, Wifi (STA and AP modes).
 
 ### Changed
+
 - Changed offset of atomvmlib and of program on Pico. See also [UPDATING.md].
 
 ### Fixed

--- a/src/platforms/rp2040/src/lib/CMakeLists.txt
+++ b/src/platforms/rp2040/src/lib/CMakeLists.txt
@@ -66,7 +66,17 @@ if (NOT AVM_USE_32BIT_FLOAT)
 endif()
 
 if (PICO_CYW43_SUPPORTED)
-    target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC pico_cyw43_arch_lwip_threadsafe_background)
+    set(BTSTACK_ROOT ${PICO_SDK_PATH}/lib/btstack)
+    set(BTSTACK_3RD_PARTY_PATH ${BTSTACK_ROOT}/3rd-party)
+
+    add_library(pan_lwip_dhserver INTERFACE)
+    target_sources(pan_lwip_dhserver INTERFACE
+        ${BTSTACK_3RD_PARTY_PATH}/lwip/dhcp-server/dhserver.c
+    )
+    target_include_directories(pan_lwip_dhserver INTERFACE
+        ${BTSTACK_3RD_PARTY_PATH}/lwip/dhcp-server
+    )
+    target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC pico_cyw43_arch_lwip_threadsafe_background INTERFACE pan_lwip_dhserver)
     target_link_options(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC "SHELL:-Wl,-u -Wl,networkregister_port_driver")
 endif()
 


### PR DESCRIPTION
Use a DHCP server that is bundled with Pico SDK (btstack)
The DHCP server unfortunatley has no callback so we cannot implement the network driver callback yet.

There still is no DNS server and no router.

Also fix a bug where the default SSID name was atomvm-000000000000 because the MAC address wasn't set. Workaround consists in always enabling STA mode.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
