### PR TITLE
Move x registers from contexts to schedulers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - ESP32: fix i2c_driver_acquire and i2c_driver_release functions, that were working only once.
+- Fixed a bug where the VM would crash when code used more than 16 x registers.
 
 ## [0.6.0-beta.0] - 2024-02-08
 

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -37,8 +37,8 @@
 #pragma GCC diagnostic pop
 
 #define RAISE_ERROR(error_type_atom) \
-    ctx->x[0] = ERROR_ATOM;          \
-    ctx->x[1] = (error_type_atom);   \
+    x_regs[0] = ERROR_ATOM;          \
+    x_regs[1] = (error_type_atom);   \
     return term_invalid_term();
 
 #define VALIDATE_VALUE(value, verify_function) \
@@ -59,13 +59,16 @@ const struct ExportedFunction *bif_registry_get_handler(AtomString module, AtomS
     return &nameAndPtr->bif.base;
 }
 
-term bif_erlang_self_0(Context *ctx)
+term bif_erlang_self_0(Context *ctx, term *x_regs)
 {
+    UNUSED(x_regs);
+
     return term_from_local_process_id(ctx->process_id);
 }
 
-term bif_erlang_byte_size_1(Context *ctx, int live, term arg1)
+term bif_erlang_byte_size_1(Context *ctx, term *x_regs, int live, term arg1)
 {
+    UNUSED(ctx);
     UNUSED(live);
 
     VALIDATE_VALUE(arg1, term_is_binary);
@@ -73,8 +76,9 @@ term bif_erlang_byte_size_1(Context *ctx, int live, term arg1)
     return term_from_int32(term_binary_size(arg1));
 }
 
-term bif_erlang_bit_size_1(Context *ctx, int live, term arg1)
+term bif_erlang_bit_size_1(Context *ctx, term *x_regs, int live, term arg1)
 {
+    UNUSED(ctx);
     UNUSED(live);
 
     VALIDATE_VALUE(arg1, term_is_binary);
@@ -82,92 +86,104 @@ term bif_erlang_bit_size_1(Context *ctx, int live, term arg1)
     return term_from_int32(term_binary_size(arg1) * 8);
 }
 
