### PR TITLE
Allow sending messages directly from ISR

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -84,7 +84,7 @@ jobs:
         - arch: "arm32v5"
           platform: "arm/v5"
           cflags: "-O2 -mthumb -mthumb-interwork -march=armv4t"
-          cmake_opts: "-DAVM_DISABLE_SMP=On"
+          cmake_opts: "-DAVM_DISABLE_SMP=On -DAVM_DISABLE_ISR=On"
           tag: "stretch"
           sources: |
             deb [trusted=yes] http://archive.debian.org/debian/ stretch-backports main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(Elixir)
 
 option(AVM_DISABLE_FP "Disable floating point support." OFF)
 option(AVM_DISABLE_SMP "Disable SMP." OFF)
+option(AVM_DISABLE_ISR "Disable ISR support." OFF)
 option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
 option(AVM_RELEASE "Build an AtomVM release" OFF)

--- a/doc/src/atomvm-internals.md
+++ b/doc/src/atomvm-internals.md
@@ -101,6 +101,22 @@ Once a scheduler thread is done executing a process, if no other thread is waiti
 
 If there already is one thread in `sys_poll_events`, other scheduler threads pick the next ready process and if there is none, wait.  Other scheduler threads can also interrupt the wait in `sys_poll_events` if a process is made ready to run.  They do so using platform function `sys_signal`.
 
+## Tasks and synchronization mechanisms
+
+AtomVM SMP builds run on operating or runtime systems implementing tasks (FreeRTOS SMP on ESP32, Unix and WebAssembly) as well as on systems with no task implementation (Raspberry Pi Pico).
+
+On runtime systems with tasks, each scheduler thread is implemented as a task. On Pico, a scheduler thread runs on Core 0 and another one runs on Core 1, and they are effectively pinned to each core.
+
+For synchronization purposes, AtomVM uses mutexes, condition variables, RW locks, spinlocks and Atomics.
+
+Availability of RW Locks and atomics are verified at compile time using detection of symbols for RW Locks and `ATOMIC_*_LOCK_FREE` C11 macros for atomics.
+
+Mutexes and condition variables are provided by the SDK or the runtime system. If RW Locks are not available, AtomVM uses mutexes. Atomics are not available on Pico and are replaced by critical sections. Spinlocks are implemented by AtomVM on top of Atomics, or using mutexes on Pico.
+
+Importantly, locking synchronization mechanisms (mutexes, RW locks, spinlocks) are not interrupt-safe. Interrupt service routines must not try to lock as they could fail forever if interrupted code owns the lock. Atomics, including emulation on Pico, are interrupt-safe.
+
+Drivers can send messages from interruption service routines using `globalcontext_send_message_from_isr` function instead of `globalcontext_send_message`. This function tries to acquire required locks and if it fails, enqueues sent message in a queue, so it is later processed when the scheduler performs context switching. On platforms with no Atomics or emulation, this feature can be disabled wih `AVM_DISABLE_ISR` option.
+
 ## Mailboxes and signals
 
 Erlang processes receive messages in a mailbox.  The mailbox is the interface with other processes.

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -130,25 +130,35 @@ endif()
 
 if (AVM_DISABLE_SMP)
     target_compile_definitions(libAtomVM PUBLIC AVM_NO_SMP)
