### PR TITLE
Remove OpenSSL

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -65,7 +65,7 @@ jobs:
       working-directory: build
       run: |
         export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
-        cmake -G Ninja -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl ..
+        cmake -G Ninja ..
 
     - name: "Build: run ninja"
       working-directory: build

--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -98,7 +98,7 @@ jobs:
             apt update &&
             apt install -y -t stretch-backports-sloppy libarchive13 &&
             apt install -y -t stretch-backports cmake &&
-            apt install -y file gcc g++ binutils make doxygen gperf zlib1g-dev libssl-dev libmbedtls-dev
+            apt install -y file gcc g++ binutils make doxygen gperf zlib1g-dev libmbedtls-dev
 
         - arch: "arm32v7"
           platform: "arm/v7"
@@ -148,7 +148,7 @@ jobs:
             ${{ matrix.install_deps }}
         else
             apt update &&
-            apt install -y file gcc g++ binutils cmake make doxygen gperf zlib1g-dev libssl-dev libmbedtls-dev
+            apt install -y file gcc g++ binutils cmake make doxygen gperf zlib1g-dev libmbedtls-dev
         fi &&
         file /bin/bash &&
         uname -a &&

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -171,10 +171,10 @@ jobs:
           cflags: "-m32 -O3"
           otp: "23"
           elixir_version: "1.11"
-          cmake_opts_other: "-DOPENSSL_CRYPTO_LIBRARY=/usr/lib/i386-linux-gnu/libcrypto.so -DAVM_CREATE_STACKTRACES=off"
+          cmake_opts_other: "-DAVM_CREATE_STACKTRACES=off"
           arch: "i386"
           compiler_pkgs: "gcc-10 g++-10 gcc-10-multilib g++-10-multilib libc6-dev-i386
-          libc6-dbg:i386 zlib1g-dev:i386 libssl-dev:i386 libmbedtls-dev:i386"
+          libc6-dbg:i386 zlib1g-dev:i386 libmbedtls-dev:i386"
 
     env:
       CC: ${{ matrix.cc }}

--- a/.github/workflows/build-libraries.yaml
+++ b/.github/workflows/build-libraries.yaml
@@ -35,7 +35,7 @@ jobs:
       run: sudo apt update -y
 
     - name: "Install deps"
-      run: sudo apt install -y build-essential cmake gperf zlib1g-dev libssl-dev valgrind
+      run: sudo apt install -y build-essential cmake gperf zlib1g-dev libmbedtls-dev valgrind
 
     # Builder info
     - name: "System info"

--- a/.github/workflows/build-linux-artifacts.yaml
+++ b/.github/workflows/build-linux-artifacts.yaml
@@ -84,10 +84,10 @@ jobs:
             apt update &&
             apt install -y -t stretch-backports-sloppy libarchive13 &&
             apt install -y -t stretch-backports cmake &&
-            apt install -y file gcc g++ binutils make doxygen gperf zlib1g-dev libssl-dev tzdata
+            apt install -y file gcc g++ binutils make doxygen gperf zlib1g-dev libmbedtls-dev tzdata
 
         - arch: "arm32v7"
-          build_name: "linux-arm32v7thl-openssl1"
+          build_name: "linux-arm32v7thl"
           docker_image: "arm32v7/debian"
           platform: "arm/v7"
           tag: "stretch"
@@ -104,14 +104,7 @@ jobs:
             apt update &&
             apt install -y -t stretch-backports-sloppy libarchive13 &&
             apt install -y -t stretch-backports cmake &&
-            apt install -y file gcc g++ binutils make doxygen gperf zlib1g-dev libssl-dev tzdata
-
-        - arch: "arm32v7"
-          build_name: "linux-arm32v7thl"
-          docker_image: "arm32v7/ubuntu"
-          platform: "arm/v7"
-          tag: "22.04"
-          cflags: "-mfloat-abi=hard -mthumb -mthumb-interwork"
+            apt install -y file gcc g++ binutils make doxygen gperf zlib1g-dev libmbedtls-dev tzdata
 
         - arch: "arm64v8"
           build_name: "linux-arm64v8"
@@ -131,18 +124,11 @@ jobs:
           build_name: "linux-x86_64"
           docker_image: "ubuntu"
           platform: "amd64"
