### PR TITLE
Fix remaining warnings for STM32 platform

### DIFF
--- a/src/platforms/stm32/src/lib/gpio_driver.c
+++ b/src/platforms/stm32/src/lib/gpio_driver.c
@@ -529,6 +529,7 @@ void gpiodriver_init(GlobalContext *glb)
 
 static Context *gpio_driver_create_port(GlobalContext *global, term opts)
 {
+    UNUSED(opts);
     Context *ctx = context_new(global);
 
     struct GPIOData *gpio_data = malloc(sizeof(struct GPIOData));
@@ -983,6 +984,7 @@ static term nif_gpio_set_pin_mode(Context *ctx, int argc, term argv[])
 
 static term nif_gpio_set_pin_pull(Context *ctx, int argc, term argv[])
 {
+    UNUSED(ctx);
     UNUSED(argc);
     UNUSED(argv);
     AVM_LOGW(TAG, "Pull mode must be set using `gpio:set_pin_mode/2` arg #2 i.e. {Mode,PullMode}");

--- a/src/platforms/stm32/src/lib/gpio_driver.c
+++ b/src/platforms/stm32/src/lib/gpio_driver.c
@@ -931,18 +931,20 @@ static NativeHandlerResult consume_gpio_mailbox(Context *ctx)
             ret = gpiodriver_close(ctx);
             break;
 
-        case GPIOInvalidCmd:
+        case GPIOInvalidCmd: {
             char *invalid_name = interop_atom_to_string(ctx, cmd_term);
             AVM_LOGE(TAG, "Invalid command: %s", invalid_name);
             free(invalid_name);
             ret = create_pair(ctx, ERROR_ATOM, UNDEFINED_ATOM);
             break;
+        }
 
-        default:
+        default: {
             char *cmd_name = interop_atom_to_string(ctx, cmd_term);
             AVM_LOGE(TAG, "Unhandled error processing command: %s", cmd_name);
             free(cmd_name);
             ret = create_pair(ctx, ERROR_ATOM, BADMATCH_ATOM);
+        }
     }
 
     term ret_msg;

--- a/src/platforms/stm32/src/lib/gpio_driver.c
+++ b/src/platforms/stm32/src/lib/gpio_driver.c
@@ -870,6 +870,7 @@ static term gpiodriver_remove_int(Context *ctx, term cmd)
             if ((gpio_listener->gpio_pin == target_num) && (gpio_listener->bank_atom == target_bank_atom)) {
                 uint16_t exti = gpio_listener->exti;
                 uint8_t irqn = pin_num_to_exti_irq(gpio_listener->gpio_pin);
+                nvic_disable_irq(irqn);
                 list_remove(&gpio_listener->gpio_listener_list_head);
                 exti_disable_request(exti);
                 free(gpio_listener);

--- a/src/platforms/stm32/src/lib/gpio_driver.c
+++ b/src/platforms/stm32/src/lib/gpio_driver.c
@@ -544,7 +544,7 @@ static Context *gpio_driver_create_port(GlobalContext *global, term opts)
     if (UNLIKELY(!globalcontext_register_process(ctx->global, atom_index, ctx->process_id))) {
         scheduler_terminate(ctx);
         AVM_LOGE(TAG, "Only a single GPIO driver can be opened.");
-        return create_pair(ctx, ERROR_ATOM, USED_ATOM);
+        return NULL;
     }
 
     return ctx;

--- a/src/platforms/stm32/src/lib/stm_sys.h
+++ b/src/platforms/stm32/src/lib/stm_sys.h
@@ -152,7 +152,6 @@ extern struct NifCollectionDefListItem *nif_collection_list;
 void sys_enable_core_periph_clocks(void);
 bool sys_lock_pin(GlobalContext *glb, uint32_t gpio_bank, uint16_t pin_num);
 
-static Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts);
 void port_driver_init_all(GlobalContext *global);
 void port_driver_destroy_all(GlobalContext *global);
 

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -119,7 +119,7 @@ void platform_defaultatoms_init(GlobalContext *glb)
 void sys_enable_core_periph_clocks()
 {
     uint32_t list[] = GPIO_CLOCK_LIST;
-    for (int i = 0; i < sizeof(list) / sizeof(list[0]); i++) {
+    for (size_t i = 0; i < sizeof(list) / sizeof(list[0]); i++) {
         rcc_periph_clock_enable((enum rcc_periph_clken) list[i]);
     }
 #ifndef AVM_DISABLE_GPIO_PORT_DRIVER

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -236,9 +236,11 @@ uint64_t sys_monotonic_time_u64_to_ms(uint64_t t)
     return t;
 }
 
-enum OpenAVMResult sys_open_avm_from_file(
-    GlobalContext *global, const char *path, struct AVMPackData **data)
+enum OpenAVMResult sys_open_avm_from_file(GlobalContext *global, const char *path, struct AVMPackData **data)
 {
+    UNUSED(global);
+    UNUSED(path);
+    UNUSED(data);
     TRACE("sys_open_avm_from_file: Going to open: %s\n", path);
 
     // TODO
@@ -248,6 +250,8 @@ enum OpenAVMResult sys_open_avm_from_file(
 
 Module *sys_load_module_from_file(GlobalContext *global, const char *path)
 {
+    UNUSED(global);
+    UNUSED(path);
     // TODO
     return NULL;
 }
@@ -291,6 +295,8 @@ Context *sys_create_port(GlobalContext *glb, const char *driver_name, term opts)
 
 term sys_get_info(Context *ctx, term key)
 {
+    UNUSED(ctx);
+    UNUSED(key);
     return UNDEFINED_ATOM;
 }
 

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -62,11 +62,10 @@ static uint8_t *_heap_end = NULL;
  * This may be overridden by defining the function
  * `local_heap_setup` (exported in `stm_sys.h`).
  */
-static void
-__local_ram(uint8_t **start, uint8_t **end)
+static void __local_ram(uint8_t **start, uint8_t **end)
 {
     *start = &_ebss;
-    *end = (uint8_t *) (&_stack - RESERVE_STACK_SIZE);
+    *end = (uint8_t *) (((uintptr_t) &_stack - RESERVE_STACK_SIZE));
 }
 
 void *_sbrk_r(struct _reent *reent, ptrdiff_t diff)

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -41,6 +41,8 @@
 #define TAG "sys"
 #define RESERVE_STACK_SIZE 4096U
 
+static Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts);
+
 struct PortDriverDefListItem *port_driver_list;
 struct NifCollectionDefListItem *nif_collection_list;
 

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -103,11 +103,6 @@ static inline void sys_clock_gettime(struct timespec *t)
     t->tv_nsec = ((int32_t) now % 1000) * 1000000;
 }
 
-static int32_t timespec_diff_to_ms(struct timespec *timespec1, struct timespec *timespec2)
-{
-    return (int32_t) ((timespec1->tv_sec - timespec2->tv_sec) * 1000 + (timespec1->tv_nsec - timespec2->tv_nsec) / 1000000);
-}
-
 /* TODO: Needed because `defaultatoms_init` in libAtomVM/defaultatoms.c calls this function.
  * We should be able to remove this after `platform_defaulatoms.{c,h}` are removed on all platforms
  * and `defaultatoms_init` is no longer called.


### PR DESCRIPTION
This set of changes fixes the remaining warnings on the STM32 platform.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
