### PR TITLE
Fix implementation of smp_atomic_compare_exchange_weak on Pico

### DIFF
--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -62,17 +62,25 @@ jobs:
         source $HOME/.nvm/nvm.sh
         nvm install 20
 
+    - name: Build tests (without SMP)
+      shell: bash
+      working-directory: ./src/platforms/rp2040/
+      run: |
+        set -euo pipefail
+        mkdir build.nosmp
+        cd build.nosmp
+        cmake .. -G Ninja -DPICO_BOARD=${{ matrix.board }} -DAVM_DISABLE_SMP=1
+        cmake --build . --target=rp2040_tests
+
     - name: Run tests with rp2040js
       shell: bash
       working-directory: ./src/platforms/rp2040/tests
-      # Unfortunately, rp2040js doesn't support cyw43 and cyw43_arch_init panics
-      if: ${{ success() && matrix.board != 'pico_w' }}
       run: |
         set -euo pipefail
         source $HOME/.nvm/nvm.sh
         nvm use node
         npm install
-        npx tsx run-tests.ts ../build/tests/rp2040_tests.uf2 ../build/tests/test_erl_sources/rp2040_test_modules.uf2
+        npx tsx run-tests.ts ../build.nosmp/tests/rp2040_tests.uf2 ../build.nosmp/tests/test_erl_sources/rp2040_test_modules.uf2
 
     - name: Build atomvmlib.uf2
       if: startsWith(github.ref, 'refs/tags/')

--- a/src/platforms/rp2040/src/lib/rp2040_sys.h
+++ b/src/platforms/rp2040/src/lib/rp2040_sys.h
@@ -67,8 +67,10 @@
 
 struct RP2040PlatformData
 {
+#ifndef AVM_NO_SMP
     mutex_t event_poll_mutex;
     cond_t event_poll_cond;
+#endif
 };
 
 typedef void (*port_driver_init_t)(GlobalContext *global);

--- a/src/platforms/rp2040/src/lib/sys.c
+++ b/src/platforms/rp2040/src/lib/sys.c
@@ -52,8 +52,11 @@ void sys_init_platform(GlobalContext *glb)
 {
     struct RP2040PlatformData *platform = malloc(sizeof(struct RP2040PlatformData));
     glb->platform_data = platform;
+#ifndef AVM_NO_SMP
     mutex_init(&platform->event_poll_mutex);
     cond_init(&platform->event_poll_cond);
+    smp_init();
+#endif
 
 #ifdef LIB_PICO_CYW43_ARCH
     cyw43_arch_init();
@@ -68,6 +71,10 @@ void sys_free_platform(GlobalContext *glb)
 
     struct RP2040PlatformData *platform = glb->platform_data;
     free(platform);
+
+#ifndef AVM_NO_SMP
+    smp_free();
+#endif
 }
 
 #ifndef AVM_NO_SMP

--- a/src/platforms/rp2040/tests/package-lock.json
+++ b/src/platforms/rp2040/tests/package-lock.json
@@ -7,7 +7,7 @@
       "name": "rp2040_tests",
       "dependencies": {
         "@tsconfig/node20": "^20.1.2",
-        "rp2040js": "github:mingpepe/rp2040js#core1",
+        "rp2040js": "^0.19.1",
         "sync-fetch": "^0.5.2",
         "tsx": "^3.12.8",
         "typescript": "^5.2.2",
@@ -469,9 +469,12 @@
       }
     },
     "node_modules/rp2040js": {
-      "version": "0.17.8",
-      "resolved": "git+ssh://git@github.com/mingpepe/rp2040js.git#23bf9d337b9dbbc69fa22b0689f3736553c902b3",
-      "license": "MIT"
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/rp2040js/-/rp2040js-0.19.1.tgz",
+      "integrity": "sha512-+k/sv5Qe/zZA6ZopLypP6ytzvyP/0neKSNayv9SkEyaaMb8seHfSIoYtpTND9hdfmJC85ZZI27CYw1vPtsXrNA==",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/src/platforms/rp2040/tests/package.json
+++ b/src/platforms/rp2040/tests/package.json
@@ -3,7 +3,7 @@
   "description": "Tests using rp2040js emulator",
   "dependencies": {
     "@tsconfig/node20": "^20.1.2",
-    "rp2040js": "github:mingpepe/rp2040js#core1",
+    "rp2040js": "^0.19.1",
     "sync-fetch": "^0.5.2",
     "tsx": "^3.12.8",
     "typescript": "^5.2.2",

--- a/src/platforms/rp2040/tests/run-tests.ts
+++ b/src/platforms/rp2040/tests/run-tests.ts
@@ -96,6 +96,5 @@ mcu.uart[0].onByte = (value) => {
   }
 };
 
-mcu.core0.PC = 0x10000000;
-mcu.core1.PC = 0x10000000;
+mcu.core.PC = 0x10000000;
 mcu.execute();

--- a/src/platforms/rp2040/tests/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/rp2040/tests/test_erl_sources/CMakeLists.txt
@@ -21,6 +21,7 @@
 ExternalProject_Add(HostAtomVM
     SOURCE_DIR ../../../../../../
     INSTALL_COMMAND cmake -E echo "Skipping install step."
+    BUILD_COMMAND cmake --build . --target=atomvmlib --target=PackBEAM
 )
 
 function(compile_erlang module_name)


### PR DESCRIPTION
Fix a bug in the implementation where the spinlock was allocated and released within smp_atomic_compare_exchange_weak, thus implementation was effectively only disabling interrupts on the executing core

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
