### PR TITLE
Fix a crash related to i2c close

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/i2c_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/i2c_driver.c
@@ -178,6 +178,7 @@ static void i2c_driver_close(Context *ctx)
         ESP_LOGW(TAG, "Failed to delete I2C driver.  err=%i", err);
     }
     free(ctx->platform_data);
+    ctx->platform_data = NULL;
 }
 
 static term i2cdriver_begin_transmission(Context *ctx, term pid, term req)


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
