### PR TITLE
Enable STM32 FPU for floating point calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug that would make the VM to loop and failing to process selected fds on Linux
 - Fixed classes of exceptions in estdlib.
 - Fixed STM32 code that was hard coded to the default target device, now configured based on the `cmake -DDEVICE=` parameter
+- Fixed changed default to `AVM_USE_32BIT_FLOAT=on` for STM32 platform to enable use of single precision hardware FPU on F4/F7 devices.
 
 ### Changed
 

--- a/src/platforms/stm32/CMakeLists.txt
+++ b/src/platforms/stm32/CMakeLists.txt
@@ -25,7 +25,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Options that make sense for this platform
-option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
+option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." ON)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
 option(AVM_CREATE_STACKTRACES "Create stacktraces" ON)
 option(AVM_NEWLIB_NANO "Use 'nano' newlib. Saves 46kB, no `long long` support" OFF)


### PR DESCRIPTION
The FPU on stm32f4 and stm32f7 devices is single precision, changing the default to `AVM_USE_32BIT_FLOAT=on` enables the use of accelerated floating point calculations on these devices.  When we can extend support to the stm32h7 series those devices should have `AVM_USE_32BIT_FLOAT=off` by defalt, as they have an on board FPU with double precision support.

For reference, the times for the `pi_test` from atomvm_benchmarks can clearly show the benefits of making this change. (times are measured in uSecs, tested on Nucleo-f429zi - 180Mhz)

`AVM_USE_32BIT_FLOAT=off`
pi_test: 26410000

`AVM_USE_32BIT_FLOAT=on`
pi_test: 17922000

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
