### PR TITLE
Fix I2C release function and improve logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0-beta.1] - Unreleased
 
+### Fixed
+
+- ESP32: fix i2c_driver_acquire and i2c_driver_release functions, that were working only once.
+
 ## [0.6.0-beta.0] - 2024-02-08
 
 ### Added

--- a/src/platforms/esp32/components/avm_builtins/i2c_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/i2c_driver.c
@@ -171,7 +171,7 @@ free_and_exit:
     return NULL;
 }
 
-static NativeHandlerResult i2c_driver_maybe_close(Context *ctx)
+static NativeHandlerResult i2c_driver_unref(Context *ctx)
 {
     struct I2CData *i2c_data = ctx->platform_data;
     if (--i2c_data->ref_count != 0) {
@@ -608,7 +608,7 @@ static NativeHandlerResult i2cdriver_consume_mailbox(Context *ctx)
             // ugly hack: we lock before closing so _release and _acquire can assume
             // ctx->platform is not changed.
             globalcontext_get_process_lock(ctx->global, ctx->process_id);
-            handler_result = i2c_driver_maybe_close(ctx);
+            handler_result = i2c_driver_unref(ctx);
             globalcontext_get_process_unlock(ctx->global, ctx);
             ret = OK_ATOM;
             break;
@@ -676,8 +676,7 @@ void i2c_driver_release(term i2c_port, GlobalContext *global)
     }
 
     struct I2CData *i2c_data = ctx->platform_data;
-    i2c_data->ref_count--;
-    NativeHandlerResult close_result = i2c_driver_maybe_close(ctx);
+    NativeHandlerResult close_result = i2c_driver_unref(ctx);
     if (close_result == NativeTerminate) {
         mailbox_send_term_signal(ctx, KillSignal, NORMAL_ATOM);
     }

--- a/src/platforms/esp32/components/avm_builtins/i2c_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/i2c_driver.c
@@ -634,7 +634,7 @@ static NativeHandlerResult i2cdriver_consume_mailbox(Context *ctx)
 I2CAcquireResult i2c_driver_acquire(term i2c_port, i2c_port_t *i2c_num, GlobalContext *global)
 {
     if (UNLIKELY(!term_is_pid(i2c_port))) {
-        ESP_LOGW(TAG, "Given term is not a I2C port driver.");
+        ESP_LOGW(TAG, "acquire: given term is not a PID.");
         return I2CAcquireInvalidPeripheral;
     }
 
@@ -643,7 +643,7 @@ I2CAcquireResult i2c_driver_acquire(term i2c_port, i2c_port_t *i2c_num, GlobalCo
 
     if ((ctx == NULL) || (ctx->native_handler != i2cdriver_consume_mailbox)
         || (ctx->platform_data == NULL)) {
-        ESP_LOGW(TAG, "Given term is not a I2C port driver.");
+        ESP_LOGW(TAG, "acquire: given term is not a I2C port driver.");
         globalcontext_get_process_unlock(global, ctx);
         return I2CAcquireInvalidPeripheral;
     }
@@ -661,7 +661,7 @@ I2CAcquireResult i2c_driver_acquire(term i2c_port, i2c_port_t *i2c_num, GlobalCo
 void i2c_driver_release(term i2c_port, GlobalContext *global)
 {
     if (UNLIKELY(!term_is_pid(i2c_port))) {
-        ESP_LOGW(TAG, "Given term is not a I2C port driver.");
+        ESP_LOGW(TAG, "release: given term is not a PID.");
         return;
     }
 
@@ -670,7 +670,7 @@ void i2c_driver_release(term i2c_port, GlobalContext *global)
 
     if ((ctx == NULL) || (ctx->native_handler != i2cdriver_consume_mailbox)
         || (ctx->platform_data == NULL)) {
-        ESP_LOGW(TAG, "Given term is not a I2C port driver.");
+        ESP_LOGW(TAG, "release: given term is not a I2C port driver.");
         globalcontext_get_process_unlock(global, ctx);
         return;
     }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