-else()
-    include(CheckIncludeFile)
-    CHECK_INCLUDE_FILE(stdatomic.h STDATOMIC_INCLUDE)
-    if(HAVE_PLATFORM_SMP_H)
-        target_compile_definitions(libAtomVM PUBLIC HAVE_PLATFORM_SMP_H)
-    endif()
-    include(CheckCSourceCompiles)
-    check_c_source_compiles("
-        #include <stdatomic.h>
-        int main() {
-            _Static_assert(ATOMIC_POINTER_LOCK_FREE == 2, \"Expected ATOMIC_POINTER_LOCK_FREE to be equal to 2\");
-        }
-    " ATOMIC_POINTER_LOCK_FREE_IS_TWO)
-    if (NOT ATOMIC_POINTER_LOCK_FREE_IS_TWO AND NOT HAVE_PLATFORM_SMP_H)
-        if (NOT STDATOMIC_INCLUDE)
-            message(FATAL_ERROR "stdatomic.h cannot be found, you need to disable SMP on this platform or provide platform_smp.h and define HAVE_PLATFORM_SMP_H")
-        else()
-            message(FATAL_ERROR "Platform doesn't support atomic pointers, you need to disable SMP or provide platform_smp.h and define HAVE_PLATFORM_SMP_H")
-        endif()
+endif()
+if (AVM_DISABLE_ISR)
+    target_compile_definitions(libAtomVM PUBLIC AVM_NO_ISR)
+endif()
+
+if(HAVE_PLATFORM_SMP_H)
+    target_compile_definitions(libAtomVM PUBLIC HAVE_PLATFORM_SMP_H)
+endif()
+if(HAVE_PLATFORM_ATOMIC_H)
+    target_compile_definitions(libAtomVM PUBLIC HAVE_PLATFORM_ATOMIC_H)
+endif()
+
+include(CheckIncludeFile)
+CHECK_INCLUDE_FILE(stdatomic.h STDATOMIC_INCLUDE)
+include(CheckCSourceCompiles)
+check_c_source_compiles("
+    #include <stdatomic.h>
+    int main() {
+        _Static_assert(ATOMIC_POINTER_LOCK_FREE == 2, \"Expected ATOMIC_POINTER_LOCK_FREE to be equal to 2\");
+    }
+" ATOMIC_POINTER_LOCK_FREE_IS_TWO)
+if (ATOMIC_POINTER_LOCK_FREE_IS_TWO)
+    target_compile_definitions(libAtomVM PUBLIC HAVE_ATOMIC)
+endif()
+if (NOT ATOMIC_POINTER_LOCK_FREE_IS_TWO AND NOT (HAVE_PLATFORM_ATOMIC_H OR (AVM_DISABLE_SMP AND AVM_DISABLE_ISR)))
+    if (NOT STDATOMIC_INCLUDE)
+        message(FATAL_ERROR "stdatomic.h cannot be found, you need to provide platform_atomic.h and define HAVE_PLATFORM_ATOMIC_H or alternatively pass AVM_DISABLE_SMP and AVM_DISABLE_ISR")
+    else()
+        message(FATAL_ERROR "Platform doesn't support atomic pointers, you need to provide platform_atomic.h and define HAVE_PLATFORM_ATOMIC_H or alternatively pass AVM_DISABLE_SMP and AVM_DISABLE_ISR")
     endif()
 endif()
 

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -35,6 +35,15 @@
 #include "term.h"
 #include "utils.h"
 
+#ifdef HAVE_PLATFORM_ATOMIC_H
+#include "platform_atomic.h"
+#endif
+
+#if defined(HAVE_ATOMIC)
+#include <stdatomic.h>
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_INT atomic_compare_exchange_weak
+#endif
+
 #define IMPL_EXECUTE_LOOP
 #include "opcodesswitch.h"
 #undef IMPL_EXECUTE_LOOP
@@ -232,7 +241,7 @@ void context_update_flags(Context *ctx, int mask, int value) CLANG_THREAD_SANITI
     enum ContextFlags desired;
     do {
         desired = (expected & mask) | value;
-    } while (!ATOMIC_COMPARE_EXCHANGE_WEAK(&ctx->flags, &expected, desired));
+    } while (!ATOMIC_COMPARE_EXCHANGE_WEAK_INT(&ctx->flags, &expected, desired));
 #else
     ctx->flags = (ctx->flags & mask) | value;
 #endif

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -29,30 +29,24 @@
 #include "defaultatoms.h"
 #include "erl_nif_priv.h"
 #include "list.h"
+#include "mailbox.h"
 #include "posix_nifs.h"
 #include "refc_binary.h"
 #include "resources.h"
+#include "scheduler.h"
+#include "smp.h"
 #include "synclist.h"
 #include "sys.h"
 #include "utils.h"
 #include "valueshashtable.h"
 
-#ifndef AVM_NO_SMP
-#define SMP_SPINLOCK_LOCK(spinlock) smp_spinlock_lock(spinlock)
-#define SMP_SPINLOCK_UNLOCK(spinlock) smp_spinlock_unlock(spinlock)
-#define SMP_MUTEX_LOCK(mutex) smp_mutex_lock(mutex)
-#define SMP_MUTEX_UNLOCK(mutex) smp_mutex_unlock(mutex)
-#define SMP_RWLOCK_RDLOCK(lock) smp_rwlock_rdlock(lock)
-#define SMP_RWLOCK_WRLOCK(lock) smp_rwlock_wrlock(lock)
-#define SMP_RWLOCK_UNLOCK(lock) smp_rwlock_unlock(lock)
-#else
-#define SMP_SPINLOCK_LOCK(spinlock)
-#define SMP_SPINLOCK_UNLOCK(spinlock)
-#define SMP_MUTEX_LOCK(mutex)
-#define SMP_MUTEX_UNLOCK(mutex)
-#define SMP_RWLOCK_RDLOCK(lock)
-#define SMP_RWLOCK_WRLOCK(lock)
-#define SMP_RWLOCK_UNLOCK(lock)
+#ifdef HAVE_PLATFORM_ATOMIC_H
+#include "platform_atomic.h"
+#endif
+
+#if defined(HAVE_ATOMIC)
+#include <stdatomic.h>
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_PTR atomic_compare_exchange_weak
 #endif
 
 struct RegisteredProcess
@@ -74,6 +68,9 @@ GlobalContext *globalcontext_new()
     list_init(&glb->waiting_processes);
 #ifndef AVM_NO_SMP
     smp_spinlock_init(&glb->processes_spinlock);
+#endif
+#ifndef AVM_NO_ISR
+    glb->message_queue = NULL;
 #endif
     synclist_init(&glb->avmpack_data);
     synclist_init(&glb->refc_binaries);
@@ -277,6 +274,29 @@ Context *globalcontext_get_process_lock(GlobalContext *glb, int32_t process_id)
     return NULL;
 }
 
+#ifndef AVM_NO_SMP
+static bool globalcontext_get_process_trylock(GlobalContext *glb, int32_t process_id, Context **output)
+{
+    struct ListHead *item;
+    Context *p = NULL;
+
+    struct ListHead *processes_table_list = synclist_tryrdlock(&glb->processes_table);
+    if (processes_table_list == NULL) {
+        return false;
+    }
+    LIST_FOR_EACH (item, processes_table_list) {
+        p = GET_LIST_ENTRY(item, Context, processes_table_head);
+
+        if (p->process_id == process_id) {
+            *output = p;
+        }
+    }
+    synclist_unlock(&glb->processes_table);
+
+    return true;
+}
+#endif
+
 void globalcontext_get_process_unlock(GlobalContext *glb, Context *c)
 {
     if (c) {
@@ -307,6 +327,78 @@ void globalcontext_send_message_nolock(GlobalContext *glb, int32_t process_id, t
         mailbox_send(p, t);
     }
 }
+
+#ifndef AVM_NO_ISR
+void globalcontext_send_message_from_isr(GlobalContext *glb, int32_t process_id, enum MessageType type, term t)
+{
+    MailboxMessage *message = NULL;
+    bool postponed = false;
+#ifndef AVM_NO_SMP
+    Context *p = NULL;
+    if (globalcontext_get_process_trylock(glb, process_id, &p)) {
+        if (p) {
+            message = mailbox_message_create_from_term(type, t);
+            // Ensure we can acquire the spinlock
+            if (smp_spinlock_trylock(&glb->processes_spinlock)) {
+                // We can send the message.
+                mailbox_enqueue_message(p, message);
+                scheduler_signal_message_from_isr(p);
+                smp_spinlock_unlock(&glb->processes_spinlock);
+            } else {
+                postponed = true;
+            }
+            globalcontext_get_process_unlock(glb, p);
+        }
+    } else {
+        postponed = true;
+    }
+#else
+    // Without SMP, we have no lock, so we must always enqueue.
+    postponed = true;
+#endif
+    if (postponed) {
+        if (message == NULL) {
+            message = mailbox_message_create_from_term(type, t);
+        }
+        struct MessageQueueItem *queued_item = malloc(sizeof(struct MessageQueueItem));
+        if (IS_NULL_PTR(queued_item)) {
+            fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
+            AVM_ABORT();
+        }
+        queued_item->message = message;
+        queued_item->process_id = process_id;
+
+        struct MessageQueueItem *current_first = NULL;
+        do {
+            queued_item->next = current_first;
+        } while (!ATOMIC_COMPARE_EXCHANGE_WEAK_PTR(&glb->message_queue, &current_first, queued_item));
+        // Make sure the scheduler is busy
+        sys_signal(glb);
+    }
+}
+
+void globalcontext_process_message_queue(GlobalContext *glb)
+{
+    struct MessageQueueItem *current = glb->message_queue;
+    // Empty outer list using CAS
+    if (current) {
+        while (!ATOMIC_COMPARE_EXCHANGE_WEAK_PTR(&glb->message_queue, &current, NULL)) {
+        };
+        (void) synclist_rdlock(&glb->processes_table);
+        while (current) {
+            Context *context = globalcontext_get_process_nolock(glb, current->process_id);
+            if (context) {
+                mailbox_enqueue_message(context, current->message);
+                scheduler_signal_message(context);
+            }
+            struct MessageQueueItem *old = current;
+            current = old->next;
+            free(old);
+        }
+        synclist_unlock(&glb->processes_table);
+    }
+}
+#endif
 
 void globalcontext_init_process(GlobalContext *glb, Context *ctx)
 {

--- a/src/libAtomVM/mailbox.c
+++ b/src/libAtomVM/mailbox.c
@@ -27,6 +27,15 @@
 #include "synclist.h"
 #include "trace.h"
 
+#ifdef HAVE_PLATFORM_ATOMIC_H
+#include "platform_atomic.h"
+#endif
+
+#if defined(HAVE_ATOMIC)
+#include <stdatomic.h>
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_PTR atomic_compare_exchange_weak
+#endif
+
 #define ADDITIONAL_PROCESSING_MEMORY_SIZE 4
 
 void mailbox_init(Mailbox *mbx)
@@ -170,54 +179,66 @@ size_t mailbox_size(Mailbox *mbox)
     return result;
 }
 
-static void mailbox_post_message(Context *c, MailboxMessage *m)
+#if !defined(AVM_NO_ISR) || !defined(AVM_NO_SMP)
+inline void mailbox_enqueue_message(Context *c, MailboxMessage *m)
 {
-    m->next = NULL;
-
     // Append message at the beginning of outer_first.
-#ifndef AVM_NO_SMP
     MailboxMessage *current_first = NULL;
     do {
         m->next = current_first;
-    } while (!ATOMIC_COMPARE_EXCHANGE_WEAK(&c->mailbox.outer_first, &current_first, m));
+    } while (!ATOMIC_COMPARE_EXCHANGE_WEAK_PTR(&c->mailbox.outer_first, &current_first, m));
+}
+
+static void mailbox_post_message(Context *c, MailboxMessage *m)
+{
+    mailbox_enqueue_message(c, m);
+    scheduler_signal_message(c);
+}
 #else
+static void mailbox_post_message(Context *c, MailboxMessage *m)
+{
     m->next = c->mailbox.outer_first;
     c->mailbox.outer_first = m;
+    scheduler_signal_message(c);
+}
 #endif
 
-    scheduler_signal_message(c);
+MailboxMessage *mailbox_message_create_from_term(enum MessageType type, term t)
+{
+    unsigned long estimated_mem_usage = memory_estimate_usage(t) + 1; // mso_list
+
+    size_t base_size = type == NormalMessage ? sizeof(Message) : sizeof(struct TermSignal);
+    void *msg_buf = malloc(base_size + estimated_mem_usage * sizeof(term));
+    if (IS_NULL_PTR(msg_buf)) {
+        fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
+        return NULL;
+    }
+
+    if (type == NormalMessage) {
+        Message *msg = msg_buf;
+        msg->base.type = NormalMessage;
+        msg->message = memory_copy_term_tree_to_storage(msg->storage, &msg->heap_end, t);
+
+        return &msg->base;
+    } else {
+        struct TermSignal *ts = msg_buf;
+        ts->base.type = type;
+        ts->signal_term = memory_copy_term_tree_to_storage(ts->storage, &ts->heap_end, t);
+
+        return &ts->base;
+    }
 }
 
 void mailbox_send(Context *c, term t)
 {
-    unsigned long estimated_mem_usage = memory_estimate_usage(t) + 1; // mso_list
-
-    Message *msg = malloc(sizeof(Message) + estimated_mem_usage * sizeof(term));
-    if (IS_NULL_PTR(msg)) {
-        fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        return;
-    }
-    msg->base.type = NormalMessage;
-    msg->message = memory_copy_term_tree_to_storage(msg->storage, &msg->heap_end, t);
-
-    TRACE("Sending %p to pid %i\n", (void *) msg->message, c->process_id);
-
-    mailbox_post_message(c, &msg->base);
+    MailboxMessage *msg = mailbox_message_create_from_term(NormalMessage, t);
+    mailbox_post_message(c, msg);
 }
 
 void mailbox_send_term_signal(Context *c, enum MessageType type, term t)
 {
-    unsigned long estimated_mem_usage = memory_estimate_usage(t) + 1; // mso_list
-
-    struct TermSignal *ts = malloc(sizeof(struct TermSignal) + estimated_mem_usage * sizeof(term));
-    if (IS_NULL_PTR(ts)) {
-        fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        return;
-    }
-    ts->base.type = type;
-    ts->signal_term = memory_copy_term_tree_to_storage(ts->storage, &ts->heap_end, t);
-
-    mailbox_post_message(c, &ts->base);
+    MailboxMessage *signal = mailbox_message_create_from_term(type, t);
+    mailbox_post_message(c, signal);
 }
 
 void mailbox_send_built_in_atom_signal(Context *c, enum MessageType type, term atom)
@@ -283,8 +304,8 @@ MailboxMessage *mailbox_process_outer_list(Mailbox *mbox)
 {
     // Empty outer list using CAS
     MailboxMessage *current = mbox->outer_first;
-#ifndef AVM_NO_SMP
-    while (!ATOMIC_COMPARE_EXCHANGE_WEAK(&mbox->outer_first, &current, NULL)) {
+#if !defined(AVM_NO_ISR) || !defined(AVM_NO_SMP)
+    while (!ATOMIC_COMPARE_EXCHANGE_WEAK_PTR(&mbox->outer_first, &current, NULL)) {
     };
 #else
     mbox->outer_first = NULL;

--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -36,9 +36,19 @@ extern "C" {
 #include <stdbool.h>
 
 #include "list.h"
-#include "smp.h"
 #include "term_typedef.h"
 #include "utils.h"
+
+#ifdef HAVE_PLATFORM_ATOMIC_H
+#include "platform_atomic.h"
+#endif
+
+#if defined(HAVE_ATOMIC) && !defined(__cplusplus)
+#include <stdatomic.h>
+#define ATOMIC _Atomic
+#else
+#define ATOMIC
+#endif
 
 struct Context;
 
@@ -54,8 +64,12 @@ struct Heap;
 typedef struct Heap Heap;
 #endif
 
-typedef struct Message Message;
+#ifndef TYPEDEF_MAILBOXMESSAGE
+#define TYPEDEF_MAILBOXMESSAGE
 typedef struct MailboxMessage MailboxMessage;
+#endif
+
+typedef struct Message Message;
 
 enum MessageType
 {
@@ -172,7 +186,7 @@ MailboxMessage *mailbox_process_outer_list(Mailbox *mbox);
  * @brief Sends a message to a certain mailbox.
  *
  * @details Sends a term to a certain process or port mailbox. Can be called
- * from another process.
+ * from another process. Cannot be called from ISR.
  * @param c the process context.
  * @param t the term that will be sent.
  */
@@ -223,6 +237,19 @@ void mailbox_send_ref_signal(Context *c, enum MessageType type, uint64_t ref_tic
  * @param type the type of the signal
  */
 void mailbox_send_empty_body_signal(Context *c, enum MessageType type);
+
+#ifndef AVM_NO_ISR
+/**
+ * @brief Enqueue message
+ *
+ * @details This function does not signal the process to be ready and is only
+ * meant to be called from ISR by `globalcontext_send_message_from_isr`.
+ *
+ * @param c the process context.
+ * @param m the message to enqueue
+ */
+void mailbox_enqueue_message(Context *c, MailboxMessage *m);
+#endif
 
 /**
  * @brief Reset mailbox receive pointer.
@@ -293,6 +320,15 @@ Message *mailbox_first(Mailbox *mbox);
  * @param heap the heap to add messages to.
  */
 void mailbox_destroy(Mailbox *mbox, Heap *heap);
+
+/**
+ * @brief Allocate and serialize a term to a mailbox message.
+ *
+ * @details Can be called from ISR (provided malloc works).
+ * @param type the message type, can be NormalMessage or a signal type
+ * @param t the term that will be sent
+ */
+MailboxMessage *mailbox_message_create_from_term(enum MessageType type, term t);
 
 /**
  * @brief Dispose a (processed) mailbox message. The message will be freed or

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2739,7 +2739,7 @@ static term nif_erlang_system_flag(Context *ctx, int argc, term argv[])
             argv[1] = BADARG_ATOM;
             return term_invalid_term();
         }
-        while (!ATOMIC_COMPARE_EXCHANGE_WEAK(&ctx->global->online_schedulers, &old_value, new_value)) {};
+        while (!ATOMIC_COMPARE_EXCHANGE_WEAK_INT(&ctx->global->online_schedulers, &old_value, new_value)) {};
         return term_from_int32(old_value);
     }
 #else

--- a/src/libAtomVM/refc_binary.h
+++ b/src/libAtomVM/refc_binary.h
@@ -30,7 +30,17 @@ extern "C" {
 
 #include "list.h"
 #include "resources.h"
-#include "smp.h"
+
+#ifdef HAVE_PLATFORM_ATOMIC_H
+#include "platform_atomic.h"
+#endif
+
+#if defined(HAVE_ATOMIC) && !defined(__cplusplus)
+#include <stdatomic.h>
+#define ATOMIC _Atomic
+#else
+#define ATOMIC
+#endif
 
 #ifndef TYPEDEF_CONTEXT
 #define TYPEDEF_CONTEXT

--- a/src/libAtomVM/scheduler.c
+++ b/src/libAtomVM/scheduler.c
@@ -28,22 +28,11 @@
 #include "sys.h"
 #include "utils.h"
 
-#ifndef AVM_NO_SMP
-#define SMP_SPINLOCK_LOCK(spinlock) smp_spinlock_lock(spinlock)
-#define SMP_SPINLOCK_UNLOCK(spinlock) smp_spinlock_unlock(spinlock)
-#define SMP_MUTEX_LOCK(mtx) smp_mutex_lock(mtx)
-#define SMP_MUTEX_TRYLOCK(mtx) smp_mutex_trylock(mtx)
-#define SMP_MUTEX_UNLOCK(mtx) smp_mutex_unlock(mtx)
-#else
-#define SMP_SPINLOCK_LOCK(spinlock)
-#define SMP_SPINLOCK_UNLOCK(spinlock)
-#define SMP_MUTEX_LOCK(mtx)
-#define SMP_MUTEX_TRYLOCK(mtx) 1
-#define SMP_MUTEX_UNLOCK(mtx)
-#endif
-
 static void scheduler_timeout_callback(struct TimerListItem *it);
 static void scheduler_make_ready(Context *ctx);
+#ifndef AVM_NO_ISR
+static void scheduler_make_ready_from_isr(Context *ctx);
+#endif
 
 static int update_timer_list(GlobalContext *global)
 {
@@ -208,6 +197,9 @@ static Context *scheduler_run0(GlobalContext *global)
         } else {
             sys_poll_events(global, SYS_POLL_EVENTS_DO_NOT_WAIT);
         }
+#ifndef AVM_NO_ISR
+        globalcontext_process_message_queue(global);
+#endif
         SMP_MUTEX_LOCK(global->schedulers_mutex);
     } while (result == NULL);
 
@@ -328,6 +320,23 @@ static void scheduler_make_ready(Context *ctx)
 #endif
 }
 
+#ifndef AVM_NO_ISR
+static void scheduler_make_ready_from_isr(Context *ctx)
+{
+    GlobalContext *global = ctx->global;
+    if (context_get_flags(ctx, Killed)) {
+        return;
+    }
+    list_remove(&ctx->processes_list_head);
+    // Move to ready queue (from waiting or running)
+    // The process may be running (it would be signaled), so mark it
+    // as ready
+    context_update_flags(ctx, ~NoFlags, Ready);
+    list_append(&global->ready_processes, &ctx->processes_list_head);
+    sys_signal(global);
+}
+#endif
+
 void scheduler_init_ready(Context *c)
 {
     scheduler_make_ready(c);
@@ -337,6 +346,13 @@ void scheduler_signal_message(Context *c)
 {
     scheduler_make_ready(c);
 }
+
+#ifndef AVM_NO_ISR
+void scheduler_signal_message_from_isr(Context *c)
+{
+    scheduler_make_ready_from_isr(c);
+}
+#endif
 
 void scheduler_terminate(Context *ctx)
 {

--- a/src/libAtomVM/scheduler.h
+++ b/src/libAtomVM/scheduler.h
@@ -61,10 +61,18 @@ void scheduler_init_ready(Context *c);
 
 /**
  * @brief Signal a process that a message was inserted in the mailbox.
+ * @details Cannot be called from ISR
  *
  * @param c the process context.
  */
 void scheduler_signal_message(Context *c);
+
+/**
+ * @brief Signal a process that a message was inserted in the mailbox.
+ * @details Must only be called while global->processes_spinlock is acquired.
+ * @param c the process context.
+ */
+void scheduler_signal_message_from_isr(Context *c);
 
 /**
  * @brief Signal a process that it was killed.

--- a/src/libAtomVM/smp.h
+++ b/src/libAtomVM/smp.h
@@ -42,20 +42,27 @@ extern "C" {
 #define CLANG_THREAD_SANITIZE_SAFE
 #endif
 
-#if defined(AVM_NO_SMP)
-#define ATOMIC
-#else
+#ifndef AVM_NO_SMP
+
 #include <stdbool.h>
-#ifndef __cplusplus
+
 #ifdef HAVE_PLATFORM_SMP_H
 #include "platform_smp.h"
-#else
-#include <stdatomic.h>
-#define ATOMIC_COMPARE_EXCHANGE_WEAK atomic_compare_exchange_weak
-#define ATOMIC _Atomic
 #endif
+
+#ifdef HAVE_PLATFORM_ATOMIC_H
+#include "platform_atomic.h"
+#endif
+
+// spinlocks are implemented using atomics
+#if !defined(SMP_PLATFORM_SPINLOCK)
+#if defined(HAVE_ATOMIC) && !defined(__cplusplus)
+#include <stdatomic.h>
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_INT atomic_compare_exchange_weak
+#define ATOMIC _Atomic
 #else
 #define ATOMIC
+#endif
 #endif
 
 #ifndef TYPEDEF_MUTEX
@@ -167,6 +174,13 @@ void smp_rwlock_destroy(RWLock *lock);
 void smp_rwlock_rdlock(RWLock *lock);
 
 /**
+ * @brief Try to acquire read lock of a rwlock.
+ * @param lock the lock to read lock
+ * @return `true` if lock was acquired
+ */
+bool smp_rwlock_tryrdlock(RWLock *lock);
+
+/**
  * @brief Write lock a rwlock.
  * @param lock the lock to write lock
  */
@@ -198,7 +212,18 @@ static inline void smp_spinlock_lock(SpinLock *lock)
     int current;
     do {
         current = 0;
-    } while (!ATOMIC_COMPARE_EXCHANGE_WEAK(&lock->lock, &current, 1));
+    } while (!ATOMIC_COMPARE_EXCHANGE_WEAK_INT(&lock->lock, &current, 1));
+}
+
+/**
+ * @brief Try to lock a spinlock.
+ * @param lock the spin lock to lock
+ * @return true if the spin lock was locked
+ */
+static inline bool smp_spinlock_trylock(SpinLock *lock)
+{
+    int current = 0;
+    return ATOMIC_COMPARE_EXCHANGE_WEAK_INT(&lock->lock, &current, 1);
 }
 
 /**
@@ -233,6 +258,29 @@ void smp_scheduler_start(GlobalContext *glb);
  */
 bool smp_is_main_thread(GlobalContext *glb);
 
+#define SMP_SPINLOCK_LOCK(spinlock) smp_spinlock_lock(spinlock)
+#define SMP_SPINLOCK_TRYLOCK(spinlock) smp_spinlock_trylock(spinlock)
+#define SMP_SPINLOCK_UNLOCK(spinlock) smp_spinlock_unlock(spinlock)
+#define SMP_MUTEX_LOCK(mutex) smp_mutex_lock(mutex)
+#define SMP_MUTEX_TRYLOCK(mutex) smp_mutex_trylock(mutex)
+#define SMP_MUTEX_UNLOCK(mutex) smp_mutex_unlock(mutex)
+#define SMP_RWLOCK_RDLOCK(lock) smp_rwlock_rdlock(lock)
+#define SMP_RWLOCK_TRYRDLOCK(lock) smp_rwlock_tryrdlock(lock)
+#define SMP_RWLOCK_WRLOCK(lock) smp_rwlock_wrlock(lock)
+#define SMP_RWLOCK_UNLOCK(lock) smp_rwlock_unlock(lock)
+
+#else
+
+#define SMP_SPINLOCK_LOCK(spinlock)
+#define SMP_SPINLOCK_TRYLOCK(spinlock)
+#define SMP_SPINLOCK_UNLOCK(spinlock)
+#define SMP_MUTEX_LOCK(mutex)
+#define SMP_MUTEX_TRYLOCK(mutex)
+#define SMP_MUTEX_UNLOCK(mutex)
+#define SMP_RWLOCK_RDLOCK(lock)
+#define SMP_RWLOCK_TRYRDLOCK(lock)
+#define SMP_RWLOCK_WRLOCK(lock)
+#define SMP_RWLOCK_UNLOCK(lock)
 #endif
 
 #ifdef __cplusplus

--- a/src/libAtomVM/synclist.h
+++ b/src/libAtomVM/synclist.h
@@ -56,6 +56,14 @@ static inline struct ListHead *synclist_rdlock(struct SyncList *synclist)
     return &synclist->head;
 }
 
+static inline struct ListHead *synclist_tryrdlock(struct SyncList *synclist)
+{
+    if (smp_rwlock_tryrdlock(synclist->lock)) {
+        return &synclist->head;
+    }
+    return NULL;
+}
+
 static inline struct ListHead *synclist_wrlock(struct SyncList *synclist)
 {
     smp_rwlock_wrlock(synclist->lock);
@@ -107,6 +115,7 @@ static inline int synclist_is_empty(struct SyncList *synclist)
 #define SyncList ListHead
 #define synclist_init(list) list_init(list)
 #define synclist_rdlock(list) list
+#define synclist_tryrdlock(list) list
 #define synclist_wrlock(list) list
 #define synclist_nolock(list) list
 #define synclist_unlock(list) UNUSED(list)

--- a/src/libAtomVM/sys.h
+++ b/src/libAtomVM/sys.h
@@ -175,24 +175,31 @@ void sys_unregister_listener(GlobalContext *global, EventListener *listener);
  */
 void sys_listener_destroy(struct ListHead *item);
 
-#ifndef AVM_NO_SMP
-
 /**
  * @brief Interrupt the wait in `sys_poll_events`.
  *
  * @details This function should signal the thread that is waiting in
- * `sys_poll_events` so it returns before the timeout. It is only used
- * for SMP builds.
+ * `sys_poll_events` so it returns before the timeout. It is mostly used for
+ * SMP builds, but also to abort sleep because of interruptions.
  *
  * Please note that this function may be called while no thread is waiting in
  * sys_poll_events and this should have no effect. This function is called in
- * scheduler loop (internal function `scheduler_run0`).
+ * scheduler loop (internal function `scheduler_run0`) and when scheduling
+ * processes.
  *
  * @param glb the global context.
  */
 void sys_signal(GlobalContext *glb);
 
-#endif
+/**
+ * @brief Determine if code is executed from ISR
+ *
+ * @details This function should return true if the code is executed from an
+ * interrupt service routine.
+ *
+ * @return true if CPU is from an ISR
+ */
+bool sys_check_if_in_isr();
 
 enum OpenAVMResult sys_open_avm_from_file(
     GlobalContext *global, const char *path, struct AVMPackData **data);

--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -33,6 +33,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules
 if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32h2")
     message("Disabling SMP as selected target only has one core")
     set(AVM_DISABLE_SMP YES FORCE)
+    set(HAVE_PLATFORM_ATOMIC_H ON)
 endif()
 
 project(atomvm-esp32)

--- a/src/platforms/esp32/components/avm_sys/platform_atomic.h
+++ b/src/platforms/esp32/components/avm_sys/platform_atomic.h
@@ -1,0 +1,76 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _PLATFORM_ATOMIC_H
+#define _PLATFORM_ATOMIC_H
+
+#include <stdatomic.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#if ATOMIC_POINTER_LOCK_FREE != 2
+
+// If we have SMP, we shouldn't need to define atomic cas operations
+#if !defined(AVM_NO_SMP)
+#error atomic cas emulation code is only meant for ISR support without SMP
+#endif
+
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_PTR(object, expected, desired) \
+    smp_atomic_compare_exchange_weak_ptr((void **) object, (void **) expected, (void *) desired)
+
+static portMUX_TYPE smp_atomic_spinlock = portMUX_INITIALIZER_UNLOCKED;
+
+// This primitive may be called from both thread and isr
+static inline bool smp_atomic_compare_exchange_weak_ptr(void **object, void **expected, void *desired)
+{
+    bool in_isr = xPortInIsrContext();
+    if (in_isr) {
+        // taskENTER_CRITICAL_FROM_ISR is broken in some versions of esp-idf we support
+        taskENTER_CRITICAL_ISR(&smp_atomic_spinlock);
+    } else {
+        taskENTER_CRITICAL(&smp_atomic_spinlock);
+    }
+
+    bool result;
+    result = *object == *expected;
+    if (result) {
+        *object = desired;
+    } else {
+        *expected = *object;
+    }
+
+    if (in_isr) {
+        taskEXIT_CRITICAL_ISR(&smp_atomic_spinlock);
+    } else {
+        taskEXIT_CRITICAL(&smp_atomic_spinlock);
+    }
+
+    return result;
+}
+
+#else
+
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_PTR(object, expected, desired) \
+    atomic_compare_exchange_weak(object, expected, desired)
+
+#endif
+
+#endif

--- a/src/platforms/esp32/components/libatomvm/CMakeLists.txt
+++ b/src/platforms/esp32/components/libatomvm/CMakeLists.txt
@@ -22,6 +22,11 @@ idf_component_register(INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../lib
 
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../../../libAtomVM" "libAtomVM")
 
+# Add directory with platform_atomic.h if we mean to use it
+if (HAVE_PLATFORM_ATOMIC_H)
+    target_include_directories(libAtomVM PUBLIC ../avm_sys/)
+endif()
+
 target_link_libraries(${COMPONENT_LIB}
     INTERFACE libAtomVM "-u platform_nifs_get_nif" "-u platform_defaultatoms_init")
 

--- a/src/platforms/generic_unix/lib/smp.c
+++ b/src/platforms/generic_unix/lib/smp.c
@@ -21,6 +21,7 @@
 #include "smp.h"
 
 #ifndef AVM_NO_SMP
+#include <errno.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -195,6 +196,18 @@ void smp_rwlock_rdlock(RWLock *lock)
     if (UNLIKELY(pthread_rwlock_rdlock(&lock->lock))) {
         AVM_ABORT();
     }
+}
+
+bool smp_rwlock_tryrdlock(RWLock *lock)
+{
+    int r = pthread_rwlock_tryrdlock(&lock->lock);
+    if (r == EBUSY) {
+        return false;
+    }
+    if (UNLIKELY(r)) {
+        AVM_ABORT();
+    }
+    return true;
 }
 
 void smp_rwlock_wrlock(RWLock *lock)

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -55,14 +55,6 @@
 // Platform uses listeners
 #include "listeners.h"
 
-#ifndef AVM_NO_SMP
-#define SMP_MUTEX_LOCK(mtx) smp_mutex_lock(mtx)
-#define SMP_MUTEX_UNLOCK(mtx) smp_mutex_unlock(mtx)
-#else
-#define SMP_MUTEX_LOCK(mtx)
-#define SMP_MUTEX_UNLOCK(mtx)
-#endif
-
 #ifdef DYNLOAD_PORT_DRIVERS
 #include <dlfcn.h>
 
@@ -314,7 +306,7 @@ void sys_poll_events(GlobalContext *glb, int timeout_ms) CLANG_THREAD_SANITIZE_S
 #endif
 }
 
-#ifndef AVM_NO_SMP
+#if !defined(AVM_NO_SMP) || !defined(AVM_NO_ISR)
 void sys_signal(GlobalContext *glb)
 {
     struct GenericUnixPlatformData *platform = glb->platform_data;

--- a/src/platforms/rp2040/src/CMakeLists.txt
+++ b/src/platforms/rp2040/src/CMakeLists.txt
@@ -28,11 +28,12 @@ if(CMAKE_COMPILER_IS_GNUCC)
     target_compile_options(AtomVM PRIVATE -Wall -pedantic -Wextra)
 endif()
 
-# libAtomVM needs to find Pico's platform_smp.h header
+# libAtomVM needs to find Pico's platform_smp.h and platform_atomic.h headers
 set(HAVE_PLATFORM_SMP_H ON)
+set(HAVE_PLATFORM_ATOMIC_H ON)
 add_subdirectory(../../../libAtomVM libAtomVM)
 target_link_libraries(AtomVM PUBLIC libAtomVM)
-# Also add lib where platform_smp.h header is
+# Also add lib where platform_smp.h and platform_atomic headers are
 target_include_directories(libAtomVM PUBLIC lib)
 
 target_link_libraries(AtomVM PUBLIC hardware_regs pico_stdlib pico_binary_info)

--- a/src/platforms/rp2040/src/lib/platform_atomic.h
+++ b/src/platforms/rp2040/src/lib/platform_atomic.h
@@ -1,0 +1,153 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _PLATFORM_ATOMIC_H
+#define _PLATFORM_ATOMIC_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+#include <pico/critical_section.h>
+
+#pragma GCC diagnostic pop
+
+#define ATOMIC
+
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_PTR(object, expected, desired) \
+    smp_atomic_compare_exchange_weak_ptr((void **) object, (void **) expected, (void *) desired)
+
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_INT(object, expected, desired) \
+    smp_atomic_compare_exchange_weak_int((void *) object, (void *) expected, (uint64_t) desired, sizeof(desired))
+
+#ifndef AVM_NO_SMP
+static critical_section_t atomic_cas_section;
+#endif
+
+/**
+ * @brief Initialize structures of atomic functions
+ */
+static inline void atomic_init()
+{
+#ifndef AVM_NO_SMP
+    critical_section_init(&atomic_cas_section);
+#endif
+}
+
+/**
+ * @brief Free structures for atomic functions
+ */
+static inline void atomic_free()
+{
+#ifndef AVM_NO_SMP
+    critical_section_deinit(&atomic_cas_section);
+#endif
+}
+
+static inline bool smp_atomic_compare_exchange_weak_ptr(void **object, void **expected, void *desired)
+{
+#ifndef AVM_NO_SMP
+    critical_section_enter_blocking(&atomic_cas_section);
+#else
+    uint32_t save = save_and_disable_interrupts();
+#endif
+
+    bool result;
+    result = *object == *expected;
+    if (result) {
+        *object = desired;
+    } else {
+        *expected = *object;
+    }
+#ifndef AVM_NO_SMP
+    critical_section_exit(&atomic_cas_section);
+#else
+    restore_interrupts(save);
+#endif
+    return result;
+}
+
+static inline bool smp_atomic_compare_exchange_weak_int(void *object, void *expected, uint64_t desired, size_t desired_len)
+{
+#ifndef AVM_NO_SMP
+    critical_section_enter_blocking(&atomic_cas_section);
+#else
+    uint32_t save = save_and_disable_interrupts();
+#endif
+
+    bool result;
+    switch (desired_len) {
+        case sizeof(uint64_t): {
+            uint64_t *object_ptr = (uint64_t *) object;
+            uint64_t *expected_ptr = (uint64_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+        case sizeof(uint32_t): {
+            uint32_t *object_ptr = (uint32_t *) object;
+            uint32_t *expected_ptr = (uint32_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+        case sizeof(uint16_t): {
+            uint16_t *object_ptr = (uint16_t *) object;
+            uint16_t *expected_ptr = (uint16_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+        case sizeof(uint8_t): {
+            uint8_t *object_ptr = (uint8_t *) object;
+            uint8_t *expected_ptr = (uint8_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+    }
+
+#ifndef AVM_NO_SMP
+    critical_section_exit(&atomic_cas_section);
+#else
+    restore_interrupts(save);
+#endif
+    return result;
+}
+
+#endif

--- a/src/platforms/rp2040/src/lib/smp.c
+++ b/src/platforms/rp2040/src/lib/smp.c
@@ -95,8 +95,7 @@ void smp_mutex_lock(Mutex *mtx)
 
 bool smp_mutex_trylock(Mutex *mtx)
 {
-    uint32_t owner;
-    return mutex_try_enter(&mtx->mutex, &owner);
+    return mutex_try_enter(&mtx->mutex, NULL);
 }
 
 void smp_mutex_unlock(Mutex *mtx)
@@ -147,6 +146,11 @@ void smp_rwlock_destroy(RWLock *lock)
 void smp_rwlock_rdlock(RWLock *lock)
 {
     mutex_enter_blocking(&lock->lock);
+}
+
+bool smp_rwlock_tryrdlock(RWLock *lock)
+{
+    return mutex_try_enter(&lock->lock, NULL);
 }
 
 void smp_rwlock_wrlock(RWLock *lock)

--- a/src/platforms/rp2040/src/lib/sys.c
+++ b/src/platforms/rp2040/src/lib/sys.c
@@ -43,6 +43,7 @@
 #include <defaultatoms.h>
 #include <utils.h>
 
+#include "platform_atomic.h"
 #include "rp2040_sys.h"
 
 struct PortDriverDefListItem *port_driver_list;
@@ -55,8 +56,9 @@ void sys_init_platform(GlobalContext *glb)
 #ifndef AVM_NO_SMP
     mutex_init(&platform->event_poll_mutex);
     cond_init(&platform->event_poll_cond);
-    smp_init();
 #endif
+
+    atomic_init();
 
 #ifdef LIB_PICO_CYW43_ARCH
     cyw43_arch_init();
@@ -72,9 +74,7 @@ void sys_free_platform(GlobalContext *glb)
     struct RP2040PlatformData *platform = glb->platform_data;
     free(platform);
 
-#ifndef AVM_NO_SMP
-    smp_free();
-#endif
+    atomic_free();
 }
 
 #ifndef AVM_NO_SMP
@@ -98,6 +98,12 @@ void sys_poll_events(GlobalContext *glb, int timeout_ms)
 {
     UNUSED(glb);
     UNUSED(timeout_ms);
+    // Immediately returns
+}
+
+void sys_signal(GlobalContext *glb)
+{
+    UNUSED(glb);
 }
 #endif
 

--- a/src/platforms/rp2040/tests/CMakeLists.txt
+++ b/src/platforms/rp2040/tests/CMakeLists.txt
@@ -31,10 +31,11 @@ if(CMAKE_COMPILER_IS_GNUCC)
     target_compile_options(rp2040_tests PRIVATE -Wall -pedantic -Wextra)
 endif()
 
-# libAtomVM needs to find Pico's platform_smp.h header
+# libAtomVM needs to find Pico's platform_smp.h and platform_atomic.h headers
 set(HAVE_PLATFORM_SMP_H ON)
+set(HAVE_PLATFORM_ATOMIC_H ON)
 target_link_libraries(rp2040_tests PUBLIC libAtomVM)
-# Also add lib where platform_smp.h header is
+# Also add lib where platform_smp.h and platform_atomic.h headers are
 target_include_directories(rp2040_tests PUBLIC ../src/lib)
 
 target_link_libraries(rp2040_tests PUBLIC hardware_regs pico_stdlib pico_binary_info unity)

--- a/src/platforms/rp2040/tests/test_erl_sources/test_clocks.erl
+++ b/src/platforms/rp2040/tests/test_erl_sources/test_clocks.erl
@@ -59,5 +59,7 @@ test_clock(Case, Fun) ->
     Delta = EndTime - StartTime,
     if
         Delta >= 100 andalso Delta < 500 -> ok;
+        % Emulator sometimes gives us 99
+        Delta =:= 99 -> ok;
         true -> throw({unexpected_delta, Delta, Case, StartTime, EndTime})
     end.

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -144,6 +144,11 @@ void sys_poll_events(GlobalContext *glb, int timeout_ms)
     UNUSED(timeout_ms);
 }
 
+void sys_signal(GlobalContext *glb)
+{
+    UNUSED(glb);
+}
+
 void sys_listener_destroy(struct ListHead *item)
 {
     UNUSED(item);


### PR DESCRIPTION
Introduce new synchronization primitives to try to acquire locks and introduce
new functions to send messages from an interrupt service routine

Also fix Pico networking code that currently does this as it's using the
low-priority interrupt mode

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