-          tag: "22.04"
-          cflags: ""
-
-        - arch: "x86_64"
-          build_name: "linux-x86_64-openssl1"
-          docker_image: "ubuntu"
-          platform: "amd64"
           tag: "18.04"
           cflags: ""
           install_deps: |
             apt update &&
-            apt install -y file gcc g++ binutils make doxygen gperf zlib1g-dev libssl-dev wget tzdata &&
+            apt install -y file gcc g++ binutils make doxygen gperf zlib1g-dev libmbedtls-dev wget tzdata &&
             apt purge -y cmake &&
             wget https://cmake.org/files/v3.13/cmake-3.13.5-Linux-x86_64.tar.gz &&
             tar xf cmake-3.13.5-Linux-x86_64.tar.gz &&
@@ -150,7 +136,7 @@ jobs:
             ln -sf /opt/cmake-3.13.5/bin/* /usr/bin/
 
         - arch: "i386"
-          build_name: "linux-i386-openssl1"
+          build_name: "linux-i386"
           docker_image: "i386/debian"
           platform: "386"
           cflags: ""
@@ -167,7 +153,7 @@ jobs:
             apt update &&
             apt install -y -t stretch-backports-sloppy libarchive13 &&
             apt install -y -t stretch-backports cmake &&
-            apt install -y file gcc g++ binutils make doxygen gperf zlib1g-dev libssl-dev
+            apt install -y file gcc g++ binutils make doxygen gperf zlib1g-dev libmbedtls-dev
 
     steps:
     - name: Checkout repo
@@ -201,7 +187,7 @@ jobs:
             ${{ matrix.install_deps }}
         else
             apt update &&
-            apt install -y file gcc g++ binutils cmake make doxygen gperf zlib1g-dev libssl-dev tzdata
+            apt install -y file gcc g++ binutils cmake make doxygen gperf zlib1g-dev libmbedtls-dev tzdata
         fi &&
         file /bin/bash &&
         uname -a &&

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -64,17 +64,14 @@ jobs:
         - os: "macos-latest"
           otp: "23"
           path_prefix: "/usr/local/opt/erlang@23/bin:"
-          cmake_opts: "-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
 
         - os: "macos-latest"
           otp: "24"
           path_prefix: "/usr/local/opt/erlang@24/bin:"
-          cmake_opts: "-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
 
         - os: "macos-latest"
           otp: "25"
           path_prefix: "/usr/local/opt/erlang@25/bin:"
-          cmake_opts: "-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
     steps:
     # Setup
     - name: "Checkout repo"
@@ -101,7 +98,7 @@ jobs:
 
     - name: "Install deps (macOS)"
       if: runner.os == 'macOS'
-      run: brew install gperf erlang@${{ matrix.otp }} ninja
+      run: brew install gperf erlang@${{ matrix.otp }} ninja mbedtls
 
     # Build
     - name: "Build: create build dir"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `crypto:one_time/4,5` on Unix and Pico as well as for `crypto:hash/2` on Pico
 - Added ability to configure STM32 Nucleo boards onboard UART->USB-COM using the `-DBOARD=nucleo` cmake option
 - Added STM32 cmake option `-DAVM_CFG_CONSOLE=` to select a different uart peripheral for the system console
+- Added `crypto:strong_rand_bytes/1` using Mbed-TLS
 
 ## [0.6.0-alpha.1] - 2023-10-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Crypto functions on generic_unix platform now rely on MbedTLS instead of OpenSSL
 - Platform function providing time used by timers was changed from `sys_monotonic_millis` to `sys_monotonic_time_u64`, `sys_monotonic_time_u64_to_ms` and `sys_monotonic_time_ms_to_u64`.
+- Implement `atomvm:random/0` and `atomvm:rand_bytes/1` on top of `crypto:strong_rand_bytes/1` on
+  generic_unix platform
 
 ### Added
 
@@ -40,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ability to configure STM32 Nucleo boards onboard UART->USB-COM using the `-DBOARD=nucleo` cmake option
 - Added STM32 cmake option `-DAVM_CFG_CONSOLE=` to select a different uart peripheral for the system console
 - Added `crypto:strong_rand_bytes/1` using Mbed-TLS
+
+### Removed
+
+- OpenSSL support, Mbed-TLS is required instead.
 
 ## [0.6.0-alpha.1] - 2023-10-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crypto functions on generic_unix platform now rely on MbedTLS instead of OpenSSL
 - Platform function providing time used by timers was changed from `sys_monotonic_millis` to `sys_monotonic_time_u64`, `sys_monotonic_time_u64_to_ms` and `sys_monotonic_time_ms_to_u64`.
 - Implement `atomvm:random/0` and `atomvm:rand_bytes/1` on top of `crypto:strong_rand_bytes/1` on
-  generic_unix platform
+  generic_unix, ESP32 and RP2040 platforms.
 
 ### Added
 
@@ -41,7 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `crypto:one_time/4,5` on Unix and Pico as well as for `crypto:hash/2` on Pico
 - Added ability to configure STM32 Nucleo boards onboard UART->USB-COM using the `-DBOARD=nucleo` cmake option
 - Added STM32 cmake option `-DAVM_CFG_CONSOLE=` to select a different uart peripheral for the system console
-- Added `crypto:strong_rand_bytes/1` using Mbed-TLS
+- Added `crypto:strong_rand_bytes/1` using Mbed-TLS (only on generic_unix, ESP32 and RP2040
+  platforms)
 
 ### Removed
 

--- a/libs/eavmlib/src/atomvm.erl
+++ b/libs/eavmlib/src/atomvm.erl
@@ -48,6 +48,10 @@
     posix_open_flag/0
 ]).
 
+-deprecated([
+    {random, 0, next_version}
+]).
+
 -type platform_name() ::
     generic_unix
     | emscripten
@@ -109,6 +113,7 @@ random() ->
 %%          Supplying a negative value will result in a badarg error.
 %%          This function will use a cryptographically strong RNG if available.
 %%          Otherwise, the random value is generated using a PRNG.
+%% @deprecated Use crypto:strong_rand_bytes/1 instead.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec rand_bytes(Len :: non_neg_integer()) -> binary().

--- a/src/libAtomVM/sys_mbedtls.h
+++ b/src/libAtomVM/sys_mbedtls.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Davide Bettio <davide@uninstall.it>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _SYS_MBEDTLS_H_
+#define _SYS_MBEDTLS_H_
+
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+
+mbedtls_entropy_context *sys_mbedtls_get_entropy_context_lock(GlobalContext *global);
+void sys_mbedtls_entropy_context_unlock(GlobalContext *global);
+int sys_mbedtls_entropy_func(void *entropy, unsigned char *buf, size_t size);
+
+mbedtls_ctr_drbg_context *sys_mbedtls_get_ctr_drbg_context_lock(GlobalContext *global);
+
+/**
+ * @warning do not call this function when already owning the entropy context
+ */
+void sys_mbedtls_ctr_drbg_context_unlock(GlobalContext *global);
+
+#endif

