### PR TITLE
Implement `esp:get_default_mac/0` based on `esp_efuse_mac_get_default`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `crypto:strong_rand_bytes/1` using Mbed-TLS (only on generic_unix, ESP32 and RP2040
   platforms)
 - Added support for setting the default receive buffer size for sockets via `socket:setopt/3`
+- Added `esp:get_default_mac/0` for retrieving the default MAC address on ESP32.
 
 ### Removed
 

--- a/libs/eavmlib/src/esp.erl
+++ b/libs/eavmlib/src/esp.erl
@@ -46,7 +46,8 @@
     rtc_slow_get_binary/0,
     rtc_slow_set_binary/1,
     freq_hz/0,
-    get_mac/1
+    get_mac/1,
+    get_default_mac/0
 ]).
 
 -deprecated([
@@ -386,4 +387,18 @@ freq_hz() ->
 %%-----------------------------------------------------------------------------
 -spec get_mac(Interface :: interface()) -> mac().
 get_mac(_Interface) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns The default MAC address of the ESP32 device.
+%% @doc     Retrieve the default MAC address of the ESP32 device.
+%%          This function accesses the EFUSE memory of the ESP32 and reads
+%%          the factory-programmed MAC address.
+%%
+%%          The mac address is returned as a 6-byte binary, per the
+%%          IEEE 802 family of specifications.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec get_default_mac() -> {ok, mac()} | {error, atom()}.
+get_default_mac() ->
     erlang:nif_error(undefined).

--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -29,6 +29,7 @@
 #include "memory.h"
 #include "nifs.h"
 #include "platform_defaultatoms.h"
+#include "port.h"
 #include "term.h"
 
 #include "esp_log.h"
@@ -492,6 +493,31 @@ static term nif_esp_get_mac(Context *ctx, int argc, term argv[])
     return term_from_literal_binary(mac, 6, &ctx->heap, ctx->global);
 }
 
+static term nif_esp_get_default_mac(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    UNUSED(argv);
+
+    uint8_t mac[6];
+    esp_err_t err = esp_efuse_mac_get_default(mac);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Unable to read default mac.  err=%i", err);
+        return port_create_error_tuple(ctx, esp_err_to_term(ctx->global, err));
+    }
+
+    if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2) + term_binary_heap_size(6)) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    term mac_term = term_from_literal_binary(mac, 6, &ctx->heap, ctx->global);
+
+    term result = term_alloc_tuple(2, &ctx->heap);
+    term_put_tuple_element(result, 0, OK_ATOM);
+    term_put_tuple_element(result, 1, mac_term);
+
+    return result;
+}
+
 //
 // NIF structures and dispatch
 //
@@ -575,6 +601,11 @@ static const struct Nif esp_get_mac_nif =
     .base.type = NIFFunctionType,
     .nif_ptr = nif_esp_get_mac
 };
+static const struct Nif esp_get_default_mac_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_esp_get_default_mac
+};
 
 const struct Nif *platform_nifs_get_nif(const char *nifname)
 {
@@ -649,6 +680,10 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
     if (strcmp("esp:get_mac/1", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &esp_get_mac_nif;
+    }
+    if (strcmp("esp:get_default_mac/0", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &esp_get_default_mac_nif;
     }
     const struct Nif *nif = nif_collection_resolve_nif(nifname);
     if (nif) {


### PR DESCRIPTION
Add `get_default_mac` function to retrieve the default MAC address from the EFUSE block of the ESP32 chip. This function utilizes the `esp_efuse_mac_get_default` API to access the factory-programmed MAC address.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
