### PR TITLE
Clean up example programs

### DIFF
--- a/examples/erlang/esp32/tcp_client_esp32.erl
+++ b/examples/erlang/esp32/tcp_client_esp32.erl
@@ -24,8 +24,8 @@
 
 start() ->
     Creds = [
-        {ssid, esp:nvs_get_binary(atomvm, sta_ssid, <<"myssid">>)},
-        {psk, esp:nvs_get_binary(atomvm, sta_psk, <<"mypsk">>)}
+        {ssid, "myssid"},
+        {psk, "mypsk"}
     ],
     case network:wait_for_sta(Creds, 30000) of
         {ok, {Address, Netmask, Gateway}} ->

--- a/examples/erlang/esp32/tcp_server_blink.erl
+++ b/examples/erlang/esp32/tcp_server_blink.erl
@@ -26,13 +26,13 @@
 
 start() ->
     Creds = [
-        {ssid, esp:nvs_get_binary(atomvm, sta_ssid, <<"myssid">>)},
-        {psk, esp:nvs_get_binary(atomvm, sta_psk, <<"mypsk">>)}
+        {ssid, "myssid"},
+        {psk, "mypsk"}
     ],
     case network:wait_for_sta(Creds, 30000) of
         {ok, {Address, Netmask, Gateway}} ->
             io:format(
-                "Acquired IP address: ~p Netmask: ~p Gateway: ~p~n",
+                "Acquired IP address: ~s Netmask: ~s Gateway: ~s~n",
                 [to_string(Address), to_string(Netmask), to_string(Gateway)]
             ),
             tcp_server_start();
@@ -56,7 +56,7 @@ accept(ListenSocket, Gpio) ->
     io:format("Waiting to accept connection...~n"),
     case gen_tcp:accept(ListenSocket) of
         {ok, Socket} ->
