### PR TITLE
Fix `net:getaddrinfo/1,2` on ESP32

### DIFF
--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -43,6 +43,7 @@ compile_erlang(test_list_to_binary)
 compile_erlang(test_md5)
 compile_erlang(test_crypto)
 compile_erlang(test_monotonic_time)
+compile_erlang(test_net)
 compile_erlang(test_rtc_slow)
 compile_erlang(test_select)
 compile_erlang(test_socket)
@@ -59,6 +60,7 @@ add_custom_command(
         test_md5.beam
         test_crypto.beam
         test_monotonic_time.beam
+        test_net.beam
         test_rtc_slow.beam
         test_select.beam
         test_socket.beam
@@ -72,6 +74,7 @@ add_custom_command(
         "${CMAKE_CURRENT_BINARY_DIR}/test_md5.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_crypto.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_monotonic_time.beam"
+        "${CMAKE_CURRENT_BINARY_DIR}/test_net.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_rtc_slow.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_select.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_socket.beam"

--- a/src/platforms/esp32/test/main/test_erl_sources/test_net.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_net.erl
@@ -1,0 +1,58 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_net).
+-export([start/0]).
+
+start() ->
+    ok = test_service_undefined(),
+    ok = test_service_https(),
+    ok = test_invalid_hostname(),
+    ok.
+
+test_service_undefined() ->
+    % Get address of github.com
+    {ok, Results} = net:getaddrinfo_nif("github.com", undefined),
+    % We should have at least one UDP and one TCP IPv4 entry
+    [_TCPAddr | _] = [
+        Addr
+     || #{addr := Addr, type := stream, protocol := tcp, family := inet} <- Results
+    ],
+    [_UDPAddr | _] = [
+        Addr
+     || #{addr := Addr, type := dgram, protocol := udp, family := inet} <- Results
+    ],
+    ok.
+
+test_service_https() ->
+    {ok, Results} = net:getaddrinfo_nif("github.com", "https"),
+    [_TCPAddr | _] = [
+        Addr
+     || #{addr := Addr, type := stream, protocol := tcp, family := inet} <- Results
+    ],
+    [_UDPAddr | _] = [
+        Addr
+     || #{addr := Addr, type := dgram, protocol := udp, family := inet} <- Results
+    ],
+    ok.
+
+test_invalid_hostname() ->
+    {error, eaifail} = net:getaddrinfo_nif("atomvm.invalid", undefined),
+    ok.

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -422,10 +422,31 @@ static void got_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t
     network_got_ip = true;
 }
 
+TEST_CASE("test_net", "[test_run]")
+{
+    // esp_netif_init() was called by network_driver_init
+    ESP_LOGI(TAG, "Registering handler\n");
+    network_got_ip = false;
+    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &got_ip_event_handler, NULL));
+    ESP_LOGI(TAG, "Starting network\n");
+    esp_netif_t *eth_netif = eth_start();
+
+    while (!network_got_ip) {
+        vTaskDelay(1);
+    }
+
+    term ret_value = avm_test_case("test_net.beam");
+    TEST_ASSERT(ret_value == OK_ATOM);
+
+    ESP_LOGI(TAG, "Stopping network\n");
+    eth_stop(eth_netif);
+}
+
 TEST_CASE("test_socket", "[test_run]")
 {
     // esp_netif_init() was called by network_driver_init
     ESP_LOGI(TAG, "Registering handler\n");
+    network_got_ip = false;
     ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &got_ip_event_handler, NULL));
     ESP_LOGI(TAG, "Starting network\n");
     esp_netif_t *eth_netif = eth_start();


### PR DESCRIPTION
Fix a memory allocation bug

Optimize memory allocation by using shared maps

Work around an issue of esp-idf's implementation of getaddrinfo that does not fill protocol and socket type and returns a larger address record

Add an esp32 qemu test for net:getaddrinfo/1,2

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
