### PR TITLE
Fix precision of time used in timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed invalid src_clk error on ESP-IDF >= 5.0
 - Fixed changed default to `AVM_USE_32BIT_FLOAT=on` for STM32 platform to enable use of single precision hardware FPU on F4/F7 devices.
 - Fixed a bug where emscripten `register_*_callback/1` functions would use x[1] as second argument
+- Fixed precision of integers used with timers which could yield to halts and wait times smaller than expected
 
 ### Changed
 
 - Crypto functions on generic_unix platform now rely on MbedTLS instead of OpenSSL
+- Platform function providing time used by timers was changed from `sys_monotonic_millis` to `sys_monotonic_time_u64`, `sys_monotonic_time_u64_to_ms` and `sys_monotonic_time_ms_to_u64`.
 
 ### Added
 

--- a/src/libAtomVM/sys.h
+++ b/src/libAtomVM/sys.h
@@ -200,7 +200,7 @@ enum OpenAVMResult sys_open_avm_from_file(
 /**
  * @brief gets wall clock time
  *
- * @details gets system wall clock time.
+ * @details gets system wall clock time, used by `erlang:system_time/1`
  * @param t the timespec that will be updated.
  */
 void sys_time(struct timespec *t);
@@ -208,21 +208,35 @@ void sys_time(struct timespec *t);
 /**
  * @brief gets monotonic time
  *
- * @details gets monotonic time. Must have the same origin as
- * `sys_monotonic_millis`.
+ * @details gets the time that is used by `erlang:monotonic_time/1`
  * @param t the timespec that will be updated.
  */
 void sys_monotonic_time(struct timespec *t);
 
 /**
- * @brief gets monotonic time in milliseconds.
- * @details This function must have the same origin as `sys_monotonic_time`.
- * The native format depends on platform and this function should be fast as it
- * is used in timers.
+ * @brief gets monotonic time for timers
+ * @details This function must return a non-overflowing counter in the highest
+ * precision the platform permits to make sure that we don't have truncation
+ * errors when compared with sys_time or sys_monotonic_time.
+ * Returning the number of microseconds or nanoseconds since boot would work.
  *
- * @return a monotonic time in milliseconds
+ * @return a monotonic time in a system-chosen unit
  */
-uint64_t sys_monotonic_millis();
+uint64_t sys_monotonic_time_u64();
+
+/**
+ * @brief convert a number of milliseconds to system-chosen unit
+ * @param ms the number of milliseconds to convert
+ * @return the result of the conversion
+ */
+uint64_t sys_monotonic_time_ms_to_u64(uint64_t ms);
+
+/**
+ * @brief convert a number in system-chosen unit to milliseconds
+ * @param t the number to convert
+ * @return the result of the conversion
+ */
+uint64_t sys_monotonic_time_u64_to_ms(uint64_t t);
 
 /**
  * @brief Loads a BEAM module using platform dependent methods.

--- a/src/platforms/emscripten/src/lib/sys.c
+++ b/src/platforms/emscripten/src/lib/sys.c
@@ -578,11 +578,21 @@ void sys_monotonic_time(struct timespec *t)
     }
 }
 
-uint64_t sys_monotonic_millis()
+uint64_t sys_monotonic_time_u64()
 {
-    struct timespec ts;
-    sys_monotonic_time(&ts);
-    return (ts.tv_nsec / 1000000UL) + (ts.tv_sec * 1000UL);
+    // 2^64/10^9/86400/365 around 585 years
+    double now = emscripten_get_now() * 1000000.0;
+    return (uint64_t) now;
+}
+
+uint64_t sys_monotonic_time_ms_to_u64(uint64_t ms)
+{
+    return ms * 1000000;
+}
+
+uint64_t sys_monotonic_time_u64_to_ms(uint64_t t)
+{
+    return t / 1000000;
 }
 
 static emscripten_fetch_t *fetch_file(const char *url)

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -167,21 +167,30 @@ void sys_time(struct timespec *t)
     }
 
     t->tv_sec = tv.tv_sec;
-    t->tv_nsec = tv.tv_usec * 1000;
+    t->tv_nsec = (uint_least64_t) tv.tv_usec * 1000;
 }
 
 void sys_monotonic_time(struct timespec *t)
 {
-    int64_t us_since_boot = esp_timer_get_time();
+    uint64_t us_since_boot = (uint64_t) esp_timer_get_time();
 
-    t->tv_sec = us_since_boot / 1000000UL;
-    t->tv_nsec = (us_since_boot % 1000000UL) * 1000UL;
+    t->tv_sec = us_since_boot / 1000000;
+    t->tv_nsec = (us_since_boot % 1000000) * 1000;
 }
 
-uint64_t sys_monotonic_millis()
+uint64_t sys_monotonic_time_u64()
 {
-    int64_t usec = esp_timer_get_time();
-    return usec / 1000UL;
+    return esp_timer_get_time();
+}
+
+uint64_t sys_monotonic_time_ms_to_u64(uint64_t ms)
+{
+    return ms * 1000;
+}
+
+uint64_t sys_monotonic_time_u64_to_ms(uint64_t t)
+{
+    return t / 1000;
 }
 
 void sys_init_platform(GlobalContext *glb)

--- a/src/platforms/rp2040/src/lib/sys.c
+++ b/src/platforms/rp2040/src/lib/sys.c
@@ -154,6 +154,8 @@ void sys_poll_events(GlobalContext *glb, int timeout_ms)
         }
         mutex_exit(&platform->event_poll_mutex);
     }
+#else
+    UNUSED(timeout_ms);
 #endif
     queue_t *event = NULL;
     while (queue_try_remove(&platform->event_queue, &event)) {
@@ -203,11 +205,20 @@ void sys_monotonic_time(struct timespec *t)
     t->tv_sec = (usec / 1000000);
 }
 
-uint64_t sys_monotonic_millis()
+uint64_t sys_monotonic_time_u64()
 {
     absolute_time_t now = get_absolute_time();
-    uint64_t usec = to_us_since_boot(now);
-    return usec / 1000;
+    return to_us_since_boot(now);
+}
+
+uint64_t sys_monotonic_time_ms_to_u64(uint64_t ms)
+{
+    return ms * 1000;
+}
+
+uint64_t sys_monotonic_time_u64_to_ms(uint64_t t)
+{
+    return t / 1000;
 }
 
 enum OpenAVMResult sys_open_avm_from_file(

--- a/src/platforms/rp2040/tests/package-lock.json
+++ b/src/platforms/rp2040/tests/package-lock.json
@@ -7,7 +7,7 @@
       "name": "rp2040_tests",
       "dependencies": {
         "@tsconfig/node20": "^20.1.2",
-        "rp2040js": "^0.19.1",
+        "rp2040js": "^0.19.3",
         "sync-fetch": "^0.5.2",
         "tsx": "^3.12.8",
         "typescript": "^5.2.2",
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/rp2040js": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/rp2040js/-/rp2040js-0.19.1.tgz",
-      "integrity": "sha512-+k/sv5Qe/zZA6ZopLypP6ytzvyP/0neKSNayv9SkEyaaMb8seHfSIoYtpTND9hdfmJC85ZZI27CYw1vPtsXrNA==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/rp2040js/-/rp2040js-0.19.3.tgz",
+      "integrity": "sha512-4isDSWdItg0P1sDprv4E04/xy0jyrajIAf7Qrb4t5cW9T2NOjG6MNoGCD7qAjYz4YbJcAQOEi4abZpp7lb1DrA==",
       "engines": {
         "node": ">=16.0.0"
       }

--- a/src/platforms/rp2040/tests/package.json
+++ b/src/platforms/rp2040/tests/package.json
@@ -3,7 +3,7 @@
   "description": "Tests using rp2040js emulator",
   "dependencies": {
     "@tsconfig/node20": "^20.1.2",
-    "rp2040js": "^0.19.1",
+    "rp2040js": "^0.19.3",
     "sync-fetch": "^0.5.2",
     "tsx": "^3.12.8",
     "typescript": "^5.2.2",

--- a/src/platforms/rp2040/tests/test_erl_sources/test_clocks.erl
+++ b/src/platforms/rp2040/tests/test_erl_sources/test_clocks.erl
@@ -34,8 +34,6 @@ start() ->
         true ->
             ok
     end,
-    % give time to the emulator to synchronize rtc time and system time
-    timer:sleep(500),
     test_clock(system_time_after_set_rtc, fun() -> erlang:system_time(millisecond) end),
     NewDate = erlang:universaltime(),
     if

--- a/src/platforms/stm32/src/lib/avm_log.h
+++ b/src/platforms/stm32/src/lib/avm_log.h
@@ -80,25 +80,25 @@ enum AVMLogLevel
 
 #define AVM_LOGE(tag, format, ...)                                                                                                               \
     do {                                                                                                                                         \
-        uint64_t logtime = sys_monotonic_millis();                                                                                               \
+        uint64_t logtime = sys_monotonic_time_u64();                                                                                             \
         if (LOG_LEVEL_MAX >= LOG_ERROR)                                                                                                          \
             printf(LOG_COLOR_ERROR "ERROR [%llu] %s: " format " (%s:%i)" LOG_RESET_COLOR "\n", logtime, tag, ##__VA_ARGS__, __FILE__, __LINE__); \
     } while (0)
 #define AVM_LOGW(tag, format, ...)                                                                                                    \
     do {                                                                                                                              \
-        uint64_t logtime = sys_monotonic_millis();                                                                                    \
+        uint64_t logtime = sys_monotonic_time_u64();                                                                                  \
         if (LOG_LEVEL_MAX >= LOG_WARN)                                                                                                \
             printf(LOG_COLOR_WARN "WARN [%llu] %s: " format LINE_FORMAT LOG_RESET_COLOR "\n", logtime, tag, ##__VA_ARGS__ LINE_DATA); \
     } while (0)
 #define AVM_LOGI(tag, format, ...)                                                                                                    \
     do {                                                                                                                              \
-        uint64_t logtime = sys_monotonic_millis();                                                                                    \
+        uint64_t logtime = sys_monotonic_time_u64();                                                                                  \
         if (LOG_LEVEL_MAX >= LOG_INFO)                                                                                                \
             printf(LOG_COLOR_INFO "INFO [%llu] %s: " format LINE_FORMAT LOG_RESET_COLOR "\n", logtime, tag, ##__VA_ARGS__ LINE_DATA); \
     } while (0)
 #define AVM_LOGD(tag, format, ...)                                                                                                      \
     do {                                                                                                                                \
-        uint64_t logtime = sys_monotonic_millis();                                                                                      \
+        uint64_t logtime = sys_monotonic_time_u64();                                                                                    \
         if (LOG_LEVEL_MAX >= LOG_DEBUG)                                                                                                 \
             printf(LOG_COLOR_DEBUG "DEBUG [%llu] %s: " format LINE_FORMAT LOG_RESET_COLOR "\n", logtime, tag, ##__VA_ARGS__ LINE_DATA); \
     } while (0)

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -97,7 +97,7 @@ void sys_tick_handler()
 
 static inline void sys_clock_gettime(struct timespec *t)
 {
-    uint64_t now = sys_monotonic_millis();
+    uint64_t now = sys_monotonic_time_u64();
     t->tv_sec = (time_t) now / 1000;
     t->tv_nsec = ((int32_t) now % 1000) * 1000000;
 }
@@ -221,9 +221,19 @@ void sys_monotonic_time(struct timespec *t)
     sys_clock_gettime(t);
 }
 
-uint64_t sys_monotonic_millis()
+uint64_t sys_monotonic_time_u64()
 {
     return system_millis;
+}
+
+uint64_t sys_monotonic_time_ms_to_u64(uint64_t ms)
+{
+    return ms;
+}
+
+uint64_t sys_monotonic_time_u64_to_ms(uint64_t t)
+{
+    return t;
 }
 
 enum OpenAVMResult sys_open_avm_from_file(


### PR DESCRIPTION
Fix a bug where truncation of system time would yield incoherent time measurement, as seen in flappy CI test with Pico.

Also fix a bug where late timers would eventually be ignored.

Eventually clean up promotion of integers in timers by using stdint.h uint_least64_t type instead of suffixes on constants.

List in #724 is old, yet this probably fixes the time out issue we had with several platforms.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
