### PR TITLE
externalterm: fix a warning related to integer promotion

### DIFF
--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -626,7 +626,7 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
         }
 
         case SMALL_BIG_EXT: {
-            uint8_t num_bytes = external_term_buf[1];
+            size_t num_bytes = external_term_buf[1];
             if (UNLIKELY(num_bytes > 8 || remaining < (SMALL_BIG_EXT_BASE_SIZE + num_bytes))) {
                 return INVALID_TERM_SIZE;
             }


### PR DESCRIPTION
`size_t < uint8_t + constant` causes a warning due to promotion of `uint8_t + constant` to int.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
