### PR TITLE
Fix broken cache in documentation workflows

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -60,7 +60,7 @@ jobs:
           key: ${{ runner.os }}-sphinx-install
 
       - name: Install Sphinx
-        if: steps.cache.outputs.sphinx-cache-hit != 'true'
+        if: ${{ steps.sphinx-cache.outputs.cache-hit != 'true' }}
         run: |
           python3 -m venv /home/runner/python-env/sphinx
           . /home/runner/python-env/sphinx/bin/activate

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -53,7 +53,7 @@ jobs:
           key: ${{ runner.os }}-sphinx-install
 
       - name: Install Sphinx
-        if: steps.cache.outputs.sphinx-cache-hit != 'true'
+        if: ${{ steps.sphinx-cache.outputs.cache-hit != 'true' }}
         run: |
           python3 -m venv /home/runner/python-env/sphinx
           . /home/runner/python-env/sphinx/bin/activate


### PR DESCRIPTION
Fixes incorrect conditional checks for downloading the extra tools to build the documentation. Previously the tools were always downloaded, even when they were restored from a valid cache.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