-term bif_erlang_is_atom_1(Context *ctx, term arg1)
+term bif_erlang_is_atom_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     return term_is_atom(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_binary_1(Context *ctx, term arg1)
+term bif_erlang_is_binary_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     return term_is_binary(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_boolean_1(Context *ctx, term arg1)
+term bif_erlang_is_boolean_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     return (arg1 == TRUE_ATOM || arg1 == FALSE_ATOM) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_float_1(Context *ctx, term arg1)
+term bif_erlang_is_float_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     return term_is_float(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_function_1(Context *ctx, term arg1)
+term bif_erlang_is_function_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     return term_is_function(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_integer_1(Context *ctx, term arg1)
+term bif_erlang_is_integer_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     return term_is_any_integer(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_list_1(Context *ctx, term arg1)
+term bif_erlang_is_list_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     return term_is_list(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_number_1(Context *ctx, term arg1)
+term bif_erlang_is_number_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     //TODO: change to term_is_number
     return term_is_any_integer(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_pid_1(Context *ctx, term arg1)
+term bif_erlang_is_pid_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     return term_is_pid(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_reference_1(Context *ctx, term arg1)
+term bif_erlang_is_reference_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     return term_is_reference(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_tuple_1(Context *ctx, term arg1)
+term bif_erlang_is_tuple_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     return term_is_tuple(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_map_1(Context *ctx, term arg1)
+term bif_erlang_is_map_1(Context *ctx, term *x_regs, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(x_regs);
 
     return term_is_map(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_map_key_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_is_map_key_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     if (UNLIKELY(!term_is_map(arg2))) {
         if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &arg2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
@@ -190,8 +206,9 @@ term bif_erlang_is_map_key_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_length_1(Context *ctx, int live, term arg1)
+term bif_erlang_length_1(Context *ctx, term *x_regs, int live, term arg1)
 {
+    UNUSED(ctx);
     UNUSED(live);
 
     VALIDATE_VALUE(arg1, term_is_list);
@@ -205,22 +222,28 @@ term bif_erlang_length_1(Context *ctx, int live, term arg1)
     return term_from_int(len);
 }
 
-term bif_erlang_hd_1(Context *ctx, term arg1)
+term bif_erlang_hd_1(Context *ctx, term *x_regs, term arg1)
 {
+    UNUSED(ctx);
+
     VALIDATE_VALUE(arg1, term_is_nonempty_list);
 
     return term_get_list_head(arg1);
 }
 
-term bif_erlang_tl_1(Context *ctx, term arg1)
+term bif_erlang_tl_1(Context *ctx, term *x_regs, term arg1)
 {
+    UNUSED(ctx);
+
     VALIDATE_VALUE(arg1, term_is_nonempty_list);
 
     return term_get_list_tail(arg1);
 }
 
-term bif_erlang_element_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_element_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
+    UNUSED(ctx);
+
     VALIDATE_VALUE(arg1, term_is_integer);
     VALIDATE_VALUE(arg2, term_is_tuple);
 
@@ -234,14 +257,16 @@ term bif_erlang_element_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_tuple_size_1(Context *ctx, term arg1)
+term bif_erlang_tuple_size_1(Context *ctx, term *x_regs, term arg1)
 {
+    UNUSED(ctx);
+
     VALIDATE_VALUE(arg1, term_is_tuple);
 
     return term_from_int32(term_get_tuple_arity(arg1));
 }
 
-term bif_erlang_map_size_1(Context *ctx, int live, term arg1)
+term bif_erlang_map_size_1(Context *ctx, term *x_regs, int live, term arg1)
 {
     UNUSED(live);
 
@@ -260,7 +285,7 @@ term bif_erlang_map_size_1(Context *ctx, int live, term arg1)
     return term_from_int32(term_get_map_size(arg1));
 }
 
-term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_map_get_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     if (!UNLIKELY(term_is_map(arg2))) {
         // We don't need to preserve registers as we're raising
@@ -291,9 +316,9 @@ term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
     return term_get_map_value(arg2, pos);
 }
 
-static inline term make_boxed_int(Context *ctx, uint32_t live, avm_int_t value)
+static inline term make_boxed_int(Context *ctx, term *x_regs, uint32_t live, avm_int_t value)
 {
-    if (UNLIKELY(memory_ensure_free_with_roots(ctx, BOXED_INT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, BOXED_INT_SIZE, live, x_regs, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -301,9 +326,9 @@ static inline term make_boxed_int(Context *ctx, uint32_t live, avm_int_t value)
 }
 
 #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-static inline term make_boxed_int64(Context *ctx, uint32_t live, avm_int64_t value)
+static inline term make_boxed_int64(Context *ctx, term *x_regs, uint32_t live, avm_int64_t value)
 {
-    if (UNLIKELY(memory_ensure_free_with_roots(ctx, BOXED_INT64_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, BOXED_INT64_SIZE, live, x_regs, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -311,10 +336,10 @@ static inline term make_boxed_int64(Context *ctx, uint32_t live, avm_int64_t val
 }
 #endif
 
-static inline term make_maybe_boxed_int(Context *ctx, uint32_t live, avm_int_t value)
+static inline term make_maybe_boxed_int(Context *ctx, term *x_regs, uint32_t live, avm_int_t value)
 {
     if ((value < MIN_NOT_BOXED_INT) || (value > MAX_NOT_BOXED_INT)) {
-        return make_boxed_int(ctx, live, value);
+        return make_boxed_int(ctx, x_regs, live, value);
 
     } else {
         return term_from_int(value);
@@ -322,13 +347,13 @@ static inline term make_maybe_boxed_int(Context *ctx, uint32_t live, avm_int_t v
 }
 
 #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-static inline term make_maybe_boxed_int64(Context *ctx, uint32_t live, avm_int64_t value)
+static inline term make_maybe_boxed_int64(Context *ctx, term *x_regs, uint32_t live, avm_int64_t value)
 {
     if ((value < AVM_INT_MIN) || (value > AVM_INT_MAX)) {
-        return make_boxed_int64(ctx, live, value);
+        return make_boxed_int64(ctx, x_regs, live, value);
 
     } else if ((value < MIN_NOT_BOXED_INT) || (value > MAX_NOT_BOXED_INT)) {
-        return make_boxed_int(ctx, live, value);
+        return make_boxed_int(ctx, x_regs, live, value);
 
     } else {
         return term_from_int(value);
@@ -336,15 +361,15 @@ static inline term make_maybe_boxed_int64(Context *ctx, uint32_t live, avm_int64
 }
 #endif
 
-static term add_overflow_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term add_overflow_helper(Context *ctx, term *x_regs, uint32_t live, term arg1, term arg2)
 {
     avm_int_t val1 = term_to_int(arg1);
     avm_int_t val2 = term_to_int(arg2);
 
-    return make_boxed_int(ctx, live, val1 + val2);
+    return make_boxed_int(ctx, x_regs, live, val1 + val2);
 }
 
-static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term add_boxed_helper(Context *ctx, term *x_regs, uint32_t live, term arg1, term arg2)
 {
     int use_float = 0;
     int size = 0;
@@ -374,7 +399,7 @@ static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
             RAISE_ERROR(BADARITH_ATOM);
         }
 
-        if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, x_regs, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, &ctx->heap);
@@ -394,7 +419,7 @@ static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
             if (BUILTIN_ADD_OVERFLOW_INT(val1, val2, &res)) {
                 #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
                     avm_int64_t res64 = (avm_int64_t) val1 + (avm_int64_t) val2;
-                    return make_boxed_int64(ctx, live, res64);
+                    return make_boxed_int64(ctx, x_regs, live, res64);
 
                 #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                     TRACE("overflow: arg1: " AVM_INT64_FMT ", arg2: " AVM_INT64_FMT "\n", arg1, arg2);
@@ -404,7 +429,7 @@ static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
                 #endif
             }
 
-            return make_maybe_boxed_int(ctx, live, res);
+            return make_maybe_boxed_int(ctx, x_regs, live, res);
         }
 
     #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
@@ -419,7 +444,7 @@ static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
                 RAISE_ERROR(OVERFLOW_ATOM);
             }
 
-            return make_maybe_boxed_int64(ctx, live, res);
+            return make_maybe_boxed_int64(ctx, x_regs, live, res);
         }
     #endif
 
@@ -428,7 +453,7 @@ static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
     }
 }
 
-term bif_erlang_add_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_add_2(Context *ctx, term *x_regs, int live, term arg1, term arg2)
 {
     UNUSED(live);
 
@@ -438,22 +463,22 @@ term bif_erlang_add_2(Context *ctx, int live, term arg1, term arg2)
         if (!BUILTIN_ADD_OVERFLOW((avm_int_t) (arg1 & ~TERM_INTEGER_TAG), (avm_int_t) (arg2 & ~TERM_INTEGER_TAG), &res)) {
             return res | TERM_INTEGER_TAG;
         } else {
-            return add_overflow_helper(ctx, live, arg1, arg2);
+            return add_overflow_helper(ctx, x_regs, live, arg1, arg2);
         }
     } else {
-        return add_boxed_helper(ctx, live, arg1, arg2);
+        return add_boxed_helper(ctx, x_regs, live, arg1, arg2);
     }
 }
 
-static term sub_overflow_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term sub_overflow_helper(Context *ctx, term *x_regs, uint32_t live, term arg1, term arg2)
 {
     avm_int_t val1 = term_to_int(arg1);
     avm_int_t val2 = term_to_int(arg2);
 
-    return make_boxed_int(ctx, live, val1 - val2);
+    return make_boxed_int(ctx, x_regs, live, val1 - val2);
 }
 
-static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term sub_boxed_helper(Context *ctx, term *x_regs, uint32_t live, term arg1, term arg2)
 {
     int use_float = 0;
     int size = 0;
@@ -482,7 +507,7 @@ static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, x_regs, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, &ctx->heap);
@@ -502,7 +527,7 @@ static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
             if (BUILTIN_SUB_OVERFLOW_INT(val1, val2, &res)) {
                 #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
                     avm_int64_t res64 = (avm_int64_t) val1 - (avm_int64_t) val2;
-                    return make_boxed_int64(ctx, live, res64);
+                    return make_boxed_int64(ctx, x_regs, live, res64);
 
                 #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                     TRACE("overflow: arg1: " AVM_INT64_FMT ", arg2: " AVM_INT64_FMT "\n", arg1, arg2);
@@ -512,7 +537,7 @@ static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
                 #endif
             }
 
-            return make_maybe_boxed_int(ctx, live, res);
+            return make_maybe_boxed_int(ctx, x_regs, live, res);
         }
 
     #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
@@ -527,7 +552,7 @@ static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
                 RAISE_ERROR(OVERFLOW_ATOM);
             }
 
-            return make_maybe_boxed_int64(ctx, live, res);
+            return make_maybe_boxed_int64(ctx, x_regs, live, res);
         }
     #endif
 
@@ -536,7 +561,7 @@ static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
     }
 }
 
-term bif_erlang_sub_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_sub_2(Context *ctx, term *x_regs, int live, term arg1, term arg2)
 {
     UNUSED(live);
 
@@ -546,14 +571,14 @@ term bif_erlang_sub_2(Context *ctx, int live, term arg1, term arg2)
         if (!BUILTIN_SUB_OVERFLOW((avm_int_t) (arg1 & ~TERM_INTEGER_TAG), (avm_int_t) (arg2 & ~TERM_INTEGER_TAG), &res)) {
             return res | TERM_INTEGER_TAG;
         } else {
-            return sub_overflow_helper(ctx, live, arg1, arg2);
+            return sub_overflow_helper(ctx, x_regs, live, arg1, arg2);
         }
     } else {
-        return sub_boxed_helper(ctx, live, arg1, arg2);
+        return sub_boxed_helper(ctx, x_regs, live, arg1, arg2);
     }
 }
 
-static term mul_overflow_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term mul_overflow_helper(Context *ctx, term *x_regs, uint32_t live, term arg1, term arg2)
 {
     avm_int_t val1 = term_to_int(arg1);
     avm_int_t val2 = term_to_int(arg2);
@@ -564,11 +589,11 @@ static term mul_overflow_helper(Context *ctx, uint32_t live, term arg1, term arg
 #endif
 
     if (!BUILTIN_MUL_OVERFLOW_INT(val1, val2, &res)) {
-        return make_boxed_int(ctx, live, res);
+        return make_boxed_int(ctx, x_regs, live, res);
 
 #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
     } else if (!BUILTIN_MUL_OVERFLOW_INT64((avm_int64_t) val1, (avm_int64_t) val2, &res64)) {
-        return make_boxed_int64(ctx, live, res64);
+        return make_boxed_int64(ctx, x_regs, live, res64);
 #endif
 
     } else {
@@ -576,7 +601,7 @@ static term mul_overflow_helper(Context *ctx, uint32_t live, term arg1, term arg
     }
 }
 
-static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term mul_boxed_helper(Context *ctx, term *x_regs, uint32_t live, term arg1, term arg2)
 {
     int use_float = 0;
     int size = 0;
@@ -605,7 +630,7 @@ static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, x_regs, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, &ctx->heap);
@@ -625,7 +650,7 @@ static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
             if (BUILTIN_MUL_OVERFLOW_INT(val1, val2, &res)) {
                 #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
                     avm_int64_t res64 = (avm_int64_t) val1 * (avm_int64_t) val2;
-                    return make_boxed_int64(ctx, live, res64);
+                    return make_boxed_int64(ctx, x_regs, live, res64);
 
                 #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                     TRACE("overflow: arg1: " AVM_INT64_FMT ", arg2: " AVM_INT64_FMT "\n", arg1, arg2);
@@ -635,7 +660,7 @@ static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
                 #endif
             }
 
-            return make_maybe_boxed_int(ctx, live, res);
+            return make_maybe_boxed_int(ctx, x_regs, live, res);
         }
 
     #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
@@ -650,7 +675,7 @@ static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
                 RAISE_ERROR(OVERFLOW_ATOM);
             }
 
-            return make_maybe_boxed_int64(ctx, live, res);
+            return make_maybe_boxed_int64(ctx, x_regs, live, res);
         }
     #endif
 
@@ -659,7 +684,7 @@ static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
     }
 }
 
-term bif_erlang_mul_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_mul_2(Context *ctx, term *x_regs, int live, term arg1, term arg2)
 {
     UNUSED(live);
 
@@ -670,14 +695,14 @@ term bif_erlang_mul_2(Context *ctx, int live, term arg1, term arg2)
         if (!BUILTIN_MUL_OVERFLOW(a, b, &res)) {
             return res | TERM_INTEGER_TAG;
         } else {
-            return mul_overflow_helper(ctx, live, arg1, arg2);
+            return mul_overflow_helper(ctx, x_regs, live, arg1, arg2);
         }
     } else {
-        return mul_boxed_helper(ctx, live, arg1, arg2);
+        return mul_boxed_helper(ctx, x_regs, live, arg1, arg2);
     }
 }
 
-static term div_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term div_boxed_helper(Context *ctx, term *x_regs, uint32_t live, term arg1, term arg2)
 {
     int size = 0;
     if (term_is_boxed_integer(arg1)) {
@@ -707,7 +732,7 @@ static term div_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
 
             } else if (UNLIKELY((val2 == -1) && (val1 == AVM_INT_MIN))) {
                 #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
-                    return make_boxed_int64(ctx, live, -((avm_int64_t) AVM_INT_MIN));
+                    return make_boxed_int64(ctx, x_regs, live, -((avm_int64_t) AVM_INT_MIN));
 
                 #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                     TRACE("overflow: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
@@ -715,7 +740,7 @@ static term div_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
                 #endif
 
             } else {
-                return make_maybe_boxed_int(ctx, live, val1 / val2);
+                return make_maybe_boxed_int(ctx, x_regs, live, val1 / val2);
             }
         }
 
@@ -732,7 +757,7 @@ static term div_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
                 RAISE_ERROR(OVERFLOW_ATOM);
 
             } else {
-                return make_maybe_boxed_int64(ctx, live, val1 / val2);
+                return make_maybe_boxed_int64(ctx, x_regs, live, val1 / val2);
             }
         }
         #endif
@@ -742,7 +767,7 @@ static term div_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
     }
 }
 
-term bif_erlang_div_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_div_2(Context *ctx, term *x_regs, int live, term arg1, term arg2)
 {
     UNUSED(live);
 
@@ -751,7 +776,7 @@ term bif_erlang_div_2(Context *ctx, int live, term arg1, term arg2)
         if (operand_b != 0) {
             avm_int_t res = term_to_int(arg1) / operand_b;
             if (UNLIKELY(res == -MIN_NOT_BOXED_INT)) {
-                return make_boxed_int(ctx, live, -MIN_NOT_BOXED_INT);
+                return make_boxed_int(ctx, x_regs, live, -MIN_NOT_BOXED_INT);
 
             } else {
                 return term_from_int(res);
@@ -761,11 +786,11 @@ term bif_erlang_div_2(Context *ctx, int live, term arg1, term arg2)
         }
 
     } else {
-        return div_boxed_helper(ctx, live, arg1, arg2);
+        return div_boxed_helper(ctx, x_regs, live, arg1, arg2);
     }
 }
 
-static term neg_boxed_helper(Context *ctx, uint32_t live, term arg1)
+static term neg_boxed_helper(Context *ctx, term *x_regs, uint32_t live, term arg1)
 {
     if (term_is_float(arg1)) {
         avm_float_t farg1 = term_conv_to_float(arg1);
@@ -773,7 +798,7 @@ static term neg_boxed_helper(Context *ctx, uint32_t live, term arg1)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, x_regs, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, &ctx->heap);
@@ -793,7 +818,7 @@ static term neg_boxed_helper(Context *ctx, uint32_t live, term arg1)
 
                     case AVM_INT_MIN:
                         #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
-                            return make_boxed_int64(ctx, live, -((avm_int64_t) val));
+                            return make_boxed_int64(ctx, x_regs, live, -((avm_int64_t) val));
 
                         #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                             TRACE("overflow: val: " AVM_INT_FMT "\n", val);
@@ -804,7 +829,7 @@ static term neg_boxed_helper(Context *ctx, uint32_t live, term arg1)
                         #endif
 
                     default:
-                        return make_boxed_int(ctx, live, -val);
+                        return make_boxed_int(ctx, x_regs, live, -val);
                 }
             }
 
@@ -817,7 +842,7 @@ static term neg_boxed_helper(Context *ctx, uint32_t live, term arg1)
                     RAISE_ERROR(OVERFLOW_ATOM);
 
                 } else {
-                    return make_boxed_int64(ctx, live, -val);
+                    return make_boxed_int64(ctx, x_regs, live, -val);
                 }
             }
             #endif
