### PR TITLE
Add hello_world AVM to release (for testing Homebrew Formula)

### DIFF
--- a/.github/workflows/build-libraries.yaml
+++ b/.github/workflows/build-libraries.yaml
@@ -84,6 +84,9 @@ jobs:
         ATOMVMLIB_FILE=atomvmlib-${{ github.ref_name }}.avm
         mv libs/atomvmlib.avm "libs/${ATOMVMLIB_FILE}" &&
         sha256sum "libs/${ATOMVMLIB_FILE}" > "libs/${ATOMVMLIB_FILE}.sha256"
+        HELLO_WORLD_FILE=hello_world-${{ github.ref_name }}.avm
+        mv examples/erlang/hello_world.avm "examples/erlang/${HELLO_WORLD_FILE}"
+        sha256sum "examples/erlang/${HELLO_WORLD_FILE}" > "examples/erlang/${HELLO_WORLD_FILE}.sha256"
 
     - name: Release
       uses: softprops/action-gh-release@v1
@@ -94,3 +97,5 @@ jobs:
         files: |
           build/libs/atomvmlib-${{ github.ref_name }}.avm
           build/libs/atomvmlib-${{ github.ref_name }}.avm.sha256
+          examples/erlang/hello_world-${{ github.ref_name }}.avm
+          examples/erlang/hello_world-${{ github.ref_name }}.avm.sha256


### PR DESCRIPTION
This PR adds the `hello_world` AVM file to the release.  This is useful for producing a releasable Homebrew Formula, as the Homebrew team requires at least one meaningful test in order to commit to their repository.

More information can be found in https://docs.brew.sh/Adding-Software-to-Homebrew

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
