### PR TITLE
Fix flappiness of Pico clock test on CI

### DIFF
--- a/src/platforms/rp2040/tests/test_erl_sources/test_clocks.erl
+++ b/src/platforms/rp2040/tests/test_erl_sources/test_clocks.erl
@@ -34,6 +34,8 @@ start() ->
         true ->
             ok
     end,
+    % give time to the emulator to synchronize rtc time and system time
+    timer:sleep(500),
     test_clock(system_time_after_set_rtc, fun() -> erlang:system_time(millisecond) end),
     NewDate = erlang:universaltime(),
     if


### PR DESCRIPTION
Add a sleep to fix an issue where, supposedly, emulator was synchronizing system time with RTC and the test randomly failed.

The test was successfully ran 8 times (4 x 2), including 2 triggered by this PR.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
