### PR TITLE
Fix: build-libraries CI

### DIFF
--- a/.github/workflows/build-libraries.yaml
+++ b/.github/workflows/build-libraries.yaml
@@ -97,5 +97,5 @@ jobs:
         files: |
           build/libs/atomvmlib-${{ github.ref_name }}.avm
           build/libs/atomvmlib-${{ github.ref_name }}.avm.sha256
-          examples/erlang/hello_world-${{ github.ref_name }}.avm
-          examples/erlang/hello_world-${{ github.ref_name }}.avm.sha256
+          build/examples/erlang/hello_world-${{ github.ref_name }}.avm
+          build/examples/erlang/hello_world-${{ github.ref_name }}.avm.sha256


### PR DESCRIPTION
Fix for missing files: https://github.com/atomvm/AtomVM/actions/runs/7831738913/job/21368781913

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
