### PR TITLE
Enable `-Werror` when safe

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -65,7 +65,7 @@ jobs:
       working-directory: build
       run: |
         export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
-        cmake -G Ninja ..
+        cmake -DAVM_WARNINGS_ARE_ERRORS=ON -G Ninja ..
 
     - name: "Build: run ninja"
       working-directory: build

--- a/.github/workflows/build-and-test-on-freebsd.yaml
+++ b/.github/workflows/build-and-test-on-freebsd.yaml
@@ -73,7 +73,7 @@ jobs:
           echo "%%"
           mkdir build
           cd build
-          cmake .. -DMBEDTLS_ROOT_DIR=/usr/local
+          cmake .. -DMBEDTLS_ROOT_DIR=/usr/local -DAVM_WARNINGS_ARE_ERRORS=ON
 
           echo "%%"
           echo "%% Building AtomVM ..."

--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -104,17 +104,20 @@ jobs:
           platform: "arm/v7"
           tag: "bullseye"
           cflags: "-mcpu=cortex-a7 -mfloat-abi=hard -O2 -mthumb -mthumb-interwork"
+          cmake_opts: "-DAVM_WARNINGS_ARE_ERRORS=ON"
 
         - arch: "arm64v8"
           platform: "arm64/v8"
           tag: "bullseye"
           cflags: "-O2"
+          cmake_opts: "-DAVM_WARNINGS_ARE_ERRORS=ON"
 
         # Required for testing big endian archs
         - arch: "s390x"
           platform: "s390x"
           tag: "bullseye"
           cflags: "-O2"
+          cmake_opts: "-DAVM_WARNINGS_ARE_ERRORS=ON"
 
     steps:
     - name: Checkout repo

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -91,18 +91,26 @@ jobs:
         - cc: "gcc-10"
           cxx: "g++-10"
           compiler_pkgs: "gcc-10 g++-10"
+          # Use Werror for recent GCC versions that have better diagnostics
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
         - cc: "gcc-11"
           cxx: "g++-11"
           compiler_pkgs: "gcc-11 g++-11"
+          # Use Werror for recent GCC versions that have better diagnostics
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
         - cc: "gcc-12"
           cxx: "g++-12"
           compiler_pkgs: "gcc-12 g++-12"
+          # Use Werror for recent GCC versions that have better diagnostics
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
         - cc: "clang-10"
           cxx: "clang++-10"
           compiler_pkgs: "clang-10"
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
         - cc: "clang-11"
           cxx: "clang++-11"
           compiler_pkgs: "clang-11"
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
 #       - cc: "clang-12"
 #         cxx: "clang++-12"
 #         compiler_pkgs: "clang-12"
@@ -171,7 +179,8 @@ jobs:
           cflags: "-m32 -O3"
           otp: "23"
           elixir_version: "1.11"
-          cmake_opts_other: "-DAVM_CREATE_STACKTRACES=off"
+          # Use Werror so we get an error with 32 bit specific warnings
+          cmake_opts_other: "-DAVM_CREATE_STACKTRACES=off -DAVM_WARNINGS_ARE_ERRORS=ON"
           arch: "i386"
           compiler_pkgs: "gcc-10 g++-10 gcc-10-multilib g++-10-multilib libc6-dev-i386
           libc6-dbg:i386 zlib1g-dev:i386 libmbedtls-dev:i386"

--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -67,6 +67,7 @@ jobs:
         set -euo pipefail
         mkdir build.nosmp
         cd build.nosmp
+        # TODO: fix all warnings and enable -DAVM_WARNINGS_ARE_ERRORS=ON
         cmake .. -G Ninja -DPICO_BOARD=${{ matrix.board }} -DAVM_DISABLE_SMP=1
         cmake --build . --target=rp2040_tests
 

--- a/.github/workflows/stm32-build.yaml
+++ b/.github/workflows/stm32-build.yaml
@@ -77,5 +77,6 @@ jobs:
         export PATH=/home/runner/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin:${PATH}
         mkdir build
         cd build
+        # -DAVM_WARNINGS_ARE_ERRORS=ON
         cmake .. -DCMAKE_TOOLCHAIN_FILE=cmake/arm-toolchain.cmake -DLIBOPENCM3_DIR=/home/runner/libopencm3
         make -j

--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -56,7 +56,7 @@ jobs:
         set -e
         mkdir build
         cd build
-        cmake .. -G Ninja
+        cmake .. -G Ninja -DAVM_WARNINGS_ARE_ERRORS=ON
         ninja AtomVM atomvmlib test_eavmlib test_alisp hello_world run_script call_cast html5_events wasm_webserver
 
     - name: Upload AtomVM and test modules

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -100,13 +100,18 @@ if (AVM_PEDANTIC_WARNINGS)
     set(MAYBE_PEDANTIC_FLAG "-pedantic")
 endif()
 
+option(AVM_WARNINGS_ARE_ERRORS "Error on warning" OFF)
+if (AVM_WARNINGS_ARE_ERRORS)
+    set(MAYBE_WERROR_FLAG "-Werror")
+endif()
+
 add_library(libAtomVM ${SOURCE_FILES} ${HEADER_FILES})
 target_include_directories(libAtomVM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(libAtomVM PUBLIC c_std_11)
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(libAtomVM PUBLIC -Wall ${MAYBE_PEDANTIC_FLAG} -Wextra -ggdb -Werror=incompatible-pointer-types)
+    target_compile_options(libAtomVM PUBLIC -Wall ${MAYBE_PEDANTIC_FLAG} ${MAYBE_WERROR_FLAG} -Wextra -ggdb -Werror=incompatible-pointer-types)
 elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
-    target_compile_options(libAtomVM PUBLIC -Wall --extra-warnings -Werror=incompatible-pointer-types)
+    target_compile_options(libAtomVM PUBLIC -Wall --extra-warnings -Werror=incompatible-pointer-types ${MAYBE_WERROR_FLAG})
 endif()
 
 # AtomVM options used in libAtomVM


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
