### PR TITLE
Doc fix broken link .html->.md

### DIFF
--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -1008,7 +1008,7 @@ To retrieve data in RTC slow memory, use the `esp:rtc_slow_get_binary/0` functio
     %% erlang
     Data = esp:rtc_slow_get_binary()
 
-By default, RTC slow memory in AtomVM is limited to 4098 (4k) bytes.  This value can be modified at build time using an IDF SDK `KConfig` setting.  For  instructions about how to build AtomVM, see the AtomVM [Build Instructions](./build-instructions.html).
+By default, RTC slow memory in AtomVM is limited to 4098 (4k) bytes.  This value can be modified at build time using an IDF SDK `KConfig` setting.  For  instructions about how to build AtomVM, see the AtomVM [Build Instructions](./build-instructions.md).
 
 
 ### Miscellaneous


### PR DESCRIPTION
current code anchor links #./build-instructions.html, and thus doesn't work.

see https://www.atomvm.net/doc/master/programmers-guide.html#rtc-memory

this fixes that.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
