### PR TITLE
STM32: remove all additional warning switches

### DIFF
--- a/src/platforms/stm32/cmake/compile-flags.cmake
+++ b/src/platforms/stm32/cmake/compile-flags.cmake
@@ -27,17 +27,11 @@ set(CMAKE_C_EXTENSIONS NO)
 set(CMAKE_CXX_EXTENSIONS NO)
 
 # Flags that apply to both C and C++
-set(COMMON_WARN_FLAGS "${COMMON_WARN_FLAGS} -pedantic -Wall -Wextra \
--Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimization -Wdouble-promotion -Wduplicated-cond \
--Wduplicated-branches -Wfloat-equal -Wformat=2 -Winit-self -Winline -Winvalid-pch -Wlogical-op \
--Wmissing-declarations -Wmissing-format-attribute -Wmissing-include-dirs -Wno-unused -Wnull-dereference -Wodr \
--Wpointer-arith -Wredundant-decls -Wrestrict -Wshadow -Wsign-conversion -Wstrict-overflow=5 -Wswitch-default \
--Wswitch-enum -Wwrite-strings -Wundef -Wuninitialized -Wunreachable-code")
+set(COMMON_WARN_FLAGS "${COMMON_WARN_FLAGS} -pedantic -Wall -Wextra")
 
 # Flags that apply only to C OR C++
-set(C_WARN_FLAGS "${COMMON_WARN_FLAGS} -Wbad-function-cast -Wmissing-prototypes -Wnested-externs")
-set(CXX_WARN_FLAGS "${COMMON_WARN_FLAGS} -Wctor-dtor-privacy -Wnoexcept -Wold-style-cast -Woverloaded-virtual \
--Wsign-promo -Wstrict-null-sentinel -Wuseless-cast -Wzero-as-null-pointer-constant")
+set(C_WARN_FLAGS "${COMMON_WARN_FLAGS}")
+set(CXX_WARN_FLAGS "${COMMON_WARN_FLAGS}")
 
 # Use C and C++ compiler optimizatons for size and speed.
 if (${CMAKE_FLASH_SIZE} STREQUAL "ROM_512K")


### PR DESCRIPTION
They make too much noise, making hard to spot relevant issues.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
