### PR TITLE
Fix emscripten register callback crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed hard fault on STM32 durung malloc on boards with more than one bank of sram
 - Fixed invalid src_clk error on ESP-IDF >= 5.0
 - Fixed changed default to `AVM_USE_32BIT_FLOAT=on` for STM32 platform to enable use of single precision hardware FPU on F4/F7 devices.
+- Fixed a bug where emscripten `register_*_callback/1` functions would use x[1] as second argument
 
 ### Changed
 

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -207,9 +207,9 @@ static bool get_register_callback_parameters(Context *ctx, int argc, term argv[]
     }
     bool use_capture_opt = false;
     bool prevent_default_opt = false;
-    if (argc >= 1 && term_is_atom(argv[1])) {
+    if (argc > 1 && term_is_atom(argv[1])) {
         use_capture_opt = argv[1] == TRUE_ATOM;
-    } else if (argc >= 1 && term_is_list(argv[1])) {
+    } else if (argc > 1 && term_is_list(argv[1])) {
         use_capture_opt = interop_proplist_get_value_default(argv[1], globalcontext_make_atom(ctx->global, ATOM_STR("\xB", "use_capture")), FALSE_ATOM) == TRUE_ATOM;
         prevent_default_opt = interop_proplist_get_value_default(argv[1], globalcontext_make_atom(ctx->global, ATOM_STR("\xF", "prevent_default")), FALSE_ATOM) == TRUE_ATOM;
     }


### PR DESCRIPTION
Fix an issue where second argument (x[1]) was incorrectly processed when register_callback/1 was called

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
