### PR TITLE
Fix clang warning and potential overflow

### DIFF
--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -46,9 +46,6 @@
         RAISE_ERROR(BADARG_ATOM);              \
     }
 
-#define INT64_MIN_AS_FLOAT (1.0 * INT64_MIN)
-#define INT64_MAX_AS_FLOAT (1.0 * INT64_MAX)
-
 const struct ExportedFunction *bif_registry_get_handler(AtomString module, AtomString function, int arity)
 {
     char bifname[MAX_BIF_NAME_LEN];
@@ -1016,7 +1013,7 @@ term bif_erlang_ceil_1(Context *ctx, int live, term arg1)
 
     if (term_is_float(arg1)) {
         avm_float_t fvalue = term_to_float(arg1);
-        if ((fvalue < INT64_MIN_AS_FLOAT) || (fvalue > INT64_MAX_AS_FLOAT)) {
+        if ((fvalue <= INT64_MIN_AS_AVM_FLOAT) || (fvalue >= INT64_MAX_AS_AVM_FLOAT)) {
             RAISE_ERROR(OVERFLOW_ATOM);
         }
 
@@ -1048,7 +1045,7 @@ term bif_erlang_floor_1(Context *ctx, int live, term arg1)
 
     if (term_is_float(arg1)) {
         avm_float_t fvalue = term_to_float(arg1);
-        if ((fvalue < INT64_MIN_AS_FLOAT) || (fvalue > INT64_MAX_AS_FLOAT)) {
+        if ((fvalue <= INT64_MIN_AS_AVM_FLOAT) || (fvalue >= INT64_MAX_AS_AVM_FLOAT)) {
             RAISE_ERROR(OVERFLOW_ATOM);
         }
 
@@ -1080,7 +1077,7 @@ term bif_erlang_round_1(Context *ctx, int live, term arg1)
 
     if (term_is_float(arg1)) {
         avm_float_t fvalue = term_to_float(arg1);
-        if ((fvalue < INT64_MIN_AS_FLOAT) || (fvalue > INT64_MAX_AS_FLOAT)) {
+        if ((fvalue <= INT64_MIN_AS_AVM_FLOAT) || (fvalue >= INT64_MAX_AS_AVM_FLOAT)) {
             RAISE_ERROR(OVERFLOW_ATOM);
         }
 
@@ -1112,7 +1109,7 @@ term bif_erlang_trunc_1(Context *ctx, int live, term arg1)
 
     if (term_is_float(arg1)) {
         avm_float_t fvalue = term_to_float(arg1);
-        if ((fvalue < INT64_MIN_AS_FLOAT) || (fvalue > INT64_MAX_AS_FLOAT)) {
+        if ((fvalue <= INT64_MIN_AS_AVM_FLOAT) || (fvalue >= INT64_MAX_AS_AVM_FLOAT)) {
             RAISE_ERROR(OVERFLOW_ATOM);
         }
 

--- a/src/libAtomVM/term_typedef.h
+++ b/src/libAtomVM/term_typedef.h
@@ -31,6 +31,7 @@
 #ifdef __cplusplus
 #include <climits>
 #else
+#include <assert.h>
 #include <limits.h>
 #endif
 #include <inttypes.h>
@@ -119,9 +120,23 @@ typedef uint64_t avm_uint64_t;
 #ifdef AVM_USE_SINGLE_PRECISION
     typedef float avm_float_t;
     #define AVM_FLOAT_FMT "%f"
+
+#ifndef __cplusplus
+    _Static_assert(sizeof(avm_float_t) == 4, "avm_float_t must be a 32-bit float");
+#endif
+
+    #define INT64_MIN_AS_AVM_FLOAT -9223372036854775808.0
+    #define INT64_MAX_AS_AVM_FLOAT 9223372036854775808.0
 #else
     typedef double avm_float_t;
     #define AVM_FLOAT_FMT "%lf"
+
+#ifndef __cplusplus
+    _Static_assert(sizeof(avm_float_t) == 8, "avm_float_t must be a 64-bit float");
+#endif
+
+    #define INT64_MIN_AS_AVM_FLOAT -9223372036854775808.0
+    #define INT64_MAX_AS_AVM_FLOAT 9223372036854775808.0
 #endif
 
 typedef union {


### PR DESCRIPTION
clang was reporting:
`error: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808
[-Werror,-Wimplicit-const-int-float-conversion]`

This change fixes that warning.

Also, there was an (unlikely) overflow with functions such as `erlang:ceil/1`, since the check was wrong due to that precision loss.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
