### PR TITLE
Fix some warnings by using size_t where it makes sense

### DIFF
--- a/src/libAtomVM/debug.c
+++ b/src/libAtomVM/debug.c
@@ -25,7 +25,7 @@ static COLD_FUNC void debug_display_type(term t, const Context *ctx)
     if (term_is_atom(t) || term_is_integer(t) || term_is_nil(t) || term_is_pid(t)) {
         term_display(stderr, t, ctx);
     } else if ((t & 0x3F) == 0) {
-        fprintf(stderr, "tuple(%i)", term_get_size_from_boxed_header(t));
+        fprintf(stderr, "tuple(%zu)", term_get_size_from_boxed_header(t));
     } else if (term_is_boxed(t)) {
         fprintf(stderr, "boxed(0x%lx)", (unsigned long) term_to_term_ptr(t));
     } else if ((t & 0x3) == 0x1) {

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -329,7 +329,7 @@ static inline int term_is_movable_boxed(term t)
  * @param header the boxed term header.
  * @return the size of the boxed term that follows the header. 0 is returned if the boxed term is just the header.
  */
-static inline int term_get_size_from_boxed_header(term header)
+static inline size_t term_get_size_from_boxed_header(term header)
 {
     return header >> 6;
 }
@@ -342,7 +342,7 @@ static inline int term_get_size_from_boxed_header(term header)
  * @return size of given term.
  *
  */
-static inline int term_boxed_size(term t)
+static inline size_t term_boxed_size(term t)
 {
     /* boxed: 10 */
     TERM_DEBUG_ASSERT((t & 0x3) == 0x2);
@@ -874,7 +874,7 @@ static inline term term_from_local_process_id(uint32_t local_process_id)
  * @param size the intended binary size
  * @return true if the binary should be allocated in the process heap; false, otherwise.
  */
-static inline bool term_binary_size_is_heap_binary(uint32_t size)
+static inline bool term_binary_size_is_heap_binary(size_t size)
 {
     return size < REFC_BINARY_MIN;
 }
@@ -886,7 +886,7 @@ static inline bool term_binary_size_is_heap_binary(uint32_t size)
  * @param size the size in bytes
  * @return the count of terms
  */
-static inline size_t term_binary_data_size_in_terms(uint32_t size)
+static inline size_t term_binary_data_size_in_terms(size_t size)
 {
     if (term_binary_size_is_heap_binary(size)) {
 #if TERM_BYTES == 4
@@ -908,7 +908,7 @@ static inline size_t term_binary_data_size_in_terms(uint32_t size)
  * @param size the size of the binary (in bytes)
  * @return the size (in terms) of a binary of size-many bytes in the heap
  */
-static inline size_t term_binary_heap_size(uint32_t size)
+static inline size_t term_binary_heap_size(size_t size)
 {
     return term_binary_data_size_in_terms(size) + BINARY_HEADER_SIZE;
 }
@@ -979,7 +979,7 @@ static inline const char *term_binary_data(term t)
 * @param glb the global context as refc binaries are global
 * @return a term pointing to the boxed binary pointer.
 */
-static inline term term_create_uninitialized_binary(uint32_t size, Heap *heap, GlobalContext *glb)
+static inline term term_create_uninitialized_binary(size_t size, Heap *heap, GlobalContext *glb)
 {
     if (term_binary_size_is_heap_binary(size)) {
         size_t size_in_terms = term_binary_data_size_in_terms(size);
@@ -1004,7 +1004,7 @@ static inline term term_create_uninitialized_binary(uint32_t size, Heap *heap, G
  * @param glb the global context as refc binaries are global
  * @return a term pointing to the boxed binary pointer.
  */
-static inline term term_from_literal_binary(const void *data, uint32_t size, Heap *heap, GlobalContext *glb)
+static inline term term_from_literal_binary(const void *data, size_t size, Heap *heap, GlobalContext *glb)
 {
     term binary = term_create_uninitialized_binary(size, heap, glb);
     memcpy((void *) term_binary_data(binary), data, size);
@@ -1062,7 +1062,7 @@ static inline void term_set_refc_binary_data(term t, const void *data)
     boxed_value[3] = (term) data;
 }
 
-static inline term term_from_const_binary(const void *data, uint32_t size, Heap *heap, GlobalContext *glb)
+static inline term term_from_const_binary(const void *data, size_t size, Heap *heap, GlobalContext *glb)
 {
     term binary = term_alloc_refc_binary(size, true, heap, glb);
     term_set_refc_binary_data(binary, data);
@@ -1078,7 +1078,7 @@ static inline term term_from_const_binary(const void *data, uint32_t size, Heap 
 * @param glb the global context as refc binaries are global
 * @return a term pointing to the boxed binary pointer.
 */
-static inline term term_create_empty_binary(uint32_t size, Heap *heap, GlobalContext *glb)
+static inline term term_create_empty_binary(size_t size, Heap *heap, GlobalContext *glb)
 {
     term t = term_create_uninitialized_binary(size, heap, glb);
     memset((char *) term_binary_data(t), 0x00, size);
@@ -1596,12 +1596,12 @@ static inline size_t term_get_map_value_offset()
     return 2;
 }
 
-static inline int term_map_size_in_terms_maybe_shared(size_t num_entries, bool is_shared)
+static inline size_t term_map_size_in_terms_maybe_shared(size_t num_entries, bool is_shared)
 {
     return is_shared ? TERM_MAP_SHARED_SIZE(num_entries) : TERM_MAP_SIZE(num_entries);
 }
 
-static inline int term_map_size_in_terms(size_t num_entries)
+static inline size_t term_map_size_in_terms(size_t num_entries)
 {
     return TERM_MAP_SIZE(num_entries);
 }

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -886,7 +886,7 @@ static inline bool term_binary_size_is_heap_binary(uint32_t size)
  * @param size the size in bytes
  * @return the count of terms
  */
-static inline int term_binary_data_size_in_terms(uint32_t size)
+static inline size_t term_binary_data_size_in_terms(uint32_t size)
 {
     if (term_binary_size_is_heap_binary(size)) {
 #if TERM_BYTES == 4
@@ -908,7 +908,7 @@ static inline int term_binary_data_size_in_terms(uint32_t size)
  * @param size the size of the binary (in bytes)
  * @return the size (in terms) of a binary of size-many bytes in the heap
  */
-static inline int term_binary_heap_size(uint32_t size)
+static inline size_t term_binary_heap_size(uint32_t size)
 {
     return term_binary_data_size_in_terms(size) + BINARY_HEADER_SIZE;
 }
@@ -982,7 +982,7 @@ static inline const char *term_binary_data(term t)
 static inline term term_create_uninitialized_binary(uint32_t size, Heap *heap, GlobalContext *glb)
 {
     if (term_binary_size_is_heap_binary(size)) {
-        int size_in_terms = term_binary_data_size_in_terms(size);
+        size_t size_in_terms = term_binary_data_size_in_terms(size);
 
         term *boxed_value = memory_heap_alloc(heap, size_in_terms + 1);
         boxed_value[0] = (size_in_terms << 6) | TERM_BOXED_HEAP_BINARY;


### PR DESCRIPTION
Fix signed/unsigned warnings and use a better type for function returning bytes or terms.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