--- a/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
+++ b/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
@@ -30,8 +30,16 @@
 #include <spi_flash_mmap.h>
 #endif
 
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+
 #include <sys/poll.h>
+#include <stdbool.h>
 #include <time.h>
+
+#ifndef AVM_NO_SMP
+#include "smp.h"
+#endif
 
 #include "sys.h"
 
@@ -94,6 +102,18 @@ struct ESP32PlatformData
     EventListener *socket_listener;
     struct SyncList sockets;
     struct ListHead ready_connections;
+
+#ifndef AVM_NO_SMP
+    Mutex *entropy_mutex;
+#endif
+    mbedtls_entropy_context entropy_ctx;
+    bool entropy_is_initialized;
+
+#ifndef AVM_NO_SMP
+    Mutex *random_mutex;
+#endif
+    mbedtls_ctr_drbg_context random_ctx;
+    bool random_is_initialized;
 };
 
 typedef void (*port_driver_init_t)(GlobalContext *global);

--- a/src/platforms/generic_unix/lib/CMakeLists.txt
+++ b/src/platforms/generic_unix/lib/CMakeLists.txt
@@ -76,16 +76,6 @@ else()
     message("WARNING:  Could NOT find MbedTLS, ssl and crypto modules will not be supported. Install MbedTLS 3.x or try to set MBEDTLS_ROOT_DIR to installation prefix of MbedTLS 2.x")
 endif()
 
