### PR TITLE
Fix esp32 mkimage matrix by only generating 5.1.2 images

### DIFF
--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        idf-version: ["4.4.6", "5.1.2"]
+        idf-version: ["5.1.2"]
         cc: ["clang-10"]
         cxx: ["clang++-10"]
         cflags: ["-O3"]
@@ -43,9 +43,6 @@ jobs:
         elixir_version: ["1.11"]
         compiler_pkgs: ["clang-10"]
         soc: ["esp32", "esp32c3", "esp32s2", "esp32s3", "esp32c6"]
-        exclude:
-        - soc: "esp32c6"
-          idf-version: "4.4.6"
 
     env:
       CC: ${{ matrix.cc }}


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
