### PR TITLE
Rename version.h to avm_version.h

### DIFF
--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -63,7 +63,7 @@ set(HEADER_FILES
     trace.h
     utils.h
     valueshashtable.h
-    ${CMAKE_CURRENT_BINARY_DIR}/version.h
+    ${CMAKE_CURRENT_BINARY_DIR}/avm_version.h
 )
 
 set(SOURCE_FILES
@@ -226,10 +226,10 @@ else()
     set(ATOMVM_VERSION ${ATOMVM_BASE_VERSION})
 endif()
 
-# Add include to directory where version.h is generated so targets linking
+# Add include to directory where avm_version.h is generated so targets linking
 # libAtomVM can access it
 target_include_directories(libAtomVM PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/avm_version.h)
 
 if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Generic")
     target_link_libraries(libAtomVM PUBLIC libAtomVM${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR})

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -32,6 +32,7 @@
 #include <time.h>
 
 #include "atomshashtable.h"
+#include "avm_version.h"
 #include "avmpack.h"
 #include "bif.h"
 #include "context.h"
@@ -51,7 +52,6 @@
 #include "sys.h"
 #include "term.h"
 #include "utils.h"
-#include "version.h"
 
 #define MAX_NIF_NAME_LEN 260
 #define FLOAT_BUF_SIZE 64

--- a/src/platforms/emscripten/src/main.c
+++ b/src/platforms/emscripten/src/main.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include <avm_version.h>
 #include <avmpack.h>
 #include <context.h>
 #include <defaultatoms.h>
@@ -29,7 +30,6 @@
 #include <iff.h>
 #include <module.h>
 #include <sys.h>
-#include <version.h>
 
 #include <emscripten.h>
 #include <emscripten/promise.h>

--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 
 #include <atom.h>
+#include <avm_version.h>
 #include <avmpack.h>
 #include <bif.h>
 #include <context.h>
@@ -35,7 +36,6 @@
 #include <module.h>
 #include <term.h>
 #include <utils.h>
-#include <version.h>
 
 #include "esp32_sys.h"
 

--- a/src/platforms/generic_unix/main.c
+++ b/src/platforms/generic_unix/main.c
@@ -27,6 +27,7 @@
 #include <unistd.h>
 
 #include "atom.h"
+#include "avm_version.h"
 #include "avmpack.h"
 #include "bif.h"
 #include "context.h"
@@ -38,7 +39,6 @@
 #include "sys.h"
 #include "term.h"
 #include "utils.h"
-#include "version.h"
 
 void print_help(const char *program_name)
 {

--- a/src/platforms/rp2040/src/main.c
+++ b/src/platforms/rp2040/src/main.c
@@ -31,13 +31,13 @@
 
 #pragma GCC diagnostic pop
 
+#include <avm_version.h>
 #include <avmpack.h>
 #include <context.h>
 #include <defaultatoms.h>
 #include <globalcontext.h>
 #include <iff.h>
 #include <module.h>
-#include <version.h>
 
 #include "rp2040_sys.h"
 

--- a/src/platforms/stm32/src/main.c
+++ b/src/platforms/stm32/src/main.c
@@ -31,13 +31,13 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/usart.h>
 
+#include <avm_version.h>
 #include <avmpack.h>
 #include <context.h>
 #include <defaultatoms.h>
 #include <globalcontext.h>
 #include <module.h>
 #include <utils.h>
-#include <version.h>
 
 #include "lib/avm_devcfg.h"
 #include "lib/avm_log.h"


### PR DESCRIPTION
In order to allow building Zepher OS ports the `version.h` file needs to be renamed to avoid a collision with the `version.h` header file that part of the zepher core libraries included in all zephyr builds.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