-# For now we still use OpenSSL for random
-find_package(OpenSSL)
-if (${OPENSSL_FOUND} STREQUAL TRUE)
-    target_include_directories(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC ${OPENSSL_INCLUDE_DIR})
-    target_compile_definitions(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC ATOMVM_HAS_OPENSSL)
-    target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
-else()
-    message("WARNING:  atomvm:random/0 and atomvm:rand_bytes/1 will not be supported.")
-endif()
-
 # enable by default dynamic loading on unix
 target_compile_definitions(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC DYNLOAD_PORT_DRIVERS)
 target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC ${CMAKE_DL_LIBS})

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -32,7 +32,17 @@
 #include "utils.h"
 
 #if ATOMVM_HAS_MBEDTLS
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+
+#if defined(MBEDTLS_VERSION_NUMBER) && (MBEDTLS_VERSION_NUMBER >= 0x03000000)
+#include <mbedtls/build_info.h>
+#else
+#include <mbedtls/config.h>
+#endif
+
 #include "otp_ssl.h"
+#include "sys_mbedtls.h"
 #endif
 
 #include <fcntl.h>
@@ -97,6 +107,20 @@ struct GenericUnixPlatformData
     int signal_pipe[2];
 #endif
 #endif
+#endif
+
+#ifdef ATOMVM_HAS_MBEDTLS
+#ifndef AVM_NO_SMP
+    Mutex *entropy_mutex;
+#endif
+    mbedtls_entropy_context entropy_ctx;
+    bool entropy_is_initialized;
+
+#ifndef AVM_NO_SMP
+    Mutex *random_mutex;
+#endif
+    mbedtls_ctr_drbg_context random_ctx;
+    bool random_is_initialized;
 #endif
 };
 
@@ -590,6 +614,18 @@ void sys_init_platform(GlobalContext *global)
     otp_net_init(global);
     otp_socket_init(global);
 #if ATOMVM_HAS_MBEDTLS
+#ifndef AVM_NO_SMP
+    platform->entropy_mutex = smp_mutex_create();
+    if (IS_NULL_PTR(platform->entropy_mutex)) {
+        AVM_ABORT();
+    }
+    platform->random_mutex = smp_mutex_create();
+    if (IS_NULL_PTR(platform->random_mutex)) {
+        AVM_ABORT();
+    }
+#endif
+    platform->entropy_is_initialized = false;
+    platform->random_is_initialized = false;
     otp_ssl_init(global);
 #endif
 
@@ -618,6 +654,22 @@ void sys_free_platform(GlobalContext *global)
 #endif
 #endif
 #endif
+
+#if !defined(AVM_NO_SMP) && ATOMVM_HAS_MBEDTLS
+    smp_mutex_destroy(platform->entropy_mutex);
+    smp_mutex_destroy(platform->random_mutex);
+#endif
+
+#if ATOMVM_HAS_MBEDTLS
+    if (platform->random_is_initialized) {
+        mbedtls_ctr_drbg_free(&platform->random_ctx);
+    }
+
+    if (platform->entropy_is_initialized) {
+        mbedtls_entropy_free(&platform->entropy_ctx);
+    }
+#endif
+
     free(platform);
 }
 
@@ -723,3 +775,73 @@ bool event_listener_is_event(EventListener *listener, listener_event_t event)
 {
     return listener->fd == event;
 }
