### PR TITLE
Fix logic of workflows on push

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -12,6 +12,8 @@ name: Build Docs
 on:
   # Triggers the workflow on push request and tag events on master branch
   pull_request:
+    tag:
+      - '**'
     branches:
       - 'master'
     paths:

--- a/.github/workflows/build-libraries.yaml
+++ b/.github/workflows/build-libraries.yaml
@@ -9,7 +9,7 @@ name: Build Libraries
 on:
   push:
     tags:
-      - '*'
+      - '**'
 
 permissions:
   contents: write

--- a/.github/workflows/build-linux-artifacts.yaml
+++ b/.github/workflows/build-linux-artifacts.yaml
@@ -9,7 +9,7 @@ name: Build Linux Artifacts
 on:
   push:
     tags:
-      - '*'
+      - '**'
 
 permissions:
   contents: write

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -15,8 +15,6 @@ on:
       - 'src/platforms/esp32/**'
       - 'src/libAtomVM/**'
       - 'tools/packbeam/**'
-    tags:
-      - '*'
   pull_request:
     paths:
       - '.github/workflows/esp32-mkimage.yaml'

--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -14,8 +14,6 @@ on:
       - 'libs/**'
       - 'src/platforms/rp2040/**'
       - 'src/libAtomVM/**'
-    tags:
-      - '*'
   pull_request:
     paths:
       - '.github/workflows/pico-build.yaml'

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -10,10 +10,10 @@ name: Publish Docs
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push request and tag events on master branch
+  # Triggers the workflow on pull request, tag events and pushes on master
   push:
     tags:
-      - '*'
+      - '**'
     branches:
       - 'master'
     paths:

--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -14,8 +14,6 @@ on:
       - 'libs/**'
       - 'src/platforms/emscripten/**'
       - 'src/libAtomVM/**'
-    tags:
-      - '*'
   pull_request:
     paths:
       - '.github/workflows/wasm-build.yaml'


### PR DESCRIPTION
Tag filter in several workflows meant any tag that doesn't contain a /. We probably wanted every tag.

And if we have a filter on a tag but no filter on branches, the workflow is only executed when a tag matches, regardless of path filtering which are always ignored on tags.

Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
