### PR TITLE
port: add helper function for parsing message tuple

### DIFF
--- a/doc/src/apidocs/libatomvm/functions.rst
+++ b/doc/src/apidocs/libatomvm/functions.rst
@@ -140,7 +140,6 @@ Functions
 .. doxygenfunction:: port_heap_create_tuple2
 .. doxygenfunction:: port_heap_create_tuple3
 .. doxygenfunction:: port_heap_create_tuple_n
-.. doxygenfunction:: port_is_standard_port_command
 .. doxygenfunction:: port_send_message
 .. doxygenfunction:: port_send_message_nolock
 .. doxygenfunction:: posix_errno_to_term

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1034,7 +1034,7 @@ static NativeHandlerResult process_console_message(Context *ctx, term msg)
             }
         }
 
-    } else if (port_parse_gen_message(msg, &gen_message) == GenMessageParseOk) {
+    } else if (port_parse_gen_message(msg, &gen_message) == GenCallMessage) {
         term pid = gen_message.pid;
         term ref = gen_message.ref;
         term cmd = gen_message.req;

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1000,6 +1000,8 @@ static NativeHandlerResult process_console_message(Context *ctx, term msg)
         AVM_ABORT();
     }
 
+    GenMessage gen_message;
+
     if (term_is_tuple(msg) && term_get_tuple_arity(msg) == 2 && term_get_tuple_element(msg, 1) == CLOSE_ATOM) {
         result = NativeTerminate;
         term pid = term_get_tuple_element(msg, 0);
@@ -1032,11 +1034,10 @@ static NativeHandlerResult process_console_message(Context *ctx, term msg)
             }
         }
 
-    } else if (port_is_standard_port_command(msg)) {
-
-        term pid = term_get_tuple_element(msg, 0);
-        term ref = term_get_tuple_element(msg, 1);
-        term cmd = term_get_tuple_element(msg, 2);
+    } else if (port_parse_gen_message(msg, &gen_message) == GenMessageParseOk) {
+        term pid = gen_message.pid;
+        term ref = gen_message.ref;
+        term cmd = gen_message.req;
 
         if (term_is_atom(cmd) && cmd == FLUSH_ATOM) {
             fflush(stdout);

--- a/src/libAtomVM/port.c
+++ b/src/libAtomVM/port.c
@@ -123,5 +123,5 @@ enum GenMessageParseResult port_parse_gen_message(term msg, GenMessage *gen_mess
 
     gen_message->req = term_get_tuple_element(msg, 2);
 
-    return GenMessageParseOk;
+    return GenCallMessage;
 }

--- a/src/libAtomVM/port.c
+++ b/src/libAtomVM/port.c
@@ -54,25 +54,6 @@ void port_ensure_available(Context *ctx, size_t size)
     }
 }
 
