### PR TITLE
Allow use of logging macros without instantiating the logger manager

### DIFF
--- a/libs/eavmlib/src/logger_manager.erl
+++ b/libs/eavmlib/src/logger_manager.erl
@@ -80,7 +80,17 @@ get_id() ->
 
 %% @hidden
 allow(Level, Module) ->
-    gen_server:call(?MODULE, {allow, Level, Module}).
+    %% if the logger manager has not been instantiated, then
+    %% "fail" silently (i.e., log nothing).  The logger manager
+    %% either needs to be instantiated manually, or it is be done
+    %% so automatically in OTP-style deployment when the kernel
+    %% is started by init.
+    case erlang:whereis(?MODULE) of
+        undefined ->
+            false;
+        _ ->
+            gen_server:call(?MODULE, {allow, Level, Module})
+    end.
 
 %%
 %% gen_server callbacks

--- a/tests/libs/estdlib/test_logger.erl
+++ b/tests/libs/estdlib/test_logger.erl
@@ -46,7 +46,11 @@ test_logger() ->
     ok.
 
 test_default_logger() ->
-    ?ASSERT_FAILURE(?LOG_NOTICE("Tried to log before starting log_manager!")),
+    %% silent "failure" (nothing will be logged) if the
+    %% logger manager has not been instantiated.  In OTP-style
+    %% deployment, the logger manager is initialized in
+    %% the kernel application.
+    ok = ?LOG_NOTICE("Tried to log before starting log_manager!"),
 
     {ok, _Pid} = logger_manager:start_link(#{}),
 


### PR DESCRIPTION
This change set allows users to use logging macros and functions in code, but for those calls not to fail with an error if the logger manager has not been instantiated.

Users must still instantiate the logger manager (or it is instantiated automatically as part of the kernel application, TBD) in order for logs to pass the initial allow phase, but all logs will be silently dropped until the EAVMLib logger manager is instaniated.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
