### PR TITLE
Tune some workflows to not run on changes to other platforms

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -9,7 +9,9 @@ name: Build and Test on macOS
 on:
   push:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
@@ -17,7 +19,9 @@ on:
       - '*.md'
   pull_request:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'

--- a/.github/workflows/build-and-test-on-freebsd.yaml
+++ b/.github/workflows/build-and-test-on-freebsd.yaml
@@ -9,7 +9,9 @@ name: build-and-test-on-freebsd
 on:
   push:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
@@ -17,7 +19,9 @@ on:
       - '*.md'
   pull_request:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'

--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -9,7 +9,9 @@ name: Build and Test on Other Architectures
 on:
   push:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
@@ -17,7 +19,9 @@ on:
       - '*.md'
   pull_request:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,7 +9,9 @@ name: Build and Test
 on:
   push:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
@@ -17,7 +19,9 @@ on:
       - '*.md'
   pull_request:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -9,7 +9,9 @@ name: "CodeQL"
 on:
   push:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'libs/**'
       - 'doc/**'
@@ -18,7 +20,9 @@ on:
       - '*.md'
   pull_request:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'libs/**'
       - 'doc/**'

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -9,7 +9,9 @@ name: Run tests with BEAM
 on:
   push:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'
@@ -17,7 +19,9 @@ on:
       - '*.md'
   pull_request:
     paths-ignore:
+      - 'src/platforms/emscripten/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/rp2040/**'
       - 'src/platforms/stm32/**'
       - 'doc/**'
       - 'LICENSES/**'


### PR DESCRIPTION
Fixes several of the workflow files to prevent them from running on changes to other platforms. Specifically, changes to the `emscripten` and `rp2040` platforms no longer trigger the following workflows:

- `build-and-test-macos`
- `build-and-test-on-freebsd`
- `build-and-test-other`
- `build-and-test`
- `codeql-analysis`
- `run-tests-with-beam`

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
