### PR TITLE
Fix a C++ illegal pointer cast ESP IDF 5.1 doesn't like

### DIFF
--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -148,7 +148,7 @@ static inline term interop_kv_get_value(term kv, AtomString key, GlobalContext *
 
 static inline term interop_bytes_to_list(const void *bytes, int len, Heap *heap)
 {
-    const uint8_t *bytes_u8 = bytes;
+    const uint8_t *bytes_u8 = (const uint8_t *) bytes;
 
     term l = term_nil();
     for (int i = len - 1; i >= 0; i--) {


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
