### PR TITLE
Resolve doxygen problems processing opcodesswitch.h

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -903,7 +903,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */libAtomVM/opcodesswitch.h
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1506,9 +1506,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
     int read_core_chunk(Module *mod)
 #else
     #ifdef IMPL_EXECUTE_LOOP
-    #ifndef DOXYGEN_SKIP_SECTION /* documented in context.h */
         int context_execute_loop(Context *ctx, Module *mod, const char *function_name, int arity)
-    #endif /* DOXYGEN_SKIP_SECTION */
     #else
         #error Need implementation type
     #endif


### PR DESCRIPTION
Since no doxygen documentation is included in `src/libAtomVM/opcodesswitch.h`, and processing the files causes build warnings and rendering errors, the file is now omitted when generating the documentation. This allows removing old doxygen macros added in PR #678, and will prevent needing to pollute the file with more macros to fix new rendering errors.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
