### PR TITLE
Revert to upstream `edown` for Erlang documentation

### DIFF
--- a/doc/edoc/edown_dep/rebar.config
+++ b/doc/edoc/edown_dep/rebar.config
@@ -3,7 +3,5 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 
 {erl_opts, [debug_info]}.
-{deps, [{edown, {git, "https://github.com/pguyot/edown.git", {ref, "e0201c8ec6444d8d41891f0a5ed2bce42fe944d0"}}}]}.
-{plugins, [
-   ex_doc
-]}.
+{deps, [{edown, "~> 0.9.1"}]}.
+{plugins, []}.


### PR DESCRIPTION
The fix in uwiger/edown#30 has been merged upstream, so we should now return to using the upstream tool available from hex.

Removes unnecessary `ex_doc` plugin.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
