### PR TITLE
tests: check chdir return value in order to fix a warning

### DIFF
--- a/tests/test.c
+++ b/tests/test.c
@@ -599,7 +599,8 @@ int test_module_execution(bool beam, struct Test *test)
 
 int test_modules_execution(bool beam, bool skip, int count, char **item)
 {
-    if (chdir("erlang_tests")) {
+    if (chdir("erlang_tests") != 0) {
+        perror("Error: ");
         return EXIT_FAILURE;
     }
 
@@ -666,7 +667,10 @@ int main(int argc, char **argv)
     fprintf(stderr, "Seed is %li\n", seed);
     srand(seed);
 
-    chdir(dirname(name));
+    if (chdir(dirname(name)) != 0) {
+        perror("Error: ");
+        return EXIT_FAILURE;
+    }
 
     int opt;
     bool beam = false;


### PR DESCRIPTION
Fix "error: ignoring return value of ‘chdir’ declared with attribute ‘warn_unused_result’".

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
