### PR TITLE
Fix ESP32 UART configuration for ESP-IDF >= 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed classes of exceptions in estdlib.
 - Fixed STM32 code that was hard coded to the default target device, now configured based on the `cmake -DDEVICE=` parameter
 - Fixed hard fault on STM32 durung malloc on boards with more than one bank of sram
+- Fixed invalid src_clk error on ESP-IDF >= 5.0
 
 ### Changed
 

--- a/src/platforms/esp32/components/avm_builtins/uart_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/uart_driver.c
@@ -257,6 +257,9 @@ Context *uart_driver_create_port(GlobalContext *global, term opts)
     }
 
     uart_config_t uart_config = {
+#if ESP_IDF_VERSION_MAJOR >= 5
+        .source_clk = UART_SCLK_DEFAULT,
+#endif
         .baud_rate = uart_speed,
         .data_bits = data_bits,
         .parity = parity,


### PR DESCRIPTION
Include `source_clk` field in the `uart_config_t` struct for ESP-IDF >= 5.0 to address compatibility error.

The issue arises due to a missing `source_clk` field in the `uart_config_t` struct in `uart_driver_create_port`.
In versions prior to ESP-IDF 5.0, this field was not required (tested against 4.4.6), but its absence in later versions leads to the following error at runtime : `uart: uart_param_config(748): Invalid src_clk`.
The choice of UART_SCLK_DEFAULT was made to allow for automatic selection of the appropriate clock source.

Open to feedback or suggestions for any improvements or alternative approaches.


These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
