### PR TITLE
Allow Pico tools to use automated `BOOTSEL` mode after application exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for utf8 encoding to `*_to_atom` and `atom_to_*` functions
 - `binary_to_atom/1` and `atom_to_binary/1` that default to utf8 (they were introduced with OTP23)
+- Added Pico cmake option `AVM_WAIT_BOOTSEL_ON_EXIT` (default `ON`) to allow tools to use automated `BOOTSEL` mode after main application exits
 
 ### Fixed
 

--- a/src/platforms/rp2040/CMakeLists.txt
+++ b/src/platforms/rp2040/CMakeLists.txt
@@ -52,6 +52,7 @@ option(AVM_DISABLE_SMP "Disable SMP support." OFF)
 option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
 option(AVM_WAIT_FOR_USB_CONNECT "Wait for USB connection before starting" OFF)
+option(AVM_WAIT_BOOTSEL_ON_EXIT "Wait in BOOTSEL rather than shutdown on exit" ON)
 option(AVM_REBOOT_ON_NOT_OK "Reboot Pico if result is not ok" OFF)
 
 set(

--- a/src/platforms/rp2040/src/CMakeLists.txt
+++ b/src/platforms/rp2040/src/CMakeLists.txt
@@ -45,6 +45,10 @@ if (AVM_WAIT_FOR_USB_CONNECT)
     target_compile_definitions(AtomVM PRIVATE PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS=-1)
 endif()
 
+if (AVM_WAIT_BOOTSEL_ON_EXIT)
+    target_compile_definitions(AtomVM PRIVATE WAIT_BOOTSEL_ON_EXIT)
+endif()
+
 set(
     PLATFORM_LIB_SUFFIX
     ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}

--- a/src/platforms/rp2040/src/main.c
+++ b/src/platforms/rp2040/src/main.c
@@ -27,6 +27,7 @@
 #include <hardware/regs/addressmap.h>
 #include <hardware/watchdog.h>
 #include <pico/binary_info.h>
+#include <pico/bootrom.h>
 #include <pico/stdlib.h>
 
 #pragma GCC diagnostic pop
@@ -183,12 +184,26 @@ int _kill(pid_t pid, int sig)
         fprintf(stderr, "Unknown signal %d\n", sig);
     }
     exit_handler(true);
+#ifdef WAIT_BOOTSEL_ON_EXIT
+    while (stdio_usb_connected()) {
+        ;
+    }
+    reset_usb_boot(0, 0);
+#else
     return 0;
+#endif
 }
 
 int main()
 {
     int reboot = app_main();
     exit_handler(reboot);
+#ifdef WAIT_BOOTSEL_ON_EXIT
+    while (stdio_usb_connected()) {
+        ;
+    }
+    reset_usb_boot(0, 0);
+#else
     return 0;
+#endif
 }


### PR DESCRIPTION
After main() exits with a return, the CPU of the pico is put into a hung state, (from the raspberry-pi-pico-c-sdk page 8, Introduction 1.1 section) which prevents triggering the device into `BOOTSEL` mode to copy a new application.

These changes introduce the cmake `AVM_WAIT_BOOTSEL_ON_EXIT` option; which is enabled by default, will have the cpu spin (if `AVM_REBOOT_ON_NOT_OK` is not enabled) while a console monitoring application is still attached, allowing users to read the console output. If no console monitor is attached (or the attached monitor closes) the pico will be reset into a mode that will allow if to be put into `BOOTSEL` mode by the atomvm_rebar3_plugin `pico_flash` task (or other tools using automated `BOOTSEL` mode solutions), so a new application (or version) can be copied to the device.

closes #906
Closes atomvm/atomvm_rebar3_plugin#18

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