@@ -830,23 +855,23 @@ static term neg_boxed_helper(Context *ctx, uint32_t live, term arg1)
     }
 }
 
-term bif_erlang_neg_1(Context *ctx, int live, term arg1)
+term bif_erlang_neg_1(Context *ctx, term *x_regs, int live, term arg1)
 {
     UNUSED(live);
 
     if (LIKELY(term_is_integer(arg1))) {
         avm_int_t int_val = term_to_int(arg1);
         if (UNLIKELY(int_val == MIN_NOT_BOXED_INT)) {
-            return make_boxed_int(ctx, live, -MIN_NOT_BOXED_INT);
+            return make_boxed_int(ctx, x_regs, live, -MIN_NOT_BOXED_INT);
         } else {
             return term_from_int(-int_val);
         }
     } else {
-        return neg_boxed_helper(ctx, live, arg1);
+        return neg_boxed_helper(ctx, x_regs, live, arg1);
     }
 }
 
-static term abs_boxed_helper(Context *ctx, uint32_t live, term arg1)
+static term abs_boxed_helper(Context *ctx, term *x_regs, uint32_t live, term arg1)
 {
     if (term_is_float(arg1)) {
         avm_float_t farg1 = term_conv_to_float(arg1);
@@ -860,7 +885,7 @@ static term abs_boxed_helper(Context *ctx, uint32_t live, term arg1)
         if (UNLIKELY(!isfinite(fresult))) {
             RAISE_ERROR(BADARITH_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, x_regs, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, &ctx->heap);
@@ -880,7 +905,7 @@ static term abs_boxed_helper(Context *ctx, uint32_t live, term arg1)
 
                 if (val == AVM_INT_MIN) {
                     #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
-                        return make_boxed_int64(ctx, live, -((avm_int64_t) val));
+                        return make_boxed_int64(ctx, x_regs, live, -((avm_int64_t) val));
 
                     #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                         TRACE("overflow: val: " AVM_INT_FMT "\n", val);
@@ -891,7 +916,7 @@ static term abs_boxed_helper(Context *ctx, uint32_t live, term arg1)
                     #endif
 
                 } else {
-                    return make_boxed_int(ctx, live, -val);
+                    return make_boxed_int(ctx, x_regs, live, -val);
                 }
             }
 
@@ -907,7 +932,7 @@ static term abs_boxed_helper(Context *ctx, uint32_t live, term arg1)
                     RAISE_ERROR(OVERFLOW_ATOM);
 
                 } else {
-                    return make_boxed_int64(ctx, live, -val);
+                    return make_boxed_int64(ctx, x_regs, live, -val);
                 }
             }
             #endif