+
+#ifdef ATOMVM_HAS_MBEDTLS
+int sys_mbedtls_entropy_func(void *entropy, unsigned char *buf, size_t size)
+{
+#ifndef MBEDTLS_THREADING_C
+    struct GenericUnixPlatformData *platform
+        = CONTAINER_OF(entropy, struct GenericUnixPlatformData, entropy_ctx);
+    SMP_MUTEX_LOCK(platform->entropy_mutex);
+    int result = mbedtls_entropy_func(entropy, buf, size);
+    SMP_MUTEX_UNLOCK(platform->entropy_mutex);
+
+    return result;
+#else
+    return mbedtls_entropy_func(entropy, buf, size);
+#endif
+}
+
+mbedtls_entropy_context *sys_mbedtls_get_entropy_context_lock(GlobalContext *global)
+{
+    struct GenericUnixPlatformData *platform = global->platform_data;
+
+    SMP_MUTEX_LOCK(platform->entropy_mutex);
+
+    if (!platform->entropy_is_initialized) {
+        mbedtls_entropy_init(&platform->entropy_ctx);
+        platform->entropy_is_initialized = true;
+    }
+
+    return &platform->entropy_ctx;
+}
+
+void sys_mbedtls_entropy_context_unlock(GlobalContext *global)
+{
+    struct GenericUnixPlatformData *platform = global->platform_data;
+    SMP_MUTEX_UNLOCK(platform->entropy_mutex);
+}
+
+mbedtls_ctr_drbg_context *sys_mbedtls_get_ctr_drbg_context_lock(GlobalContext *global)
+{
+    struct GenericUnixPlatformData *platform = global->platform_data;
+
+    SMP_MUTEX_LOCK(platform->random_mutex);
+
+    if (!platform->random_is_initialized) {
+        mbedtls_ctr_drbg_init(&platform->random_ctx);
+
+        mbedtls_entropy_context *entropy_ctx = sys_mbedtls_get_entropy_context_lock(global);
+        // Safe to unlock it now, sys_mbedtls_entropy_func will lock it again later
+        sys_mbedtls_entropy_context_unlock(global);
+
+        const char *seed = "AtomVM Mbed-TLS initial seed.";
+        int seed_len = strlen(seed);
+        int seed_err = mbedtls_ctr_drbg_seed(&platform->random_ctx, sys_mbedtls_entropy_func,
+            entropy_ctx, (const unsigned char *) seed, seed_len);
+        if (UNLIKELY(seed_err != 0)) {
+            abort();
+        }
+        platform->random_is_initialized = true;
+    }
+
+    return &platform->random_ctx;
+}
+
+void sys_mbedtls_ctr_drbg_context_unlock(GlobalContext *global)
+{
+    struct GenericUnixPlatformData *platform = global->platform_data;
+    SMP_MUTEX_UNLOCK(platform->random_mutex);
+}
+
+#endif

--- a/src/platforms/rp2040/src/lib/rp2040_sys.h
+++ b/src/platforms/rp2040/src/lib/rp2040_sys.h
@@ -30,6 +30,9 @@
 #include <pico/cond.h>
 #include <pico/util/queue.h>
 
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+
 #pragma GCC diagnostic pop
 
 #include "sys.h"
@@ -112,6 +115,18 @@ struct RP2040PlatformData
     cond_t event_poll_cond;
 #endif
     queue_t event_queue;
+
+#ifndef AVM_NO_SMP
+    Mutex *entropy_mutex;
+#endif
+    mbedtls_entropy_context entropy_ctx;
+    bool entropy_is_initialized;
+
+#ifndef AVM_NO_SMP
+    Mutex *random_mutex;
+#endif
+    mbedtls_ctr_drbg_context random_ctx;
+    bool random_is_initialized;
 };
 
 typedef void (*port_driver_init_t)(GlobalContext *global);

--- a/src/platforms/rp2040/src/lib/sys.c
+++ b/src/platforms/rp2040/src/lib/sys.c
@@ -44,6 +44,12 @@
 #include <otp_socket.h>
 #endif
 
+#if defined(MBEDTLS_VERSION_NUMBER) && (MBEDTLS_VERSION_NUMBER >= 0x03000000)
+#include <mbedtls/build_info.h>
+#else
+#include <mbedtls/config.h>
+#endif
+
 // libAtomVM
 #include <avmpack.h>
 #include <defaultatoms.h>
@@ -56,6 +62,14 @@
 
 // Platform uses listeners
 #include "listeners.h"
+
+#ifndef AVM_NO_SMP
+#define SMP_MUTEX_LOCK(mtx) smp_mutex_lock(mtx)
+#define SMP_MUTEX_UNLOCK(mtx) smp_mutex_unlock(mtx)
+#else
+#define SMP_MUTEX_LOCK(mtx)
+#define SMP_MUTEX_UNLOCK(mtx)
+#endif
 
 struct PortDriverDefListItem *port_driver_list;
 struct NifCollectionDefListItem *nif_collection_list;
@@ -75,6 +89,9 @@ void sys_init_platform(GlobalContext *glb)
     cyw43_arch_init();
     otp_socket_init(glb);
 #endif
+
+    platform->entropy_is_initialized = false;
+    platform->random_is_initialized = false;
 }
 
 void sys_free_platform(GlobalContext *glb)
@@ -85,6 +102,15 @@ void sys_free_platform(GlobalContext *glb)
 
     struct RP2040PlatformData *platform = glb->platform_data;
     queue_free(&platform->event_queue);
