### PR TITLE
CI: update esp-idf 5.1.x to 5.1.2

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -37,7 +37,7 @@ jobs:
         idf-version:
         - '4.4.6'
         - '5.0.4'
-        - '5.1.1'
+        - '5.1.2'
 
     steps:
     - name: Checkout repo


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
