### PR TITLE
Fix CI failure of test_gc test on OTP-26

### DIFF
--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -61,7 +61,7 @@ jobs:
           otp: "25"
 
         - os: "ubuntu-22.04"
-          test_erlang_opts: "-s prime_smp"
+          test_erlang_opts: "-s prime_smp,test_gc"
           otp: "26"
           container: erlang:26
 


### PR DESCRIPTION
This change addresses a CI test failure on the `master` branch, due to (mistaken?) assumptions about how the OTP garbage collector works.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
