### PR TITLE
`UNLIKELY(IS_NULL_PTR(ptr))` -> `IS_NULL_PTR(ptr)`

### DIFF
--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -139,7 +139,7 @@ enum ExternalTermResult externalterm_from_binary(Context *ctx, term *dst, term b
     size_t len = term_binary_size(binary);
     const uint8_t *data = (const uint8_t *) term_binary_data(binary);
     uint8_t *buf = malloc(len);
-    if (UNLIKELY(IS_NULL_PTR(buf))) {
+    if (IS_NULL_PTR(buf)) {
         fprintf(stderr, "Unable to allocate %zu bytes for binary buffer.\n", len);
         return EXTERNAL_TERM_MALLOC;
     }
@@ -161,7 +161,7 @@ static int externalterm_from_term(uint8_t **buf, size_t *len, term t, GlobalCont
 {
     *len = compute_external_size(t, glb) + 1;
     *buf = malloc(*len);
-    if (UNLIKELY(IS_NULL_PTR(*buf))) {
+    if (IS_NULL_PTR(*buf)) {
         fprintf(stderr, "Unable to allocate %zu bytes for externalized term.\n", *len);
         AVM_ABORT();
     }

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -411,7 +411,7 @@ int globalcontext_insert_atom_maybe_copy(GlobalContext *glb, AtomString atom_str
         if (copy) {
             uint8_t len = *((uint8_t *) atom_string);
             uint8_t *buf = malloc(1 + len);
-            if (UNLIKELY(IS_NULL_PTR(buf))) {
+            if (IS_NULL_PTR(buf)) {
                 fprintf(stderr, "Unable to allocate memory for atom string\n");
                 AVM_ABORT();
             }

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -4308,7 +4308,7 @@ wait_timeout_trap_handler:
 
                     size_t remaining = 0;
                     const uint8_t *str = module_get_str(mod, offset, &remaining);
-                    if (UNLIKELY(IS_NULL_PTR(str))) {
+                    if (IS_NULL_PTR(str)) {
                         TRACE("bs_put_string: Bad offset in strings table.\n");
                         RAISE_ERROR(BADARG_ATOM);
                     }
@@ -4538,7 +4538,7 @@ wait_timeout_trap_handler:
 
                     size_t remaining = 0;
                     const uint8_t *str = module_get_str(mod, offset, &remaining);
-                    if (UNLIKELY(IS_NULL_PTR(str))) {
+                    if (IS_NULL_PTR(str)) {
                         TRACE("bs_match_string: Bad offset in strings table.\n");
                         RAISE_ERROR(BADARG_ATOM);
                     }

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -595,7 +595,7 @@ static void start_network(Context *ctx, term pid, term ref, term config)
 
     wifi_config_t *sta_wifi_config = get_sta_wifi_config(sta_config, ctx->global);
     wifi_config_t *ap_wifi_config = get_ap_wifi_config(ap_config, ctx->global);
-    if (UNLIKELY(IS_NULL_PTR(sta_wifi_config) && IS_NULL_PTR(ap_wifi_config))) {
+    if (IS_NULL_PTR(sta_wifi_config) && IS_NULL_PTR(ap_wifi_config)) {
         ESP_LOGE(TAG, "Unable to get STA or AP configuration");
         term error = port_create_error_tuple(ctx, BADARG_ATOM);
         port_send_reply(ctx, pid, ref, error);

--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -140,7 +140,7 @@ static term nif_esp_random_bytes(Context *ctx, int argc, term argv[])
         return binary;
     } else {
         uint8_t *buf = malloc(len);
-        if (UNLIKELY(IS_NULL_PTR(buf))) {
+        if (IS_NULL_PTR(buf)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         esp_fill_random(buf, len);

--- a/src/platforms/generic_unix/lib/platform_nifs.c
+++ b/src/platforms/generic_unix/lib/platform_nifs.c
@@ -173,7 +173,7 @@ static term nif_openssl_rand_bytes(Context *ctx, int argc, term argv[])
     avm_int_t n = term_maybe_unbox_int(t);
 
     char *buf = malloc(n);
-    if (UNLIKELY(IS_NULL_PTR(buf))) {
+    if (IS_NULL_PTR(buf)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 

--- a/src/platforms/stm32/src/lib/gpio_driver.c
+++ b/src/platforms/stm32/src/lib/gpio_driver.c
@@ -777,7 +777,7 @@ static term gpiodriver_set_int(Context *ctx, int32_t target_pid, term cmd)
     }
 
     struct GPIOListenerData *data = malloc(sizeof(struct GPIOListenerData));
-    if (UNLIKELY(IS_NULL_PTR(data))) {
+    if (IS_NULL_PTR(data)) {
         AVM_LOGE(TAG, "Out of memory!");
         AVM_ABORT();
     }


### PR DESCRIPTION
`IS_NULL_PTR(ptr)` is already defined as `UNLIKELY(x == NULL)`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