@@ -920,7 +945,7 @@ static term abs_boxed_helper(Context *ctx, uint32_t live, term arg1)
     }
 }
 
-term bif_erlang_abs_1(Context *ctx, int live, term arg1)
+term bif_erlang_abs_1(Context *ctx, term *x_regs, int live, term arg1)
 {
     UNUSED(live);
 
@@ -929,7 +954,7 @@ term bif_erlang_abs_1(Context *ctx, int live, term arg1)
 
         if (int_val < 0) {
             if (UNLIKELY(int_val == MIN_NOT_BOXED_INT)) {
-                return make_boxed_int(ctx, live, -MIN_NOT_BOXED_INT);
+                return make_boxed_int(ctx, x_regs, live, -MIN_NOT_BOXED_INT);
             } else {
                 return term_from_int(-int_val);
             }
@@ -938,11 +963,11 @@ term bif_erlang_abs_1(Context *ctx, int live, term arg1)
         }
 
     } else {
-        return abs_boxed_helper(ctx, live, arg1);
+        return abs_boxed_helper(ctx, x_regs, live, arg1);
     }
 }
 
-static term rem_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term rem_boxed_helper(Context *ctx, term *x_regs, uint32_t live, term arg1, term arg2)
 {
     int size = 0;
     if (term_is_boxed_integer(arg1)) {
@@ -971,7 +996,7 @@ static term rem_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
                 RAISE_ERROR(BADARITH_ATOM);
             }
 
-            return make_maybe_boxed_int(ctx, live, val1 % val2);
+            return make_maybe_boxed_int(ctx, x_regs, live, val1 % val2);
         }
 
         #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
@@ -983,7 +1008,7 @@ static term rem_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
                 RAISE_ERROR(BADARITH_ATOM);
             }
 
-            return make_maybe_boxed_int64(ctx, live, val1 % val2);
+            return make_maybe_boxed_int64(ctx, x_regs, live, val1 % val2);
         }
         #endif
 
@@ -992,7 +1017,7 @@ static term rem_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
     }
 }
 
-term bif_erlang_rem_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_rem_2(Context *ctx, term *x_regs, int live, term arg1, term arg2)
 {
     UNUSED(live);
 
@@ -1006,11 +1031,11 @@ term bif_erlang_rem_2(Context *ctx, int live, term arg1, term arg2)
         }
 
     } else {
-        return rem_boxed_helper(ctx, live, arg1, arg2);
+        return rem_boxed_helper(ctx, x_regs, live, arg1, arg2);
     }
 }
 
-term bif_erlang_ceil_1(Context *ctx, int live, term arg1)
+term bif_erlang_ceil_1(Context *ctx, term *x_regs, int live, term arg1)
 {
     UNUSED(live);
 
@@ -1028,9 +1053,9 @@ term bif_erlang_ceil_1(Context *ctx, int live, term arg1)
         #endif
 
         #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-            return make_maybe_boxed_int64(ctx, live, result);
+            return make_maybe_boxed_int64(ctx, x_regs, live, result);
         #else
-            return make_maybe_boxed_int(ctx, live, result);
+            return make_maybe_boxed_int(ctx, x_regs, live, result);
         #endif
     }
 
@@ -1042,7 +1067,7 @@ term bif_erlang_ceil_1(Context *ctx, int live, term arg1)
     }
 }
 
-term bif_erlang_floor_1(Context *ctx, int live, term arg1)
+term bif_erlang_floor_1(Context *ctx, term *x_regs, int live, term arg1)
 {
     UNUSED(live);
 
@@ -1060,9 +1085,9 @@ term bif_erlang_floor_1(Context *ctx, int live, term arg1)
         #endif
 
         #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-            return make_maybe_boxed_int64(ctx, live, result);
+            return make_maybe_boxed_int64(ctx, x_regs, live, result);
         #else
-            return make_maybe_boxed_int(ctx, live, result);
+            return make_maybe_boxed_int(ctx, x_regs, live, result);
         #endif
     }
 
@@ -1074,7 +1099,7 @@ term bif_erlang_floor_1(Context *ctx, int live, term arg1)
     }
 }
 
-term bif_erlang_round_1(Context *ctx, int live, term arg1)
+term bif_erlang_round_1(Context *ctx, term *x_regs, int live, term arg1)
 {
     UNUSED(live);
 
@@ -1092,9 +1117,9 @@ term bif_erlang_round_1(Context *ctx, int live, term arg1)
         #endif
 
         #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-            return make_maybe_boxed_int64(ctx, live, result);
+            return make_maybe_boxed_int64(ctx, x_regs, live, result);
         #else
-            return make_maybe_boxed_int(ctx, live, result);
+            return make_maybe_boxed_int(ctx, x_regs, live, result);
         #endif
     }
 
@@ -1106,7 +1131,7 @@ term bif_erlang_round_1(Context *ctx, int live, term arg1)
     }
 }
 
-term bif_erlang_trunc_1(Context *ctx, int live, term arg1)
+term bif_erlang_trunc_1(Context *ctx, term *x_regs, int live, term arg1)
 {
     UNUSED(live);
 
@@ -1124,9 +1149,9 @@ term bif_erlang_trunc_1(Context *ctx, int live, term arg1)
         #endif
 
         #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-            return make_maybe_boxed_int64(ctx, live, result);
+            return make_maybe_boxed_int64(ctx, x_regs, live, result);
         #else
-            return make_maybe_boxed_int(ctx, live, result);
+            return make_maybe_boxed_int(ctx, x_regs, live, result);
         #endif
     }
 
@@ -1140,7 +1165,7 @@ term bif_erlang_trunc_1(Context *ctx, int live, term arg1)
 
 typedef int64_t (*bitwise_op)(int64_t a, int64_t b);
 
-static inline term bitwise_helper(Context *ctx, int live, term arg1, term arg2, bitwise_op op)
+static inline term bitwise_helper(Context *ctx, term *x_regs, int live, term arg1, term arg2, bitwise_op op)
 {
     UNUSED(live);
 
@@ -1153,9 +1178,9 @@ static inline term bitwise_helper(Context *ctx, int live, term arg1, term arg2, 
     int64_t result = op(a, b);
 
     #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-        return make_maybe_boxed_int64(ctx, live, result);
+        return make_maybe_boxed_int64(ctx, x_regs, live, result);
     #else
-        return make_maybe_boxed_int(ctx, live, result);
+        return make_maybe_boxed_int(ctx, x_regs, live, result);
     #endif
 }
 
@@ -1164,12 +1189,12 @@ static inline int64_t bor(int64_t a, int64_t b)
     return a | b;
 }
 
-term bif_erlang_bor_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_bor_2(Context *ctx, term *x_regs, int live, term arg1, term arg2)
 {
     if (LIKELY(term_is_integer(arg1) && term_is_integer(arg2))) {
         return arg1 | arg2;
     } else {
-        return bitwise_helper(ctx, live, arg1, arg2, bor);
+        return bitwise_helper(ctx, x_regs, live, arg1, arg2, bor);
     }
 }
 
@@ -1178,12 +1203,12 @@ static inline int64_t band(int64_t a, int64_t b)
     return a & b;
 }
 
-term bif_erlang_band_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_band_2(Context *ctx, term *x_regs, int live, term arg1, term arg2)
 {
     if (LIKELY(term_is_integer(arg1) && term_is_integer(arg2))) {
         return arg1 & arg2;
     } else {
-        return bitwise_helper(ctx, live, arg1, arg2, band);
+        return bitwise_helper(ctx, x_regs, live, arg1, arg2, band);
     }
 }
 
