### PR TITLE
Update workflow restictions

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -14,6 +14,7 @@ on:
       - 'doc/**'
       - 'LICENSES/**'
       - '*.Md'
+      - '*.md'
   pull_request:
     paths-ignore:
       - 'src/platforms/esp32/**'
@@ -21,6 +22,7 @@ on:
       - 'doc/**'
       - 'LICENSES/**'
       - '*.Md'
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/master' && github.ref || github.run_id }}

--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -14,6 +14,7 @@ on:
       - 'doc/**'
       - 'LICENSES/**'
       - '*.Md'
+      - '*.md'
   pull_request:
     paths-ignore:
       - 'src/platforms/esp32/**'
@@ -21,6 +22,7 @@ on:
       - 'doc/**'
       - 'LICENSES/**'
       - '*.Md'
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/master' && github.ref || github.run_id }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -14,6 +14,7 @@ on:
       - 'doc/**'
       - 'LICENSES/**'
       - '*.Md'
+      - '*.md'
   pull_request:
     paths-ignore:
       - 'src/platforms/esp32/**'
@@ -21,6 +22,7 @@ on:
       - 'doc/**'
       - 'LICENSES/**'
       - '*.Md'
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/master' && github.ref || github.run_id }}

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -14,6 +14,8 @@ on:
       - 'libs/**'
       - 'doc/**'
       - 'LICENSES/**'
+      - '*.Md'
+      - '*.md'
   pull_request:
     paths-ignore:
       - 'src/platforms/esp32/**'
@@ -21,6 +23,8 @@ on:
       - 'libs/**'
       - 'doc/**'
       - 'LICENSES/**'
+      - '*.Md'
+      - '*.md'
   schedule:
     - cron: '45 18 * * 5'
 

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -14,6 +14,7 @@ on:
       - 'doc/**'
       - 'LICENSES/**'
       - '*.Md'
+      - '*.md'
   pull_request:
     paths-ignore:
       - 'src/platforms/esp32/**'
@@ -21,6 +22,7 @@ on:
       - 'doc/**'
       - 'LICENSES/**'
       - '*.Md'
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/master' && github.ref || github.run_id }}


### PR DESCRIPTION
Updates several workflows to accomodate the file decriptor change in markdown files from `.Md` to `.md`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