+
+    if (platform->random_is_initialized) {
+        mbedtls_ctr_drbg_free(&platform->random_ctx);
+    }
+
+    if (platform->entropy_is_initialized) {
+        mbedtls_entropy_free(&platform->entropy_ctx);
+    }
+
     free(platform);
 
 #ifndef AVM_NO_SMP
@@ -386,4 +412,73 @@ void sys_unregister_listener_from_event(GlobalContext *global, listener_event_t 
         }
     }
     synclist_unlock(&global->listeners);
+}
+
+// TODO: enable mbedtls threading support by defining MBEDTLS_THREADING_ALT
+// and remove this function.
+int sys_mbedtls_entropy_func(void *entropy, unsigned char *buf, size_t size)
+{
+#ifndef MBEDTLS_THREADING_C
+    struct RP2040PlatformData *platform
+        = CONTAINER_OF(entropy, struct RP2040PlatformData, entropy_ctx);
+    SMP_MUTEX_LOCK(platform->entropy_mutex);
+    int result = mbedtls_entropy_func(entropy, buf, size);
+    SMP_MUTEX_UNLOCK(platform->entropy_mutex);
+
+    return result;
+#else
+    return mbedtls_entropy_func(entropy, buf, size);
+#endif
+}
+
+mbedtls_entropy_context *sys_mbedtls_get_entropy_context_lock(GlobalContext *global)
+{
+    struct RP2040PlatformData *platform = global->platform_data;
+
+    SMP_MUTEX_LOCK(platform->entropy_mutex);
+
+    if (!platform->entropy_is_initialized) {
+        mbedtls_entropy_init(&platform->entropy_ctx);
+        platform->entropy_is_initialized = true;
+    }
+
+    return &platform->entropy_ctx;
+}
+
+void sys_mbedtls_entropy_context_unlock(GlobalContext *global)
+{
+    struct RP2040PlatformData *platform = global->platform_data;
+    SMP_MUTEX_UNLOCK(platform->entropy_mutex);
+}
+
+mbedtls_ctr_drbg_context *sys_mbedtls_get_ctr_drbg_context_lock(GlobalContext *global)
+{
+    struct RP2040PlatformData *platform = global->platform_data;
+
+    SMP_MUTEX_LOCK(platform->random_mutex);
+
+    if (!platform->random_is_initialized) {
+        mbedtls_ctr_drbg_init(&platform->random_ctx);
+
+        mbedtls_entropy_context *entropy_ctx = sys_mbedtls_get_entropy_context_lock(global);
+        // Safe to unlock it now, sys_mbedtls_entropy_func will lock it again later
+        sys_mbedtls_entropy_context_unlock(global);
+
+        const char *seed = "AtomVM RP2040 Mbed-TLS initial seed.";
+        int seed_len = strlen(seed);
+        int seed_err = mbedtls_ctr_drbg_seed(&platform->random_ctx, sys_mbedtls_entropy_func,
+            entropy_ctx, (const unsigned char *) seed, seed_len);
+        if (UNLIKELY(seed_err != 0)) {
+            abort();
+        }
+        platform->random_is_initialized = true;
+    }
+
+    return &platform->random_ctx;
+}
+
+void sys_mbedtls_ctr_drbg_context_unlock(GlobalContext *global)
+{
+    struct RP2040PlatformData *platform = global->platform_data;
+    SMP_MUTEX_UNLOCK(platform->random_mutex);
 }

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -486,6 +486,8 @@ compile_erlang(test_module_info)
 
 compile_erlang(int64_build_binary)
 
