### PR TITLE
Fix interop: use term_is_nonempty_list instead of term_is_nil

### DIFF
--- a/src/libAtomVM/interop.c
+++ b/src/libAtomVM/interop.c
@@ -165,7 +165,7 @@ term interop_proplist_get_value_default(term list, term key, term default_value)
 {
     term t = list;
 
-    while (!term_is_nil(t)) {
+    while (term_is_nonempty_list(t)) {
         term *t_ptr = term_get_list_ptr(t);
 
         term head = t_ptr[1];


### PR DESCRIPTION
Avoid crashes with improper lists.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
