### PR TITLE
Update macos CI to run on Ventura and trim updates on Homebrew dependencies

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-11"]
+        os: ["macos-13"]
         otp: ["24", "25", "26"]
 
     steps:
@@ -44,7 +44,7 @@ jobs:
         submodules: 'recursive'
 
     - name: "Install deps"
-      run: brew install gperf doxygen erlang@${{ matrix.otp }} ninja mbedtls
+      run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen erlang@${{ matrix.otp }} ninja mbedtls
 
     # Builder info
     - name: "System info"


### PR DESCRIPTION
Due to the outdated OS version, Homebrew ends up having to build most of the dependencies instead of installing them from bottles.

This change cuts the build time of dependencies from around 40 minutes to around 4 minutes.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
