### PR TITLE
Fix a bug where recvfrom would eventually return address 0.0.0.0

### DIFF
--- a/src/libAtomVM/otp_socket.h
+++ b/src/libAtomVM/otp_socket.h
@@ -63,8 +63,8 @@ struct LWIPEvent
         {
             struct SocketResource *rsrc_obj;
             struct pbuf *buf;
-            const ip_addr_t *addr;
-            u16_t port;
+            uint32_t addr;
+            uint16_t port;
         } udp_recv;
         struct
         {


### PR DESCRIPTION
const ip_addr_t * passed to udp_recv callback is not valid after the callback returns. Store the IPv4 address accordingly.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
