### PR TITLE
Update clang format to version 16

### DIFF
--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -40,16 +40,16 @@ jobs:
     - name: "Install run-clang-format"
       run: |
         wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-        echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" | sudo tee -a /etc/apt/sources.list
-        echo "deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" | sudo tee -a /etc/apt/sources.list
+        echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main" | sudo tee -a /etc/apt/sources.list
+        echo "deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get update
-        sudo apt-get install -y clang-format-13
+        sudo apt-get install -y clang-format-16
         curl -sSfL https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-clang-format.py -o run-clang-format
         chmod +x run-clang-format
 
     - name: "Check formatting with clang-format"
       run: |
-        ./run-clang-format --style=file --clang-format-executable=clang-format-13 -r src/ tests/
+        ./run-clang-format --style=file --clang-format-executable=clang-format-16 -r src/ tests/
 
     - name: "Check formatting with Erlang fmt"
       if: success() || failure()

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -31,7 +31,7 @@
 #include "tempstack.h"
 #include "term.h"
 
-//#define ENABLE_TRACE
+// #define ENABLE_TRACE
 
 #include "trace.h"
 #include "utils.h"

--- a/src/libAtomVM/refc_binary.c
+++ b/src/libAtomVM/refc_binary.c
@@ -29,7 +29,7 @@
 #include "tempstack.h"
 #include "utils.h"
 
-//#define ENABLE_TRACE
+// #define ENABLE_TRACE
 
 #include "trace.h"
 

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -36,7 +36,7 @@
 
 #include <math.h>
 
-//#define ENABLE_TRACE
+// #define ENABLE_TRACE
 #include <trace.h>
 
 #include "emscripten_sys.h"

--- a/src/platforms/rp2040/src/lib/platform_nifs.c
+++ b/src/platforms/rp2040/src/lib/platform_nifs.c
@@ -39,7 +39,7 @@
 
 #include "gpiodriver.h"
 
-//#define ENABLE_TRACE
+// #define ENABLE_TRACE
 #include "trace.h"
 
 #define VALIDATE_VALUE(value, verify_function) \

--- a/tests/test.c
+++ b/tests/test.c
@@ -48,19 +48,19 @@ struct Test
 // Favor modules that return 0
 #define TEST_CASE(module)        \
     {                            \
-#module, 0, false, false \
+        #module, 0, false, false \
     }
 #define TEST_CASE_EXPECTED(module, expected) \
     {                                        \
-#module, expected, false, false      \
+        #module, expected, false, false      \
     }
 #define TEST_CASE_ATOMVM_ONLY(module, expected) \
     {                                           \
-#module, expected, false, true          \
+        #module, expected, false, true          \
     }
 #define TEST_CASE_COND(module, expected, skip) \
     {                                          \
-#module, expected, skip, false         \
+        #module, expected, skip, false         \
     }
 
 #ifndef AVM_NO_SMP


### PR DESCRIPTION
Also updated files with format violations.

Addresses issue #848 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
