### PR TITLE
Update to esp-idf 4.4.6 in mkimage

### DIFF
--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -37,7 +37,7 @@ jobs:
 
     strategy:
       matrix:
-        idf-version: ["4.4.3"]
+        idf-version: ["4.4.6"]
         cc: ["clang-10"]
         cxx: ["clang++-10"]
         cflags: ["-O3"]


### PR DESCRIPTION
Matching CI version in #871. Previously the CI/mkimage versions were out of sync.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
