### PR TITLE
Fix STM32 GPIO driver Issue #915

### DIFF
--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -130,7 +130,9 @@ bool sys_unlock_pin(GlobalContext *glb, uint32_t gpio_bank, uint16_t pin_num)
 
 void sys_init_platform(GlobalContext *glb)
 {
-    UNUSED(glb);
+    struct STM32PlatformData *platform = malloc(sizeof(struct STM32PlatformData));
+    glb->platform_data = platform;
+    list_init(&platform->locked_pins);
 }
 
 void sys_free_platform(GlobalContext *glb)


### PR DESCRIPTION
During the PR review and snd subsequent bug fixes the code required for `sys_platform_init` was inadvertantly dropped.

Closes #915

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
