### PR TITLE
Add support for esp32c6

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -68,7 +68,7 @@ jobs:
             gcc g++ zlib1g-dev
 
     - name: Install qemu binary from espressif/qemu
-      if: matrix.idf-version != '5.1.1'
+      if: matrix.idf-version != '5.1.2'
       run: |
         set -eu
         QEMU_VER=esp-develop-20220919

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -35,14 +35,17 @@ jobs:
 
     strategy:
       matrix:
-        idf-version: ["4.4.6"]
+        idf-version: ["4.4.6", "5.1.2"]
         cc: ["clang-10"]
         cxx: ["clang++-10"]
         cflags: ["-O3"]
         otp: ["24"]
         elixir_version: ["1.11"]
         compiler_pkgs: ["clang-10"]
-        soc: ["esp32", "esp32c3", "esp32s2", "esp32s3"]
+        soc: ["esp32", "esp32c3", "esp32s2", "esp32s3", "esp32c6"]
+        exclude:
+        - soc: "esp32c6"
+          idf-version: "4.4.6"
 
     env:
       CC: ${{ matrix.cc }}

--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -551,6 +551,7 @@ static term nif_gpio_hold_dis(Context *ctx, int argc, term argv[])
     return hold_dis(argv[0]);
 }
 
+#if !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
 static term nif_gpio_deep_sleep_hold_en(Context *ctx, int argc, term argv[])
 {
     UNUSED(ctx);
@@ -570,6 +571,7 @@ static term nif_gpio_deep_sleep_hold_dis(Context *ctx, int argc, term argv[])
     gpio_deep_sleep_hold_dis();
     return OK_ATOM;
 }
+#endif
 
 static term nif_gpio_digital_write(Context *ctx, int argc, term argv[])
 {
@@ -605,6 +607,7 @@ static const struct Nif gpio_hold_dis_nif =
     .nif_ptr = nif_gpio_hold_dis
 };
 
+#if !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
 static const struct Nif gpio_deep_sleep_hold_en_nif =
 {
     .base.type = NIFFunctionType,
@@ -616,6 +619,7 @@ static const struct Nif gpio_deep_sleep_hold_dis_nif =
     .base.type = NIFFunctionType,
     .nif_ptr = nif_gpio_deep_sleep_hold_dis
 };
+#endif
 
 static const struct Nif gpio_digital_write_nif =
 {
@@ -654,6 +658,7 @@ const struct Nif *gpio_nif_get_nif(const char *nifname)
         return &gpio_hold_dis_nif;
     }
 
+#if !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
     if (strcmp("gpio:deep_sleep_hold_en/0", nifname) == 0 || strcmp("Elixir.GPIO:deep_sleep_hold_en/0", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &gpio_deep_sleep_hold_en_nif;
@@ -663,6 +668,7 @@ const struct Nif *gpio_nif_get_nif(const char *nifname)
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &gpio_deep_sleep_hold_dis_nif;
     }
+#endif
 
     if (strcmp("gpio:digital_write/2", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -113,9 +113,23 @@ static const AtomStringIntPair spi_cmd_table[] = {
 };
 
 static const AtomStringIntPair spi_host_table[] = {
+// aliases for different chips, deprecated for the chips after esp32s2
+#ifdef SPI_HOST
+    { ATOM_STR("\x3", "spi"), SPI_HOST },
+#endif
+#ifdef HSPI_HOST
     { ATOM_STR("\x4", "hspi"), HSPI_HOST },
-#ifndef CONFIG_IDF_TARGET_ESP32C3
+#endif
+#ifdef VSPI_HOST
     { ATOM_STR("\x4", "vspi"), VSPI_HOST },
+#endif
+#ifdef FSPI_HOST
+    { ATOM_STR("\x4", "fspi"), FSPI_HOST },
+#endif
+    { ATOM_STR("\x4", "spi1"), SPI1_HOST },
+    { ATOM_STR("\x4", "spi2"), SPI2_HOST },
+#if SOC_SPI_PERIPH_NUM > 2
+    { ATOM_STR("\x4", "spi3"), SPI3_HOST },
 #endif
     SELECT_INT_DEFAULT(-1)
 };
@@ -125,8 +139,8 @@ static spi_host_device_t get_spi_host_device(term spi_peripheral, GlobalContext 
     int peripheral = interop_atom_term_select_int(spi_host_table, spi_peripheral, global);
 
     if (peripheral < 0) {
-        ESP_LOGW(TAG, "Unrecognized SPI peripheral.  Must be either hspi or vspi.  Defaulting to hspi.");
-        return HSPI_HOST;
+        ESP_LOGW(TAG, "Unrecognized SPI peripheral.  Defaulting to spi2.");
+        return SPI2_HOST;
     }
 
     return peripheral;


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