+compile_erlang(test_crypto_strong_rand_bytes)
+
 add_custom_target(erlang_test_modules DEPENDS
     code_load_files
 
@@ -935,4 +937,6 @@ add_custom_target(erlang_test_modules DEPENDS
     test_module_info.beam
 
     int64_build_binary.beam
+
+    test_crypto_strong_rand_bytes.beam
 )

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -487,6 +487,7 @@ compile_erlang(test_module_info)
 compile_erlang(int64_build_binary)
 
 compile_erlang(test_crypto_strong_rand_bytes)
+compile_erlang(test_atomvm_random)
 
 add_custom_target(erlang_test_modules DEPENDS
     code_load_files
@@ -939,4 +940,5 @@ add_custom_target(erlang_test_modules DEPENDS
     int64_build_binary.beam
 
     test_crypto_strong_rand_bytes.beam
+    test_atomvm_random.beam
 )

--- a/tests/erlang_tests/test_atomvm_random.erl
+++ b/tests/erlang_tests/test_atomvm_random.erl
@@ -1,0 +1,75 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_atomvm_random).
+-export([start/0]).
+
+start() ->
+    TestScore = times((fun() -> do_test() end), 19, 0),
+    if
+        TestScore >= 19 -> 1;
+        true -> 0
+    end.
+
+do_test() ->
+    RandomTuple = random_tuple(),
+    1 = all_integer(RandomTuple),
+    Test1 = all_equal(RandomTuple),
+
+    Bin = atomvm_rand_bytes(4),
+    RandomTuple2 = binary_to_tuple(Bin),
+    Test2 = all_equal(RandomTuple2),
+    Test1 + Test2 * 2.
+
+all_integer({A, B, C, D}) when
+    is_integer(A) and is_integer(B) and is_integer(C) and is_integer(D)
+->
+    1;
+all_integer(_) ->
+    0.
+
+all_equal({A, B, C, D}) when (A =/= B) and (B =/= C) and (C =/= D) ->
+    0;
+all_equal(_) ->
+    1.
+
+random_tuple() ->
+    {atomvm_random(), atomvm_random(), atomvm_random(), atomvm_random()}.
+
+atomvm_random() ->
+    case erlang:system_info(machine) of
+        "BEAM" -> rand:uniform(2147483647);
+        _ -> atomvm:random()
+    end.
+
+atomvm_rand_bytes(N) ->
+    case erlang:system_info(machine) of
+        "BEAM" -> crypto:strong_rand_bytes(N);
+        _ -> atomvm:rand_bytes(N)
+    end.
+
+binary_to_tuple(B) ->
+    L = erlang:binary_to_list(B),
+    erlang:list_to_tuple(L).
+
+times(_Fun, 0, Acc) ->
+    Acc;
+times(Fun, N, Acc) ->
+    times(Fun, N - 1, Acc + Fun()).

--- a/tests/erlang_tests/test_crypto_strong_rand_bytes.erl
+++ b/tests/erlang_tests/test_crypto_strong_rand_bytes.erl
@@ -1,0 +1,48 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_crypto_strong_rand_bytes).
+-export([start/0]).
+
+start() ->
+    TestScore = times((fun() -> do_test() end), 10, 0),
+    if
+        TestScore >= 9 -> 1;
+        true -> 0
+    end.
+
+do_test() ->
+    Bin = crypto:strong_rand_bytes(4),
+    RandomTuple = binary_to_tuple(Bin),
+    all_equal(RandomTuple).
+
+all_equal({A, B, C, D}) when (A =/= B) and (B =/= C) and (C =/= D) ->
+    0;
+all_equal(_) ->
+    1.
+
+binary_to_tuple(B) ->
+    L = erlang:binary_to_list(B),
+    erlang:list_to_tuple(L).
+
+times(_Fun, 0, Acc) ->
+    Acc;
+times(Fun, N, Acc) ->
+    times(Fun, N - 1, Acc + Fun()).

--- a/tests/test.c
+++ b/tests/test.c
@@ -516,6 +516,7 @@ struct Test tests[] = {
 
 #if defined ATOMVM_HAS_MBEDTLS
     TEST_CASE(test_crypto_strong_rand_bytes),
+    TEST_CASE(test_atomvm_random),
 #endif
 
     // TEST CRASHES HERE: TEST_CASE(memlimit),

--- a/tests/test.c
+++ b/tests/test.c
@@ -513,6 +513,11 @@ struct Test tests[] = {
     TEST_CASE(test_crypto),
     TEST_CASE(test_min_max_guard),
     TEST_CASE(int64_build_binary),
+
+#if defined ATOMVM_HAS_MBEDTLS
+    TEST_CASE(test_crypto_strong_rand_bytes),
+#endif
+
     // TEST CRASHES HERE: TEST_CASE(memlimit),
 
     { NULL, 0, false, false }


### PR DESCRIPTION
Do not depend both on Mbed-TLS and OpenSSL at the same time, just use Mbed-TLS.
Also now the  same code base can be both used on generic unix and MCUs.

Closes #950 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