-            io:format("Accepted connection.  local: ~p peer: ~p~n", [
+            io:format("Accepted connection.  local: ~s peer: ~s~n", [
                 local_address(Socket), peer_address(Socket)
             ]),
             spawn(fun() -> accept(ListenSocket, Gpio) end),
@@ -73,7 +73,7 @@ echo(Gpio, PinState) ->
             io:format("Connection closed.~n"),
             ok;
         {tcp, Socket, Packet} ->
-            io:format("Received packet ~p from ~p.  Echoing back...~n", [
+            io:format("Received packet ~p from ~s.  Echoing back...~n", [
                 Packet, peer_address(Socket)
             ]),
             gen_tcp:send(Socket, Packet),

--- a/examples/erlang/esp32/udp_server_blink.erl
+++ b/examples/erlang/esp32/udp_server_blink.erl
@@ -28,13 +28,13 @@
 
 start() ->
     Creds = [
-        {ssid, esp:nvs_get_binary(atomvm, sta_ssid, <<"myssid">>)},
-        {psk, esp:nvs_get_binary(atomvm, sta_psk, <<"mypsk">>)}
+        {ssid, "myssid"},
+        {psk, "mypsk"}
     ],
     case network:wait_for_sta(Creds, 30000) of
         {ok, {Address, Netmask, Gateway}} ->
             io:format(
-                "Acquired IP address: ~p Netmask: ~p Gateway: ~p~n",
+                "Acquired IP address: ~s Netmask: ~s Gateway: ~s~n",
                 [to_string(Address), to_string(Netmask), to_string(Gateway)]
             ),
             udp_server_start();
@@ -45,7 +45,7 @@ start() ->
 udp_server_start() ->
     case gen_udp:open(44404, [{active, true}]) of
         {ok, Socket} ->
-            io:format("Opened UDP socket on ~p.~n", [local_address(Socket)]),
+            io:format("Opened UDP socket on ~s.~n", [local_address(Socket)]),
             Gpio = gpio:open(),
             gpio:set_direction(Gpio, ?PIN, output),
             loop(Socket, Gpio, 0);
@@ -58,7 +58,7 @@ loop(Socket, Gpio, PinState) ->
     gpio:set_level(Gpio, ?PIN, PinState),
     receive
         {udp, _Socket, Address, Port, Packet} ->
-            io:format("Received UDP packet ~p from ~p~n", [Packet, to_string({Address, Port})])
+            io:format("Received UDP packet ~p from ~s~n", [Packet, to_string({Address, Port})])
     end,
     loop(Socket, Gpio, 1 - PinState).
 

--- a/examples/erlang/tcp_client.erl
+++ b/examples/erlang/tcp_client.erl
@@ -23,27 +23,27 @@
 -export([start/0]).
 
 start() ->
-    Address = "localhost",
+    Address = {127, 0, 0, 1},
     Port = 44404,
     case gen_tcp:connect(Address, Port, [{active, true}, binary]) of
         {ok, Socket} ->
-            io:format("Connected to ~p from ~p~n", [peer_address(Socket), local_address(Socket)]),
+            io:format("Connected to ~s from ~s~n", [peer_address(Socket), local_address(Socket)]),
             loop(Socket);
         Error ->
             io:format("An error occurred connecting: ~p~n", [Error])
     end.
 
 loop(Socket) ->
-    SendPacket = <<":アトムＶＭ">>,
+    SendPacket = <<"AtomVM">>,
     case gen_tcp:send(Socket, SendPacket) of
         ok ->
-            io:format("Sent ~p to ~p\n", [SendPacket, peer_address(Socket)]),
+            io:format("Sent ~p to ~s\n", [SendPacket, peer_address(Socket)]),
             receive
                 {tcp_closed, _Socket} ->
                     io:format("Connection closed.~n"),
                     ok;
                 {tcp, _Socket, ReceivedPacket} ->
-                    io:format("Received ~p from ~p~n", [ReceivedPacket, peer_address(Socket)]),
+                    io:format("Received ~p from ~s~n", [ReceivedPacket, peer_address(Socket)]),
                     timer:sleep(1000),
                     loop(Socket)
             end;

--- a/examples/erlang/tcp_server.erl
+++ b/examples/erlang/tcp_server.erl
@@ -36,7 +36,7 @@ accept(ListenSocket) ->
     io:format("Waiting to accept connection...~n"),
     case gen_tcp:accept(ListenSocket) of
         {ok, Socket} ->
-            io:format("Accepted connection.  local: ~p peer: ~p~n", [
+            io:format("Accepted connection.  local: ~s peer: ~s~n", [
                 local_address(Socket), peer_address(Socket)
             ]),
             spawn(fun() -> accept(ListenSocket) end),
@@ -52,7 +52,7 @@ echo() ->
             io:format("Connection closed.~n"),
             ok;
         {tcp, Socket, Packet} ->
-            io:format("Received packet ~p from ~p.  Echoing back...~n", [
+            io:format("Received packet ~p from ~s.  Echoing back...~n", [
                 Packet, peer_address(Socket)
             ]),
             gen_tcp:send(Socket, Packet),

--- a/examples/erlang/udp_client.erl
+++ b/examples/erlang/udp_client.erl
@@ -25,14 +25,14 @@
 start() ->
     case gen_udp:open(0, [{active, false}, binary]) of
         {ok, Socket} ->
-            io:format("Opened UDP socket on ~p.~n", [local_address(Socket)]),
+            io:format("Opened UDP socket on ~s.~n", [local_address(Socket)]),
             loop(Socket);
         Error ->
             io:format("An error occurred opening UDP socket: ~p~n", [Error])
     end.
 
 loop(Socket) ->
-    Packet = <<":アトムＶＭ">>,
+    Packet = <<"AtomVM">>,
     case gen_udp:send(Socket, {127, 0, 0, 1}, 44404, Packet) of
         ok ->
             io:format("Sent ~p~n", [Packet]);

--- a/examples/erlang/udp_server.erl
+++ b/examples/erlang/udp_server.erl
@@ -25,7 +25,7 @@
 start() ->
     case gen_udp:open(44404, [{active, true}, binary]) of
         {ok, Socket} ->
-            io:format("Opened UDP socket on ~p.~n", [local_address(Socket)]),
+            io:format("Opened UDP socket on ~s.~n", [local_address(Socket)]),
             active_loop();
         Error ->
             io:format("An error occurred opening UDP socket: ~p~n", [Error])
@@ -35,7 +35,7 @@ active_loop() ->
     io:format("Waiting to receive data...~n"),
     receive
         {udp, _Socket, Address, Port, Packet} ->
-            io:format("Received UDP packet ~p from ~p~n", [Packet, to_string({Address, Port})])
+            io:format("Received UDP packet ~p from ~s~n", [Packet, to_string({Address, Port})])
     end,
     active_loop().
 


### PR DESCRIPTION
This change set makes the following improvements to the example programs:

* Fixes formatting of peer and local addresses so that strings are properly displayed
* Removed some old code that used NVS credentials (no longer supported)
* Removes use of `localhost` as an address, which is technically not supported by the spec
* Replaced unicode packet <<":アトムＶＭ">> with <<"AtomVM">> so that it renders properly on the console

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
