### PR TITLE
New atom table implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New gpio driver for STM32 with nif and port support for read and write functions.
 - Added support for interrupts to STM32 GPIO port driver.
 
+## Changed
+- New atom table, which uses less memory, has improved performances and better code.
+
 ## [0.6.0-alpha.1] - 2023-10-09
 
 ### Added

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -24,6 +24,7 @@ project (libAtomVM)
 set(HEADER_FILES
     atom.h
     atomshashtable.h
+    atom_table.h
     avmpack.h
     bif.h
     bitstring.h
@@ -69,6 +70,7 @@ set(HEADER_FILES
 set(SOURCE_FILES
     atom.c
     atomshashtable.c
+    atom_table.c
     avmpack.c
     bif.c
     bitstring.c

--- a/src/libAtomVM/atom.c
+++ b/src/libAtomVM/atom.c
@@ -30,7 +30,7 @@ void atom_string_to_c(AtomString atom_string, char *buf, size_t bufsize)
 {
     size_t atom_len = *((const uint8_t *) atom_string);
 
-    if (bufsize < atom_len) {
+    if (bufsize <= atom_len) {
         atom_len = bufsize - 1;
     }
     memcpy(buf, ((const uint8_t *) atom_string) + 1, atom_len);

--- a/src/libAtomVM/atom_table.c
+++ b/src/libAtomVM/atom_table.c
@@ -225,6 +225,33 @@ AtomString atom_table_get_atom_string(struct AtomTable *table, long index)
     return NULL;
 }
 
+int atom_table_cmp_using_atom_index(struct AtomTable *table, int t_atom_index, int other_atom_index)
+{
+    AtomString t_atom_string = atom_table_get_atom_string(table, t_atom_index);
+
+    int t_atom_len = atom_string_len(t_atom_string);
+    const char *t_atom_data = (const char *) atom_string_data(t_atom_string);
+
+    AtomString other_atom_string = atom_table_get_atom_string(table, other_atom_index);
+
+    int other_atom_len = atom_string_len(other_atom_string);
+    const char *other_atom_data = (const char *) atom_string_data(other_atom_string);
+
+    int cmp_size = (t_atom_len > other_atom_len) ? other_atom_len : t_atom_len;
+
+    int memcmp_result = memcmp(t_atom_data, other_atom_data, cmp_size);
+
+    if (memcmp_result == 0) {
+        if (t_atom_len == other_atom_len) {
+            return 0;
+        } else {
+            return (t_atom_len > other_atom_len) ? 1 : -1;
+        }
+    }
+
+    return memcmp_result;
+}
+
 static inline void init_node(struct HNode *node, AtomString atom, long index)
 {
     node->key = atom;

--- a/src/libAtomVM/atom_table.c
+++ b/src/libAtomVM/atom_table.c
@@ -52,7 +52,14 @@ struct HNode
     long index;
 };
 
-struct HNodeGroup;
+struct HNodeGroup
+{
+    struct HNodeGroup *next;
+    long first_index;
+    uint16_t len;
+
+    struct HNode nodes[];
+};
 
 struct AtomTable
 {
@@ -66,15 +73,6 @@ struct AtomTable
 
     struct HNodeGroup *first_node_group;
     struct HNodeGroup *last_node_group;
-};
-
-struct HNodeGroup
-{
-    struct HNodeGroup *next;
-    long first_index;
-    uint16_t len;
-
-    struct HNode nodes[];
 };
 
 static struct HNodeGroup *new_node_group(struct AtomTable *table, int len);

--- a/src/libAtomVM/atom_table.c
+++ b/src/libAtomVM/atom_table.c
@@ -1,0 +1,270 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Davide Bettio <davide@uninstall.it>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include "atom_table.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "atom.h"
+#include "smp.h"
+#include "utils.h"
+
+#ifndef AVM_NO_SMP
+#define SMP_RDLOCK(htable) smp_rwlock_rdlock(htable->lock)
+#define SMP_WRLOCK(htable) smp_rwlock_wrlock(htable->lock)
+#define SMP_UNLOCK(htable) smp_rwlock_unlock(htable->lock)
+#else
+#define SMP_RDLOCK(htable)
+#define SMP_WRLOCK(htable)
+#define SMP_UNLOCK(htable)
+#endif
+
+#define DEFAULT_SIZE 8
+
+struct HNode
+{
+    struct HNode *next;
+    AtomString key;
+    long index;
+};
+
+struct HNodeGroup;
+
+struct AtomTable
+{
+    int capacity;
+    int count;
+#ifndef AVM_NO_SMP
+    RWLock *lock;
+#endif
+    struct HNode **buckets;
+
+    struct HNodeGroup *first_node_group;
+    struct HNodeGroup *last_node_group;
+};
+
+struct HNodeGroup
+{
+    struct HNodeGroup *next;
+    long first_index;
+    uint16_t len;
+    uint16_t avail;
+
+    struct HNode nodes[];
+};
+
+static struct HNodeGroup *new_node_group(struct AtomTable *table, int len);
+
+struct AtomTable *atom_table_new()
+{
+    struct AtomTable *htable = malloc(sizeof(struct AtomTable));
+    if (IS_NULL_PTR(htable)) {
+        return NULL;
+    }
+    htable->buckets = calloc(DEFAULT_SIZE, sizeof(struct HNode *));
+    if (IS_NULL_PTR(htable->buckets)) {
+        free(htable);
+        return NULL;
+    }
+
+    htable->count = 0;
+    htable->capacity = DEFAULT_SIZE;
+
+    htable->last_node_group = NULL;
+    htable->first_node_group = new_node_group(htable, DEFAULT_SIZE);
+
+#ifndef AVM_NO_SMP
+    htable->lock = smp_rwlock_create();
+#endif
+
+    return htable;
+}
+
+void atom_table_destroy(struct AtomTable *table)
+{
+    struct HNodeGroup *node_group = table->first_node_group;
+    while (node_group) {
+        struct HNodeGroup *next_group = node_group->next;
+        free(node_group);
+        node_group = next_group;
+    }
+#ifndef AVM_NO_SMP
+    smp_rwlock_destroy(table->lock);
+#endif
+    free(table->buckets);
+    free(table);
+}
+
+int atom_table_count(struct AtomTable *table)
+{
+    SMP_RDLOCK(table);
+    int count = table->count;
+    SMP_UNLOCK(table);
+
+    return count;
+}
+
+static struct HNodeGroup *new_node_group(struct AtomTable *table, int len)
+{
+    struct HNodeGroup *new_group = malloc(sizeof(struct HNodeGroup) + sizeof(struct HNode) * len);
+    new_group->next = NULL;
+    new_group->first_index = table->count;
+    new_group->len = len;
+    new_group->avail = len;
+
+    if (LIKELY(table->last_node_group != NULL)) {
+        table->last_node_group->next = new_group;
+    }
+    table->last_node_group = new_group;
+
+    return new_group;
+}
+
+static unsigned long sdbm_hash(const unsigned char *str, int len)
+{
+    unsigned long hash = 0;
+    int c;
+
+    for (int i = 0; i < len; i++) {
+        c = *str++;
+        hash = c + (hash << 6) + (hash << 16) - hash;
+    }
+
+    return hash;
+}
+
+static inline struct HNode *get_node_from_bucket(
+    const struct AtomTable *hash_table, unsigned long bucket_index, AtomString string)
+{
+    struct HNode *node = hash_table->buckets[bucket_index];
+    while (node) {
+        if (atom_are_equals(string, node->key)) {
+            return node;
+        }
+
+        node = node->next;
+    }
+
+    return NULL;
+}
+
+static inline struct HNode *get_node(const struct AtomTable *hash_table, AtomString string)
+{
+    unsigned long hash = sdbm_hash(string, atom_string_len(string));
+
+    unsigned long bucket_index = hash % hash_table->capacity;
+    return get_node_from_bucket(hash_table, bucket_index, string);
+}
+
+static inline struct HNode *lock_and_get_node(struct AtomTable *hash_table, AtomString string)
+{
+    unsigned long hash = sdbm_hash(string, atom_string_len(string));
+
+    SMP_RDLOCK(hash_table);
+    unsigned long bucket_index = hash % hash_table->capacity;
+    return get_node_from_bucket(hash_table, bucket_index, string);
+}
+
+long atom_table_get_index(struct AtomTable *table, AtomString string)
+{
+    struct HNode *node = lock_and_get_node(table, string);
+    long result = (node != NULL) ? node->index : ATOM_TABLE_NOT_FOUND;
+
+    SMP_UNLOCK(table);
+    return result;
+}
+
+// TODO: this function needs to be optimized
+AtomString atom_table_get_atom_string(struct AtomTable *table, long index)
+{
+    SMP_RDLOCK(table);
+
+    struct HNodeGroup *node_group = table->first_node_group;
+    while (node_group) {
+        long first_index = node_group->first_index;
+        if (first_index + node_group->len > index) {
+            if (index - first_index > (node_group->len - node_group->avail)) {
+                SMP_UNLOCK(table);
+                return NULL;
+            }
+
+            SMP_UNLOCK(table);
+            return node_group->nodes[index - first_index].key;
+        }
+
+        node_group = node_group->next;
+    }
+
+    SMP_UNLOCK(table);
+    return NULL;
+}
+
+static inline void init_node(struct HNode *node, AtomString atom, long index)
+{
+    node->key = atom;
+    node->index = index;
+}
+
+static inline void insert_node_into_bucket(
+    struct AtomTable *table, int bucket_index, struct HNode *node)
+{
+    struct HNode *maybe_existing_node = table->buckets[bucket_index];
+    table->buckets[bucket_index] = node;
+    node->next = maybe_existing_node;
+}
+
+static inline long insert_node(struct AtomTable *table, struct HNodeGroup *node_group,
+    unsigned long bucket_index, AtomString string)
+{
+    long new_index = table->count;
+    table->count++;
+
+    struct HNode *node = &node_group->nodes[new_index - node_group->first_index];
+    node_group->avail--;
+    init_node(node, string, new_index);
+    insert_node_into_bucket(table, bucket_index, node);
+
+    return new_index;
+}
+
+long atom_table_ensure_atom(struct AtomTable *table, AtomString string)
+{
+    unsigned long hash = sdbm_hash(string, atom_string_len(string));
+    SMP_WRLOCK(table);
+    unsigned long bucket_index = hash % table->capacity;
+
+    struct HNode *node = get_node_from_bucket(table, bucket_index, string);
+    if (node) {
+        SMP_UNLOCK(table);
+        return node->index;
+    }
+
+    struct HNodeGroup *node_group = table->last_node_group;
+    if (!node_group->avail) {
+        node_group = new_node_group(table, DEFAULT_SIZE);
+    }
+
+    long new_index = insert_node(table, node_group, bucket_index, string);
+
+    SMP_UNLOCK(table);
+    return new_index;
+}

--- a/src/libAtomVM/atom_table.c
+++ b/src/libAtomVM/atom_table.c
@@ -213,8 +213,9 @@ AtomString atom_table_get_atom_string(struct AtomTable *table, long index)
     while (node_group) {
         long first_index = node_group->first_index;
         if (first_index + node_group->len > index) {
+            AtomString found_key = node_group->nodes[index - first_index].key;
             SMP_UNLOCK(table);
-            return node_group->nodes[index - first_index].key;
+            return found_key;
         }
 
         node_group = node_group->next;

--- a/src/libAtomVM/atom_table.h
+++ b/src/libAtomVM/atom_table.h
@@ -47,4 +47,7 @@ long atom_table_get_index(struct AtomTable *table, AtomString string);
 int atom_table_ensure_atoms(
     struct AtomTable *table, const void *atoms, int count, int *translate_table);
 
+int atom_table_cmp_using_atom_index(
+    struct AtomTable *table, int t_atom_index, int other_atom_index);
+
 #endif

--- a/src/libAtomVM/atom_table.h
+++ b/src/libAtomVM/atom_table.h
@@ -36,4 +36,7 @@ long atom_table_ensure_atom(struct AtomTable *table, AtomString string);
 AtomString atom_table_get_atom_string(struct AtomTable *table, long index);
 long atom_table_get_index(struct AtomTable *table, AtomString string);
 
+void atom_table_ensure_atoms(
+    struct AtomTable *table, const void *atoms, int count, int *translate_table);
+
 #endif

--- a/src/libAtomVM/atom_table.h
+++ b/src/libAtomVM/atom_table.h
@@ -27,12 +27,20 @@
 
 struct AtomTable;
 
+enum AtomTableCopyOpt
+{
+    AtomTableNoOpts = 0,
+    AtomTableCopyAtom = 1,
+    AtomTableAlreadyExisting = 2
+};
+
 struct AtomTable *atom_table_new();
 void atom_table_destroy(struct AtomTable *table);
 
 int atom_table_count(struct AtomTable *table);
 
-long atom_table_ensure_atom(struct AtomTable *table, AtomString string);
+long atom_table_ensure_atom(
+    struct AtomTable *table, AtomString string, enum AtomTableCopyOpt opts);
 AtomString atom_table_get_atom_string(struct AtomTable *table, long index);
 long atom_table_get_index(struct AtomTable *table, AtomString string);
 

--- a/src/libAtomVM/atom_table.h
+++ b/src/libAtomVM/atom_table.h
@@ -35,13 +35,19 @@ enum AtomTableCopyOpt
     AtomTableAlreadyExisting = 2
 };
 
+typedef const void *atom_ref_t;
+
 struct AtomTable *atom_table_new();
 void atom_table_destroy(struct AtomTable *table);
 
 int atom_table_count(struct AtomTable *table);
 
 long atom_table_ensure_atom(struct AtomTable *table, AtomString string, enum AtomTableCopyOpt opts);
+
+// This function is deprecated and it will be removed.
+// atom strings should be copied to caller owned buffers.
 AtomString atom_table_get_atom_string(struct AtomTable *table, long index);
+
 long atom_table_get_index(struct AtomTable *table, AtomString string);
 
 int atom_table_ensure_atoms(
@@ -49,5 +55,9 @@ int atom_table_ensure_atoms(
 
 int atom_table_cmp_using_atom_index(
     struct AtomTable *table, int t_atom_index, int other_atom_index);
+atom_ref_t atom_table_get_atom_ptr_and_len(struct AtomTable *table, long index, size_t *out_len);
+void atom_table_write_bytes(struct AtomTable *table, atom_ref_t atom, size_t buf_len, void *outbuf);
+void atom_table_write_cstring(
+    struct AtomTable *table, atom_ref_t atom, size_t buf_len, char *outbuf);
 
 #endif

--- a/src/libAtomVM/atom_table.h
+++ b/src/libAtomVM/atom_table.h
@@ -24,6 +24,7 @@
 #include "atom.h"
 
 #define ATOM_TABLE_NOT_FOUND -1
+#define ATOM_TABLE_ALLOC_FAIL -2
 
 struct AtomTable;
 
@@ -39,12 +40,11 @@ void atom_table_destroy(struct AtomTable *table);
 
 int atom_table_count(struct AtomTable *table);
 
-long atom_table_ensure_atom(
-    struct AtomTable *table, AtomString string, enum AtomTableCopyOpt opts);
+long atom_table_ensure_atom(struct AtomTable *table, AtomString string, enum AtomTableCopyOpt opts);
 AtomString atom_table_get_atom_string(struct AtomTable *table, long index);
 long atom_table_get_index(struct AtomTable *table, AtomString string);
 
-void atom_table_ensure_atoms(
+int atom_table_ensure_atoms(
     struct AtomTable *table, const void *atoms, int count, int *translate_table);
 
 #endif

--- a/src/libAtomVM/atom_table.h
+++ b/src/libAtomVM/atom_table.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Davide Bettio <davide@uninstall.it>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _ATOM_TABLE_
+#define _ATOM_TABLE_
+
+#include "atom.h"
+
+#define ATOM_TABLE_NOT_FOUND -1
+
+struct AtomTable;
+
+struct AtomTable *atom_table_new();
+void atom_table_destroy(struct AtomTable *table);
+
+int atom_table_count(struct AtomTable *table);
+
+long atom_table_ensure_atom(struct AtomTable *table, AtomString string);
+AtomString atom_table_get_atom_string(struct AtomTable *table, long index);
+long atom_table_get_index(struct AtomTable *table, AtomString string);
+
+#endif

--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -264,15 +264,13 @@ static int serialize_term(uint8_t *buf, term t, GlobalContext *glb)
         return NEW_FLOAT_EXT_SIZE;
 
     } else if (term_is_atom(t)) {
-        AtomString atom_string = globalcontext_atomstring_from_term(glb, t);
-        size_t atom_len = atom_string_len(atom_string);
+        int atom_index = term_to_atom_index(t);
+        size_t atom_len;
+        atom_ref_t atom_ref = atom_table_get_atom_ptr_and_len(glb->atom_table, atom_index, &atom_len);
         if (!IS_NULL_PTR(buf)) {
             buf[0] = ATOM_EXT;
             WRITE_16_UNALIGNED(buf + 1, atom_len);
-            int8_t *atom_data = (int8_t *) atom_string_data(atom_string);
-            for (size_t i = 3; i < atom_len + 3; ++i) {
-                buf[i] = (int8_t) atom_data[i - 3];
-            }
+            atom_table_write_bytes(glb->atom_table, atom_ref, atom_len, buf + 3);
         }
         return 3 + atom_len;
 

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -386,7 +386,7 @@ int globalcontext_get_registered_process(GlobalContext *glb, int atom_index)
 
 int globalcontext_insert_atom(GlobalContext *glb, AtomString atom_string)
 {
-    long index = atom_table_ensure_atom(glb->atom_table, atom_string);
+    long index = atom_table_ensure_atom(glb->atom_table, atom_string, AtomTableNoOpts);
     if (UNLIKELY(index == ATOM_TABLE_NOT_FOUND)) {
         abort();
     }
@@ -395,19 +395,8 @@ int globalcontext_insert_atom(GlobalContext *glb, AtomString atom_string)
 
 int globalcontext_insert_atom_maybe_copy(GlobalContext *glb, AtomString atom_string, int copy)
 {
-    // TODO: this leaks, fix it
-    if (copy) {
-        uint8_t len = *((uint8_t *) atom_string);
-        uint8_t *buf = malloc(1 + len);
-        if (UNLIKELY(IS_NULL_PTR(buf))) {
-            fprintf(stderr, "Unable to allocate memory for atom string\n");
-            AVM_ABORT();
-        }
-        memcpy(buf, atom_string, 1 + len);
-        atom_string = buf;
-    }
-
-    long index = atom_table_ensure_atom(glb->atom_table, atom_string);
+    long index = atom_table_ensure_atom(
+        glb->atom_table, atom_string, copy ? AtomTableCopyAtom : AtomTableNoOpts);
     return index;
 }
 

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -23,6 +23,7 @@
 
 #include "globalcontext.h"
 
+#include "atom_table.h"
 #include "atomshashtable.h"
 #include "avmpack.h"
 #include "context.h"
@@ -85,17 +86,8 @@ GlobalContext *globalcontext_new()
 
     glb->last_process_id = 0;
 
-#ifndef AVM_NO_SMP
-    smp_spinlock_init(&glb->atom_insert_lock);
-#endif
-    glb->atoms_table = atomshashtable_new();
-    if (IS_NULL_PTR(glb->atoms_table)) {
-        free(glb);
-        return NULL;
-    }
-    glb->atoms_ids_table = valueshashtable_new();
-    if (IS_NULL_PTR(glb->atoms_ids_table)) {
-        free(glb->atoms_table);
+    glb->atom_table = atom_table_new();
+    if (IS_NULL_PTR(glb->atom_table)) {
         free(glb);
         return NULL;
     }
@@ -106,8 +98,7 @@ GlobalContext *globalcontext_new()
     glb->loaded_modules_count = 0;
     glb->modules_table = atomshashtable_new();
     if (IS_NULL_PTR(glb->modules_table)) {
-        free(glb->atoms_ids_table);
-        free(glb->atoms_table);
+        atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
     }
@@ -115,8 +106,7 @@ GlobalContext *globalcontext_new()
     glb->modules_lock = smp_rwlock_create();
     if (IS_NULL_PTR(glb->modules_lock)) {
         free(glb->modules_table);
-        free(glb->atoms_ids_table);
-        free(glb->atoms_table);
+        atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
     }
@@ -141,8 +131,7 @@ GlobalContext *globalcontext_new()
         smp_rwlock_destroy(glb->modules_lock);
 #endif
         free(glb->modules_table);
-        free(glb->atoms_ids_table);
-        free(glb->atoms_table);
+        atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
     }
@@ -158,8 +147,7 @@ GlobalContext *globalcontext_new()
 #endif
         smp_rwlock_destroy(glb->modules_lock);
         free(glb->modules_table);
-        free(glb->atoms_ids_table);
-        free(glb->atoms_table);
+        atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
     }
@@ -171,8 +159,7 @@ GlobalContext *globalcontext_new()
 #endif
         smp_rwlock_destroy(glb->modules_lock);
         free(glb->modules_table);
-        free(glb->atoms_ids_table);
-        free(glb->atoms_table);
+        atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
     }
@@ -399,57 +386,35 @@ int globalcontext_get_registered_process(GlobalContext *glb, int atom_index)
 
 int globalcontext_insert_atom(GlobalContext *glb, AtomString atom_string)
 {
-    return globalcontext_insert_atom_maybe_copy(glb, atom_string, 0);
+    long index = atom_table_ensure_atom(glb->atom_table, atom_string);
+    if (UNLIKELY(index == ATOM_TABLE_NOT_FOUND)) {
+        abort();
+    }
+    return index;
 }
 
 int globalcontext_insert_atom_maybe_copy(GlobalContext *glb, AtomString atom_string, int copy)
 {
-    struct AtomsHashTable *htable = glb->atoms_table;
-
-    unsigned long atom_index = atomshashtable_get_value(htable, atom_string, ULONG_MAX);
-    if (atom_index == ULONG_MAX) {
-        if (copy) {
-            uint8_t len = *((uint8_t *) atom_string);
-            uint8_t *buf = malloc(1 + len);
-            if (IS_NULL_PTR(buf)) {
-                fprintf(stderr, "Unable to allocate memory for atom string\n");
-                AVM_ABORT();
-            }
-            memcpy(buf, atom_string, 1 + len);
-            atom_string = buf;
+    // TODO: this leaks, fix it
+    if (copy) {
+        uint8_t len = *((uint8_t *) atom_string);
+        uint8_t *buf = malloc(1 + len);
+        if (UNLIKELY(IS_NULL_PTR(buf))) {
+            fprintf(stderr, "Unable to allocate memory for atom string\n");
+            AVM_ABORT();
         }
-        // TODO: This lock can be avoided by returning from a new atomshashtable_get_or_insert
-        // function the new atom index, and using it when calling valueshashtable_insert.
-        // See also https://github.com/atomvm/AtomVM/pull/812 discussion
-        SMP_SPINLOCK_LOCK(&glb->atom_insert_lock);
-
-        // things might have changed in the meantime, so let's check this again now that there is
-        // a lock.
-        atom_index = atomshashtable_get_value(htable, atom_string, ULONG_MAX);
-        if (atom_index != ULONG_MAX) {
-            SMP_SPINLOCK_UNLOCK(&glb->atom_insert_lock);
-            return atom_index;
-        }
-
-        atom_index = htable->count;
-        if (!atomshashtable_insert(htable, atom_string, atom_index)) {
-            SMP_SPINLOCK_UNLOCK(&glb->atom_insert_lock);
-            return -1;
-        }
-        if (!valueshashtable_insert(glb->atoms_ids_table, atom_index, (unsigned long) atom_string)) {
-            SMP_SPINLOCK_UNLOCK(&glb->atom_insert_lock);
-            return -1;
-        }
-        SMP_SPINLOCK_UNLOCK(&glb->atom_insert_lock);
+        memcpy(buf, atom_string, 1 + len);
+        atom_string = buf;
     }
 
-    return (int) atom_index;
+    long index = atom_table_ensure_atom(glb->atom_table, atom_string);
+    return index;
 }
 
 bool globalcontext_is_atom_index_equal_to_atom_string(GlobalContext *glb, int atom_index_a, AtomString atom_string_b)
 {
     AtomString atom_string_a;
-    atom_string_a = (AtomString) valueshashtable_get_value(glb->atoms_ids_table, atom_index_a, 0);
+    atom_string_a = atom_table_get_atom_string(glb->atom_table, atom_index_a);
     return atom_are_equals(atom_string_a, atom_string_b);
 }
 
@@ -459,18 +424,17 @@ AtomString globalcontext_atomstring_from_term(GlobalContext *glb, term t)
         AVM_ABORT();
     }
     unsigned long atom_index = term_to_atom_index(t);
-    unsigned long ret;
-    ret = valueshashtable_get_value(glb->atoms_ids_table, atom_index, ULONG_MAX);
-    if (ret == ULONG_MAX) {
+    AtomString str = atom_table_get_atom_string(glb->atom_table, atom_index);
+    if (IS_NULL_PTR(str)) {
         return NULL;
     }
-    return (AtomString) ret;
+    return str;
 }
 
 term globalcontext_existing_term_from_atom_string(GlobalContext *glb, AtomString atom_string)
 {
-    unsigned long atom_index = atomshashtable_get_value(glb->atoms_table, atom_string, ULONG_MAX);
-    if (atom_index == ULONG_MAX) {
+    long atom_index = atom_table_get_index(glb->atom_table, atom_string);
+    if (UNLIKELY(atom_index == ATOM_TABLE_NOT_FOUND)) {
         return term_invalid_term();
     }
     return term_from_atom_index(atom_index);

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -384,22 +384,6 @@ int globalcontext_get_registered_process(GlobalContext *glb, int atom_index)
     return 0;
 }
 
-int globalcontext_insert_atom(GlobalContext *glb, AtomString atom_string)
-{
-    long index = atom_table_ensure_atom(glb->atom_table, atom_string, AtomTableNoOpts);
-    if (UNLIKELY(index == ATOM_TABLE_NOT_FOUND)) {
-        abort();
-    }
-    return index;
-}
-
-int globalcontext_insert_atom_maybe_copy(GlobalContext *glb, AtomString atom_string, int copy)
-{
-    long index = atom_table_ensure_atom(
-        glb->atom_table, atom_string, copy ? AtomTableCopyAtom : AtomTableNoOpts);
-    return index;
-}
-
 bool globalcontext_is_atom_index_equal_to_atom_string(GlobalContext *glb, int atom_index_a, AtomString atom_string_b)
 {
     AtomString atom_string_a;

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -35,6 +35,7 @@ extern "C" {
 #include <stdint.h>
 
 #include "atom.h"
+#include "atom_table.h"
 #include "erl_nif.h"
 #include "list.h"
 #include "smp.h"
@@ -82,12 +83,7 @@ struct GlobalContext
 
     int32_t last_process_id;
 
-    // TODO: this SpinLock should be removed
-#ifndef AVM_NO_SMP
-    SpinLock atom_insert_lock;
-#endif
-    struct AtomsHashTable *atoms_table;
-    struct ValuesHashTable *atoms_ids_table;
+    struct AtomTable *atom_table;
     struct AtomsHashTable *modules_table;
 
 #ifndef AVM_NO_SMP

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -267,11 +267,6 @@ bool globalcontext_unregister_process(GlobalContext *glb, int atom_index);
 void globalcontext_maybe_unregister_process_id(GlobalContext *glb, int process_id);
 
 /**
- * @brief equivalent to globalcontext_insert_atom_maybe_copy(glb, atom_string, 0);
- */
-int globalcontext_insert_atom(GlobalContext *glb, AtomString atom_string);
-
-/**
  * @brief Inserts an atom into the global atoms table, making a copy of the supplied atom
  * string, if copy is non-zero.
  *
@@ -282,7 +277,23 @@ int globalcontext_insert_atom(GlobalContext *glb, AtomString atom_string);
  * assumes "ownership" of the allocated memory.
  * @returns newly added atom id or -1 in case of failure.
  */
-int globalcontext_insert_atom_maybe_copy(GlobalContext *glb, AtomString atom_string, int copy);
+static inline int globalcontext_insert_atom_maybe_copy(GlobalContext *glb, AtomString atom_string, int copy)
+{
+    long index = atom_table_ensure_atom(
+        glb->atom_table, atom_string, copy ? AtomTableCopyAtom : AtomTableNoOpts);
+    if (UNLIKELY(index) < 0) {
+        return -1;
+    }
+    return index;
+}
+
+/**
+ * @brief equivalent to globalcontext_insert_atom_maybe_copy(glb, atom_string, 0);
+ */
+static inline int globalcontext_insert_atom(GlobalContext *glb, AtomString atom_string)
+{
+    return globalcontext_insert_atom_maybe_copy(glb, atom_string, 0);
+}
 
 /**
  * @brief Compares an atom table index with an AtomString.

--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -20,6 +20,7 @@
 
 #include "interop.h"
 
+#include "atom_table.h"
 #include "bitstring.h"
 #include "defaultatoms.h"
 #include "tempstack.h"
@@ -140,7 +141,7 @@ char *interop_list_to_string(term list, int *ok)
 char *interop_atom_to_string(Context *ctx, term atom)
 {
     int atom_index = term_to_atom_index(atom);
-    AtomString atom_string = (AtomString) valueshashtable_get_value(ctx->global->atoms_ids_table, atom_index, (unsigned long) NULL);
+    AtomString atom_string = atom_table_get_atom_string(ctx->global->atom_table, atom_index);
     int len = atom_string_len(atom_string);
 
     char *str = malloc(len + 1);

--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -140,15 +140,18 @@ char *interop_list_to_string(term list, int *ok)
 
 char *interop_atom_to_string(Context *ctx, term atom)
 {
+    GlobalContext *glb = ctx->global;
+
     int atom_index = term_to_atom_index(atom);
-    AtomString atom_string = atom_table_get_atom_string(ctx->global->atom_table, atom_index);
-    int len = atom_string_len(atom_string);
+
+    size_t len;
+    atom_ref_t atom_ref = atom_table_get_atom_ptr_and_len(glb->atom_table, atom_index, &len);
 
     char *str = malloc(len + 1);
     if (IS_NULL_PTR(str)) {
         return NULL;
     }
-    atom_string_to_c(atom_string, str, len + 1);
+    atom_table_write_cstring(glb->atom_table, atom_ref, len + 1, str);
 
     return str;
 }

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -412,8 +412,8 @@ term module_load_literal(Module *mod, int index, Context *ctx)
 const struct ExportedFunction *module_resolve_function0(Module *mod, int import_table_index, struct UnresolvedFunctionCall *unresolved, GlobalContext *glb)
 {
 
-    AtomString module_name_atom = (AtomString) valueshashtable_get_value(glb->atoms_ids_table, unresolved->module_atom_index, (unsigned long) NULL);
-    AtomString function_name_atom = (AtomString) valueshashtable_get_value(glb->atoms_ids_table, unresolved->function_atom_index, (unsigned long) NULL);
+    AtomString module_name_atom = atom_table_get_atom_string(glb->atom_table, unresolved->module_atom_index);
+    AtomString function_name_atom = atom_table_get_atom_string(glb->atom_table, unresolved->function_atom_index);
     int arity = unresolved->arity;
 
     Module *found_module = globalcontext_get_module(glb, module_name_atom);

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -80,9 +80,12 @@ static enum ModuleLoadResult module_populate_atoms_table(Module *this_module, ui
         return MODULE_ERROR_FAILED_ALLOCATION;
     }
 
-    // TODO check return value
-    atom_table_ensure_atoms(
+    long ensure_result = atom_table_ensure_atoms(
         glb->atom_table, current_atom, atoms_count, this_module->local_atoms_to_global_table + 1);
+    if (ensure_result == ATOM_TABLE_ALLOC_FAIL) {
+        fprintf(stderr, "Cannot allocate memory while loading module (line: %i).\n", __LINE__);
+        return MODULE_ERROR_FAILED_ALLOCATION;
+    }
 
     return MODULE_LOAD_OK;
 }

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -80,22 +80,9 @@ static enum ModuleLoadResult module_populate_atoms_table(Module *this_module, ui
         return MODULE_ERROR_FAILED_ALLOCATION;
     }
 
-    const char *atom = NULL;
-    for (int i = 1; i <= atoms_count; i++) {
-        // atom 0 is NON TERM for historical reasons
-        int atom_len = *current_atom;
-        atom = current_atom;
-
-        int global_atom_id = globalcontext_insert_atom(glb, (AtomString) atom);
-        if (UNLIKELY(global_atom_id < 0)) {
-            fprintf(stderr, "Cannot allocate memory while loading module (line: %i).\n", __LINE__);
-            return MODULE_ERROR_FAILED_ALLOCATION;
-        }
-
-        this_module->local_atoms_to_global_table[i] = global_atom_id;
-
-        current_atom += atom_len + 1;
-    }
+    // TODO check return value
+    atom_table_ensure_atoms(
+        glb->atom_table, current_atom, atoms_count, this_module->local_atoms_to_global_table + 1);
 
     return MODULE_LOAD_OK;
 }

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -36,6 +36,7 @@ extern "C" {
 #include <stdint.h>
 
 #include "atom.h"
+#include "atom_table.h"
 #include "atomshashtable.h"
 #include "context.h"
 #include "exportedfunction.h"
@@ -244,7 +245,7 @@ term module_load_literal(Module *mod, int index, Context *ctx);
 static inline AtomString module_get_atom_string_by_id(const Module *mod, int local_atom_id, GlobalContext *glb)
 {
     int global_id = mod->local_atoms_to_global_table[local_atom_id];
-    return (AtomString) valueshashtable_get_value(glb->atoms_ids_table, global_id, (unsigned long) NULL);
+    return atom_table_get_atom_string(glb->atom_table, global_id);
 }
 
 /**

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1956,22 +1956,16 @@ static term binary_to_atom(Context *ctx, int argc, term argv[], int create_new)
     ((uint8_t *) atom)[0] = atom_string_len;
     memcpy(((char *) atom) + 1, atom_string, atom_string_len);
 
-    // FIXME: here there is a potential race condition
-    long global_atom_index = atom_table_get_index(ctx->global->atom_table, atom);
-    bool has_atom = (global_atom_index != ATOM_TABLE_NOT_FOUND);
-
-    if (create_new || has_atom) {
-        if (!has_atom) {
-            global_atom_index = globalcontext_insert_atom(ctx->global, atom);
-        } else {
-            free((void *) atom);
-        }
-        return term_from_atom_index(global_atom_index);
-
-    } else {
-        free((void *) atom);
+    enum AtomTableCopyOpt atom_opts = AtomTableCopyAtom;
+    if (!create_new) {
+        atom_opts |= AtomTableAlreadyExisting;
+    }
+    long global_atom_index = atom_table_ensure_atom(ctx->global->atom_table, atom, atom_opts);
+    free((void *) atom);
+    if (UNLIKELY(global_atom_index == ATOM_TABLE_NOT_FOUND)) {
         RAISE_ERROR(BADARG_ATOM);
     }
+    return term_from_atom_index(global_atom_index);
 }
 
 term nif_erlang_list_to_atom_1(Context *ctx, int argc, term argv[])
@@ -2007,22 +2001,16 @@ term list_to_atom(Context *ctx, int argc, term argv[], int create_new)
     ((uint8_t *) atom)[0] = atom_string_len;
     memcpy(((char *) atom) + 1, atom_string, atom_string_len);
 
-    // FIXME: here there is a potential race condition
-    long global_atom_index = atom_table_get_index(ctx->global->atom_table, atom);
-    bool has_atom = (global_atom_index != ATOM_TABLE_NOT_FOUND);
-
-    if (create_new || has_atom) {
-        if (!has_atom) {
-            global_atom_index = globalcontext_insert_atom(ctx->global, atom);
-        } else {
-            free((void *) atom);
-        }
-        return term_from_atom_index(global_atom_index);
-
-    } else {
-        free((void *) atom);
+    enum AtomTableCopyOpt atom_opts = AtomTableCopyAtom;
+    if (!create_new) {
+        atom_opts |= AtomTableAlreadyExisting;
+    }
+    long global_atom_index = atom_table_ensure_atom(ctx->global->atom_table, atom, atom_opts);
+    free((void *) atom);
+    if (UNLIKELY(global_atom_index == ATOM_TABLE_NOT_FOUND)) {
         RAISE_ERROR(BADARG_ATOM);
     }
+    return term_from_atom_index(global_atom_index);
 }
 
 static term nif_erlang_atom_to_binary_2(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -606,29 +606,14 @@ TermCompareResult term_compare(term t, term other, TermCompareOpts opts, GlobalC
 
         } else if (term_is_atom(t) && term_is_atom(other)) {
             int t_atom_index = term_to_atom_index(t);
-            AtomString t_atom_string = atom_table_get_atom_string(global->atom_table,
-                t_atom_index);
-
-            int t_atom_len = atom_string_len(t_atom_string);
-            const char *t_atom_data = (const char *) atom_string_data(t_atom_string);
-
             int other_atom_index = term_to_atom_index(other);
-            AtomString other_atom_string = atom_table_get_atom_string(global->atom_table,
-                other_atom_index);
 
-            int other_atom_len = atom_string_len(other_atom_string);
-            const char *other_atom_data = (const char *) atom_string_data(other_atom_string);
-
-            int cmp_size = (t_atom_len > other_atom_len) ? other_atom_len : t_atom_len;
-
-            int memcmp_result = memcmp(t_atom_data, other_atom_data, cmp_size);
-            if (memcmp_result == 0) {
-                result = (t_atom_len > other_atom_len) ? TermGreaterThan : TermLessThan;
-                break;
-            } else {
-                result = memcmp_result > 0 ? TermGreaterThan : TermLessThan;
-                break;
-            }
+            // it cannot be equal since we check for term equality as first thing
+            // so let's ignore 0
+            int atom_cmp_result = atom_table_cmp_using_atom_index(
+                global->atom_table, t_atom_index, other_atom_index);
+            result = (atom_cmp_result > 0) ? TermGreaterThan : TermLessThan;
+            break;
 
         } else if (term_is_pid(t) && term_is_pid(other)) {
             //TODO: handle ports

--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -21,10 +21,10 @@
 #include "term.h"
 
 #include "atom.h"
+#include "atom_table.h"
 #include "context.h"
 #include "interop.h"
 #include "tempstack.h"
-#include "valueshashtable.h"
 
 #include <ctype.h>
 #include <inttypes.h>
@@ -113,8 +113,7 @@ int term_funprint(PrinterFun *fun, term t, const GlobalContext *global)
 {
     if (term_is_atom(t)) {
         int atom_index = term_to_atom_index(t);
-        AtomString atom_string = (AtomString) valueshashtable_get_value(
-            global->atoms_ids_table, atom_index, (unsigned long) NULL);
+        AtomString atom_string = atom_table_get_atom_string(global->atom_table, atom_index);
         return fun->print(fun, "%.*s", (int) atom_string_len(atom_string),
             (char *) atom_string_data(atom_string));
 
@@ -607,15 +606,15 @@ TermCompareResult term_compare(term t, term other, TermCompareOpts opts, GlobalC
 
         } else if (term_is_atom(t) && term_is_atom(other)) {
             int t_atom_index = term_to_atom_index(t);
-            AtomString t_atom_string = (AtomString) valueshashtable_get_value(global->atoms_ids_table,
-                t_atom_index, (unsigned long) NULL);
+            AtomString t_atom_string = atom_table_get_atom_string(global->atom_table,
+                t_atom_index);
 
             int t_atom_len = atom_string_len(t_atom_string);
             const char *t_atom_data = (const char *) atom_string_data(t_atom_string);
 
             int other_atom_index = term_to_atom_index(other);
-            AtomString other_atom_string = (AtomString) valueshashtable_get_value(global->atoms_ids_table,
-                other_atom_index, (unsigned long) NULL);
+            AtomString other_atom_string = atom_table_get_atom_string(global->atom_table,
+                other_atom_index);
 
             int other_atom_len = atom_string_len(other_atom_string);
             const char *other_atom_data = (const char *) atom_string_data(other_atom_string);

--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -252,7 +252,7 @@ Context *gpio_driver_create_port(GlobalContext *global, term opts)
 static term gpiodriver_close(Context *ctx)
 {
     GlobalContext *glb = ctx->global;
-    int gpio_atom_index = atom_table_ensure_atom(glb->atom_table, gpio_atom);
+    int gpio_atom_index = atom_table_ensure_atom(glb->atom_table, gpio_atom, AtomTableNoOpts);
     if (UNLIKELY(!globalcontext_get_registered_process(glb, gpio_atom_index))) {
         return ERROR_ATOM;
     }

--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -252,8 +252,7 @@ Context *gpio_driver_create_port(GlobalContext *global, term opts)
 static term gpiodriver_close(Context *ctx)
 {
     GlobalContext *glb = ctx->global;
-    struct AtomsHashTable *htable = glb->atoms_table;
-    int gpio_atom_index = atomshashtable_get_value(htable, gpio_atom, ULONG_MAX);
+    int gpio_atom_index = atom_table_ensure_atom(glb->atom_table, gpio_atom);
     if (UNLIKELY(!globalcontext_get_registered_process(glb, gpio_atom_index))) {
         return ERROR_ATOM;
     }

--- a/tests/test-structs.c
+++ b/tests/test-structs.c
@@ -278,140 +278,140 @@ int insert_atoms_into_atom_table(struct AtomTable *table)
 {
     int decimals_index;
 
-    atom_table_ensure_atom(table, false_atom);
-    atom_table_ensure_atom(table, true_atom);
+    atom_table_ensure_atom(table, false_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, true_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, ok_atom);
-    atom_table_ensure_atom(table, error_atom);
+    atom_table_ensure_atom(table, ok_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, error_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, undefined_atom);
+    atom_table_ensure_atom(table, undefined_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, badarg_atom);
-    atom_table_ensure_atom(table, badarith_atom);
-    atom_table_ensure_atom(table, badarity_atom);
-    atom_table_ensure_atom(table, badfun_atom);
-    atom_table_ensure_atom(table, function_clause_atom);
-    atom_table_ensure_atom(table, try_clause_atom);
-    atom_table_ensure_atom(table, out_of_memory_atom);
-    atom_table_ensure_atom(table, overflow_atom);
-    atom_table_ensure_atom(table, system_limit_atom);
+    atom_table_ensure_atom(table, badarg_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, badarith_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, badarity_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, badfun_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, function_clause_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, try_clause_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, out_of_memory_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, overflow_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, system_limit_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, flush_atom);
-    atom_table_ensure_atom(table, heap_size_atom);
-    atom_table_ensure_atom(table, latin1_atom);
-    atom_table_ensure_atom(table, max_heap_size_atom);
-    atom_table_ensure_atom(table, memory_atom);
-    atom_table_ensure_atom(table, message_queue_len_atom);
-    atom_table_ensure_atom(table, puts_atom);
-    atom_table_ensure_atom(table, stack_size_atom);
-    atom_table_ensure_atom(table, min_heap_size_atom);
-    atom_table_ensure_atom(table, process_count_atom);
-    atom_table_ensure_atom(table, port_count_atom);
-    atom_table_ensure_atom(table, atom_count_atom);
-    atom_table_ensure_atom(table, system_architecture_atom);
-    atom_table_ensure_atom(table, wordsize_atom);
+    atom_table_ensure_atom(table, flush_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, heap_size_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, latin1_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, max_heap_size_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, memory_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, message_queue_len_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, puts_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, stack_size_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, min_heap_size_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, process_count_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, port_count_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, atom_count_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, system_architecture_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, wordsize_atom, AtomTableNoOpts);
 
-    decimals_index = atom_table_ensure_atom(table, decimals_atom);
-    atom_table_ensure_atom(table, scientific_atom);
-    atom_table_ensure_atom(table, compact_atom);
+    decimals_index = atom_table_ensure_atom(table, decimals_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, scientific_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, compact_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, badmatch_atom);
-    atom_table_ensure_atom(table, case_clause_atom);
-    atom_table_ensure_atom(table, if_clause_atom);
-    atom_table_ensure_atom(table, throw_atom);
-    atom_table_ensure_atom(table, low_entropy_atom);
-    atom_table_ensure_atom(table, unsupported_atom);
-    atom_table_ensure_atom(table, used_atom);
-    atom_table_ensure_atom(table, all_atom);
-    atom_table_ensure_atom(table, start_atom);
+    atom_table_ensure_atom(table, badmatch_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, case_clause_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, if_clause_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, throw_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, low_entropy_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, unsupported_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, used_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, all_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, start_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, undef_atom);
-    atom_table_ensure_atom(table, vm_abort_atom);
+    atom_table_ensure_atom(table, undef_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, vm_abort_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, link_atom);
-    atom_table_ensure_atom(table, monitor_atom);
-    atom_table_ensure_atom(table, normal_atom);
-    atom_table_ensure_atom(table, down_atom);
-    atom_table_ensure_atom(table, process_atom);
-    atom_table_ensure_atom(table, nocatch_atom);
-    atom_table_ensure_atom(table, refc_binary_info_atom);
+    atom_table_ensure_atom(table, link_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, monitor_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, normal_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, down_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, process_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, nocatch_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, refc_binary_info_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, noproc_atom);
-    atom_table_ensure_atom(table, trap_exit_atom);
-    atom_table_ensure_atom(table, exit_atom);
+    atom_table_ensure_atom(table, noproc_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, trap_exit_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, exit_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, badmap_atom);
-    atom_table_ensure_atom(table, badkey_atom);
-    atom_table_ensure_atom(table, none_atom);
+    atom_table_ensure_atom(table, badmap_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, badkey_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, none_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, io_request_atom);
-    atom_table_ensure_atom(table, io_reply_atom);
-    atom_table_ensure_atom(table, put_chars_atom);
+    atom_table_ensure_atom(table, io_request_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, io_reply_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, put_chars_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, lowercase_exit_atom);
-    atom_table_ensure_atom(table, atomvm_version_atom);
+    atom_table_ensure_atom(table, lowercase_exit_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, atomvm_version_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, second_atom);
-    atom_table_ensure_atom(table, millisecond_atom);
-    atom_table_ensure_atom(table, microsecond_atom);
+    atom_table_ensure_atom(table, second_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, millisecond_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, microsecond_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, infinity_atom);
-    atom_table_ensure_atom(table, timeout_value_atom);
+    atom_table_ensure_atom(table, infinity_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, timeout_value_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, schedulers_atom);
-    atom_table_ensure_atom(table, schedulers_online_atom);
+    atom_table_ensure_atom(table, schedulers_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, schedulers_online_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, append_atom);
-    atom_table_ensure_atom(table, private_append_atom);
-    atom_table_ensure_atom(table, binary_atom);
-    atom_table_ensure_atom(table, integer_atom);
-    atom_table_ensure_atom(table, little_atom);
-    atom_table_ensure_atom(table, native_atom);
-    atom_table_ensure_atom(table, string_atom);
-    atom_table_ensure_atom(table, utf8_atom);
-    atom_table_ensure_atom(table, utf16_atom);
-    atom_table_ensure_atom(table, utf32_atom);
-    atom_table_ensure_atom(table, badrecord_atom);
+    atom_table_ensure_atom(table, append_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, private_append_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, binary_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, integer_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, little_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, native_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, string_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, utf8_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, utf16_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, utf32_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, badrecord_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, copy_atom);
-    atom_table_ensure_atom(table, reuse_atom);
-    atom_table_ensure_atom(table, ensure_at_least_atom);
-    atom_table_ensure_atom(table, ensure_exactly_atom);
-    atom_table_ensure_atom(table, skip_atom);
-    atom_table_ensure_atom(table, get_tail_atom);
-    atom_table_ensure_atom(table, equal_colon_equal_atom);
-    atom_table_ensure_atom(table, signed_atom);
+    atom_table_ensure_atom(table, copy_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, reuse_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, ensure_at_least_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, ensure_exactly_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, skip_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, get_tail_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, equal_colon_equal_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, signed_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, machine_atom);
-    atom_table_ensure_atom(table, avm_floatsize_atom);
+    atom_table_ensure_atom(table, machine_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, avm_floatsize_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, close_atom);
-    atom_table_ensure_atom(table, closed_atom);
-    atom_table_ensure_atom(table, port_atom);
+    atom_table_ensure_atom(table, close_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, closed_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, port_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, info_atom);
+    atom_table_ensure_atom(table, info_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, module_atom);
+    atom_table_ensure_atom(table, module_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, select_atom);
-    atom_table_ensure_atom(table, ready_input_atom);
-    atom_table_ensure_atom(table, ready_output_atom);
+    atom_table_ensure_atom(table, select_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, ready_input_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, ready_output_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, attributes_atom);
-    atom_table_ensure_atom(table, compile_atom);
-    atom_table_ensure_atom(table, exports_atom);
+    atom_table_ensure_atom(table, attributes_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, compile_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, exports_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, incomplete_atom);
+    atom_table_ensure_atom(table, incomplete_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, kill_atom);
-    atom_table_ensure_atom(table, killed_atom);
-    atom_table_ensure_atom(table, links_atom);
+    atom_table_ensure_atom(table, kill_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, killed_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, links_atom, AtomTableNoOpts);
 
-    atom_table_ensure_atom(table, total_heap_size_atom);
-    atom_table_ensure_atom(table, atomvm_heap_growth_atom);
-    atom_table_ensure_atom(table, bounded_free_atom);
-    atom_table_ensure_atom(table, minimum_atom);
-    atom_table_ensure_atom(table, fibonacci_atom);
+    atom_table_ensure_atom(table, total_heap_size_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, atomvm_heap_growth_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, bounded_free_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, minimum_atom, AtomTableNoOpts);
+    atom_table_ensure_atom(table, fibonacci_atom, AtomTableNoOpts);
 
     return decimals_index;
 }
@@ -422,10 +422,10 @@ void test_atom_table()
 
     assert(atom_table_get_index(table, "\x4" "ciao") == ATOM_TABLE_NOT_FOUND);
 
-    assert(atom_table_ensure_atom(table, "\x3" "bar") == 0);
-    assert(atom_table_ensure_atom(table, "\x4" "ciao") == 1);
-    assert(atom_table_ensure_atom(table, "\x3" "foo") == 2);
-    assert(atom_table_ensure_atom(table, "\x3" "foo") == 2);
+    assert(atom_table_ensure_atom(table, "\x3" "bar", AtomTableNoOpts) == 0);
+    assert(atom_table_ensure_atom(table, "\x4" "ciao", AtomTableNoOpts) == 1);
+    assert(atom_table_ensure_atom(table, "\x3" "foo", AtomTableNoOpts) == 2);
+    assert(atom_table_ensure_atom(table, "\x3" "foo", AtomTableNoOpts) == 2);
 
     assert(atom_table_get_index(table, "\x4" "ciao") == 1);
 
@@ -434,7 +434,7 @@ void test_atom_table()
     int decimals_index = insert_atoms_into_atom_table(table);
 
     assert(atom_table_get_index(table, "\x8" "decimals") == decimals_index);
-    assert(atom_table_ensure_atom(table, "\x8" "decimals") == decimals_index);
+    assert(atom_table_ensure_atom(table, "\x8" "decimals", AtomTableNoOpts) == decimals_index);
 
     atom_table_destroy(table);
 }

--- a/tests/test-structs.c
+++ b/tests/test-structs.c
@@ -22,8 +22,143 @@
 #include <stdlib.h>
 
 #include "atomshashtable.h"
+#include "atom_table.h"
 #include "utils.h"
 #include "valueshashtable.h"
+
+static const char *const false_atom = "\x05" "false";
+static const char *const true_atom = "\x04" "true";
+
+static const char *const ok_atom = "\x2" "ok";
+static const char *const error_atom = "\x5" "error";
+
+static const char *const undefined_atom = "\x9" "undefined";
+
+static const char *const badarg_atom = "\x6" "badarg";
+static const char *const badarith_atom = "\x08" "badarith";
+static const char *const badarity_atom = "\x08" "badarity";
+static const char *const badfun_atom = "\x06" "badfun";
+static const char *const system_limit_atom = "\xC" "system_limit";
+static const char *const function_clause_atom = "\x0F" "function_clause";
+static const char *const try_clause_atom = "\xA" "try_clause";
+static const char *const out_of_memory_atom = "\xD" "out_of_memory";
+static const char *const overflow_atom = "\x8" "overflow";
+
+static const char *const flush_atom = "\x5" "flush";
+static const char *const heap_size_atom = "\x9" "heap_size";
+static const char *const latin1_atom = "\x6" "latin1";
+static const char *const max_heap_size_atom = "\xD" "max_heap_size";
+static const char *const memory_atom = "\x6" "memory";
+static const char *const message_queue_len_atom = "\x11" "message_queue_len";
+static const char *const puts_atom = "\x4" "puts";
+static const char *const stack_size_atom = "\xA" "stack_size";
+static const char *const min_heap_size_atom = "\xD" "min_heap_size";
+static const char *const process_count_atom = "\xD" "process_count";
+static const char *const port_count_atom = "\xA" "port_count";
+static const char *const atom_count_atom = "\xA" "atom_count";
+static const char *const system_architecture_atom = "\x13" "system_architecture";
+static const char *const wordsize_atom = "\x8" "wordsize";
+
+static const char *const decimals_atom = "\x8" "decimals";
+static const char *const scientific_atom = "\xA" "scientific";
+static const char *const compact_atom = "\x7" "compact";
+
+static const char *const badmatch_atom = "\x8" "badmatch";
+static const char *const case_clause_atom = "\xB" "case_clause";
+static const char *const if_clause_atom = "\x9" "if_clause";
+static const char *const throw_atom = "\x5" "throw";
+static const char *const low_entropy_atom = "\xB" "low_entropy";
+static const char *const unsupported_atom = "\xB" "unsupported";
+static const char *const used_atom = "\x4" "used";
+static const char *const all_atom = "\x3" "all";
+static const char *const start_atom = "\x5" "start";
+
+static const char *const undef_atom = "\x5" "undef";
+static const char *const vm_abort_atom = "\x8" "vm_abort";
+
+static const char *const link_atom = "\x4" "link";
+static const char *const monitor_atom = "\x7" "monitor";
+static const char *const normal_atom = "\x6" "normal";
+static const char *const down_atom = "\x4" "DOWN";
+static const char *const process_atom = "\x7" "process";
+static const char *const nocatch_atom = "\x7" "nocatch";
+static const char *const refc_binary_info_atom = "\x10" "refc_binary_info";
+static const char *const noproc_atom = "\x6" "noproc";
+static const char *const trap_exit_atom = "\x9" "trap_exit";
+static const char *const exit_atom = "\x4" "EXIT";
+
+static const char *const badmap_atom = "\x6" "badmap";
+static const char *const badkey_atom = "\x6" "badkey";
+static const char *const none_atom = "\x4" "none";
+
+static const char *const io_request_atom = "\xA" "io_request";
+static const char *const io_reply_atom = "\x8" "io_reply";
+static const char *const put_chars_atom = "\x9" "put_chars";
+
+static const char *const lowercase_exit_atom = "\x4" "exit";
+static const char *const atomvm_version_atom = "\xE" "atomvm_version";
+
+static const char *const second_atom = "\x6" "second";
+static const char *const millisecond_atom = "\xB" "millisecond";
+static const char *const microsecond_atom = "\xB" "microsecond";
+
+static const char *const infinity_atom = "\x8" "infinity";
+static const char *const timeout_value_atom = "\xD" "timeout_value";
+
+static const char *const schedulers_atom = "\xA" "schedulers";
+static const char *const schedulers_online_atom = "\x11" "schedulers_online";
+
+static const char *const append_atom = "\x6" "append";
+static const char *const private_append_atom = "\xE" "private_append";
+static const char *const binary_atom = "\x6" "binary";
+static const char *const integer_atom = "\x7" "integer";
+static const char *const little_atom = "\x6" "little";
+static const char *const native_atom = "\x6" "native";
+static const char *const string_atom = "\x6" "string";
+static const char *const utf8_atom = "\x4" "utf8";
+static const char *const utf16_atom = "\x5" "utf16";
+static const char *const utf32_atom = "\x5" "utf32";
+static const char *const badrecord_atom = "\x9" "badrecord";
+
+static const char *const copy_atom = "\x4" "copy";
+static const char *const reuse_atom = "\x5" "reuse";
+static const char *const ensure_at_least_atom = "\xF" "ensure_at_least";
+static const char *const ensure_exactly_atom = "\xE" "ensure_exactly";
+static const char *const skip_atom = "\x4" "skip";
+static const char *const get_tail_atom = "\x8" "get_tail";
+static const char *const equal_colon_equal_atom = "\x3" "=:=";
+static const char *const signed_atom = "\x6" "signed";
+
+static const char *const machine_atom = "\x7" "machine";
+static const char *const avm_floatsize_atom = "\xD" "avm_floatsize";
+
+static const char *const close_atom = "\x5" "close";
+static const char *const closed_atom = "\x6" "closed";
+static const char *const port_atom = "\x4" "port";
+
+static const char *const info_atom = "\x4" "info";
+
+static const char *const module_atom = "\x06" "module";
+
+static const char *const select_atom = "\x6" "select";
+static const char *const ready_input_atom = "\xB" "ready_input";
+static const char *const ready_output_atom = "\xC" "ready_output";
+
+static const char *const attributes_atom = "\xA" "attributes";
+static const char *const compile_atom = "\x7" "compile";
+static const char *const exports_atom = "\x7" "exports";
+
+static const char *const incomplete_atom = "\xA" "incomplete";
+
+static const char *const kill_atom = "\x4" "kill";
+static const char *const killed_atom = "\x6" "killed";
+static const char *const links_atom = "\x5" "links";
+
+static const char *const total_heap_size_atom = "\xF" "total_heap_size";
+static const char *const atomvm_heap_growth_atom = "\x12" "atomvm_heap_growth";
+static const char *const bounded_free_atom = "\xC" "bounded_free";
+static const char *const minimum_atom = "\x7" "minimum";
+static const char *const fibonacci_atom = "\x9" "fibonacci";
 
 void test_atomshashtable()
 {
@@ -139,6 +274,171 @@ void test_valueshashtable()
     }
 }
 
+int insert_atoms_into_atom_table(struct AtomTable *table)
+{
+    int decimals_index;
+
+    atom_table_ensure_atom(table, false_atom);
+    atom_table_ensure_atom(table, true_atom);
+
+    atom_table_ensure_atom(table, ok_atom);
+    atom_table_ensure_atom(table, error_atom);
+
+    atom_table_ensure_atom(table, undefined_atom);
+
+    atom_table_ensure_atom(table, badarg_atom);
+    atom_table_ensure_atom(table, badarith_atom);
+    atom_table_ensure_atom(table, badarity_atom);
+    atom_table_ensure_atom(table, badfun_atom);
+    atom_table_ensure_atom(table, function_clause_atom);
+    atom_table_ensure_atom(table, try_clause_atom);
+    atom_table_ensure_atom(table, out_of_memory_atom);
+    atom_table_ensure_atom(table, overflow_atom);
+    atom_table_ensure_atom(table, system_limit_atom);
+
+    atom_table_ensure_atom(table, flush_atom);
+    atom_table_ensure_atom(table, heap_size_atom);
+    atom_table_ensure_atom(table, latin1_atom);
+    atom_table_ensure_atom(table, max_heap_size_atom);
+    atom_table_ensure_atom(table, memory_atom);
+    atom_table_ensure_atom(table, message_queue_len_atom);
+    atom_table_ensure_atom(table, puts_atom);
+    atom_table_ensure_atom(table, stack_size_atom);
+    atom_table_ensure_atom(table, min_heap_size_atom);
+    atom_table_ensure_atom(table, process_count_atom);
+    atom_table_ensure_atom(table, port_count_atom);
+    atom_table_ensure_atom(table, atom_count_atom);
+    atom_table_ensure_atom(table, system_architecture_atom);
+    atom_table_ensure_atom(table, wordsize_atom);
+
+    decimals_index = atom_table_ensure_atom(table, decimals_atom);
+    atom_table_ensure_atom(table, scientific_atom);
+    atom_table_ensure_atom(table, compact_atom);
+
+    atom_table_ensure_atom(table, badmatch_atom);
+    atom_table_ensure_atom(table, case_clause_atom);
+    atom_table_ensure_atom(table, if_clause_atom);
+    atom_table_ensure_atom(table, throw_atom);
+    atom_table_ensure_atom(table, low_entropy_atom);
+    atom_table_ensure_atom(table, unsupported_atom);
+    atom_table_ensure_atom(table, used_atom);
+    atom_table_ensure_atom(table, all_atom);
+    atom_table_ensure_atom(table, start_atom);
+
+    atom_table_ensure_atom(table, undef_atom);
+    atom_table_ensure_atom(table, vm_abort_atom);
+
+    atom_table_ensure_atom(table, link_atom);
+    atom_table_ensure_atom(table, monitor_atom);
+    atom_table_ensure_atom(table, normal_atom);
+    atom_table_ensure_atom(table, down_atom);
+    atom_table_ensure_atom(table, process_atom);
+    atom_table_ensure_atom(table, nocatch_atom);
+    atom_table_ensure_atom(table, refc_binary_info_atom);
+
+    atom_table_ensure_atom(table, noproc_atom);
+    atom_table_ensure_atom(table, trap_exit_atom);
+    atom_table_ensure_atom(table, exit_atom);
+
+    atom_table_ensure_atom(table, badmap_atom);
+    atom_table_ensure_atom(table, badkey_atom);
+    atom_table_ensure_atom(table, none_atom);
+
+    atom_table_ensure_atom(table, io_request_atom);
+    atom_table_ensure_atom(table, io_reply_atom);
+    atom_table_ensure_atom(table, put_chars_atom);
+
+    atom_table_ensure_atom(table, lowercase_exit_atom);
+    atom_table_ensure_atom(table, atomvm_version_atom);
+
+    atom_table_ensure_atom(table, second_atom);
+    atom_table_ensure_atom(table, millisecond_atom);
+    atom_table_ensure_atom(table, microsecond_atom);
+
+    atom_table_ensure_atom(table, infinity_atom);
+    atom_table_ensure_atom(table, timeout_value_atom);
+
+    atom_table_ensure_atom(table, schedulers_atom);
+    atom_table_ensure_atom(table, schedulers_online_atom);
+
+    atom_table_ensure_atom(table, append_atom);
+    atom_table_ensure_atom(table, private_append_atom);
+    atom_table_ensure_atom(table, binary_atom);
+    atom_table_ensure_atom(table, integer_atom);
+    atom_table_ensure_atom(table, little_atom);
+    atom_table_ensure_atom(table, native_atom);
+    atom_table_ensure_atom(table, string_atom);
+    atom_table_ensure_atom(table, utf8_atom);
+    atom_table_ensure_atom(table, utf16_atom);
+    atom_table_ensure_atom(table, utf32_atom);
+    atom_table_ensure_atom(table, badrecord_atom);
+
+    atom_table_ensure_atom(table, copy_atom);
+    atom_table_ensure_atom(table, reuse_atom);
+    atom_table_ensure_atom(table, ensure_at_least_atom);
+    atom_table_ensure_atom(table, ensure_exactly_atom);
+    atom_table_ensure_atom(table, skip_atom);
+    atom_table_ensure_atom(table, get_tail_atom);
+    atom_table_ensure_atom(table, equal_colon_equal_atom);
+    atom_table_ensure_atom(table, signed_atom);
+
+    atom_table_ensure_atom(table, machine_atom);
+    atom_table_ensure_atom(table, avm_floatsize_atom);
+
+    atom_table_ensure_atom(table, close_atom);
+    atom_table_ensure_atom(table, closed_atom);
+    atom_table_ensure_atom(table, port_atom);
+
+    atom_table_ensure_atom(table, info_atom);
+
+    atom_table_ensure_atom(table, module_atom);
+
+    atom_table_ensure_atom(table, select_atom);
+    atom_table_ensure_atom(table, ready_input_atom);
+    atom_table_ensure_atom(table, ready_output_atom);
+
+    atom_table_ensure_atom(table, attributes_atom);
+    atom_table_ensure_atom(table, compile_atom);
+    atom_table_ensure_atom(table, exports_atom);
+
+    atom_table_ensure_atom(table, incomplete_atom);
+
+    atom_table_ensure_atom(table, kill_atom);
+    atom_table_ensure_atom(table, killed_atom);
+    atom_table_ensure_atom(table, links_atom);
+
+    atom_table_ensure_atom(table, total_heap_size_atom);
+    atom_table_ensure_atom(table, atomvm_heap_growth_atom);
+    atom_table_ensure_atom(table, bounded_free_atom);
+    atom_table_ensure_atom(table, minimum_atom);
+    atom_table_ensure_atom(table, fibonacci_atom);
+
+    return decimals_index;
+}
+
+void test_atom_table()
+{
+    struct AtomTable *table = atom_table_new();
+
+    assert(atom_table_get_index(table, "\x4" "ciao") == ATOM_TABLE_NOT_FOUND);
+
+    assert(atom_table_ensure_atom(table, "\x3" "bar") == 0);
+    assert(atom_table_ensure_atom(table, "\x4" "ciao") == 1);
+    assert(atom_table_ensure_atom(table, "\x3" "foo") == 2);
+    assert(atom_table_ensure_atom(table, "\x3" "foo") == 2);
+
+    assert(atom_table_get_index(table, "\x4" "ciao") == 1);
+
+    assert(((char *) atom_table_get_atom_string(table, 0))[0] == 3);
+
+    int decimals_index = insert_atoms_into_atom_table(table);
+
+    assert(atom_table_get_index(table, "\x8" "decimals") == decimals_index);
+    assert(atom_table_ensure_atom(table, "\x8" "decimals") == decimals_index);
+
+    atom_table_destroy(table);
+}
+
 int main(int argc, char **argv)
 {
     UNUSED(argc);
@@ -146,6 +446,7 @@ int main(int argc, char **argv)
 
     test_atomshashtable();
     test_valueshashtable();
+    test_atom_table();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Implement new atom table that overcomes previous implementation shortcomings.

Some further improvements are not part of this PR and they will be addressed with further PRs, such as:

- Using gperf for default atoms
- Removing `atom_table_get_atom_string`
- Coalescing together atom strings that are allocated on the heap (instead of using `strdup`)

Memory benchmark:

With atom table:

```
[...]
Heap summary for capabilities 0x00000004:
  At 0x3ffb70e8 len 167704 free 104160 allocated 58664 min_free 102252
    largest_free_block 102400 alloc_blocks 814 free_blocks 2 total_blocks 816
[...]
```

without:
```
[...]
Heap summary for capabilities 0x00000004:
  At 0x3ffb70e8 len 167704 free 96076 allocated 63096 min_free 94252
    largest_free_block 94208 alloc_blocks 1727 free_blocks 2 total_blocks 1729
[...]
```

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
