### PR TITLE
Fix a bug in handling listeners and sockets on platforms with poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed support for big endian CPUs (such as some MIPS CPUs).
 - Fixed STM32 not aborting when `AVM_ABORT()` is used
 - Fixed a bug that would leave the STM32 trapped in a loop on hard faults, rather than aborting
+- Fixed a bug that would make the VM to loop and failing to process selected fds on Linux
 
 ### Changed
 


### PR DESCRIPTION
On platforms with poll (Linux), the list of fds was not properly built and as a result, the VM could loop without processing selected fds

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