@@ -1192,18 +1217,18 @@ static inline int64_t bxor(int64_t a, int64_t b)
     return a ^ b;
 }
 
-term bif_erlang_bxor_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_bxor_2(Context *ctx, term *x_regs, int live, term arg1, term arg2)
 {
     if (LIKELY(term_is_integer(arg1) && term_is_integer(arg2))) {
         return (arg1 ^ arg2) | TERM_INTEGER_TAG;
     } else {
-        return bitwise_helper(ctx, live, arg1, arg2, bxor);
+        return bitwise_helper(ctx, x_regs, live, arg1, arg2, bxor);
     }
 }
 
 typedef int64_t (*bitshift_op)(int64_t a, avm_int_t b);
 
-static inline term bitshift_helper(Context *ctx, int live, term arg1, term arg2, bitshift_op op)
+static inline term bitshift_helper(Context *ctx, term *x_regs, int live, term arg1, term arg2, bitshift_op op)
 {
     UNUSED(live);
 
@@ -1216,9 +1241,9 @@ static inline term bitshift_helper(Context *ctx, int live, term arg1, term arg2,
     int64_t result = op(a, b);
 
     #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-        return make_maybe_boxed_int64(ctx, live, result);
+        return make_maybe_boxed_int64(ctx, x_regs, live, result);
     #else
-        return make_maybe_boxed_int(ctx, live, result);
+        return make_maybe_boxed_int(ctx, x_regs, live, result);
     #endif
 }
 
@@ -1228,9 +1253,9 @@ static inline int64_t bsl(int64_t a, avm_int_t b)
     return a << b;
 }
 
-term bif_erlang_bsl_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_bsl_2(Context *ctx, term *x_regs, int live, term arg1, term arg2)
 {
-    return bitshift_helper(ctx, live, arg1, arg2, bsl);
+    return bitshift_helper(ctx, x_regs, live, arg1, arg2, bsl);
 }
 
 static inline int64_t bsr(int64_t a, avm_int_t b)
@@ -1239,13 +1264,14 @@ static inline int64_t bsr(int64_t a, avm_int_t b)
     return a >> b;
 }
 
-term bif_erlang_bsr_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_bsr_2(Context *ctx, term *x_regs, int live, term arg1, term arg2)
 {
-    return bitshift_helper(ctx, live, arg1, arg2, bsr);
+    return bitshift_helper(ctx, x_regs, live, arg1, arg2, bsr);
 }
 
-term bif_erlang_bnot_1(Context *ctx, int live, term arg1)
+term bif_erlang_bnot_1(Context *ctx, term *x_regs, int live, term arg1)
 {
+    UNUSED(ctx);
     UNUSED(live);
 
     if (LIKELY(term_is_integer(arg1))) {
@@ -1256,8 +1282,10 @@ term bif_erlang_bnot_1(Context *ctx, int live, term arg1)
     }
 }
 
-term bif_erlang_not_1(Context *ctx, term arg1)
+term bif_erlang_not_1(Context *ctx, term *x_regs, term arg1)
 {
+    UNUSED(ctx);
+
     if (arg1 == TRUE_ATOM) {
         return FALSE_ATOM;
 
@@ -1269,8 +1297,10 @@ term bif_erlang_not_1(Context *ctx, term arg1)
     }
 }
 
