### PR TITLE
MOSI or MISO can be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced support to non-integer peripheral names, `"i2c0"`, `"uart1"` (instead of just `0` and
 - `1`, which now they are deprecated)
 - New atom table, which uses less memory, has improved performances and better code.
+- SPI: when gpio number is not provided for `miso` or `mosi` default to disabled
 
 ## [0.6.0-alpha.2] - 2023-12-10
 

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -196,16 +196,16 @@ Context *spi_driver_create_port(GlobalContext *global, term opts)
     term hspi_atom = globalcontext_make_atom(global, ATOM_STR("\x4", "hspi"));
 
     term bus_config = interop_kv_get_value(opts, ATOM_STR("\xA", "bus_config"), global);
-    term miso_term = interop_kv_get_value(bus_config, ATOM_STR("\x4", "miso"), global);
-    term mosi_term = interop_kv_get_value(bus_config, ATOM_STR("\x4", "mosi"), global);
-    term sclk_term = interop_kv_get_value(bus_config, ATOM_STR("\x4", "sclk"), global);
-    term peripheral_term = interop_kv_get_value_default(bus_config, ATOM_STR("\xA", "peripheral"), hspi_atom, global);
-    spi_host_device_t host_device = get_spi_host_device(peripheral_term, global);
+    term miso = interop_kv_get_value(bus_config, ATOM_STR("\x4", "miso"), global);
+    term mosi = interop_kv_get_value(bus_config, ATOM_STR("\x4", "mosi"), global);
+    term sclk = interop_kv_get_value(bus_config, ATOM_STR("\x4", "sclk"), global);
+    term peripheral = interop_kv_get_value_default(bus_config, ATOM_STR("\xA", "peripheral"), hspi_atom, global);
+    spi_host_device_t host_device = get_spi_host_device(peripheral, global);
 
     spi_bus_config_t buscfg = { 0 };
-    buscfg.miso_io_num = term_to_int32(miso_term);
-    buscfg.mosi_io_num = term_to_int32(mosi_term);
-    buscfg.sclk_io_num = term_to_int32(sclk_term);
+    buscfg.miso_io_num = term_to_int32(miso);
+    buscfg.mosi_io_num = term_to_int32(mosi);
+    buscfg.sclk_io_num = term_to_int32(sclk);
     buscfg.quadwp_io_num = -1;
     buscfg.quadhd_io_num = -1;
 

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -193,11 +193,12 @@ Context *spi_driver_create_port(GlobalContext *global, term opts)
     TRACE("spi_driver_create_port\n");
     Context *ctx = context_new(global);
 
+    term no_pin = term_from_int(-1);
     term hspi_atom = globalcontext_make_atom(global, ATOM_STR("\x4", "hspi"));
 
     term bus_config = interop_kv_get_value(opts, ATOM_STR("\xA", "bus_config"), global);
-    term miso = interop_kv_get_value(bus_config, ATOM_STR("\x4", "miso"), global);
-    term mosi = interop_kv_get_value(bus_config, ATOM_STR("\x4", "mosi"), global);
+    term miso = interop_kv_get_value_default(bus_config, ATOM_STR("\x4", "miso"), no_pin, global);
+    term mosi = interop_kv_get_value_default(bus_config, ATOM_STR("\x4", "mosi"), no_pin, global);
     term sclk = interop_kv_get_value(bus_config, ATOM_STR("\x4", "sclk"), global);
     term peripheral = interop_kv_get_value_default(bus_config, ATOM_STR("\xA", "peripheral"), hspi_atom, global);
     spi_host_device_t host_device = get_spi_host_device(peripheral, global);


### PR DESCRIPTION
Instead of using `-1` magic value, just omit the config entry.

`%{miso: -1, mosi: 25, sclk: 26, peripheral: "spi2"}` -> `%{mosi: 25, sclk: 26, peripheral: "spi2"}`

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
