### PR TITLE
Opt-in purerlang implementation of gen_tcp and gen_udp using socket API

### DIFF
--- a/libs/estdlib/src/CMakeLists.txt
+++ b/libs/estdlib/src/CMakeLists.txt
@@ -33,7 +33,11 @@ set(ERLANG_MODULES
     gen_server
     gen_statem
     gen_udp
+    gen_udp_inet
+    gen_udp_socket
     gen_tcp
+    gen_tcp_inet
+    gen_tcp_socket
     supervisor
     inet
     io_lib

--- a/libs/estdlib/src/gen_tcp_inet.erl
+++ b/libs/estdlib/src/gen_tcp_inet.erl
@@ -1,0 +1,220 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2019-2022 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%% @hidden
+-module(gen_tcp_inet).
+
+-export([
+    connect/3, send/2, recv/2, recv/3, close/1, listen/2, accept/1, accept/2, controlling_process/2
+]).
+
+%% inet API
+-export([port/1, sockname/1, peername/1]).
+
+-type reason() :: term().
+
+-type option() ::
+    {active, boolean()}
+    | {buffer, pos_integer()}
+    | {timeout, timeout()}
+    | list
+    | binary
+    | {binary, boolean()}.
+
+-type listen_option() :: option().
+-type connect_option() :: option().
+-type packet() :: string() | binary().
+
+-define(DEFAULT_PARAMS, [{active, true}, {buffer, 512}, {timeout, infinity}]).
+
+%% @hidden
+-spec connect(
+    Address :: inet:ip_address() | inet:hostname(),
+    Port :: inet:port_number(),
+    Options :: [connect_option()]
+) ->
+    {ok, Socket :: inet:socket()} | {error, Reason :: reason()}.
+connect(Address, Port, Params0) ->
+    Socket = open_port({spawn, "socket"}, []),
+    Params = merge(Params0, ?DEFAULT_PARAMS),
+    connect(Socket, normalize_address(Address), Port, Params).
+
+%% @hidden
+-spec send(Socket :: inet:socket(), Packet :: packet()) -> ok | {error, Reason :: reason()}.
+send(Socket, Packet) ->
+    case call(Socket, {send, Packet}) of
+        {ok, _Len} ->
+            ok;
+        Error ->
+            Error
+    end.
+
+%% @hidden
+-spec recv(Socket :: inet:socket(), Length :: non_neg_integer()) ->
+    {ok, packet()} | {error, Reason :: reason()}.
+recv(Socket, Length) ->
+    recv(Socket, Length, infinity).
+
+%% @hidden
+-spec recv(Socket :: inet:socket(), Length :: non_neg_integer(), Timeout :: non_neg_integer()) ->
+    {ok, packet()} | {error, Reason :: reason()}.
+recv(Socket, Length, Timeout) ->
+    call(Socket, {recv, Length, Timeout}).
+
+%% @hidden
+-spec listen(Port :: inet:port_number(), Options :: [listen_option()]) ->
+    {ok, ListeningSocket :: inet:socket()} | {error, Reason :: reason()}.
+listen(Port, Options) ->
+    Socket = open_port({spawn, "socket"}, []),
+    Params = merge(Options, ?DEFAULT_PARAMS),
+    InitParams = [
+        {proto, tcp},
+        {listen, true},
+        {controlling_process, self()},
+        {port, Port},
+        {backlog, 5}
+        | Params
+    ],
+    case call(Socket, {init, InitParams}) of
+        ok ->
+            {ok, Socket};
+        ErrorReason ->
+            %% TODO close port
+            ErrorReason
+    end.
+
+%% @hidden
+-spec accept(ListenSocket :: inet:socket()) ->
+    {ok, Socket :: inet:socket()} | {error, Reason :: reason()}.
+accept(ListenSocket) ->
+    accept(ListenSocket, infinity).
+
+%% @hidden
+-spec accept(ListenSocket :: inet:socket(), Timeout :: timeout()) ->
+    {ok, Socket :: inet:socket()} | {error, Reason :: reason()}.
+accept(ListenSocket, Timeout) ->
+    case call(ListenSocket, {accept, Timeout}) of
+        {ok, Socket} when is_pid(Socket) ->
+            {ok, Socket};
+        ErrorReason ->
+            %% TODO close port
+            ErrorReason
+    end.
+
+%% @hidden
+-spec close(Socket :: inet:socket()) -> ok.
+close(Socket) ->
+    call(Socket, {close}),
+    ok.
+
+%% @hidden
+-spec controlling_process(Socket :: inet:socket(), Pid :: pid()) ->
+    ok | {error, Reason :: reason()}.
+controlling_process(Socket, Pid) ->
+    call(Socket, {controlling_process, Pid}).
+
+%%
+%% inet API
+%%
+
+%% @hidden
+port(Socket) ->
+    call(Socket, {get_port}).
+
+%% @hidden
+sockname(Socket) ->
+    call(Socket, {sockname}).
+
+%% @hidden
+peername(Socket) ->
+    call(Socket, {peername}).
+
+%% internal operations
+
+%% @private
+connect(DriverPid, Address, Port, Params) ->
+    InitParams = [
+        {proto, tcp},
+        {connect, true},
+        {controlling_process, self()},
+        {address, Address},
+        {port, Port}
+        | Params
+    ],
+    case call(DriverPid, {init, InitParams}) of
+        ok ->
+            {ok, DriverPid};
+        ErrorReason ->
+            %% TODO close port
+            ErrorReason
+    end.
+
+%% TODO implement this in lists
+
+%% @private
+merge(Config, Defaults) ->
+    merge(Config, Defaults, []) ++ Config.
+
+%% @private
+merge(_Config, [], Accum) ->
+    Accum;
+merge(Config, [H | T], Accum) ->
+    Key =
+        case H of
+            {K, _V} -> K;
+            K -> K
+        end,
+    case proplists:get_value(Key, Config) of
+        undefined ->
+            merge(Config, T, [H | Accum]);
+        Value ->
+            merge(Config, T, [{Key, Value} | Accum])
+    end.
+
+%% @private
+normalize_address(localhost) ->
+    "127.0.0.1";
+normalize_address(loopback) ->
+    "127.0.0.1";
+normalize_address(Address) when is_list(Address) ->
+    Address;
+normalize_address({A, B, C, D}) when
+    is_integer(A) and is_integer(B) and is_integer(C) and is_integer(D)
+->
+    integer_to_list(A) ++
+        "." ++
+        integer_to_list(B) ++
+        "." ++
+        integer_to_list(C) ++
+        "." ++ integer_to_list(D).
+
+%% TODO IPv6
+
+%%
+%% Internal operations
+%%
+
+%% @private
+call(Port, Msg) ->
+    case port:call(Port, Msg) of
+        {error, noproc} -> {error, closed};
+        out_of_memory -> {error, enomem};
+        Result -> Result
+    end.

--- a/libs/estdlib/src/gen_tcp_socket.erl
+++ b/libs/estdlib/src/gen_tcp_socket.erl
@@ -1,0 +1,548 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%% @hidden
+-module(gen_tcp_socket).
+
+-export([
+    connect/3,
+    send/2,
+    recv/2,
+    recv/3,
+    close/1,
+    listen/2,
+    accept/1,
+    accept/2,
+    controlling_process/2
+]).
+
+-include("inet-priv.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+%% inet API
+-export([port/1, sockname/1, peername/1]).
+
+%% gen_server implementation (hidden)
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-type reason() :: term().
+
+-type option() ::
+    {active, boolean()}
+    | {buffer, pos_integer()}
+    | {timeout, timeout()}
+    | list
+    | binary.
+
+-type listen_option() :: option().
+-type connect_option() :: option().
+-type packet() :: string() | binary().
+
+-define(DEFAULT_OPTIONS, #{
+    active => true,
+    buffer => 0,
+    timeout => infinity
+}).
+
+-spec connect(
+    Address :: inet:ip_address() | inet:hostname(),
+    Port :: inet:port_number(),
+    Options :: [connect_option()]
+) ->
+    {ok, Socket :: inet:socket()} | {error, Reason :: reason()}.
+%% @hidden
+connect(Address, Port, Options) ->
+    ControllingProcess = self(),
+    case socket:open(inet, stream, tcp) of
+        {ok, Socket} ->
+            case socket:connect(Socket, #{family => inet, addr => Address, port => Port}) of
+                ok ->
+                    EffectiveOptions = maps:merge(?DEFAULT_OPTIONS, proplist_to_map(Options)),
+                    gen_server:start_link(
+                        ?MODULE, {Socket, ControllingProcess, connect, EffectiveOptions}, []
+                    );
+                ConnectError ->
+                    ConnectError
+            end;
+        OpenError ->
+            OpenError
+    end.
+
+%% @hidden
+-spec send(Socket :: inet:socket(), Packet :: packet()) -> ok | {error, Reason :: reason()}.
+send(Socket, Packet) ->
+    call(Socket, {send, Packet}).
+
+%% @hidden
+-spec recv(Socket :: inet:socket(), Length :: non_neg_integer()) ->
+    {ok, packet()} | {error, Reason :: reason()}.
+recv(Socket, Length) ->
+    recv(Socket, Length, infinity).
+
+%% @hidden
+-spec recv(Socket :: inet:socket(), Length :: non_neg_integer(), Timeout :: non_neg_integer()) ->
+    {ok, packet()} | {error, Reason :: reason()}.
+recv(Socket, Length, Timeout) ->
+    call(Socket, {recv, Length, Timeout}).
+
+%% @hidden
+-spec listen(Port :: inet:port_number(), Options :: [listen_option()]) ->
+    {ok, ListeningSocket :: inet:socket()} | {error, Reason :: reason()}.
+listen(Port, Options) ->
+    ControllingProcess = self(),
+    case socket:open(inet, stream, tcp) of
+        {ok, Socket} ->
+            EffectiveOptions = maps:merge(
+                ?DEFAULT_OPTIONS, proplist_to_map(Options)
+            ),
+            Addr = maps:get(ifaddr, EffectiveOptions, any),
+            case socket:bind(Socket, #{family => inet, addr => Addr, port => Port}) of
+                ok ->
+                    case socket:listen(Socket) of
+                        ok ->
+                            gen_server:start_link(
+                                ?MODULE, {Socket, ControllingProcess, listen, EffectiveOptions}, []
+                            );
+                        ListenError ->
+                            socket:close(Socket),
+                            ListenError
+                    end;
+                BindError ->
+                    socket:close(Socket),
+                    BindError
+            end;
+        OpenError ->
+            OpenError
+    end.
+
+%% @hidden
+-spec accept(ListenSocket :: inet:socket()) ->
+    {ok, Socket :: inet:socket()} | {error, Reason :: reason()}.
+accept(ListenSocket) ->
+    accept(ListenSocket, infinity).
+
+%% @hidden
+-spec accept(ListenSocket :: inet:socket(), Timeout :: timeout()) ->
+    {ok, Socket :: inet:socket()} | {error, Reason :: reason()}.
+accept(ListenSocket, Timeout) ->
+    AcceptingProc = self(),
+    call(ListenSocket, {accept, Timeout, AcceptingProc}).
+
+%% @hidden
+-spec close(Socket :: inet:socket()) -> ok.
+close(Socket) ->
+    call(Socket, close).
+
+%% @hidden
+-spec controlling_process(Socket :: inet:socket(), Pid :: pid()) ->
+    ok | {error, Reason :: reason()}.
+controlling_process(Socket, Pid) ->
+    %% WARNING: calling process is potentially spoofable
+    call(Socket, {controlling_process, Pid, self()}).
+
+%%
+%% inet API
+%%
+
+%% @hidden
+port(Socket) ->
+    call(Socket, get_port).
+
+%% @hidden
+sockname(Socket) ->
+    call(Socket, sockname).
+
+%% @hidden
+peername(Socket) ->
+    call(Socket, peername).
+
+%%
+%% gen_server implementation
+%%
+
+-record(state, {
+    socket,
+    controlling_process = undefined,
+    monitor_ref = undefined,
+    active,
+    options,
+    pending_selects = #{}
+}).
+
+init({Socket, ControllingProcess, Mode, Options}) ->
+    case (Mode =:= connect orelse Mode =:= accept) andalso maps:get(active, Options, true) of
+        true ->
+            Ref = erlang:make_ref(),
+            case socket:nif_select_read(Socket, Ref) of
+                ok ->
+                    ?LOG_INFO(
+                        "Starting process in ~p (active) mode.  Socket=~p ControllingProcess=~p Options=~p Ref=~p",
+                        [
+                            Mode, Socket, ControllingProcess, Options, Ref
+                        ]
+                    ),
+                    MonitorRef = erlang:monitor(process, ControllingProcess),
+                    {ok, #state{
+                        socket = Socket,
+                        controlling_process = ControllingProcess,
+                        monitor_ref = MonitorRef,
+                        active = true,
+                        options = Options,
+                        pending_selects = #{Ref => active}
+                    }};
+                {error, _Reason} = Error ->
+                    %% is there a better return from init?
+                    Error
+            end;
+        _ ->
+            ?LOG_INFO(
+                "Starting process in ~p (passive) mode.  Socket=~p ControllingProcess=~p Options=~p",
+                [
+                    Mode, Socket, ControllingProcess, Options
+                ]
+            ),
+            {ok, #state{
+                socket = Socket,
+                active = false,
+                options = Options
+            }}
+    end.
+
+%% @hidden
+handle_call({accept, Timeout, AcceptingProc}, From, State) ->
+    ?LOG_DEBUG("handle_call [~p], ~p, ~p]", [
+        {accept, Timeout, AcceptingProc}, From, State
+    ]),
+    Ref = erlang:make_ref(),
+    case Timeout of
+        TimeoutMs when is_integer(TimeoutMs) andalso TimeoutMs >= 0 ->
+            erlang:send_after(TimeoutMs, self(), {timeout, Ref, From});
+        infinity ->
+            ok
+    end,
+    case socket:nif_select_read(State#state.socket, Ref) of
+        ok ->
+            ?LOG_INFO("Starting accept select with ref ~p", [Ref]),
+            PendingSelects = State#state.pending_selects,
+            NewPendingSelects = PendingSelects#{Ref => {accept, From, AcceptingProc, Timeout}},
+            {noreply, State#state{pending_selects = NewPendingSelects}};
+        {error, _Reason} = Error ->
+            ?LOG_ERROR("An error occurred in select for accept ~p", [Error]),
+            {reply, Error, State}
+    end;
+handle_call({send, Packet}, From, State) ->
+    ?LOG_DEBUG("handle_call [~p], ~p, ~p]", [
+        {send, Packet}, From, State
+    ]),
+    ?LOG_INFO("Sending packet"),
+    {reply, socket:send(State#state.socket, Packet), State};
+handle_call({recv, Length, Timeout}, From, State) ->
+    ?LOG_DEBUG("handle_call [~p], ~p, ~p]", [
+        {recv, Length, Timeout}, From, State
+    ]),
+    case State#state.active of
+        true ->
+            {reply, {error, einval}, State};
+        _ ->
+            Ref = erlang:make_ref(),
+            case Timeout of
+                TimeoutMs when is_integer(TimeoutMs) andalso TimeoutMs >= 0 ->
+                    ?LOG_DEBUG("setting timeout counter for TimeoutMs=~p on ref=~p", [
+                        TimeoutMs, Ref
+                    ]),
+                    erlang:send_after(TimeoutMs, self(), {timeout, Ref, From});
+                infinity ->
+                    %% TEST
+                    erlang:send_after(30000, self(), {timeout, Ref, From}),
+                    ok
+            end,
+            case socket:nif_select_read(State#state.socket, Ref) of
+                ok ->
+                    PendingSelects = State#state.pending_selects,
+                    NewPendingSelects = PendingSelects#{Ref => {passive, From, Length, Timeout}},
+                    ?LOG_INFO("Added pending select.  NewPendingSelects=~p", [NewPendingSelects]),
+                    {noreply, State#state{pending_selects = NewPendingSelects}};
+                {error, _Reason} = Error ->
+                    ?LOG_ERROR("An error occurred calling socket:nif_select_read/2: ~p", [Error]),
+                    {noreply, State}
+            end
+    end;
+handle_call(port, _From, State) ->
+    Reply =
+        case socket:sockname(State#state.socket) of
+            {ok, Addr} ->
+                #{port := Port} = Addr,
+                {ok, Port};
+            SocknameError ->
+                SocknameError
+        end,
+    {reply, Reply, State};
+handle_call(sockname, _From, State) ->
+    Reply =
+        case socket:sockname(State#state.socket) of
+            {ok, Addr} ->
+                #{port := Port, addr := Address} = Addr,
+                {ok, {Address, Port}};
+            SocknameError ->
+                SocknameError
+        end,
+    {reply, Reply, State};
+handle_call(peername, _From, State) ->
+    Reply =
+        case socket:peername(State#state.socket) of
+            {ok, Addr} ->
+                #{port := Port, addr := Address} = Addr,
+                {ok, {Address, Port}};
+            SocknameError ->
+                SocknameError
+        end,
+    {reply, Reply, State};
+handle_call({controlling_process, Pid, Caller}, _From, State) ->
+    case State#state.active of
+        false ->
+            {reply, {error, einval}, State};
+        _ ->
+            case State#state.controlling_process =/= Caller of
+                true ->
+                    {reply, {error, not_owner}, State};
+                _ ->
+                    MonitorRef = erlang:monitor(process, Pid),
+                    true = erlang:demonitor(State#state.monitor_ref),
+                    ?LOG_INFO("Set controlling process to ~p", [Pid]),
+                    {reply, ok, State#state{controlling_process = Pid, monitor_ref = MonitorRef}}
+            end
+    end;
+handle_call(close, _From, State) ->
+    {stop, normal, socket:close(State#state.socket), State};
+handle_call(Request, _From, State) ->
+    {reply, {unknown_request, Request}, State}.
+
+%% @hidden
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+%% @hidden
+handle_info({select, _Socket, Ref, ready_input}, State) ->
+    ?LOG_DEBUG("handle_info [~p], ~p]", [
+        {select, _Socket, Ref, ready_input}, State
+    ]),
+    %% TODO cancel timer
+    case maps:get(Ref, State#state.pending_selects, undefined) of
+        undefined ->
+            ?LOG_WARNING("Unable to find select ref ~p in pending selects", [Ref]),
+            %% select_stop?
+            {noreply, State};
+        {accept, From, AcceptingProc, _Timeout} ->
+            ?LOG_INFO("Select ready for read on accept"),
+            NewState = handle_accept(State, From, AcceptingProc),
+            {noreply, NewState#state{
+                pending_selects = maps:remove(Ref, State#state.pending_selects)
+            }};
+        active ->
+            ?LOG_INFO("Select ready for read on active recv"),
+            NewState = handle_active_recv(State),
+            {noreply, NewState};
+        {passive, From, Length, Timeout} ->
+            ?LOG_INFO("Select ready for read on passive recv"),
+            NewState = handle_passive_recv(State, From, Length, Timeout),
+            {noreply, NewState#state{
+                pending_selects = maps:remove(Ref, State#state.pending_selects)
+            }}
+    end;
+handle_info({timeout, Ref, From}, State) ->
+    ?LOG_DEBUG("handle_info [~p], ~p]", [
+        {timeout, Ref, From}, State
+    ]),
+    case maps:get(Ref, State#state.pending_selects, undefined) of
+        undefined ->
+            %% The request was already processed.  Ignore the message
+            {noreply, State};
+        _ ->
+            ?LOG_INFO("Select ref ~p in pending selects has timed out.", [Ref]),
+            gen_server:reply(From, {error, timeout}),
+            {noreply, State#state{pending_selects = maps:remove(Ref, State#state.pending_selects)}}
+    end;
+handle_info({'DOWN', MonitorRef, process, ControllingProcess, Info}, State) ->
+    ?LOG_DEBUG("handle_info [~p], ~p", [
+        {'DOWN', MonitorRef, process, ControllingProcess, Info}
+    ]),
+    case State#state.monitor_ref =:= MonitorRef of
+        true ->
+            ?LOG_INFO("Controlling process ~p has terminated.  Stopping ~p.", [
+                ControllingProcess, ?MODULE
+            ]),
+            {stop, normal, State};
+        _ ->
+            {noreply, State}
+    end;
+handle_info(Info, State) ->
+    ?LOG_WARNING("Received unexpected Info msg ~p with State ~p", [Info, State]),
+    {noreply, State}.
+
+%% @hidden
+terminate(Reason, State) ->
+    ?LOG_INFO("Closing socket ~p for reason ~p", [State#state.socket, Reason]),
+    catch socket:close(State#state.socket).
+
+%%
+%% Internal operations
+%%
+
+%% @private
+proplist_to_map(PropList) ->
+    proplist_to_map(PropList, #{}).
+
+%% @private
+proplist_to_map([], Accum) ->
+    Accum;
+proplist_to_map([Atom | T], Accum) when is_atom(Atom) ->
+    proplist_to_map(T, Accum#{Atom => true});
+proplist_to_map([{K, V} | T], Accum) ->
+    proplist_to_map(T, Accum#{K => V}).
+
+%% @private
+handle_accept(State, From, AcceptingProc) ->
+    Socket = State#state.socket,
+    ControllingProcess = AcceptingProc,
+    Options = State#state.options,
+    %% CAUTION: internal API
+    case socket:nif_accept(Socket) of
+        {ok, ConnectedSocket} ->
+            Reply =
+                gen_server:start_link(
+                    ?MODULE, {ConnectedSocket, ControllingProcess, accept, Options}, []
+                ),
+            ?LOG_INFO("Accepted connection.  Attempted to start connected socket: ~p", [Reply]),
+            gen_server:reply(From, Reply),
+            State;
+        {error, _Reason} = Error ->
+            ?LOG_ERROR("Failed to accept connection: ~p", [Error]),
+            %% CAUTION: internal API
+            socket:nif_select_stop(Socket),
+            gen_server:reply(From, Error),
+            State
+    end.
+
+%% @private
+handle_active_recv(State) ->
+    Socket = State#state.socket,
+    Length = maps:get(buffer, State#state.options, 0),
+    WrappedSocket = {?GEN_TCP_MONIKER, self(), ?MODULE},
+    %% CAUTION: internal API
+    case socket:nif_recv(Socket, Length) of
+        {ok, Data} ->
+            ?LOG_INFO("Received data len=~p", [erlang:byte_size(Data)]),
+            BinaryOrList = maybe_encode_binary(State#state.options, Data),
+            ?LOG_INFO("Sending tcp message to controlling process ~p", [
+                State#state.controlling_process
+            ]),
+            State#state.controlling_process ! {tcp, WrappedSocket, BinaryOrList},
+
+            %% start a new select
+            Ref = erlang:make_ref(),
+            case socket:nif_select_read(Socket, Ref) of
+                ok ->
+                    ?LOG_INFO("Started read select on ref=~p", [Ref]),
+                    PendingSelects = State#state.pending_selects,
+                    NewPendingSelects = maps:remove(Ref, PendingSelects),
+                    State#state{pending_selects = NewPendingSelects#{Ref => active}};
+                Error ->
+                    ?LOG_ERROR("Unable to start select on new ref=~p Error=~p", [Ref, Error]),
+                    State
+            end;
+        {closed, OtherRef} ->
+            ?LOG_INFO("Socket was closed other ref=~p", [OtherRef]),
+            % socket was closed by another process
+            % TODO: we need to handle:
+            % (a) SELECT_STOP being scheduled
+            % (b) flush of messages as we can have both
+            % {closed, Ref} and {select, _, Ref, _} in the
+            % queue
+            State#state.controlling_process ! {tcp_closed, WrappedSocket},
+            State;
+        {error, closed} ->
+            ?LOG_INFO("Socket was closed by peer"),
+            %% CAUTION: internal API
+            socket:nif_select_stop(Socket),
+            %% peer has closed the connection
+            WrappedSocket = {?GEN_TCP_MONIKER, self(), ?MODULE},
+            State#state.controlling_process ! {tcp_closed, WrappedSocket},
+            State;
+        {error, _} = Error ->
+            ?LOG_ERROR("Error on receive on pending select Error=~p", [Error]),
+            %% CAUTION: internal API
+            socket:nif_select_stop(Socket),
+            %% TODO is this right?  I don't think active receivers would know
+            %% what to do with this message.  Maybe log it instead?
+            State#state.controlling_process ! {tcp_error, WrappedSocket, Error},
+            State
+    end.
+
+%% @private
+handle_passive_recv(State, From, Length, _Timeout) ->
+    Socket = State#state.socket,
+    %% CAUTION: internal API
+    case socket:nif_recv(Socket, Length) of
+        {ok, Data} ->
+            ?LOG_INFO("Received data len=~p", [erlang:byte_size(Data)]),
+            BinaryOrList = maybe_encode_binary(State#state.options, Data),
+            gen_server:reply(From, {ok, BinaryOrList}),
+            State;
+        {closed, OtherRef} ->
+            ?LOG_INFO("Socket was closed other ref=~p", [OtherRef]),
+            % socket was closed by another process
+            % TODO: we need to handle:
+            % (a) SELECT_STOP being scheduled
+            % (b) flush of messages as we can have both
+            % {closed, Ref} and {select, _, Ref, _} in the
+            % queue
+            gen_server:reply(From, {error, closed}),
+            State;
+        {error, _} = Error ->
+            ?LOG_ERROR("Error on receive from socket:nif_recv Error=~p", [Error]),
+            socket:nif_select_stop(Socket),
+            ?LOG_INFO("unable to receive on pending select~n"),
+            gen_server:reply(From, Error),
+            State
+    end.
+
+%% @private
+call(Pid, Request) ->
+    gen_server:call(Pid, Request, infinity).
+
+%% @private
+maybe_encode_binary(Options, Data) ->
+    case encode_binary(Options) of
+        true ->
+            Data;
+        _ ->
+            binary_to_list(Data)
+    end.
+
+%% @private
+encode_binary(Options) ->
+    case {maps:get(binary, Options, undefined), maps:get(list, Options, undefined)} of
+        {undefined, undefined} ->
+            true;
+        {true, _} ->
+            true;
+        _ ->
+            false
+    end.

--- a/libs/estdlib/src/gen_udp_inet.erl
+++ b/libs/estdlib/src/gen_udp_inet.erl
@@ -1,0 +1,161 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2018-2022 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%% @hidden
+-module(gen_udp_inet).
+
+-export([open/1, open/2, send/4, recv/2, recv/3, close/1, controlling_process/2]).
+
+%% inet API
+-export([port/1, sockname/1]).
+
+-type packet() :: string() | binary().
+-type reason() :: term().
+
+-type option() ::
+    {active, boolean()}
+    | {buffer, pos_integer()}
+    | {timeout, timeout()}
+    | list
+    | binary
+    | {binary, boolean()}.
+
+-define(DEFAULT_PARAMS, [{active, true}, {buffer, 128}, {timeout, infinity}]).
+
+%% @hidden
+-spec open(PortNum :: inet:port_number()) -> {ok, inet:socket()} | {error, Reason :: reason()}.
+open(PortNum) ->
+    open(PortNum, []).
+
+%% @hidden
+-spec open(PortNum :: inet:port_number(), Options :: [option()]) ->
+    {ok, inet:socket()} | {error, Reason :: reason()}.
+open(PortNum, Options) ->
+    DriverPid = open_port({spawn, "socket"}, []),
+    Params = merge(Options, ?DEFAULT_PARAMS),
+    init(DriverPid, PortNum, Params).
+
+%% @hidden
+-spec send(
+    Socket :: inet:socket(),
+    Address :: inet:ip_address(),
+    PortNum :: inet:port_number(),
+    Packet :: packet()
+) -> ok | {error, reason()}.
+send(Socket, Address, PortNum, Packet) ->
+    case call(Socket, {sendto, Address, PortNum, Packet}) of
+        {ok, _Sent} ->
+            ok;
+        Else ->
+            Else
+    end.
+
+%% @hidden
+-spec recv(Socket :: inet:socket(), Length :: non_neg_integer()) ->
+    {ok, {inet:ip_address(), inet:port_number(), packet()}} | {error, reason()}.
+recv(Socket, Length) ->
+    recv(Socket, Length, infinity).
+
+%% @hidden
+-spec recv(Socket :: inet:socket(), Length :: non_neg_integer(), Timeout :: timeout()) ->
+    {ok, {inet:ip_address(), inet:port_number(), packet()}} | {error, reason()}.
+recv(Socket, Length, Timeout) ->
+    %% Note.  Currently, timeout is not supported in the native (C) driver
+    call(Socket, {recvfrom, Length, Timeout}, Timeout).
+
+%% @hidden
+-spec close(inet:socket()) -> ok.
+close(Socket) ->
+    call(Socket, {close}),
+    ok.
+
+%% @hidden
+-spec controlling_process(Socket :: inet:socket(), Pid :: pid()) ->
+    ok | {error, Reason :: reason()}.
+controlling_process(Socket, Pid) ->
+    call(Socket, {controlling_process, Pid}).
+
+%%
+%% inet API
+%%
+
+%% @hidden
+port(Socket) ->
+    call(Socket, {get_port}).
+
+%% @hidden
+sockname(Socket) ->
+    call(Socket, {sockname}).
+
+%% internal operations
+
+%% @private
+init(DriverPid, PortNum, Params) ->
+    InitParams = [
+        {proto, udp},
+        {port, PortNum},
+        {controlling_process, self()}
+        | Params
+    ],
+    case call(DriverPid, {init, InitParams}) of
+        ok ->
+            {ok, DriverPid};
+        ErrorReason ->
+            %% TODO close port
+            ErrorReason
+    end.
+
+%% TODO implement this in lists
+
+%% @private
+merge(Config, Defaults) ->
+    merge(Config, Defaults, []) ++ Config.
+
+%% @private
+merge(_Config, [], Accum) ->
+    Accum;
+merge(Config, [H | T], Accum) ->
+    Key =
+        case H of
+            {K, _V} -> K;
+            K -> K
+        end,
+    case proplists:get_value(Key, Config) of
+        undefined ->
+            merge(Config, T, [H | Accum]);
+        Value ->
+            merge(Config, T, [{Key, Value} | Accum])
+    end.
+
+%%
+%% Internal operations
+%%
+
+%% @private
+call(Port, Msg) ->
+    call(Port, Msg, infinity).
+
+%% @private
+call(Port, Msg, Timeout) ->
+    case port:call(Port, Msg, Timeout) of
+        {error, noproc} -> {error, closed};
+        out_of_memory -> {error, enomem};
+        Result -> Result
+    end.

--- a/libs/estdlib/src/gen_udp_socket.erl
+++ b/libs/estdlib/src/gen_udp_socket.erl
@@ -1,0 +1,384 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%% @hidden
+-module(gen_udp_socket).
+
+-export([
+    open/1, open/2,
+    send/4,
+    recv/2, recv/3,
+    close/1,
+    controlling_process/2
+]).
+
+-include("inet-priv.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+%% inet API
+-export([port/1, sockname/1]).
+
+%% gen_server implementation (hidden)
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-type packet() :: string() | binary().
+-type reason() :: term().
+
+-type option() ::
+    {active, boolean()}
+    | {buffer, pos_integer()}
+    | {timeout, timeout()}
+    | list
+    | binary
+    | {binary, boolean()}
+    | {ifaddr, inet:ip_address()}.
+
+-define(DEFAULT_OPTIONS, #{
+    active => true,
+    buffer => 0,
+    timeout => infinity
+}).
+
+%% @hidden
+-spec open(Port :: inet:port_number()) -> {ok, inet:socket()} | {error, Reason :: reason()}.
+open(Port) ->
+    open(Port, []).
+
+%% @hidden
+-spec open(Port :: inet:port_number(), Options :: [option()]) ->
+    {ok, inet:socket()} | {error, Reason :: reason()}.
+open(Port, Options) ->
+    ControllingProcess = self(),
+    case socket:open(inet, dgram, udp) of
+        {ok, Socket} ->
+            EffectiveOptions = maps:merge(?DEFAULT_OPTIONS, proplist_to_map(Options)),
+            Addr = maps:get(ifaddr, EffectiveOptions, any),
+            case socket:bind(Socket, #{family => inet, addr => Addr, port => Port}) of
+                ok ->
+                    gen_server:start_link(
+                        ?MODULE, {Socket, ControllingProcess, EffectiveOptions}, []
+                    );
+                BindError ->
+                    BindError
+            end;
+        OpenError ->
+            OpenError
+    end.
+
+%% @hidden
+-spec send(
+    Socket :: inet:socket(),
+    Address :: inet:ip_address(),
+    Port :: inet:port_number(),
+    Packet :: packet()
+) -> ok | {error, reason()}.
+send(Socket, Address, Port, Packet) ->
+    call(Socket, {sendto, Address, Port, Packet}).
+
+%% @hidden
+-spec recv(Socket :: inet:socket(), Length :: non_neg_integer()) ->
+    {ok, {inet:ip_address(), inet:port_number(), packet()}} | {error, reason()}.
+recv(Socket, Length) ->
+    recv(Socket, Length, infinity).
+
+%% @hidden
+-spec recv(Socket :: inet:socket(), Length :: non_neg_integer(), Timeout :: timeout()) ->
+    {ok, {inet:ip_address(), inet:port_number(), packet()}} | {error, reason()}.
+recv(Socket, Length, Timeout) ->
+    call(Socket, {recvfrom, Length, Timeout}).
+
+%% @hidden
+-spec close(inet:socket()) -> ok.
+close(Socket) ->
+    call(Socket, close).
+
+%% @hidden
+-spec controlling_process(Socket :: inet:socket(), Pid :: pid()) ->
+    ok | {error, Reason :: reason()}.
+controlling_process(Socket, Pid) when is_pid(Pid) ->
+    %% WARNING: calling process is potentially spoofable
+    call(Socket, {controlling_process, Pid, self()}).
+
+%%
+%% inet API
+%%
+
+%% @hidden
+port(Socket) ->
+    call(Socket, port).
+
+%% @hidden
+sockname(Socket) ->
+    call(Socket, sockname).
+
+%%
+%% gen_server implementation
+%%
+
+-record(state, {
+    socket,
+    controlling_process = undefined,
+    monitor_ref = undefined,
+    active,
+    options,
+    pending_selects = #{}
+}).
+
+init({Socket, ControllingProcess, Options}) ->
+    case maps:get(active, Options, true) of
+        true ->
+            Ref = erlang:make_ref(),
+            case socket:nif_select_read(Socket, Ref) of
+                ok ->
+                    MonitorRef = erlang:monitor(process, ControllingProcess),
+                    {ok, #state{
+                        socket = Socket,
+                        controlling_process = ControllingProcess,
+                        monitor_ref = MonitorRef,
+                        active = true,
+                        options = Options,
+                        pending_selects = #{Ref => active}
+                    }};
+                {error, _Reason} = Error ->
+                    Error
+            end;
+        _ ->
+            {ok, #state{
+                socket = Socket,
+                controlling_process = ControllingProcess,
+                active = false,
+                options = Options
+            }}
+    end.
+
+%% @hidden
+handle_call({sendto, Address, Port, Packet}, _From, State) ->
+    Dest = #{
+        family => inet,
+        port => Port,
+        addr => Address
+    },
+    {reply, socket:sendto(State#state.socket, Packet, Dest), State};
+handle_call({recvfrom, Length, Timeout}, From, State) ->
+    case State#state.active of
+        true ->
+            {reply, {error, einval}, State};
+        _ ->
+            Ref = erlang:make_ref(),
+            case Timeout of
+                TimeoutMs when is_integer(TimeoutMs) andalso TimeoutMs >= 0 ->
+                    erlang:send_after(TimeoutMs, self(), {timeout, Ref, From});
+                infinity ->
+                    ok
+            end,
+            case socket:nif_select_read(State#state.socket, Ref) of
+                ok ->
+                    PendingSelects = State#state.pending_selects,
+                    NewPendingSelects = PendingSelects#{Ref => {passive, From, Length, Timeout}},
+                    {noreply, State#state{pending_selects = NewPendingSelects}};
+                {error, _Reason} = Error ->
+                    ?LOG_ERROR("An error occurred calling socket:nif_select_read/2: ~p", [Error]),
+                    {noreply, State}
+            end
+    end;
+handle_call(port, _From, State) ->
+    Reply =
+        case socket:sockname(State#state.socket) of
+            {ok, Addr} ->
+                #{port := Port} = Addr,
+                {ok, Port};
+            SocknameError ->
+                SocknameError
+        end,
+    {reply, Reply, State};
+handle_call(sockname, _From, State) ->
+    Reply =
+        case socket:sockname(State#state.socket) of
+            {ok, Addr} ->
+                #{port := Port, addr := Address} = Addr,
+                {ok, {Address, Port}};
+            SocknameError ->
+                SocknameError
+        end,
+    {reply, Reply, State};
+handle_call(close, _From, State) ->
+    {stop, normal, socket:close(State#state.socket), State};
+handle_call({controlling_process, Pid, Caller}, _From, State) ->
+    case State#state.active of
+        false ->
+            {reply, {error, einval}, State};
+        _ ->
+            case State#state.controlling_process =/= Caller of
+                true ->
+                    {reply, {error, not_owner}, State};
+                _ ->
+                    MonitorRef = erlang:monitor(process, Pid),
+                    true = erlang:demonitor(State#state.monitor_ref),
+                    {reply, ok, State#state{controlling_process = Pid, monitor_ref = MonitorRef}}
+            end
+    end;
+handle_call(Request, _From, State) ->
+    {reply, {unknown_request, Request}, State}.
+
+%% @hidden
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+%% @hidden
+handle_info({select, _Socket, Ref, ready_input}, State) ->
+    case maps:get(Ref, State#state.pending_selects, undefined) of
+        undefined ->
+            ?LOG_INFO("Unable to find select ref ~p in pending selects", [Ref]),
+            {noreply, State};
+        active ->
+            NewState = handle_active_recvfrom(State),
+            {noreply, NewState};
+        {passive, From, Length, Timeout} ->
+            NewState = handle_passive_recvfrom(State, From, Length, Timeout),
+            {noreply, NewState#state{
+                pending_selects = maps:remove(Ref, State#state.pending_selects)
+            }}
+    end;
+handle_info({timeout, Ref, From}, State) ->
+    case maps:get(Ref, State#state.pending_selects, undefined) of
+        undefined ->
+            %% in all liklhood the request as processed.  Ignore the message
+            {noreply, State};
+        _ ->
+            ?LOG_INFO("Select ref ~p in pending selects has timed out.", [Ref]),
+            gen_server:reply(From, {error, timeout}),
+            {noreply, State#state{pending_selects = maps:remove(Ref, State#state.pending_selects)}}
+    end;
+handle_info({'DOWN', MonitorRef, process, ControllingProcess, _Info}, State) ->
+    case State#state.monitor_ref =:= MonitorRef of
+        true ->
+            ?LOG_INFO("Controlling process ~p has terminated.  Stopping ~p.", [
+                ControllingProcess, ?MODULE
+            ]),
+            {stop, normal, State};
+        _ ->
+            {noreply, State}
+    end;
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @hidden
+terminate(Reason, State) ->
+    ?LOG_INFO("Closing socket ~p for reason ~p", [State#state.socket, Reason]),
+    catch socket:close(State#state.socket).
+
+%%
+%% Internal operations
+%%
+
+%% @private
+proplist_to_map(PropList) ->
+    proplist_to_map(PropList, #{}).
+
+%% @private
+proplist_to_map([], Accum) ->
+    Accum;
+proplist_to_map([Atom | T], Accum) when is_atom(Atom) ->
+    proplist_to_map(T, Accum#{Atom => true});
+proplist_to_map([{K, V} | T], Accum) ->
+    proplist_to_map(T, Accum#{K => V}).
+
+%% @private
+handle_active_recvfrom(State) ->
+    Socket = State#state.socket,
+    Length = maps:get(buffer, State#state.options, 0),
+    ControllingProcess = State#state.controlling_process,
+    WrappedSocket = {?GEN_UDP_MONIKER, self(), ?MODULE},
+    %% CAUTION: internal API
+    case socket:nif_recvfrom(Socket, Length) of
+        {ok, {Address, Data}} ->
+            BinaryOrList = maybe_encode_binary(State#state.options, Data),
+            #{addr := Addr, port := Port} = Address,
+            ?LOG_INFO("Sending message to ControllingProcess ~p", [ControllingProcess]),
+            ControllingProcess ! {udp, WrappedSocket, Addr, Port, BinaryOrList},
+
+            %% start a new select
+            Ref = erlang:make_ref(),
+            case socket:nif_select_read(Socket, Ref) of
+                ok ->
+                    PendingSelects = State#state.pending_selects,
+                    NewPendingSelects = maps:remove(Ref, PendingSelects),
+                    State#state{pending_selects = NewPendingSelects#{Ref => active}};
+                _ ->
+                    State
+            end;
+        {closed, _Ref} ->
+            % socket was closed by another process
+            % TODO: we need to handle:
+            % (a) SELECT_STOP being scheduled
+            % (b) flush of messages as we can have both
+            % {closed, Ref} and {select, _, Ref, _} in the
+            % queue
+            State#state.controlling_process ! {udp_closed, WrappedSocket},
+            State;
+        {error, _} = E ->
+            %% CAUTION: internal API
+            socket:nif_select_stop(Socket),
+            ?LOG_INFO("unable to receive on pending select~n"),
+            State#state.controlling_process ! {udp_error, WrappedSocket, E},
+            State
+    end.
+
+%% @private
+handle_passive_recvfrom(State, From, Length, _Timeout) ->
+    Socket = State#state.socket,
+    %% CAUTION: internal API
+    case socket:nif_recvfrom(Socket, Length) of
+        {ok, {Address, Data}} ->
+            BinaryOrList = maybe_encode_binary(State#state.options, Data),
+            #{addr := Addr, port := Port} = Address,
+            % WrappedSocket = {?GEN_UDP_MONIKER, self(), ?MODULE},
+            gen_server:reply(From, {ok, {Addr, Port, BinaryOrList}}),
+            State;
+        {error, _} = E ->
+            socket:nif_select_stop(Socket),
+            ?LOG_INFO("unable to receive on pending select~n"),
+            gen_server:reply(From, E),
+            State
+    end.
+
+%% @private
+call(Pid, Request) ->
+    gen_server:call(Pid, Request, infinity).
+
+%% @private
+maybe_encode_binary(Options, Data) ->
+    case encode_binary(Options) of
+        true ->
+            Data;
+        _ ->
+            binary_to_list(Data)
+    end.
+
+%% @private
+encode_binary(Options) ->
+    case {maps:get(binary, Options, undefined), maps:get(list, Options, undefined)} of
+        {undefined, undefined} ->
+            true;
+        {true, _} ->
+            true;
+        _ ->
+            false
+    end.

--- a/libs/estdlib/src/inet-priv.hrl
+++ b/libs/estdlib/src/inet-priv.hrl
@@ -1,0 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-define(GEN_TCP_MONIKER, '$avm_gen_tcp').
+-define(GEN_UDP_MONIKER, '$avm_gen_udp').

--- a/libs/estdlib/src/inet.erl
+++ b/libs/estdlib/src/inet.erl
@@ -22,8 +22,12 @@
 
 -export([port/1, close/1, sockname/1, peername/1]).
 
+-include("inet-priv.hrl").
+
+-type moniker() :: ?GEN_TCP_MONIKER | ?GEN_UDP_MONIKER.
+-type socket_impl() :: any().
+-type socket() :: {moniker(), socket_impl(), module()}.
 -type port_number() :: 0..65535.
--type socket() :: pid().
 -type ip_address() :: ip4_address().
 -type ip4_address() :: {0..255, 0..255, 0..255, 0..255}.
 -type hostname() :: iodata().
@@ -39,8 +43,10 @@
 %% @end
 %%-----------------------------------------------------------------------------
 -spec port(Socket :: socket()) -> port_number().
-port(Socket) ->
-    call(Socket, {get_port}).
+port({Moniker, Socket, Module}) when
+    Moniker =:= ?GEN_TCP_MONIKER orelse Moniker =:= ?GEN_UDP_MONIKER
+->
+    Module:port(Socket).
 
 %%-----------------------------------------------------------------------------
 %% @param   Socket the socket to close
@@ -49,9 +55,10 @@ port(Socket) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec close(Socket :: socket()) -> ok.
-close(Socket) ->
-    call(Socket, {close}),
-    ok.
+close({Moniker, Socket, Module}) when
+    Moniker =:= ?GEN_TCP_MONIKER orelse Moniker =:= ?GEN_UDP_MONIKER
+->
+    Module:close(Socket).
 
 %%-----------------------------------------------------------------------------
 %% @param   Socket the socket
@@ -62,8 +69,10 @@ close(Socket) ->
 %%-----------------------------------------------------------------------------
 -spec sockname(Socket :: socket()) ->
     {ok, {ip_address(), port_number()}} | {error, Reason :: term()}.
-sockname(Socket) ->
-    call(Socket, {sockname}).
+sockname({Moniker, Socket, Module}) when
+    Moniker =:= ?GEN_TCP_MONIKER orelse Moniker =:= ?GEN_UDP_MONIKER
+->
+    Module:sockname(Socket).
 
 %%-----------------------------------------------------------------------------
 %% @param   Socket the socket
@@ -74,16 +83,5 @@ sockname(Socket) ->
 %%-----------------------------------------------------------------------------
 -spec peername(Socket :: socket()) ->
     {ok, {ip_address(), port_number()}} | {error, Reason :: term()}.
-peername(Socket) ->
-    call(Socket, {peername}).
-
-%%
-%% Internal operations
-%%
-
-call(Port, Msg) ->
-    case port:call(Port, Msg) of
-        {error, noproc} -> {error, einval};
-        out_of_memory -> {error, enomem};
-        Result -> Result
-    end.
+peername({?GEN_TCP_MONIKER, Socket, Module}) ->
+    Module:peername(Socket).

--- a/src/platforms/esp32/components/avm_sys/include/otp_socket_platform.h
+++ b/src/platforms/esp32/components/avm_sys/include/otp_socket_platform.h
@@ -29,6 +29,9 @@ extern "C" {
 
 #define TAG "otp_socket"
 
+#define AVM_LOGD(tag, format, ...) \
+    ;
+
 #define AVM_LOGI ESP_LOGI
 #define AVM_LOGW ESP_LOGW
 #define AVM_LOGE ESP_LOGE

--- a/src/platforms/generic_unix/lib/otp_socket_platform.h
+++ b/src/platforms/generic_unix/lib/otp_socket_platform.h
@@ -26,6 +26,9 @@
 
 #define TAG "otp_socket"
 
+#define AVM_LOGD(tag, format, ...) \
+    ;
+
 #define AVM_LOGI(tag, format, ...) \
     fprintf(stderr, "I %s: " format " (%s:%i)\n", tag, ##__VA_ARGS__, __FILE__, __LINE__);
 

--- a/src/platforms/rp2040/src/lib/otp_socket_platform.h
+++ b/src/platforms/rp2040/src/lib/otp_socket_platform.h
@@ -33,6 +33,9 @@
 
 #define TAG "otp_socket"
 
+#define AVM_LOGD(tag, format, ...) \
+    ;
+
 #define AVM_LOGI(tag, format, ...) \
     printf("I %s: " format " (%s:%i)\n", tag, ##__VA_ARGS__, __FILE__, __LINE__);
 

--- a/tests/libs/estdlib/test_gen_tcp.erl
+++ b/tests/libs/estdlib/test_gen_tcp.erl
@@ -39,16 +39,18 @@ test_echo_server(SpawnControllingProcess) ->
     {ok, {_Address, Port}} = inet:sockname(ListenSocket),
 
     Self = self(),
-    spawn(fun() ->
-        Self ! ready,
-        accept(Self, ListenSocket, SpawnControllingProcess)
-    end),
+    spawn(
+        fun() ->
+            Self ! ready,
+            accept(Self, ListenSocket, SpawnControllingProcess)
+        end
+    ),
     receive
         ready ->
             ok
     end,
 
-    test_send_receive(Port, 100, SpawnControllingProcess),
+    test_send_receive(Port, 10, SpawnControllingProcess),
 
     %% TODO bug closing listening socket
     % gen_tcp:close(ListenSocket),
@@ -77,11 +79,13 @@ echo(Pid, Socket) ->
             ok;
         {tcp, Socket, Packet} ->
             ok = gen_tcp:send(Socket, Packet),
-            echo(Pid, Socket)
+            echo(Pid, Socket);
+        SomethingElse ->
+            erlang:display({echo, unexpected_message, SomethingElse})
     end.
 
 test_send_receive(Port, N, SpawnControllingProcess) ->
-    {ok, Socket} = gen_tcp:connect(localhost, Port, [{active, true}]),
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, Port, [{active, true}]),
     case SpawnControllingProcess of
         false ->
             loop(Socket, N);
@@ -119,8 +123,25 @@ loop(Socket, I) ->
     end.
 
 test_listen_connect_parameters() ->
+    case get_otp_version() of
+        Version when Version =:= atomvm orelse (is_integer(Version) andalso Version >= 24) ->
+            ok = test_listen_connect_parameters(socket, socket),
+            ok = test_listen_connect_parameters(inet, inet);
+        _ ->
+            ok = test_listen_connect_parameters(inet, inet)
+    end,
+    ok.
+
+test_listen_connect_parameters(InetClientBackend, InetServerBackend) ->
     Results = [
-        test_listen_connect_parameters(ListenMode, ConnectMode, ListenActive, ConnectActive)
+        test_listen_connect_parameters(
+            InetClientBackend,
+            InetServerBackend,
+            ListenMode,
+            ConnectMode,
+            ListenActive,
+            ConnectActive
+        )
      || ListenMode <- [binary, list],
         ConnectMode <- [binary, list],
         ListenActive <- [false, true],
@@ -129,14 +150,46 @@ test_listen_connect_parameters() ->
     [] = [Error || Error <- Results, Error =/= ok],
     ok.
 
-test_listen_connect_parameters(ListenMode, ConnectMode, ListenActive, ConnectActive) ->
-    {ok, ListenSocket} = gen_tcp:listen(0, [ListenMode, {active, ListenActive}, {buffer, 32}]),
+test_listen_connect_parameters(
+    InetClientBackend, InetServerBackend, ListenMode, ConnectMode, ListenActive, ConnectActive
+) ->
+    etest:flush_msg_queue(),
+
+    case get_otp_version() of
+        Version when Version =:= atomvm orelse (is_integer(Version) andalso Version >= 24) ->
+            ServerBackendOption = [{inet_backend, InetServerBackend}],
+            ClientBackendOption = [{inet_backend, InetClientBackend}];
+        _ ->
+            ServerBackendOption = [],
+            ClientBackendOption = []
+    end,
+
+    io:format(
+        "GEN_TCP-TEST> ServerBackendOption=~p ClientBackendOption=~p ListenMode=~p ConnectMode=~p ListenActive=~p ConnectActive=~p~n",
+        [
+            ServerBackendOption,
+            ClientBackendOption,
+            ListenMode,
+            ConnectMode,
+            ListenActive,
+            ConnectActive
+        ]
+    ),
+
+    NumMessages = 10,
+
+    {ok, ListenSocket} = gen_tcp:listen(
+        0,
+        ServerBackendOption ++ [ListenMode, {active, ListenActive}, {buffer, 32}]
+    ),
     {ok, {_Address, Port}} = inet:sockname(ListenSocket),
 
     Self = self(),
     ServerPid = spawn(fun() ->
         Self ! {self(), ready},
-        Result = test_listen_connect_parameters_accept(ListenMode, ListenActive, ListenSocket),
+        Result = test_listen_connect_parameters_accept(
+            ListenMode, ListenActive, ListenSocket, NumMessages, Self
+        ),
         Self ! {self(), Result}
     end),
     receive
@@ -144,12 +197,33 @@ test_listen_connect_parameters(ListenMode, ConnectMode, ListenActive, ConnectAct
             ok
     end,
 
-    {ok, Socket} = gen_tcp:connect(localhost, Port, [ConnectMode, {active, ConnectActive}]),
-    ok = test_listen_connect_parameters_client_loop(Socket, ConnectMode, ConnectActive, 10),
-    ok = gen_tcp:close(Socket),
+    {ok, Socket} = gen_tcp:connect(
+        {127, 0, 0, 1},
+        Port,
+        ClientBackendOption ++ [ConnectMode, {active, ConnectActive}]
+    ),
+    ok = test_listen_connect_parameters_client_loop(
+        Socket, ConnectMode, ConnectActive, NumMessages
+    ),
+
+    %% race condition in active receive; client might
+    %% close connection before service has consumed (and delivered)
+    %% all messages to active recipient process.  So we need
+    %% to wait until the server has actually processed all the
+    %% messages it is expected to.
     receive
-        {ServerPid, Result} -> Result
-    after 5000 -> throw({timeout, waiting, recv, server_closed})
+        server_done ->
+            ok
+    end,
+
+    ok = gen_tcp:close(Socket),
+
+    receive
+        {ServerPid, Result} ->
+            ok = gen_tcp:close(ListenSocket),
+            Result
+    after 5000 ->
+        throw({timeout, waiting, recv, server_closed})
     end.
 
 test_listen_connect_parameters_client_loop(_Socket, _Mode, _Active, 0) ->
@@ -161,22 +235,25 @@ test_listen_connect_parameters_client_loop(Socket, Mode, Active, I) ->
 
 test_listen_connect_parameters_client_loop0(Socket, Mode, true = Active, I) ->
     receive
-        {tcp_closed, Socket} ->
+        {tcp_closed, _Socket} ->
             ok;
-        {tcp, Socket, Packet} ->
+        {tcp, _Socket, Packet} ->
             if
                 Mode =:= binary andalso is_binary(Packet) ->
                     test_listen_connect_parameters_client_loop(Socket, Mode, Active, I - 1);
                 Mode =:= list andalso is_list(Packet) ->
                     test_listen_connect_parameters_client_loop(Socket, Mode, Active, I - 1);
                 true ->
-                    {error, {unexpected_packet_format, client, Packet, Mode}}
+                    {error,
+                        {unexpected_packet_format, client, active_receive, Packet, Mode, Active}}
             end;
-        Other ->
-            {error, {unexpected_message, Other}}
+        {error, _Reason} = Error ->
+            {error, {unexpected_message, client, active_receive, Error}}
+    after 5000 ->
+        {error, {timeout, client, active_receive, Mode, I}}
     end;
 test_listen_connect_parameters_client_loop0(Socket, Mode, false = Active, I) ->
-    case gen_tcp:recv(Socket, 0) of
+    case gen_tcp:recv(Socket, 0, 5000) of
         {error, closed} ->
             ok;
         {ok, Packet} ->
@@ -186,49 +263,87 @@ test_listen_connect_parameters_client_loop0(Socket, Mode, false = Active, I) ->
                 Mode =:= list andalso is_list(Packet) ->
                     test_listen_connect_parameters_client_loop(Socket, Mode, Active, I - 1);
                 true ->
-                    {error, {unexpected_packet_format, client, Packet, Mode}}
+                    {error, {unexpected_packet_format, client, passive_receive, Packet, Mode}}
             end;
         Other ->
-            {error, {unexpected_result, client, Other}}
+            {error, {unexpected_result, client, passive_receive, Other}}
     end.
 
-test_listen_connect_parameters_accept(ListenMode, ListenActive, ListenSocket) ->
+test_listen_connect_parameters_accept(
+    ListenMode, ListenActive, ListenSocket, NumMessages, WaitingPid
+) ->
     {ok, Socket} = gen_tcp:accept(ListenSocket),
-    test_listen_connect_parameters_server_loop(ListenMode, ListenActive, Socket).
+    try
+        test_listen_connect_parameters_server_loop(
+            ListenMode, ListenActive, Socket, NumMessages, WaitingPid
+        )
+    after
+        ok = gen_tcp:close(Socket)
+    end.
 
-test_listen_connect_parameters_server_loop(ListenMode, true = ListenActive, Socket) ->
+test_listen_connect_parameters_server_loop(
+    _ListenMode, true = _ListenActive, Socket, 0, WaitingPid
+) ->
+    WaitingPid ! server_done,
     receive
         {tcp_closed, Socket} ->
-            ok;
+            ok
+    after 5000 ->
+        {error, {timeout, server, active_receive, waiting_for_close}}
+    end;
+test_listen_connect_parameters_server_loop(ListenMode, true = ListenActive, Socket, I, WaitingPid) ->
+    receive
+        {tcp_closed, _Socket} ->
+            {error, {unexpected_close, server, active_receive}};
         {tcp, Socket, Packet} ->
             ok = gen_tcp:send(Socket, Packet),
             if
                 ListenMode =:= binary andalso is_binary(Packet) ->
-                    test_listen_connect_parameters_server_loop(ListenMode, ListenActive, Socket);
+                    test_listen_connect_parameters_server_loop(
+                        ListenMode, ListenActive, Socket, I - 1, WaitingPid
+                    );
                 ListenMode =:= list andalso is_list(Packet) ->
-                    test_listen_connect_parameters_server_loop(ListenMode, ListenActive, Socket);
+                    test_listen_connect_parameters_server_loop(
+                        ListenMode, ListenActive, Socket, I - 1, WaitingPid
+                    );
                 true ->
-                    {error, {unexpected_packet_format, server, Packet, ListenMode}}
+                    {error, {unexpected_packet_format, server, active_receive, Packet, ListenMode}}
             end;
         Other ->
-            {error, {unexpected_message, Other}}
+            {error, {unexpected_message, server, active_receive, Other}}
+    after 5000 ->
+        {error, {timeout, server, active_receive, ListenMode}}
     end;
-test_listen_connect_parameters_server_loop(ListenMode, false = ListenActive, Socket) ->
-    case gen_tcp:recv(Socket, 0) of
+test_listen_connect_parameters_server_loop(
+    _ListenMode, false = _ListenActive, Socket, 0, WaitingPid
+) ->
+    WaitingPid ! server_done,
+    case gen_tcp:recv(Socket, 0, 5000) of
         {error, closed} ->
             ok;
+        {error, timeout} ->
+            {error, {timeout, server, passive_receive, waiting_for_close}}
+    end;
+test_listen_connect_parameters_server_loop(ListenMode, false = ListenActive, Socket, I, WaitingPid) ->
+    case gen_tcp:recv(Socket, 0, 5000) of
+        {error, closed} ->
+            {error, {unexpected_close, server, passive_receive}};
         {ok, Packet} ->
             ok = gen_tcp:send(Socket, Packet),
             if
                 ListenMode =:= binary andalso is_binary(Packet) ->
-                    test_listen_connect_parameters_server_loop(ListenMode, ListenActive, Socket);
+                    test_listen_connect_parameters_server_loop(
+                        ListenMode, ListenActive, Socket, I - 1, WaitingPid
+                    );
                 ListenMode =:= list andalso is_list(Packet) ->
-                    test_listen_connect_parameters_server_loop(ListenMode, ListenActive, Socket);
+                    test_listen_connect_parameters_server_loop(
+                        ListenMode, ListenActive, Socket, I - 1, WaitingPid
+                    );
                 true ->
-                    {error, {unexpected_packet_format, server, Packet, ListenMode}}
+                    {error, {unexpected_packet_format, server, passive_receive, Packet, ListenMode}}
             end;
         Other ->
-            {error, {unexpected_result, server, Other}}
+            {error, {unexpected_result, server, passive_receive, Other}}
     end.
 
 test_tcp_double_close() ->
@@ -237,3 +352,11 @@ test_tcp_double_close() ->
     ok = gen_tcp:close(Socket),
     {error, closed} = gen_tcp:recv(Socket, 512, 5000),
     ok.
+
+get_otp_version() ->
+    case erlang:system_info(machine) of
+        "BEAM" ->
+            list_to_integer(erlang:system_info(otp_release));
+        _ ->
+            atomvm
+    end.


### PR DESCRIPTION
This PR adds the ability to use the `gen_tcp` and `gen_udp` interfaces using the OTP socket interface as a "back-end", eliminating the need for the native C drivers on generic_unix and ESP32.

Using the feature also allows use of the `gen_tcp` and `gen_udp` interfaces on the rp2040 platform.

This feature is still considered "experimental" and therefore is not currently documented.  However, the configuration APIs follow the OTP `inet_backend` configuration option introduced in OTP-23.

This PR addresses issue #893 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
