### PR TITLE
Enable STM32 flash and instruction caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for the OTP `socket` interface.
+- Enhancd performance of STM32 by enabling flash cache and i-cache with branch prediction.
 
 ## [0.6.0-alpha.1] - 2023-10-09
 

--- a/src/platforms/stm32/src/main.c
+++ b/src/platforms/stm32/src/main.c
@@ -126,6 +126,9 @@ int _write(int file, char *ptr, int len)
 
 int main()
 {
+    // Flash cache must be enabled before system clock is activated
+    sys_enable_flash_cache();
+    sys_init_icache();
     clock_setup();
     systick_setup();
     usart_setup();


### PR DESCRIPTION
Enables flash cache and i-cache with branch prediction for modest to significant boosts in performance, depending on workloads.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
