### PR TITLE
Fix listen backlog with OTP Socket lwIP

### DIFF
--- a/libs/estdlib/src/socket.erl
+++ b/libs/estdlib/src/socket.erl
@@ -44,7 +44,7 @@
 
 %% internal nifs
 -export([
-    nif_select_read/3,
+    nif_select_read/2,
     nif_accept/1,
     nif_recv/2,
     nif_recvfrom/2,
@@ -237,10 +237,9 @@ accept(Socket) ->
 -spec accept(Socket :: socket(), Timeout :: timeout()) ->
     {ok, Connection :: socket()} | {error, Reason :: term()}.
 accept(Socket, Timeout) ->
-    Self = self(),
     Ref = erlang:make_ref(),
-    ?TRACE("select read for accept.  self=~p ref=~p~n", [Self, Ref]),
-    case ?MODULE:nif_select_read(Socket, Self, Ref) of
+    ?TRACE("select read for accept.  self=~p ref=~p~n", [self(), Ref]),
+    case ?MODULE:nif_select_read(Socket, Ref) of
         ok ->
             receive
                 {select, _AcceptedSocket, Ref, ready_input} ->
@@ -300,10 +299,9 @@ recv(Socket, Length) ->
 -spec recv(Socket :: socket(), Length :: non_neg_integer(), Timeout :: timeout()) ->
     {ok, Data :: binary()} | {error, Reason :: term()}.
 recv(Socket, Length, Timeout) ->
-    Self = self(),
     Ref = erlang:make_ref(),
-    ?TRACE("select read for recv.  self=~p ref=~p~n", [Self, Ref]),
-    case ?MODULE:nif_select_read(Socket, Self, Ref) of
+    ?TRACE("select read for recv.  self=~p ref=~p~n", [self(), Ref]),
+    case ?MODULE:nif_select_read(Socket, Ref) of
         ok ->
             receive
                 {select, _AcceptedSocket, Ref, ready_input} ->
@@ -372,10 +370,9 @@ recvfrom(Socket, Length) ->
 -spec recvfrom(Socket :: socket(), Length :: non_neg_integer(), Timeout :: timeout()) ->
     {ok, {Address :: sockaddr(), Data :: binary()}} | {error, Reason :: term()}.
 recvfrom(Socket, Length, Timeout) ->
-    Self = self(),
     Ref = erlang:make_ref(),
-    ?TRACE("select read for recvfrom.  self=~p ref=~p", [Self, Ref]),
-    case ?MODULE:nif_select_read(Socket, Self, Ref) of
+    ?TRACE("select read for recvfrom.  self=~p ref=~p", [self(), Ref]),
+    case ?MODULE:nif_select_read(Socket, Ref) of
         ok ->
             receive
                 {select, _AcceptedSocket, Ref, ready_input} ->
@@ -513,7 +510,7 @@ shutdown(_Socket, _How) ->
 %%
 
 %% @private
-nif_select_read(_Socket, _Self, _Ref) ->
+nif_select_read(_Socket, _Ref) ->
     erlang:nif_error(undefined).
 
 %% @private

--- a/src/libAtomVM/otp_socket.h
+++ b/src/libAtomVM/otp_socket.h
@@ -52,7 +52,7 @@ struct LWIPEvent
         {
             struct SocketResource *rsrc_obj;
             struct tcp_pcb *newpcb;
-        } accept_make_resource;
+        } tcp_accept;
         struct
         {
             struct tcp_pcb *tpcb;

--- a/src/platforms/rp2040/src/lib/lwipopts.h
+++ b/src/platforms/rp2040/src/lib/lwipopts.h
@@ -105,4 +105,5 @@
 void sntp_set_system_time_us(unsigned long sec, unsigned long usec);
 #define SNTP_SET_SYSTEM_TIME_US(sec, usec) sntp_set_system_time_us(sec, usec)
 
+#define TCP_LISTEN_BACKLOG 1
 #endif /* __LWIPOPTS_H__ */

--- a/tests/libs/estdlib/test_tcp_socket.erl
+++ b/tests/libs/estdlib/test_tcp_socket.erl
@@ -254,7 +254,7 @@ test_abandon_select() ->
 
     Owner = self(),
     spawn(fun() ->
-        socket:nif_select_read(ListenSocket, self(), erlang:make_ref()),
+        socket:nif_select_read(ListenSocket, erlang:make_ref()),
         Owner ! done
     end),
 


### PR DESCRIPTION
Fix logic as apparently lwIP doesn't allow for delaying accept (SYN-ACK), so accept_cb is treated like recv_cb, incoming connections are enqueued

Also simplify nif_select_read as we're always selecting for ourselves

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
