### PR TITLE
Add support to new I2C, SPI and UART peripheral names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `esp:get_default_mac/0` for retrieving the default MAC address on ESP32.
 - Added support for `pico` and `poci` as an alternative to `mosi` and `miso` for SPI
+- ESP32: Added support to SPI peripherals other than hspi and vspi
 
 ### Changed
 
 - Shorten SPI config options, such as `sclk_io_num` -> `sclk`
 - Shorten I2C config options, such as `scl_io_num` -> `scl`
 - Shorten UART config options, such as `tx_pin` -> `tx`
+- Introduced support to non-integer peripheral names, `"i2c0"`, `"uart1"` (instead of just `0` and
+- `1`, which now they are deprecated)
 
 ## [0.6.0-alpha.2] - 2023-12-10
 

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -1162,7 +1162,7 @@ The AtomVM I2C implementation uses the AtomVM Port mechanism and must be initial
 | `scl` | `integer()` | yes | I2C clock pin (SCL) |
 | `sda` | `integer()` | yes | I2C data pin (SDA) |
 | `clock_speed_hz` | `integer()` | yes | I2C clock frequency (in hertz) |
-| `peripheral` | `0 .. I2C_NUM_MAX - 1` | no (default: `0`) | I2C port number.  `I2C_NUM_MAX` is defined by the device SDK.  On ESP32, this value is 1. |
+| `peripheral` | `string() | binary()` | no (platform dependent default) | I2C peripheral, such as `"i2c0"` |
 
 For example,
 

--- a/libs/eavmlib/src/i2c.erl
+++ b/libs/eavmlib/src/i2c.erl
@@ -44,7 +44,9 @@
 
 -type pin() :: non_neg_integer().
 -type freq_hz() :: non_neg_integer().
--type param() :: {scl, pin()} | {sda, pin()} | {clock_speed_hz, freq_hz()}.
+-type peripheral() :: string() | binary().
+-type param() ::
+    {scl, pin()} | {sda, pin()} | {clock_speed_hz, freq_hz()} | {peripheral, peripheral()}.
 -type params() :: [param()].
 -type i2c() :: pid().
 -type address() :: non_neg_integer().
@@ -206,7 +208,13 @@ migrate_config([]) ->
 migrate_config([{K, V} | T]) ->
     NewK = rename_key(K),
     warn_deprecated(K, NewK),
-    [{NewK, V} | migrate_config(T)].
+    NewV = migrate_value(NewK, V),
+    [{NewK, NewV} | migrate_config(T)].
+
+migrate_value(peripheral, Peripheral) ->
+    validate_peripheral(Peripheral);
+migrate_value(_K, V) ->
+    V.
 
 rename_key(Key) ->
     case Key of
@@ -221,3 +229,23 @@ warn_deprecated(Key, Key) ->
     ok;
 warn_deprecated(OldKey, NewKey) ->
     io:format("I2C: found deprecated ~p, use ~p instead!!!~n", [OldKey, NewKey]).
+
+validate_peripheral(I) when is_integer(I) ->
+    io:format("I2C: deprecated integer peripheral is used.~n"),
+    I;
+validate_peripheral([$i, $2, $c | N] = Value) ->
+    try list_to_integer(N) of
+        % Internally integers are still used
+        % TODO: change this as soon as ESP32 code is reworked
+        I -> I
+    catch
+        error:_ -> {bardarg, {peripheral, Value}}
+    end;
+validate_peripheral(<<"i2c", N/binary>> = Value) ->
+    try binary_to_integer(N) of
+        I -> I
+    catch
+        error:_ -> {bardarg, {peripheral, Value}}
+    end;
+validate_peripheral(Value) ->
+    throw({bardarg, {peripheral, Value}}).

--- a/libs/eavmlib/src/spi.erl
+++ b/libs/eavmlib/src/spi.erl
@@ -42,7 +42,7 @@
 
 -export([open/1, close/1, read_at/4, write_at/5, write/3, write_read/3]).
 
--type peripheral() :: hspi | vspi.
+-type peripheral() :: hspi | vspi | string() | binary().
 -type bus_config() :: [
     {poci, non_neg_integer()}
     | {pico, non_neg_integer()}
@@ -378,9 +378,20 @@ validate_is_integer(Key, Value) ->
     throw({badarg, {not_an_integer_value, {Key, Value}}}).
 
 %% @private
-validate_peripheral(hspi) -> hspi;
-validate_peripheral(vspi) -> vspi;
-validate_peripheral(Value) -> throw({bardarg, {peripheral, Value}}).
+validate_peripheral(hspi) ->
+    io:format("SPI: deprecated peripheral name!!!~n"),
+    hspi;
+validate_peripheral(vspi) ->
+    io:format("SPI: deprecated peripheral name!!!~n"),
+    vspi;
+validate_peripheral(PeripheralString) when is_list(PeripheralString) ->
+    % Internally atoms are still used, so it is easier to convert them here
+    % TODO: use just strings in the future
+    erlang:list_to_atom(PeripheralString);
+validate_peripheral(PeripheralBinString) when is_binary(PeripheralBinString) ->
+    erlang:binary_to_atom(PeripheralBinString, latin1);
+validate_peripheral(Value) ->
+    throw({bardarg, {peripheral, Value}}).
 
 %% @private
 validate_device_config(DeviceConfig) when is_map(DeviceConfig) ->


### PR DESCRIPTION
New peripheral names are strings now, such as `uart1`, `spi2` or `i2c1`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
