### PR TITLE
Simplify crypto code and fix compatibility issue with Erlang/OTP

### DIFF
--- a/src/libAtomVM/otp_crypto.c
+++ b/src/libAtomVM/otp_crypto.c
@@ -287,14 +287,10 @@ static term nif_crypto_hash(Context *ctx, int argc, term argv[])
     return term_from_literal_binary(digest, digest_len, &ctx->heap, ctx->global);
 }
 
-static const AtomStringIntPair cipher_no_iv_table[] = {
+static const AtomStringIntPair cipher_table[] = {
     { ATOM_STR("\xB", "aes_128_ecb"), MBEDTLS_CIPHER_AES_128_ECB },
     { ATOM_STR("\xB", "aes_192_ecb"), MBEDTLS_CIPHER_AES_192_ECB },
     { ATOM_STR("\xB", "aes_256_ecb"), MBEDTLS_CIPHER_AES_256_ECB },
-    SELECT_INT_DEFAULT(MBEDTLS_CIPHER_NONE)
-};
-
-static const AtomStringIntPair cipher_iv_table[] = {
     { ATOM_STR("\xB", "aes_128_cbc"), MBEDTLS_CIPHER_AES_128_CBC },
     { ATOM_STR("\xB", "aes_192_cbc"), MBEDTLS_CIPHER_AES_192_CBC },
     { ATOM_STR("\xB", "aes_256_cbc"), MBEDTLS_CIPHER_AES_256_CBC },
@@ -395,19 +391,16 @@ static term make_crypto_error(const char *file, int line, const char *message, C
 static term nif_crypto_crypto_one_time(Context *ctx, int argc, term argv[])
 {
     bool has_iv = argc == 5;
-    const AtomStringIntPair *cipher_table;
     term key;
     term iv;
     term data;
     term flag_or_options;
     if (has_iv) {
-        cipher_table = cipher_iv_table;
         key = argv[1];
         iv = argv[2];
         data = argv[3];
         flag_or_options = argv[4];
     } else {
-        cipher_table = cipher_no_iv_table;
         key = argv[1];
         data = argv[2];
         flag_or_options = argv[3];

--- a/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
@@ -202,6 +202,13 @@ test_available_ciphers() ->
         crypto:crypto_one_time(aes_192_ecb, <<1:192>>, <<2:128>>, false),
     <<9, 134, 59, 77, 138, 44, 15, 97, 69, 171, 187, 23, 29, 143, 25, 227>> =
         crypto:crypto_one_time(aes_256_ecb, <<1:256>>, <<2:128>>, false),
+    % Erlang/OTP also allows to call aes_*_ecb with an iv
+    <<171, 29, 253, 3, 110, 255, 225, 168, 40, 2, 92, 101, 18, 22, 104, 91>> =
+        crypto:crypto_one_time(aes_128_ecb, <<1:128>>, <<2:128>>, <<3:128>>, false),
+    <<172, 173, 71, 170, 66, 92, 132, 117, 22, 33, 191, 18, 17, 207, 171, 236>> =
+        crypto:crypto_one_time(aes_192_ecb, <<1:192>>, <<2:128>>, <<3:128>>, false),
+    <<33, 51, 81, 23, 26, 72, 178, 26, 115, 82, 208, 26, 225, 24, 76, 247>> =
+        crypto:crypto_one_time(aes_256_ecb, <<1:256>>, <<2:128>>, <<3:128>>, false),
     ok.
 
 get_error(F) ->


### PR DESCRIPTION
Follow Erlang/OTP and allow calling ciphers that do not require an IV with an IV.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
