### PR TITLE
Fix missing memory allocation check in STM32 platorm

### DIFF
--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -173,6 +173,10 @@ bool sys_unlock_pin(GlobalContext *glb, uint32_t gpio_bank, uint16_t pin_num)
 void sys_init_platform(GlobalContext *glb)
 {
     struct STM32PlatformData *platform = malloc(sizeof(struct STM32PlatformData));
+    if (IS_NULL_PTR(platform)) {
+        AVM_LOGE(TAG, "Out of memory!");
+        AVM_ABORT();
+    }
     glb->platform_data = platform;
     list_init(&platform->locked_pins);
 }


### PR DESCRIPTION
Adds memory allocation check for the `STM32PlatformData` struct before use.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
