### PR TITLE
Add a timeout to the freebsd CI, to prevent runaway jobs

### DIFF
--- a/.github/workflows/build-and-test-on-freebsd.yaml
+++ b/.github/workflows/build-and-test-on-freebsd.yaml
@@ -41,6 +41,7 @@ jobs:
     - name: Build and Test on FreeBSD
       id: build-and-test-on-freebsd
       uses: vmactions/freebsd-vm@v0
+      timeout-minutes: 20
       with:
         envs: 'ATOMVM_EXAMPLE'
         usesh: true


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
