### PR TITLE
Fix memory bugs in libAtomVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `1`, which now they are deprecated)
 - New atom table, which uses less memory, has improved performances and better code.
 
+### Fixed
+
+- Fix several missing memory allocation checks in libAtomVM.
+
 ## [0.6.0-alpha.2] - 2023-12-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix several missing memory allocation checks in libAtomVM.
+- Fixed a possible memory leak in libAtomVM/module.c `module_destroy`.
 
 ## [0.6.0-alpha.2] - 2023-12-10
 

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -321,6 +321,7 @@ COLD_FUNC void module_destroy(Module *module)
     free(module->labels);
     free(module->imported_funcs);
     free(module->literals_table);
+    free(module->local_atoms_to_global_table);
     if (module->free_literals_data) {
         free(module->literals_data);
     }

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3772,6 +3772,9 @@ static term nif_atomvm_read_priv(Context *ctx, int argc, term argv[])
     size_t app_len;
     atom_ref_t atom_ref = atom_table_get_atom_ptr_and_len(glb->atom_table, atom_index, &app_len);
     char *app = malloc(app_len + 1);
+    if (IS_NULL_PTR(app)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
     atom_table_write_cstring(glb->atom_table, atom_ref, app_len + 1, app);
 
     int ok;
@@ -4171,6 +4174,10 @@ static term nif_code_load_abs(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
     char *path = malloc(strlen(abs) + strlen(".beam") + 1);
+    if (IS_NULL_PTR(path)) {
+        free(abs);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
     strcpy(path, abs);
     strcat(path, ".beam");
 

--- a/src/libAtomVM/resources.c
+++ b/src/libAtomVM/resources.c
@@ -174,6 +174,9 @@ int enif_select(ErlNifEnv *env, ErlNifEvent event, enum ErlNifSelectFlags mode, 
     // Create new event if it doesn't exist.
     if (select_event == NULL) {
         select_event = malloc(sizeof(struct SelectEvent));
+        if (IS_NULL_PTR(select_event)) {
+            AVM_ABORT();
+        }
         select_event->event = event;
         select_event->resource = resource;
         // Resource is used in select_event, so we increase refcount.


### PR DESCRIPTION
Adds missing checks for `NULL` after memory allocations, and fix potential memory leaks in libAtomVM.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
