### PR TITLE
Fix encoding of atoms with format

### DIFF
--- a/tests/libs/estdlib/test_io_lib.erl
+++ b/tests/libs/estdlib/test_io_lib.erl
@@ -120,6 +120,18 @@ test() ->
     ),
 
     ?ASSERT_MATCH(?FLT(io_lib:format("~p", [foo])), "foo"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~p", ['-foo'])), "'-foo'"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~p", ['try'])), "'try'"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~p", ['maybe'])), "maybe"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~w", [foo])), "foo"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~w", ['-foo'])), "'-foo'"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~w", ['try'])), "'try'"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~w", ['maybe'])), "maybe"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~s", [foo])), "foo"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~s", ['-foo'])), "-foo"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~s", ['try'])), "try"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~s", ['maybe'])), "maybe"),
+
     ?ASSERT_MATCH(?FLT(io_lib:format("\t~p", [bar])), "\tbar"),
 
     ?ASSERT_MATCH(


### PR DESCRIPTION
Closes  #923

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
