### PR TITLE
Fix typo in function name `nif_collection_resove_nif_cb`

### DIFF
--- a/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
+++ b/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
@@ -21,17 +21,17 @@
 #ifndef _ESP32_SYS_H_
 #define _ESP32_SYS_H_
 
+#include "esp_pthread.h"
 #include "freertos/FreeRTOS.h"
 #include <esp_partition.h>
 #include <freertos/queue.h>
-#include "esp_pthread.h"
 
 #if ESP_IDF_VERSION_MAJOR >= 5
 #include <spi_flash_mmap.h>
 #endif
 
-#include <time.h>
 #include <sys/poll.h>
+#include <time.h>
 
 #include "sys.h"
 
@@ -57,7 +57,7 @@
     struct NifCollectionDef NAME##_nif_collection_def = {                   \
         .nif_collection_init_cb = INIT_CB,                                  \
         .nif_collection_destroy_cb = DESTROY_CB,                            \
-        .nif_collection_resove_nif_cb = RESOLVE_NIF_CB                      \
+        .nif_collection_resolve_nif_cb = RESOLVE_NIF_CB                     \
     };                                                                      \
                                                                             \
     struct NifCollectionDefListItem NAME##_nif_collection_def_list_item = { \
@@ -122,7 +122,7 @@ struct NifCollectionDef
 {
     const nif_collection_init_t nif_collection_init_cb;
     const nif_collection_destroy_t nif_collection_destroy_cb;
-    const nif_collection_resolve_nif_t nif_collection_resove_nif_cb;
+    const nif_collection_resolve_nif_t nif_collection_resolve_nif_cb;
 };
 
 struct NifCollectionDefListItem

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -550,7 +550,7 @@ void nif_collection_destroy_all(GlobalContext *global)
 const struct Nif *nif_collection_resolve_nif(const char *name)
 {
     for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
-        const struct Nif *res = item->def->nif_collection_resove_nif_cb(name);
+        const struct Nif *res = item->def->nif_collection_resolve_nif_cb(name);
         if (res) {
             return res;
         }

--- a/src/platforms/rp2040/src/lib/rp2040_sys.h
+++ b/src/platforms/rp2040/src/lib/rp2040_sys.h
@@ -52,7 +52,7 @@
     struct NifCollectionDef NAME##_nif_collection_def = {                   \
         .nif_collection_init_cb = INIT_CB,                                  \
         .nif_collection_destroy_cb = DESTROY_CB,                            \
-        .nif_collection_resove_nif_cb = RESOLVE_NIF_CB                      \
+        .nif_collection_resolve_nif_cb = RESOLVE_NIF_CB                     \
     };                                                                      \
                                                                             \
     struct NifCollectionDefListItem NAME##_nif_collection_def_list_item = { \
@@ -97,7 +97,7 @@ struct NifCollectionDef
 {
     const nif_collection_init_t nif_collection_init_cb;
     const nif_collection_destroy_t nif_collection_destroy_cb;
-    const nif_collection_resolve_nif_t nif_collection_resove_nif_cb;
+    const nif_collection_resolve_nif_t nif_collection_resolve_nif_cb;
 };
 
 struct NifCollectionDefListItem

--- a/src/platforms/rp2040/src/lib/sys.c
+++ b/src/platforms/rp2040/src/lib/sys.c
@@ -239,7 +239,7 @@ void nif_collection_destroy_all(GlobalContext *global)
 const struct Nif *nif_collection_resolve_nif(const char *name)
 {
     for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
-        const struct Nif *res = item->def->nif_collection_resove_nif_cb(name);
+        const struct Nif *res = item->def->nif_collection_resolve_nif_cb(name);
         if (res) {
             return res;
         }

--- a/src/platforms/stm32/src/lib/stm_sys.h
+++ b/src/platforms/stm32/src/lib/stm_sys.h
@@ -45,7 +45,7 @@
     struct NifCollectionDef NAME##_nif_collection_def = {                   \
         .nif_collection_init_cb = INIT_CB,                                  \
         .nif_collection_destroy_cb = DESTROY_CB,                            \
-        .nif_collection_resove_nif_cb = RESOLVE_NIF_CB                      \
+        .nif_collection_resolve_nif_cb = RESOLVE_NIF_CB                     \
     };                                                                      \
                                                                             \
     struct NifCollectionDefListItem NAME##_nif_collection_def_list_item = { \
@@ -84,7 +84,7 @@ struct NifCollectionDef
 {
     const nif_collection_init_t nif_collection_init_cb;
     const nif_collection_destroy_t nif_collection_destroy_cb;
-    const nif_collection_resolve_nif_t nif_collection_resove_nif_cb;
+    const nif_collection_resolve_nif_t nif_collection_resolve_nif_cb;
 };
 
 struct NifCollectionDefListItem

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -217,7 +217,7 @@ void nif_collection_destroy_all(GlobalContext *global)
 const struct Nif *nif_collection_resolve_nif(const char *name)
 {
     for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
-        const struct Nif *res = item->def->nif_collection_resove_nif_cb(name);
+        const struct Nif *res = item->def->nif_collection_resolve_nif_cb(name);
         if (res) {
             return res;
         }


### PR DESCRIPTION
This fixes the typo resove -> resolve across all platforms.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
