### PR TITLE
Fix empty struct warning

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -114,7 +114,7 @@ typedef dreg_t dreg_gc_safe_t;
 #define T_DEST_REG_GC_SAFE(dreg) T_DEST_REG(dreg)
 #else
 
-typedef struct {} dreg_t;
+TYPEDEF_EMPTY_STRUCT(dreg_t)
 typedef dreg_t dreg_gc_safe_t;
 
 #endif

--- a/src/libAtomVM/utils.h
+++ b/src/libAtomVM/utils.h
@@ -296,4 +296,18 @@ static inline __attribute__((always_inline)) void *cast_func_to_void_ptr(func_pt
     #define UNREACHABLE(...)
 #endif
 
+/**
+ * The following is a woraround for disabling "warning: struct has no members [-Wpedantic]"
+ */
+#ifdef __GNUC__
+    #define TYPEDEF_EMPTY_STRUCT(name) \
+        _Pragma("GCC diagnostic push") \
+        _Pragma("GCC diagnostic ignored \"-Wpedantic\"") \
+        typedef struct {} name; \
+        _Pragma("GCC diagnostic pop")
+#else
+    #define TYPEDEF_EMPTY_STRUCT(name) \
+        typedef struct {int dummy} name;
+#endif
+
 #endif


### PR DESCRIPTION
Empty structs are just a (useful) GCC extension, so let's use them on GCC (while also locally disabling pedantic).
On other compilers just define an 'int dummy' inside of it.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
