### PR TITLE
Fix: add missing mutex init/destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix several missing memory allocation checks in libAtomVM.
 - Fixed a possible memory leak in libAtomVM/module.c `module_destroy`.
+- Fix possibile bug in random number generator on ESP32 and RPi2040
 
 ## [0.6.0-alpha.2] - 2023-12-10
 

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -254,6 +254,15 @@ void sys_init_platform(GlobalContext *glb)
     if (UNLIKELY(esp_pthread_set_cfg(&esp_pthread_cfg))) {
         AVM_ABORT();
     }
+
+    platform->entropy_mutex = smp_mutex_create();
+    if (IS_NULL_PTR(platform->entropy_mutex)) {
+        AVM_ABORT();
+    }
+    platform->random_mutex = smp_mutex_create();
+    if (IS_NULL_PTR(platform->random_mutex)) {
+        AVM_ABORT();
+    }
 #endif
 
     platform->entropy_is_initialized = false;
@@ -281,6 +290,11 @@ void sys_free_platform(GlobalContext *glb)
     if (platform->entropy_is_initialized) {
         mbedtls_entropy_free(&platform->entropy_ctx);
     }
+
+#ifndef AVM_NO_SMP
+    smp_mutex_destroy(platform->entropy_mutex);
+    smp_mutex_destroy(platform->random_mutex);
+#endif
 
     free(platform);
 }

--- a/src/platforms/rp2040/src/lib/sys.c
+++ b/src/platforms/rp2040/src/lib/sys.c
@@ -90,6 +90,17 @@ void sys_init_platform(GlobalContext *glb)
     otp_socket_init(glb);
 #endif
 
+#ifndef AVM_NO_SMP
+    platform->entropy_mutex = smp_mutex_create();
+    if (IS_NULL_PTR(platform->entropy_mutex)) {
+        AVM_ABORT();
+    }
+    platform->random_mutex = smp_mutex_create();
+    if (IS_NULL_PTR(platform->random_mutex)) {
+        AVM_ABORT();
+    }
+#endif
+
     platform->entropy_is_initialized = false;
     platform->random_is_initialized = false;
 }
@@ -110,6 +121,11 @@ void sys_free_platform(GlobalContext *glb)
     if (platform->entropy_is_initialized) {
         mbedtls_entropy_free(&platform->entropy_ctx);
     }
+
+#ifndef AVM_NO_SMP
+    smp_mutex_destroy(platform->entropy_mutex);
+    smp_mutex_destroy(platform->random_mutex);
+#endif
 
     free(platform);
 


### PR DESCRIPTION
entropy and random mutexes were initialized only on generic_unix.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