-int port_is_standard_port_command(term t)
-{
-    if (!term_is_tuple(t)) {
-        return 0;
-    } else if (term_get_tuple_arity(t) != 3) {
-        return 0;
-    } else {
-        term pid = term_get_tuple_element(t, 0);
-        term ref = term_get_tuple_element(t, 1);
-        if (!term_is_pid(pid)) {
-            return 0;
-        } else if (!term_is_reference(ref)) {
-            return 0;
-        } else {
-            return 1;
-        }
-    }
-}
-
 term port_heap_create_tuple2(Heap *heap, term a, term b)
 {
     term terms[2];
@@ -122,4 +103,25 @@ term port_heap_create_ok_tuple(Heap *heap, term t)
 term port_heap_create_reply(Heap *heap, term ref, term payload)
 {
     return port_heap_create_tuple2(heap, ref, payload);
+}
+
+enum GenMessageParseResult port_parse_gen_message(term msg, GenMessage *gen_message)
+{
+    if (UNLIKELY(!term_is_tuple(msg) || term_get_tuple_arity(msg) != 3)) {
+        return GenMessageParseError;
+    }
+
+    gen_message->pid = term_get_tuple_element(msg, 0);
+    if (UNLIKELY(!term_is_pid(gen_message->pid))) {
+        return GenMessageParseError;
+    }
+
+    gen_message->ref = term_get_tuple_element(msg, 1);
+    if (UNLIKELY(!term_is_reference(gen_message->ref))) {
+        return GenMessageParseError;
+    }
+
+    gen_message->req = term_get_tuple_element(msg, 2);
+
+    return GenMessageParseOk;
 }

--- a/src/libAtomVM/port.h
+++ b/src/libAtomVM/port.h
@@ -92,7 +92,7 @@ typedef struct
 
 enum GenMessageParseResult
 {
-    GenMessageParseOk,
+    GenCallMessage,
     GenMessageParseError
 };
 

--- a/src/libAtomVM/port.h
+++ b/src/libAtomVM/port.h
@@ -74,7 +74,6 @@ static inline term port_create_reply(Context *ctx, term ref, term payload)
 void port_send_message(GlobalContext *glb, term pid, term msg);
 void port_send_message_nolock(GlobalContext *glb, term pid, term msg);
 void port_ensure_available(Context *ctx, size_t size);
-int port_is_standard_port_command(term msg);
 
 // Helper to send a message from NIFs or from the native handler.
 static inline void port_send_reply(Context *ctx, term pid, term ref, term payload)
@@ -82,6 +81,22 @@ static inline void port_send_reply(Context *ctx, term pid, term ref, term payloa
     term reply = port_create_reply(ctx, ref, payload);
     port_send_message(ctx->global, pid, reply);
 }
+
+typedef struct
+{
+    term req;
+
+    term pid;
+    term ref;
+} GenMessage;
+
+enum GenMessageParseResult
+{
+    GenMessageParseOk,
+    GenMessageParseError
+};
+
+enum GenMessageParseResult port_parse_gen_message(term msg, GenMessage *gen_message);
 
 #ifdef __cplusplus
 }

