### PR TITLE
Implement lists:split/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `pico` and `poci` as an alternative to `mosi` and `miso` for SPI
 - ESP32: Added support to SPI peripherals other than hspi and vspi
 - Added `gpio:set_int/4`, with the 4th parameter being the pid() or registered name of the process to receive interrupt messages
+- Added support for `lists:split/2`
 
 ### Changed
 

--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -2,6 +2,7 @@
 % This file is part of AtomVM.
 %
 % Copyright 2017-2023 Fred Dushin <fred@dushin.net>
+% split/2 function Copyright Ericsson AB 1996-2023.
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -49,6 +50,7 @@
     join/2,
     seq/2, seq/3,
     sort/1, sort/2,
+    split/2,
     usort/1, usort/2,
     duplicate/2,
     sublist/2
@@ -501,6 +503,39 @@ sort(List) when is_list(List) ->
 -spec sort(Fun :: fun((T, T) -> boolean()), List :: [T]) -> [T].
 sort(Fun, List) when is_function(Fun), is_list(List) ->
     quick_sort(Fun, List).
+
+%%-----------------------------------------------------------------------------
+%% @param   N elements non negative Integer
+%% @param   List1 list to split
+%% @returns Tuple with the two lists
+%% @doc     Splits List1 into List2 and List3. List2 contains the first N elements
+%%          and List3 the remaining elements (the Nth tail).
+%% @end
+%%-----------------------------------------------------------------------------
+%% Attribution: https://github.com/erlang/otp/blob/5c8a9cbd125f3db5f5d13ff5ba2a12c076912425/lib/stdlib/src/lists.erl#L1801
+-spec split(N, List1) -> {List2, List3} when
+    N :: non_neg_integer(),
+    List1 :: [T],
+    List2 :: [T],
+    List3 :: [T],
+    T :: term().
+
+split(N, List) when is_integer(N), N >= 0, is_list(List) ->
+    case split(N, List, []) of
+        {_, _} = Result ->
+            Result;
+        Fault when is_atom(Fault) ->
+            erlang:error(Fault, [N, List])
+    end;
+split(N, List) ->
+    erlang:error(badarg, [N, List]).
+
+split(0, L, R) ->
+    {lists:reverse(R, []), L};
+split(N, [H | T], R) ->
+    split(N - 1, T, [H | R]);
+split(_, [], _) ->
+    badarg.
 
 %% Attribution: https://erlang.org/doc/programming_examples/list_comprehensions.html#quick-sort
 %% @private

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -41,6 +41,7 @@ test() ->
     ok = test_join(),
     ok = test_seq(),
     ok = test_sort(),
+    ok = test_split(),
     ok = test_usort(),
     ok.
 
@@ -208,6 +209,23 @@ test_sort() ->
     ?ASSERT_ERROR(lists:sort(fun(A, B) -> A > B end, 1), function_clause),
     ?ASSERT_ERROR(lists:sort(1, [1]), function_clause),
 
+    ok.
+
+test_split() ->
+    ?ASSERT_MATCH(
+        lists:split(1, ["Foo", "Bar", "Alice", "Bob", "lowercase"]),
+        {["Foo"], ["Bar", "Alice", "Bob", "lowercase"]}
+    ),
+    ?ASSERT_MATCH(
+        lists:split(4, ["Foo", "Bar", "Alice", "Bob", "lowercase"]),
+        {["Foo", "Bar", "Alice", "Bob"], ["lowercase"]}
+    ),
+    ?ASSERT_MATCH(lists:split(0, []), {[], []}),
+    ?ASSERT_MATCH(lists:split(0, ["Foo"]), {[], ["Foo"]}),
+    ?ASSERT_MATCH(lists:split(1, ["Foo"]), {["Foo"], []}),
+    ?ASSERT_ERROR(lists:split(1, []), badarg),
+    ?ASSERT_ERROR(lists:split(2, ["Foo"]), badarg),
+    ?ASSERT_ERROR(lists:split(-1, ["Foo"]), badarg),
     ok.
 
 test_usort() ->


### PR DESCRIPTION
As implemented in lists: module in OTP https://github.com/erlang/otp/blob/0e66b88db447954e1de70ec1fa0822d3a7e6133d/lib/stdlib/src/lists.erl#L1808

Unsure where the line goes for functions to be implemented by estdlib, so feel free to close PR.

Use case: 
Using https://github.com/discord/limited_queue/ on top of the erlang queue: module (copy pasted), and the only missing lists function needed was the split/2 - so would be nice to have it out of the box.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
