### PR TITLE
otp_crypto: make sure ensure heap size includes binary header

### DIFF
--- a/src/libAtomVM/otp_crypto.c
+++ b/src/libAtomVM/otp_crypto.c
@@ -532,7 +532,8 @@ static term nif_crypto_crypto_one_time(Context *ctx, int argc, term argv[])
     free(allocated_iv_data);
     free(allocated_data_data);
 
-    if (UNLIKELY(memory_ensure_free(ctx, temp_buf_size) != MEMORY_GC_OK)) {
+    int ensure_size = term_binary_heap_size(temp_buf_size);
+    if (UNLIKELY(memory_ensure_free(ctx, ensure_size) != MEMORY_GC_OK)) {
         free(temp_buf);
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }


### PR DESCRIPTION
Use term_binary_heap_size for exact size calculation before ensuring memory.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