--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -479,7 +479,7 @@ static NativeHandlerResult consume_gpio_mailbox(Context *ctx)
 {
     Message *message = mailbox_first(&ctx->mailbox);
     GenMessage gen_message;
-    if (UNLIKELY(port_parse_gen_message(message->message, &gen_message) != GenMessageParseOk)) {
+    if (UNLIKELY(port_parse_gen_message(message->message, &gen_message) != GenCallMessage)) {
         ESP_LOGW(TAG, "Received invalid message.");
         mailbox_remove_message(&ctx->mailbox, &ctx->heap);
         return NativeContinue;

--- a/src/platforms/esp32/components/avm_builtins/i2c_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/i2c_driver.c
@@ -547,7 +547,7 @@ static NativeHandlerResult i2cdriver_consume_mailbox(Context *ctx)
 {
     Message *message = mailbox_first(&ctx->mailbox);
     GenMessage gen_message;
-    if (UNLIKELY(port_parse_gen_message(message->message, &gen_message) != GenMessageParseOk)) {
+    if (UNLIKELY(port_parse_gen_message(message->message, &gen_message) != GenCallMessage)) {
         ESP_LOGW(TAG, "Received invalid message.");
         mailbox_remove_message(&ctx->mailbox, &ctx->heap);
         return NativeContinue;

--- a/src/platforms/esp32/components/avm_builtins/i2c_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/i2c_driver.c
@@ -546,9 +546,12 @@ static term create_pair(Context *ctx, term term1, term term2)
 static NativeHandlerResult i2cdriver_consume_mailbox(Context *ctx)
 {
     Message *message = mailbox_first(&ctx->mailbox);
-    term msg = message->message;
-    term pid = term_get_tuple_element(msg, 0);
-    term req = term_get_tuple_element(msg, 2);
+    GenMessage gen_message;
+    if (UNLIKELY(port_parse_gen_message(message->message, &gen_message) != GenMessageParseOk)) {
+        ESP_LOGW(TAG, "Received invalid message.");
+        mailbox_remove_message(&ctx->mailbox, &ctx->heap);
+        return NativeContinue;
+    }
 
 #ifdef ENABLE_TRACE
     TRACE("message: ");
@@ -556,35 +559,35 @@ static NativeHandlerResult i2cdriver_consume_mailbox(Context *ctx)
     TRACE("\n");
 #endif
 
-    term cmd_term = term_get_tuple_element(req, 0);
+    term cmd_term = term_get_tuple_element(gen_message.req, 0);
 
-    int local_process_id = term_to_local_process_id(pid);
+    int local_process_id = term_to_local_process_id(gen_message.pid);
 
     term ret;
 
     enum i2c_cmd cmd = interop_atom_term_select_int(cmd_table, cmd_term, ctx->global);
     switch (cmd) {
         case I2CBeginTransmissionCmd:
-            ret = i2cdriver_begin_transmission(ctx, pid, req);
+            ret = i2cdriver_begin_transmission(ctx, gen_message.pid, gen_message.req);
             break;
 
         case I2CEndTransmissionCmd:
-            ret = i2cdriver_end_transmission(ctx, pid);
+            ret = i2cdriver_end_transmission(ctx, gen_message.pid);
             break;
 
         case I2CWriteByteCmd:
-            ret = i2cdriver_write_byte(ctx, pid, req);
+            ret = i2cdriver_write_byte(ctx, gen_message.pid, gen_message.req);
             break;
 
         case I2CReadBytesCmd:
-            ret = i2cdriver_read_bytes(ctx, pid, req);
+            ret = i2cdriver_read_bytes(ctx, gen_message.pid, gen_message.req);
             break;
 
         case I2CWriteBytesCmd:
-            if (term_get_tuple_arity(req) == 2) {
-                ret = i2cdriver_qwrite_bytes(ctx, pid, req);
+            if (term_get_tuple_arity(gen_message.req) == 2) {
+                ret = i2cdriver_qwrite_bytes(ctx, gen_message.pid, gen_message.req);
             } else {
-                ret = i2cdriver_write_bytes(ctx, pid, req);
+                ret = i2cdriver_write_bytes(ctx, gen_message.pid, gen_message.req);
             }
             break;
         case I2CCloseCmd:
@@ -601,8 +604,7 @@ static NativeHandlerResult i2cdriver_consume_mailbox(Context *ctx)
     if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &ret, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         ret_msg = OUT_OF_MEMORY_ATOM;
     } else {
-        term ref = term_get_tuple_element(msg, 1);
-        ret_msg = create_pair(ctx, ref, ret);
+        ret_msg = create_pair(ctx, gen_message.ref, ret);
     }
 
     globalcontext_send_message(ctx->global, local_process_id, ret_msg);

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -761,6 +761,7 @@ static NativeHandlerResult consume_mailbox(Context *ctx)
         return NativeContinue;
     }
 
+    //TODO: port this code to standard port (and gen_message)
     term pid = term_get_tuple_element(msg, 0);
     term ref = term_get_tuple_element(msg, 1);
     term cmd = term_get_tuple_element(msg, 2);

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -32,6 +32,7 @@
 #include "globalcontext.h"
 #include "interop.h"
 #include "mailbox.h"
+#include "port.h"
 #include "scheduler.h"
 #include "sys.h"
 #include "term.h"
@@ -50,6 +51,8 @@
 
 //#define ENABLE_TRACE 1
 #include "trace.h"
+
+#define TAG "socket_driver"
 
 typedef struct SocketListener
 {
@@ -534,12 +537,12 @@ static void accept_conn(Context *ctx, struct TCPServerSocketData *tcp_data, uint
 
 }
 
-static void do_accept(Context *ctx, term msg)
+static void do_accept(Context *ctx, const GenMessage *gen_message)
 {
     struct TCPServerSocketData *tcp_data = ctx->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
 
     if (tcp_data->ready_connections) {
         TRACE("accepting existing connections.\n");
@@ -815,15 +818,18 @@ static bool bool_term_to_bool(term b, bool *ok)
     }
 }
 
-static void do_connect(Context *ctx, term msg)
+static void do_connect(Context *ctx, const GenMessage *gen_message)
 {
     GlobalContext *glb = ctx->global;
     struct ESP32PlatformData *platform = glb->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
-    term cmd = term_get_tuple_element(msg, 2);
-    term params = term_get_tuple_element(cmd, 1);
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
+    if (UNLIKELY(term_get_tuple_arity(gen_message->req) != 2)) {
+        ESP_LOGW(TAG, "Received invalid message.");
+        return;
+    }
+    term params = term_get_tuple_element(gen_message->req, 1);
 
     term address_term = interop_proplist_get_value(params, ADDRESS_ATOM);
     term port_term = interop_proplist_get_value(params, PORT_ATOM);
@@ -902,15 +908,18 @@ static void do_connect(Context *ctx, term msg)
     do_send_reply(ctx, OK_ATOM, ref_ticks, pid);
 }
 
-static void do_listen(Context *ctx, term msg)
+static void do_listen(Context *ctx, const GenMessage *gen_message)
 {
     GlobalContext *glb = ctx->global;
     struct ESP32PlatformData *platform = glb->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
-    term cmd = term_get_tuple_element(msg, 2);
-    term params = term_get_tuple_element(cmd, 1);
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
+    if (UNLIKELY(term_get_tuple_arity(gen_message->req) != 2)) {
+        ESP_LOGW(TAG, "Received invalid message.");
+        return;
+    }
+    term params = term_get_tuple_element(gen_message->req, 1);
 
     term port_term = interop_proplist_get_value(params, PORT_ATOM);
     term backlog_term = interop_proplist_get_value(params, BACKLOG_ATOM);
@@ -974,15 +983,18 @@ static void do_listen(Context *ctx, term msg)
     do_send_reply(ctx, OK_ATOM, ref_ticks, pid);
 }
 
-void do_udp_open(Context *ctx, term msg)
+void do_udp_open(Context *ctx, const GenMessage *gen_message)
 {
     GlobalContext *glb = ctx->global;
     struct ESP32PlatformData *platform = glb->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
-    term cmd = term_get_tuple_element(msg, 2);
-    term params = term_get_tuple_element(cmd, 1);
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
+    if (UNLIKELY(term_get_tuple_arity(gen_message->req) != 2)) {
+        ESP_LOGW(TAG, "Received invalid message.");
+        return;
+    }
+    term params = term_get_tuple_element(gen_message->req, 1);
 
     term port_term = interop_proplist_get_value(params, PORT_ATOM);
     term binary_term = interop_proplist_get_value_default(params, BINARY_ATOM, FALSE_ATOM);
@@ -1048,34 +1060,40 @@ void do_udp_open(Context *ctx, term msg)
 
 // Required for compatibility with existing erlang libraries
 // TODO: remove this when not required anymore
-static void do_init(Context *ctx, term msg)
+static void do_init(Context *ctx, const GenMessage *gen_message)
 {
-    term cmd = term_get_tuple_element(msg, 2);
-    term params = term_get_tuple_element(cmd, 1);
+    if (UNLIKELY(term_get_tuple_arity(gen_message->req) < 2)) {
+        ESP_LOGW(TAG, "Received invalid message.");
+        return;
+    }
+    term params = term_get_tuple_element(gen_message->req, 1);
 
     if (interop_proplist_get_value_default(params, LISTEN_ATOM, FALSE_ATOM) == TRUE_ATOM) {
         TRACE("listen\n");
-        do_listen(ctx, msg);
+        do_listen(ctx, gen_message);
 
     } else if (interop_proplist_get_value_default(params, CONNECT_ATOM, FALSE_ATOM) == TRUE_ATOM) {
         TRACE("connect\n");
-        do_connect(ctx, msg);
+        do_connect(ctx, gen_message);
 
     } else if (interop_proplist_get_value_default(params, PROTO_ATOM, FALSE_ATOM) == UDP_ATOM) {
         TRACE("udp_open\n");
-        do_udp_open(ctx, msg);
+        do_udp_open(ctx, gen_message);
     }
 }
 
-static void do_send(Context *ctx, term msg)
+static void do_send(Context *ctx, const GenMessage *gen_message)
 {
     struct TCPServerSocketData *tcp_data = ctx->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
-    term cmd = term_get_tuple_element(msg, 2);
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
 
-    term data = term_get_tuple_element(cmd, 1);
+    if (UNLIKELY(term_get_tuple_arity(gen_message->req) != 2)) {
+        ESP_LOGW(TAG, "Received invalid message.");
+        return;
+    }
+    term data = term_get_tuple_element(gen_message->req, 1);
 
     size_t buffer_size;
     switch (interop_iolist_size(data, &buffer_size)) {
@@ -1114,14 +1132,18 @@ static void do_send(Context *ctx, term msg)
     do_send_reply(ctx, OK_ATOM, ref_ticks, pid);
 }
 
-static void do_sendto(Context *ctx, term msg)
+static void do_sendto(Context *ctx, const GenMessage *gen_message)
 {
     struct UDPSocketData *udp_data = ctx->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
-    term cmd = term_get_tuple_element(msg, 2);
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
 
+    if (UNLIKELY(term_get_tuple_arity(gen_message->req) != 4)) {
+        ESP_LOGW(TAG, "Received invalid message.");
+        return;
+    }
+    term cmd = gen_message->req;
     term dest_addr_term = term_get_tuple_element(cmd, 1);
     term dest_port_term = term_get_tuple_element(cmd, 2);
     term data = term_get_tuple_element(cmd, 3);
@@ -1180,12 +1202,12 @@ static void do_sendto(Context *ctx, term msg)
     do_send_reply(ctx, OK_ATOM, ref_ticks, pid);
 }
 
-static void do_close(Context *ctx, term msg)
+static void do_close(Context *ctx, const GenMessage *gen_message)
 {
     struct SocketData *socket_data = ctx->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
 
     if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2) + REPLY_SIZE) != MEMORY_GC_OK)) {
         AVM_ABORT();
@@ -1211,12 +1233,12 @@ static void do_close(Context *ctx, term msg)
     }
 }
 
-static NativeHandlerResult do_recvfrom(Context *ctx, term msg)
+static NativeHandlerResult do_recvfrom(Context *ctx, const GenMessage *gen_message)
 {
     struct SocketData *socket_data = ctx->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
 
     // We cannot stack blocked queries
     if (socket_data->passive_receiver_process_pid != 0) {
@@ -1234,12 +1256,12 @@ static NativeHandlerResult do_recvfrom(Context *ctx, term msg)
     return NativeContinue;
 }
 
-static void do_get_port(Context *ctx, term msg)
+static void do_get_port(Context *ctx, const GenMessage *gen_message)
 {
     struct SocketData *socket_data = ctx->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
 
     if (socket_data->port == 0) {
         do_send_error_reply(ctx, ERR_ARG, ref_ticks, pid);
@@ -1254,12 +1276,12 @@ static void do_get_port(Context *ctx, term msg)
     }
 }
 
-static void do_sockname(Context *ctx, term msg)
+static void do_sockname(Context *ctx, const GenMessage *gen_message)
 {
     struct SocketData *socket_data = ctx->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
 
     ip_addr_t addr;
     u16_t port;
@@ -1283,12 +1305,12 @@ static void do_sockname(Context *ctx, term msg)
     }
 }
 
-static void do_peername(Context *ctx, term msg)
+static void do_peername(Context *ctx, const GenMessage *gen_message)
 {
     struct SocketData *socket_data = ctx->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
 
     ip_addr_t addr;
     u16_t port;
@@ -1313,16 +1335,18 @@ static void do_peername(Context *ctx, term msg)
     }
 }
 
-static void do_controlling_process(Context *ctx, term msg)
+static void do_controlling_process(Context *ctx, const GenMessage *gen_message)
 {
     struct SocketData *socket_data = ctx->platform_data;
 
-    int32_t pid = term_to_local_process_id(term_get_tuple_element(msg, 0));
-    uint64_t ref_ticks = term_to_ref_ticks(term_get_tuple_element(msg, 1));
+    int32_t pid = term_to_local_process_id(gen_message->pid);
+    uint64_t ref_ticks = term_to_ref_ticks(gen_message->ref);
 
-    term cmd = term_get_tuple_element(msg, 2);
-
-    term new_pid_term = term_get_tuple_element(cmd, 1);
+    if (UNLIKELY(term_get_tuple_arity(gen_message->req) != 2)) {
+        ESP_LOGW(TAG, "Received invalid message.");
+        return;
+    }
+    term new_pid_term = term_get_tuple_element(gen_message->req, 1);
     if (UNLIKELY(!term_is_pid(new_pid_term))) {
         do_send_error_reply(ctx, ERR_ARG, ref_ticks, pid);
     } else {
@@ -1371,69 +1395,76 @@ static NativeHandlerResult socket_consume_mailbox(Context *ctx)
             continue;
         }
 
-        term cmd = term_get_tuple_element(msg, 2);
-        term cmd_name = term_get_tuple_element(cmd, 0);
+        GenMessage gen_message;
+        if (UNLIKELY((port_parse_gen_message(msg, &gen_message) != GenMessageParseOk)
+                || !term_is_tuple(gen_message.req) || term_get_tuple_arity(gen_message.req) < 1)) {
+            ESP_LOGW(TAG, "Received invalid message.");
+            mailbox_remove_message(&ctx->mailbox, &ctx->heap);
+            return NativeContinue;
+        }
+
+        term cmd_name = term_get_tuple_element(gen_message.req, 0);
 
         switch (cmd_name) {
             //TODO: remove this
             case INIT_ATOM:
                 TRACE("init\n");
-                do_init(ctx, msg);
+                do_init(ctx, &gen_message);
                 break;
 
             case SENDTO_ATOM:
                 TRACE("sendto\n");
-                do_sendto(ctx, msg);
+                do_sendto(ctx, &gen_message);
                 break;
 
             case SEND_ATOM:
                 TRACE("send\n");
-                do_send(ctx, msg);
+                do_send(ctx, &gen_message);
                 break;
 
             case RECVFROM_ATOM:
                 TRACE("recvfrom\n");
-                if (do_recvfrom(ctx, msg) == NativeTerminate) {
+                if (do_recvfrom(ctx, &gen_message) == NativeTerminate) {
                     return NativeTerminate;
                 }
                 break;
 
             case RECV_ATOM:
                 TRACE("recv\n");
-                if (do_recvfrom(ctx, msg) == NativeTerminate) {
+                if (do_recvfrom(ctx, &gen_message) == NativeTerminate) {
                     return NativeTerminate;
                 }
                 break;
 
             case ACCEPT_ATOM:
                 TRACE("accept\n");
-                do_accept(ctx, msg);
+                do_accept(ctx, &gen_message);
                 break;
 
             case CLOSE_ATOM:
                 TRACE("close\n");
-                do_close(ctx, msg);
+                do_close(ctx, &gen_message);
                 // We don't need to remove message.
                 return NativeTerminate;
 
             case GET_PORT_ATOM:
                 TRACE("get_port\n");
-                do_get_port(ctx, msg);
+                do_get_port(ctx, &gen_message);
                 break;
 
             case SOCKNAME_ATOM:
                 TRACE("sockname\n");
-                do_sockname(ctx, msg);
+                do_sockname(ctx, &gen_message);
                 break;
 
             case PEERNAME_ATOM:
                 TRACE("peername\n");
-                do_peername(ctx, msg);
+                do_peername(ctx, &gen_message);
                 break;
 
             case CONTROLLING_PROCESS_ATOM:
                 TRACE("controlling_process\n");
-                do_controlling_process(ctx, msg);
+                do_controlling_process(ctx, &gen_message);
                 break;
 
             default:

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -1396,7 +1396,7 @@ static NativeHandlerResult socket_consume_mailbox(Context *ctx)
         }
 
         GenMessage gen_message;
-        if (UNLIKELY((port_parse_gen_message(msg, &gen_message) != GenMessageParseOk)
+        if (UNLIKELY((port_parse_gen_message(msg, &gen_message) != GenCallMessage)
                 || !term_is_tuple(gen_message.req) || term_get_tuple_arity(gen_message.req) < 1)) {
             ESP_LOGW(TAG, "Received invalid message.");
             mailbox_remove_message(&ctx->mailbox, &ctx->heap);

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -603,7 +603,7 @@ static NativeHandlerResult spidriver_consume_mailbox(Context *ctx)
 {
     Message *message = mailbox_first(&ctx->mailbox);
     GenMessage gen_message;
-    if (UNLIKELY(port_parse_gen_message(message->message, &gen_message) != GenMessageParseOk)) {
+    if (UNLIKELY(port_parse_gen_message(message->message, &gen_message) != GenCallMessage)) {
         ESP_LOGW(TAG, "Received invalid message.");
         mailbox_remove_message(&ctx->mailbox, &ctx->heap);
         return NativeContinue;

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -41,6 +41,7 @@
 #include "mailbox.h"
 #include "module.h"
 #include "platform_defaultatoms.h"
+#include "port.h"
 #include "scheduler.h"
 #include "term.h"
 #include "utils.h"
@@ -601,14 +602,16 @@ static term create_pair(Context *ctx, term term1, term term2)
 static NativeHandlerResult spidriver_consume_mailbox(Context *ctx)
 {
     Message *message = mailbox_first(&ctx->mailbox);
-    term msg = message->message;
-    term pid = term_get_tuple_element(msg, 0);
-    term ref = term_get_tuple_element(msg, 1);
-    term req = term_get_tuple_element(msg, 2);
+    GenMessage gen_message;
+    if (UNLIKELY(port_parse_gen_message(message->message, &gen_message) != GenMessageParseOk)) {
+        ESP_LOGW(TAG, "Received invalid message.");
+        mailbox_remove_message(&ctx->mailbox, &ctx->heap);
+        return NativeContinue;
+    }
 
-    term cmd_term = term_get_tuple_element(req, 0);
+    term cmd_term = term_get_tuple_element(gen_message.req, 0);
 
-    int local_process_id = term_to_local_process_id(pid);
+    int local_process_id = term_to_local_process_id(gen_message.pid);
     Context *target = globalcontext_get_process_lock(ctx->global, local_process_id);
 
     term ret;
@@ -617,22 +620,22 @@ static NativeHandlerResult spidriver_consume_mailbox(Context *ctx)
     switch (cmd) {
         case SPIReadAtCmd:
             TRACE("spi: read at.\n");
-            ret = spidriver_read_at(ctx, req);
+            ret = spidriver_read_at(ctx, gen_message.req);
             break;
 
         case SPIWriteAtCmd:
             TRACE("spi: write at.\n");
-            ret = spidriver_write_at(ctx, req);
+            ret = spidriver_write_at(ctx, gen_message.req);
             break;
 
         case SPIWriteCmd:
             TRACE("spi: write.\n");
-            ret = spidriver_write(ctx, req);
+            ret = spidriver_write(ctx, gen_message.req);
             break;
 
         case SPIWriteReadCmd:
             TRACE("spi: write_read.\n");
-            ret = spidriver_write_read(ctx, req);
+            ret = spidriver_write_read(ctx, gen_message.req);
             break;
 
         case SPICloseCmd:
@@ -652,8 +655,7 @@ static NativeHandlerResult spidriver_consume_mailbox(Context *ctx)
     if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &ret, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         ret_msg = OUT_OF_MEMORY_ATOM;
     } else {
-        ref = term_get_tuple_element(msg, 1);
-        ret_msg = create_pair(ctx, ref, ret);
+        ret_msg = create_pair(ctx, gen_message.ref, ret);
     }
 
     mailbox_send(target, ret_msg);

--- a/src/platforms/esp32/components/avm_builtins/uart_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/uart_driver.c
@@ -454,7 +454,7 @@ static NativeHandlerResult uart_driver_consume_mailbox(Context *ctx)
         Message *message = mailbox_first(&ctx->mailbox);
         term msg = message->message;
         GenMessage gen_message;
-        if (UNLIKELY(port_parse_gen_message(msg, &gen_message) != GenMessageParseOk)) {
+        if (UNLIKELY(port_parse_gen_message(msg, &gen_message) != GenCallMessage)) {
             ESP_LOGW(TAG, "Received invalid message.");
             mailbox_remove_message(&ctx->mailbox, &ctx->heap);
             return NativeContinue;

--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -1135,7 +1135,7 @@ static NativeHandlerResult socket_consume_mailbox(Context *ctx)
     }
 
     GenMessage gen_message;
-    if (UNLIKELY((port_parse_gen_message(msg, &gen_message) != GenMessageParseOk)
+    if (UNLIKELY((port_parse_gen_message(msg, &gen_message) != GenCallMessage)
             || !term_is_tuple(gen_message.req) || term_get_tuple_arity(gen_message.req) < 1)) {
         fprintf(stderr, "Received invalid socket message.\n");
         mailbox_remove_message(&ctx->mailbox, &ctx->heap);

--- a/src/platforms/stm32/src/lib/gpio_driver.c
+++ b/src/platforms/stm32/src/lib/gpio_driver.c
@@ -938,7 +938,7 @@ static NativeHandlerResult consume_gpio_mailbox(Context *ctx)
 {
     Message *message = mailbox_first(&ctx->mailbox);
     GenMessage gen_message;
-    if (UNLIKELY(port_parse_gen_message(message->message, &gen_message) != GenMessageParseOk)
+    if (UNLIKELY(port_parse_gen_message(message->message, &gen_message) != GenCallMessage)
         || !term_is_tuple(gen_message.req) || term_get_tuple_arity(gen_message.req) < 1) {
         AVM_LOGW(TAG, "Received invalid message.");
         mailbox_remove_message(&ctx->mailbox, &ctx->heap);

--- a/src/platforms/stm32/src/lib/gpio_driver.c
+++ b/src/platforms/stm32/src/lib/gpio_driver.c
@@ -35,6 +35,7 @@
 #include <interop.h>
 #include <mailbox.h>
 #include <nifs.h>
+#include <port.h>
 #include <scheduler.h>
 #include <sys.h>
 #include <term.h>
@@ -936,12 +937,17 @@ static term gpiodriver_remove_int(Context *ctx, term cmd)
 static NativeHandlerResult consume_gpio_mailbox(Context *ctx)
 {
     Message *message = mailbox_first(&ctx->mailbox);
-    term msg = message->message;
-    term pid = term_get_tuple_element(msg, 0);
-    term req = term_get_tuple_element(msg, 2);
+    GenMessage gen_message;
+    if (UNLIKELY(port_parse_gen_message(message->message, &gen_message) != GenMessageParseOk)
+        || !term_is_tuple(gen_message.req) || term_get_tuple_arity(gen_message.req) < 1) {
+        AVM_LOGW(TAG, "Received invalid message.");
+        mailbox_remove_message(&ctx->mailbox, &ctx->heap);
+        return NativeContinue;
+    }
+    term req = gen_message.req;
     term cmd_term = term_get_tuple_element(req, 0);
 
-    int local_process_id = term_to_local_process_id(pid);
+    int local_process_id = term_to_local_process_id(gen_message.pid);
 
     term ret;
 
@@ -991,8 +997,7 @@ static NativeHandlerResult consume_gpio_mailbox(Context *ctx)
     if (UNLIKELY(memory_ensure_free_with_roots(ctx, TUPLE_SIZE(2), 1, &ret, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         ret_msg = OUT_OF_MEMORY_ATOM;
     } else {
-        term ref = term_get_tuple_element(msg, 1);
-        ret_msg = create_pair(ctx, ref, ret);
+        ret_msg = create_pair(ctx, gen_message.ref, ret);
     }
 
     globalcontext_send_message(ctx->global, local_process_id, ret_msg);


### PR DESCRIPTION
Add function for hiding port message tuple format details, so code doesn't need to hardcode indexes or repeat always the same checks, that can be instead shared across different port drivers.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