-term bif_erlang_and_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_and_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
+    UNUSED(ctx);
+
     if ((arg1 == FALSE_ATOM) && (arg2 == FALSE_ATOM)) {
         return FALSE_ATOM;
 
@@ -1288,8 +1318,10 @@ term bif_erlang_and_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_or_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_or_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
+    UNUSED(ctx);
+
     if ((arg1 == FALSE_ATOM) && (arg2 == FALSE_ATOM)) {
         return FALSE_ATOM;
 
@@ -1307,8 +1339,10 @@ term bif_erlang_or_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_xor_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_xor_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
+    UNUSED(ctx);
+
     if ((arg1 == FALSE_ATOM) && (arg2 == FALSE_ATOM)) {
         return FALSE_ATOM;
 
@@ -1326,7 +1360,7 @@ term bif_erlang_xor_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_equal_to_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_equal_to_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result == TermEquals) {
@@ -1338,7 +1372,7 @@ term bif_erlang_equal_to_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_not_equal_to_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_not_equal_to_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result & (TermLessThan | TermGreaterThan)) {
@@ -1350,7 +1384,7 @@ term bif_erlang_not_equal_to_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_exactly_equal_to_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_exactly_equal_to_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     //TODO: 5.0 != 5
     TermCompareResult result = term_compare(arg1, arg2, TermCompareExact, ctx->global);
@@ -1363,7 +1397,7 @@ term bif_erlang_exactly_equal_to_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_exactly_not_equal_to_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_exactly_not_equal_to_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareExact, ctx->global);
     if (result & (TermLessThan | TermGreaterThan)) {
@@ -1375,7 +1409,7 @@ term bif_erlang_exactly_not_equal_to_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_greater_than_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_greater_than_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result == TermGreaterThan) {
@@ -1387,7 +1421,7 @@ term bif_erlang_greater_than_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_less_than_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_less_than_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result == TermLessThan) {
@@ -1399,7 +1433,7 @@ term bif_erlang_less_than_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_less_than_or_equal_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_less_than_or_equal_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result & (TermLessThan | TermEquals)) {
@@ -1411,7 +1445,7 @@ term bif_erlang_less_than_or_equal_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_greater_than_or_equal_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_greater_than_or_equal_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result & (TermGreaterThan | TermEquals)) {
@@ -1423,7 +1457,7 @@ term bif_erlang_greater_than_or_equal_2(Context *ctx, term arg1, term arg2)
     }
 }
 
-term bif_erlang_get_1(Context *ctx, term arg1)
+term bif_erlang_get_1(Context *ctx, term *x_regs, term arg1)
 {
     term value;
     DictionaryFunctionResult result = dictionary_get(&ctx->dictionary, arg1, &value, ctx->global);
@@ -1434,7 +1468,7 @@ term bif_erlang_get_1(Context *ctx, term arg1)
     return value;
 }
 
-term bif_erlang_min_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_min_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     TermCompareResult r = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (UNLIKELY(r == TermCompareMemoryAllocFail)) {
@@ -1443,7 +1477,7 @@ term bif_erlang_min_2(Context *ctx, term arg1, term arg2)
     return r == TermLessThan ? arg1 : arg2;
 }
 
-term bif_erlang_max_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_max_2(Context *ctx, term *x_regs, term arg1, term arg2)
 {
     TermCompareResult r = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (UNLIKELY(r == TermCompareMemoryAllocFail)) {

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -41,74 +41,74 @@ extern "C" {
 
 const struct ExportedFunction *bif_registry_get_handler(AtomString module, AtomString function, int arity);
 
-term bif_erlang_self_0(Context *ctx);
-term bif_erlang_byte_size_1(Context *ctx, int live, term arg1);
-term bif_erlang_bit_size_1(Context *ctx, int live, term arg1);
-term bif_erlang_length_1(Context *ctx, int live, term arg1);
+term bif_erlang_self_0(Context *ctx, term *x_regs);
+term bif_erlang_byte_size_1(Context *ctx, term *x_regs, int live, term arg1);
+term bif_erlang_bit_size_1(Context *ctx, term *x_regs, int live, term arg1);
+term bif_erlang_length_1(Context *ctx, term *x_regs, int live, term arg1);
 
-term bif_erlang_is_atom_1(Context *ctx, term arg1);
-term bif_erlang_is_binary_1(Context *ctx, term arg1);
-term bif_erlang_is_boolean_1(Context *ctx, term arg1);
-term bif_erlang_is_float_1(Context *ctx, term arg1);
-term bif_erlang_is_function_1(Context *ctx, term arg1);
-term bif_erlang_is_integer_1(Context *ctx, term arg1);
-term bif_erlang_is_list_1(Context *ctx, term arg1);
-term bif_erlang_is_number_1(Context *ctx, term arg1);
-term bif_erlang_is_pid_1(Context *ctx, term arg1);
-term bif_erlang_is_reference_1(Context *ctx, term arg1);
-term bif_erlang_is_tuple_1(Context *ctx, term arg1);
-term bif_erlang_is_map_1(Context *ctx, term arg1);
-term bif_erlang_is_map_key_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_is_atom_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_binary_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_boolean_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_float_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_function_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_integer_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_list_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_number_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_pid_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_reference_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_tuple_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_map_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_is_map_key_2(Context *ctx, term *x_regs, term arg1, term arg2);
 
-term bif_erlang_hd_1(Context *ctx, term arg1);
-term bif_erlang_tl_1(Context *ctx, term arg1);
+term bif_erlang_hd_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_tl_1(Context *ctx, term *x_regs, term arg1);
 
-term bif_erlang_element_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_tuple_size_1(Context *ctx, term arg1);
+term bif_erlang_element_2(Context *ctx, term *x_regs, term arg1, term arg2);
+term bif_erlang_tuple_size_1(Context *ctx, term *x_regs, term arg1);
 
-term bif_erlang_map_size_1(Context *ctx, int live, term arg1);
-term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_map_size_1(Context *ctx, term *x_regs, int live, term arg1);
+term bif_erlang_map_get_2(Context *ctx, term *x_regs, term arg1, term arg2);
 
-term bif_erlang_add_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_sub_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_mul_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_div_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_rem_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_neg_1(Context *ctx, int live, term arg1);
-term bif_erlang_abs_1(Context *ctx, int live, term arg1);
+term bif_erlang_add_2(Context *ctx, term *x_regs, int live, term arg1, term arg2);
+term bif_erlang_sub_2(Context *ctx, term *x_regs, int live, term arg1, term arg2);
+term bif_erlang_mul_2(Context *ctx, term *x_regs, int live, term arg1, term arg2);
+term bif_erlang_div_2(Context *ctx, term *x_regs, int live, term arg1, term arg2);
+term bif_erlang_rem_2(Context *ctx, term *x_regs, int live, term arg1, term arg2);
+term bif_erlang_neg_1(Context *ctx, term *x_regs, int live, term arg1);
+term bif_erlang_abs_1(Context *ctx, term *x_regs, int live, term arg1);
 
-term bif_erlang_ceil_1(Context *ctx, int live, term arg1);
-term bif_erlang_floor_1(Context *ctx, int live, term arg1);
-term bif_erlang_round_1(Context *ctx, int live, term arg1);
-term bif_erlang_trunc_1(Context *ctx, int live, term arg1);
+term bif_erlang_ceil_1(Context *ctx, term *x_regs, int live, term arg1);
+term bif_erlang_floor_1(Context *ctx, term *x_regs, int live, term arg1);
+term bif_erlang_round_1(Context *ctx, term *x_regs, int live, term arg1);
+term bif_erlang_trunc_1(Context *ctx, term *x_regs, int live, term arg1);
 
-term bif_erlang_bor_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_band_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_bxor_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_bsl_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_bsr_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_bnot_1(Context *ctx, int live, term arg1);
+term bif_erlang_bor_2(Context *ctx, term *x_regs, int live, term arg1, term arg2);
+term bif_erlang_band_2(Context *ctx, term *x_regs, int live, term arg1, term arg2);
+term bif_erlang_bxor_2(Context *ctx, term *x_regs, int live, term arg1, term arg2);
+term bif_erlang_bsl_2(Context *ctx, term *x_regs, int live, term arg1, term arg2);
+term bif_erlang_bsr_2(Context *ctx, term *x_regs, int live, term arg1, term arg2);
+term bif_erlang_bnot_1(Context *ctx, term *x_regs, int live, term arg1);
 
-term bif_erlang_not_1(Context *ctx, term arg1);
-term bif_erlang_and_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_or_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_xor_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_not_1(Context *ctx, term *x_regs, term arg1);
+term bif_erlang_and_2(Context *ctx, term *x_regs, term arg1, term arg2);
+term bif_erlang_or_2(Context *ctx, term *x_regs, term arg1, term arg2);
+term bif_erlang_xor_2(Context *ctx, term *x_regs, term arg1, term arg2);
 
-term bif_erlang_equal_to_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_not_equal_to_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_equal_to_2(Context *ctx, term *x_regs, term arg1, term arg2);
+term bif_erlang_not_equal_to_2(Context *ctx, term *x_regs, term arg1, term arg2);
 
-term bif_erlang_exactly_equal_to_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_exactly_not_equal_to_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_exactly_equal_to_2(Context *ctx, term *x_regs, term arg1, term arg2);
+term bif_erlang_exactly_not_equal_to_2(Context *ctx, term *x_regs, term arg1, term arg2);
 
-term bif_erlang_greater_than_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_less_than_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_less_than_or_equal_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_greater_than_or_equal_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_greater_than_2(Context *ctx, term *x_regs, term arg1, term arg2);
+term bif_erlang_less_than_2(Context *ctx, term *x_regs, term arg1, term arg2);
+term bif_erlang_less_than_or_equal_2(Context *ctx, term *x_regs, term arg1, term arg2);
+term bif_erlang_greater_than_or_equal_2(Context *ctx, term *x_regs, term arg1, term arg2);
 
-term bif_erlang_get_1(Context *ctx, term arg1);
+term bif_erlang_get_1(Context *ctx, term *x_regs, term arg1);
 
-term bif_erlang_min_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_max_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_min_2(Context *ctx, term *x_regs, term arg1, term arg2);
+term bif_erlang_max_2(Context *ctx, term *x_regs, term arg1, term arg2);
 
 #ifdef __cplusplus
 }

--- a/src/libAtomVM/debug.c
+++ b/src/libAtomVM/debug.c
@@ -76,13 +76,6 @@ COLD_FUNC void debug_dump_memory(Context *ctx, term *start, term *end, const cha
     fprintf(stderr, "DEBUG:\n");
 }
 
-COLD_FUNC void debug_dump_context(Context *ctx)
-{
-    debug_dump_heap(ctx);
-    debug_dump_stack(ctx);
-    debug_dump_registers(ctx);
-}
-
 COLD_FUNC void debug_dump_heap(Context *ctx)
 {
     debug_dump_memory(ctx, ctx->heap.heap_start, ctx->heap.heap_ptr, "heap");
@@ -92,11 +85,6 @@ COLD_FUNC void debug_dump_stack(Context *ctx)
 {
     term *stack_base = context_stack_base(ctx);
     debug_dump_memory(ctx, ctx->e, stack_base, "stack");
-}
-
-COLD_FUNC void debug_dump_registers(Context *ctx)
-{
-    debug_dump_memory(ctx, ctx->x, ctx->x + 16, "register");
 }
 
 COLD_FUNC void debug_print_processes_list(struct ListHead *processes)
@@ -127,6 +115,9 @@ COLD_FUNC char reg_type_c(int reg_type)
 
         case 4:
             return 'y';
+
+        case 11:
+            return 'x';
 
         case 12:
             return 'y';

--- a/src/libAtomVM/debug.h
+++ b/src/libAtomVM/debug.h
@@ -35,14 +35,6 @@ extern "C" {
 #include "context.h"
 
 /**
- * @brief Print a repreentation of the context to stderr.
- *
- * @details Print heap, stack, and registers of the given context to stderr.
- * @param ctx the process context.
- */
-void debug_dump_context(Context *ctx);
-
-/**
  * @brief Print heap contents to stderr.
  *
  * @details Print the dump of the heap of the given context to stderr.
@@ -57,14 +49,6 @@ void debug_dump_heap(Context *ctx);
  * @param ctx the process context.
  */
 void debug_dump_stack(Context *ctx);
-
-/**
- * @brief Print register contents to stderr.
- *
- * @details Print the dump of the registers of the given context to stderr.
- * @param ctx the process context.
- */
-void debug_dump_registers(Context *ctx);
 
 /**
  * @brief Print a region of (term) memory to stderr.

--- a/src/libAtomVM/erl_nif_priv.h
+++ b/src/libAtomVM/erl_nif_priv.h
@@ -33,7 +33,6 @@ struct ErlNifEnv
     GlobalContext *global;
     Heap heap;
     term *stack_pointer; // Context stack pointer, NULL for non-context envs
-    term x[2];
 };
 
 _Static_assert(offsetof(struct ErlNifEnv, global) == offsetof(struct Context, global) ? 1 : 0,
@@ -42,8 +41,6 @@ _Static_assert(offsetof(struct ErlNifEnv, heap) == offsetof(struct Context, heap
     "ErlNifEnv.heap doesn't match Context.heap");
 _Static_assert(offsetof(struct ErlNifEnv, stack_pointer) == offsetof(struct Context, e) ? 1 : 0,
     "ErlNifEnv.stack_pointer doesn't match Context.e");
-_Static_assert(offsetof(struct ErlNifEnv, x) == offsetof(struct Context, x) ? 1 : 0,
-    "ErlNifEnv.x doesn't match Context.x");
 
 static inline ErlNifEnv *erl_nif_env_from_context(Context *ctx)
 {
@@ -63,8 +60,6 @@ static inline void erl_nif_env_partial_init_from_globalcontext(ErlNifEnv *env, G
     env->heap.heap_ptr = NULL;
     env->heap.heap_end = NULL;
     env->stack_pointer = NULL;
-    env->x[0] = term_nil();
-    env->x[1] = term_nil();
 }
 
 #ifdef __cplusplus

--- a/src/libAtomVM/exportedfunction.h
+++ b/src/libAtomVM/exportedfunction.h
@@ -37,13 +37,13 @@ struct Module;
 typedef struct Module Module;
 #endif
 
-typedef term (*BifImpl0)(Context *ctx);
-typedef term (*BifImpl1)(Context *ctx, term arg1);
-typedef term (*BifImpl2)(Context *ctx, term arg1, term arg2);
+typedef term (*BifImpl0)(Context *ctx, term *x_regs);
+typedef term (*BifImpl1)(Context *ctx, term *x_regs, term arg1);
+typedef term (*BifImpl2)(Context *ctx, term *x_regs, term arg1, term arg2);
 
-typedef term (*GCBifImpl1)(Context *ctx, int live, term arg1);
-typedef term (*GCBifImpl2)(Context *ctx, int live, term arg1, term arg2);
-typedef term (*GCBifImpl3)(Context *ctx, int live, term arg1, term arg2, term arg3);
+typedef term (*GCBifImpl1)(Context *ctx, term *x_regs, int live, term arg1);
+typedef term (*GCBifImpl2)(Context *ctx, term *x_regs, int live, term arg1, term arg2);
+typedef term (*GCBifImpl3)(Context *ctx, term *x_regs, int live, term arg1, term arg2, term arg3);
 
 typedef term (*NifImpl)(Context *ctx, int argc, term argv[]);
 

--- a/src/libAtomVM/nifs.h
+++ b/src/libAtomVM/nifs.h
@@ -42,8 +42,8 @@ extern "C" {
     }
 
 #define RAISE_ERROR(error_type_atom) \
-    ctx->x[0] = ERROR_ATOM;          \
-    ctx->x[1] = (error_type_atom);   \
+    argv[0] = ERROR_ATOM;            \
+    argv[1] = (error_type_atom);     \
     return term_invalid_term();
 
 const struct Nif *nifs_get(AtomString module, AtomString function, int arity);

--- a/src/libAtomVM/otp_ssl.c
+++ b/src/libAtomVM/otp_ssl.c
@@ -485,7 +485,7 @@ static term nif_ssl_setup(Context *ctx, int argc, term argv[])
     return OK_ATOM;
 }
 
-static term make_err_result(int err, Context *ctx)
+static term make_err_result(int err, Context *ctx, term argv[])
 {
     switch (err) {
         case 0:
@@ -537,7 +537,7 @@ static term nif_ssl_handshake_step(Context *ctx, int argc, term argv[])
         return globalcontext_make_atom(ctx->global, ATOM_STR("\x4", "done"));
     }
 #endif
-    return make_err_result(err, ctx);
+    return make_err_result(err, ctx, argv);
 }
 
 static term nif_ssl_close_notify(Context *ctx, int argc, term argv[])
@@ -552,7 +552,7 @@ static term nif_ssl_close_notify(Context *ctx, int argc, term argv[])
     struct SSLContextResource *context_rsrc = (struct SSLContextResource *) rsrc_obj_ptr;
 
     int err = mbedtls_ssl_close_notify(&context_rsrc->context);
-    return make_err_result(err, ctx);
+    return make_err_result(err, ctx, argv);
 }
 
 static term nif_ssl_write(Context *ctx, int argc, term argv[])
@@ -589,7 +589,7 @@ static term nif_ssl_write(Context *ctx, int argc, term argv[])
         return port_create_tuple2(ctx, OK_ATOM, rest);
     }
 
-    return make_err_result(res, ctx);
+    return make_err_result(res, ctx, argv);
 }
 
 static term nif_ssl_read(Context *ctx, int argc, term argv[])
@@ -644,7 +644,7 @@ static term nif_ssl_read(Context *ctx, int argc, term argv[])
         return port_create_tuple2(ctx, OK_ATOM, rest);
     }
 
-    return make_err_result(res, ctx);
+    return make_err_result(res, ctx, argv);
 }
 
 static const struct Nif ssl_entropy_init_nif = {

--- a/src/libAtomVM/scheduler.h
+++ b/src/libAtomVM/scheduler.h
@@ -113,6 +113,7 @@ void scheduler_cancel_timeout(Context *ctx);
  * @brief Entry point for schedulers.
  *
  * @param glb the global context.
+ * @return the result of the execution, 0 on success and 1 on error
  */
 int scheduler_entry_point(GlobalContext *glb);
 

--- a/src/libAtomVM/stacktrace.h
+++ b/src/libAtomVM/stacktrace.h
@@ -29,15 +29,16 @@ extern "C" {
 #include "module.h"
 #include "term.h"
 
-term stacktrace_create_raw(Context *ctx, Module *mod, int current_offset, term exception_class);
+term stacktrace_create_raw(Context *ctx, term *x_regs, Module *mod, int current_offset, term exception_class);
 /**
  * @brief Build a stack trace
  * @param ctx           context
+ * @param x_regs        x registers
  * @param stack_info    pointer to stack info tuple
  * @param live          number of x registers to preserve, which should include stack_info
  * @return the built stack trace
  */
-term stacktrace_build(Context *ctx, term *stack_info, uint32_t live);
+term stacktrace_build(Context *ctx, term *x_regs, term *stack_info, uint32_t live);
 term stacktrace_exception_class(term stack_info);
 
 #ifdef __cplusplus

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -252,7 +252,7 @@ static bool get_register_callback_parameters(Context *ctx, int argc, term argv[]
     return true;
 }
 
-static term term_from_emscripten_result(EMSCRIPTEN_RESULT em_result, Context *ctx)
+static term term_from_emscripten_result(EMSCRIPTEN_RESULT em_result, Context *ctx, term argv[])
 {
     if (em_result == EMSCRIPTEN_RESULT_SUCCESS) {
         return OK_ATOM;
@@ -677,7 +677,7 @@ static EM_BOOL html5api_touch_callback(int eventType, const EmscriptenTouchEvent
         resource->event = event_constant;                                                                                                                                                \
         EMSCRIPTEN_RESULT result = emscripten_set_##callback##_callback_on_thread(target, resource, use_capture, html5api_##event_type##_callback, emscripten_main_runtime_thread_id()); \
         if (result != EMSCRIPTEN_RESULT_SUCCESS && result != EMSCRIPTEN_RESULT_DEFERRED) {                                                                                               \
-            return term_from_emscripten_result(result, ctx);                                                                                                                             \
+            return term_from_emscripten_result(result, ctx, argv);                                                                                                                       \
         }                                                                                                                                                                                \
         term resource_term = enif_make_resource(erl_nif_env_from_context(ctx), resource);                                                                                                \
         if (UNLIKELY(memory_ensure_free_with_roots(ctx, TUPLE_SIZE(3), 1, &resource_term, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {                                                         \
@@ -713,7 +713,7 @@ static EM_BOOL html5api_touch_callback(int eventType, const EmscriptenTouchEvent
         }                                                                                                                                                                                \
         EMSCRIPTEN_RESULT result = emscripten_set_##callback##_callback_on_thread(target, NULL, false, NULL, emscripten_main_runtime_thread_id());                                       \
         free(str);                                                                                                                                                                       \
-        return term_from_emscripten_result(result, ctx);                                                                                                                                 \
+        return term_from_emscripten_result(result, ctx, argv);                                                                                                                           \
     }                                                                                                                                                                                    \
     static const struct Nif emscripten_unregister_##callback##_callback_nif = {                                                                                                          \
         .base.type = NIFFunctionType,                                                                                                                                                    \

--- a/src/platforms/emscripten/src/main.c
+++ b/src/platforms/emscripten/src/main.c
@@ -98,7 +98,7 @@ static int start(void)
     Context *ctx = context_new(global);
     ctx->leader = 1;
     context_execute_loop(ctx, main_module, "start", 0);
-    term ret_value = ctx->x[0];
+    term ret_value = ctx->saved_x[0];
     fprintf(stdout, "Return value: ");
     term_display(stdout, ret_value, ctx);
     fprintf(stdout, "\n");

--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -112,7 +112,7 @@ void app_main()
     fprintf(stdout, "---\n");
 
     context_execute_loop(ctx, mod, "start", 0);
-    term ret_value = ctx->x[0];
+    term ret_value = ctx->saved_x[0];
 
     fprintf(stdout, "AtomVM finished with return value: ");
     term_display(stdout, ret_value, ctx);

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -155,7 +155,7 @@ term avm_test_case(const char *test_module)
     ESP_LOGI(TAG, "Running start/0 from %s...\n", test_module);
 
     context_execute_loop(ctx, mod, "start", 0);
-    term ret_value = ctx->x[0];
+    term ret_value = ctx->saved_x[0];
 
     fprintf(stdout, "AtomVM finished with return value: ");
     term_display(stdout, ret_value, ctx);

--- a/src/platforms/generic_unix/lib/platform_nifs.c
+++ b/src/platforms/generic_unix/lib/platform_nifs.c
@@ -44,8 +44,8 @@
     }
 
 #define RAISE_ERROR(error_type_atom) \
-    ctx->x[0] = ERROR_ATOM;          \
-    ctx->x[1] = (error_type_atom);   \
+    argv[0] = ERROR_ATOM;          \
+    argv[1] = (error_type_atom);   \
     return term_invalid_term();
 
 #if ATOMVM_HAS_MBEDTLS

--- a/src/platforms/generic_unix/main.c
+++ b/src/platforms/generic_unix/main.c
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
 
     context_execute_loop(ctx, mod, "start", 0);
 
-    term ret_value = ctx->x[0];
+    term ret_value = ctx->saved_x[0];
     fprintf(stderr, "Return value: ");
     term_display(stderr, ret_value, ctx);
     fprintf(stderr, "\n");

--- a/src/platforms/rp2040/src/main.c
+++ b/src/platforms/rp2040/src/main.c
@@ -138,7 +138,7 @@ static int app_main()
     fprintf(stdout, "---\n");
 
     context_execute_loop(ctx, mod, "start", 0);
-    term ret_value = ctx->x[0];
+    term ret_value = ctx->saved_x[0];
 
     fprintf(stdout, "AtomVM finished with return value: ");
     term_display(stdout, ret_value, ctx);

--- a/src/platforms/rp2040/tests/test_main.c
+++ b/src/platforms/rp2040/tests/test_main.c
@@ -121,7 +121,7 @@ static term avm_test_case(const char *test_module)
     ctx->leader = 1;
 
     context_execute_loop(ctx, mod, "start", 0);
-    term ret_value = ctx->x[0];
+    term ret_value = ctx->saved_x[0];
 
     nif_collection_destroy_all(glb);
 

--- a/src/platforms/stm32/src/main.c
+++ b/src/platforms/stm32/src/main.c
@@ -275,7 +275,7 @@ int main()
 
     context_execute_loop(ctx, mod, "start", 0);
 
-    term ret_value = ctx->x[0];
+    term ret_value = ctx->saved_x[0];
     char *ret_atom_string = interop_atom_to_string(ctx, ret_value);
     if (ret_atom_string != NULL) {
         AVM_LOGI(TAG, "Exited with return: %s", ret_atom_string);

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -490,6 +490,7 @@ compile_erlang(test_crypto_strong_rand_bytes)
 compile_erlang(test_atomvm_random)
 
 compile_erlang(float_decode)
+compile_erlang(test_many_xregs)
 
 add_custom_target(erlang_test_modules DEPENDS
     code_load_files
@@ -945,4 +946,5 @@ add_custom_target(erlang_test_modules DEPENDS
     test_atomvm_random.beam
 
     float_decode.beam
+    test_many_xregs.beam
 )

--- a/tests/erlang_tests/test_many_xregs.erl
+++ b/tests/erlang_tests/test_many_xregs.erl
@@ -1,0 +1,50 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_many_xregs).
+-export([start/0]).
+
+start() ->
+    make_funs(),
+    0.
+
+id(X) -> X.
+
+make_funs() ->
+    [
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+        fun id/1,
+
+        fun id/1
+    ].

--- a/tests/test.c
+++ b/tests/test.c
@@ -495,6 +495,8 @@ struct Test tests[] = {
 
     TEST_CASE(test_module_info),
 
+    TEST_CASE(test_many_xregs),
+
     // noisy tests, keep them at the end
     TEST_CASE_EXPECTED(spawn_opt_monitor_normal, 1),
     TEST_CASE_EXPECTED(spawn_opt_link_normal, 1),
@@ -545,11 +547,11 @@ static int test_atom(struct Test *test)
 
     context_execute_loop(ctx, mod, "start", 0);
 
-    if (!term_is_any_integer(ctx->x[0])) {
+    if (!term_is_any_integer(ctx->saved_x[0])) {
         fprintf(stderr, "\x1b[1;31mExpected %i but result is not an integer\x1b[0m\n", test->expected_value);
         result = -1;
     } else {
-        int32_t value = (int32_t) term_maybe_unbox_int(ctx->x[0]);
+        int32_t value = (int32_t) term_maybe_unbox_int(ctx->saved_x[0]);
         if (value != test->expected_value) {
             fprintf(stderr, "\x1b[1;31mExpected %i, got: %i\x1b[0m\n", test->expected_value, value);
             result = -1;


### PR DESCRIPTION
X registers are saved in context on context switching but are otherwise
allocated only once per scheduler thread, thus allowing up to 1024 registers
as the compiler allows

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
