### PR TITLE
Allow disabling pedantic GCC flag

### DIFF
--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -95,11 +95,16 @@ set(SOURCE_FILES
     valueshashtable.c
 )
 
+option(AVM_PEDANTIC_WARNINGS "Pedantic compiler warnings" ON)
+if (AVM_PEDANTIC_WARNINGS)
+    set(MAYBE_PEDANTIC_FLAG "-pedantic")
+endif()
+
 add_library(libAtomVM ${SOURCE_FILES} ${HEADER_FILES})
 target_include_directories(libAtomVM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(libAtomVM PUBLIC c_std_11)
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(libAtomVM PUBLIC -Wall -pedantic -Wextra -ggdb -Werror=incompatible-pointer-types)
+    target_compile_options(libAtomVM PUBLIC -Wall ${MAYBE_PEDANTIC_FLAG} -Wextra -ggdb -Werror=incompatible-pointer-types)
 elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
     target_compile_options(libAtomVM PUBLIC -Wall --extra-warnings -Werror=incompatible-pointer-types)
 endif()

--- a/src/platforms/esp32/components/libatomvm/CMakeLists.txt
+++ b/src/platforms/esp32/components/libatomvm/CMakeLists.txt
@@ -19,6 +19,11 @@
 #
 
 idf_component_register(INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../libAtomVM")
+
+# GCC complains about "warning: #include_next is a GCC extension" when using pedantic flag
+# "pedantic" flag should be disabled rather poluting diagnostics with warnings caused from 3rd party
+option(AVM_PEDANTIC_WARNINGS "Pedantic compiler warnings" OFF)
+
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../../../libAtomVM" "libAtomVM")
 
 target_link_libraries(${COMPONENT_LIB}


### PR DESCRIPTION
Introduce new `AVM_PEDANTIC_WARNINGS` cmake option and set it to ON on ESP32.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
