### PR TITLE
Prepare v0.6.0-beta.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0-beta.0] - Unreleased
+## [0.6.0-beta.0] - 2024-02-08
 
 ### Added
 - Added `esp:get_default_mac/0` for retrieving the default MAC address on ESP32.

--- a/version.cmake
+++ b/version.cmake
@@ -19,4 +19,4 @@
 #
 
 set(ATOMVM_BASE_VERSION "0.6.0-beta.0")
-set(ATOMVM_DEV TRUE)
+set(ATOMVM_DEV FALSE)


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
