### PR TITLE
Fix for broken FreeBSD build

### DIFF
--- a/src/libAtomVM/otp_net.c
+++ b/src/libAtomVM/otp_net.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 // #define ENABLE_TRACE


### PR DESCRIPTION
Fixes FreeBSD build due to missing include

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
