### PR TITLE
Static mbedtls x86_64 build

### DIFF
--- a/.github/workflows/build-linux-artifacts.yaml
+++ b/.github/workflows/build-linux-artifacts.yaml
@@ -121,6 +121,22 @@ jobs:
           cflags: ""
 
         - arch: "x86_64"
+          build_name: "linux-x86_64-static-mbedtls"
+          docker_image: "ubuntu"
+          platform: "amd64"
+          tag: "18.04"
+          cflags: ""
+          cmake_opts: "-DAVM_STATIC_MBEDTLS=ON"
+          install_deps: |
+            apt update &&
+            apt install -y file gcc g++ binutils make doxygen gperf zlib1g-dev libmbedtls-dev wget tzdata &&
+            apt purge -y cmake &&
+            wget https://cmake.org/files/v3.13/cmake-3.13.5-Linux-x86_64.tar.gz &&
+            tar xf cmake-3.13.5-Linux-x86_64.tar.gz &&
+            mv cmake-3.13.5-Linux-x86_64 /opt/cmake-3.13.5 &&
+            ln -sf /opt/cmake-3.13.5/bin/* /usr/bin/
+
+        - arch: "x86_64"
           build_name: "linux-x86_64"
           docker_image: "ubuntu"
           platform: "amd64"


### PR DESCRIPTION
Also build x86_64 artifact with builtin (static linked) mbedtls.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
