### PR TITLE
Corrections to libAtomVM doxgen comments

### DIFF
--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -399,7 +399,7 @@ bool context_get_process_info(Context *ctx, term *out, term atom_key);
  * the link.
  *
  * @param ctx context to link
- * @param link_pid process to link ctx to
+ * @param monitor_pid process to link ctx to
  * @return 0 on success
  */
 int context_link(Context *ctx, term monitor_pid);
@@ -430,7 +430,7 @@ struct ResourceMonitor *context_resource_monitor(Context *ctx, void *resource);
  * the link.
  *
  * @param ctx context to monitor
- * @param link_id process to unlink
+ * @param monitor_pid process to unlink
  */
 void context_unlink(Context *ctx, term monitor_pid);
 

--- a/src/libAtomVM/erl_nif.h
+++ b/src/libAtomVM/erl_nif.h
@@ -231,7 +231,7 @@ int enif_monitor_process(ErlNifEnv *env, void *obj, const ErlNifPid *target_pid,
 /**
  * @brief Unmonitor a process
  *
- * @param env current environment
+ * @param caller_env current environment
  * @param obj resource used by monitor
  * @param mon monitor
  * @return 0 on success

--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -76,11 +76,13 @@ static int serialize_term(uint8_t *buf, term t, GlobalContext *glb);
 /**
  * @brief
  * @param   external_term   buffer containing external term
+ * @param   size            size of the external_term
  * @param   ctx             current context in which terms may be stored
  * @param   opts            additional opts, such as ExternalTermToHeapFragment for storing parsed
  * terms in a heap fragment.
  *                          are stored in the context heap.
  * @param   bytes_read      the number of bytes read off external_term in order to yield a term
+ * @param   copy            whether to copy binary data and atom strings (pass `true', unless `external_term' is a const binary and will not be deallocated)
  * @return  the parsed term
  */
 static term externalterm_to_term_internal(const void *external_term, size_t size, Context *ctx,

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -310,7 +310,7 @@ bool globalcontext_is_atom_index_equal_to_atom_string(GlobalContext *glb, int at
  * @brief Compares a term with an AtomString.
  *
  * @details Checks if the given term and the given AtomString refers to the same atom.
- * @param glb the global context.
+ * @param global the global context.
  * @param atom_a any term of any type, when it is not an atom false is always returned.
  * @param atom_string_b an atom string, which is the atom length followed by atom characters.
  * @returns true if they both refer to the same atom, otherwise false.

--- a/src/libAtomVM/inet.h
+++ b/src/libAtomVM/inet.h
@@ -69,7 +69,7 @@ enum inet_protocol
 
 /**
  * @brief Parse an inet protocol
- * @param type the inet protocol atom
+ * @param protocol the inet protocol atom
  * @param global the global context
  * @returns the parsed protocol
  */

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -240,6 +240,7 @@ term module_load_literal(Module *mod, int index, Context *ctx);
  * @details Gets an AtomString for the given local atom id from the global table.
  * @param mod the module that owns the atom.
  * @param local_atom_id module atom table index.
+ * @param glb the global context.
  * @return the AtomString for the given module atom index.
  */
 static inline AtomString module_get_atom_string_by_id(const Module *mod, int local_atom_id, GlobalContext *glb)

--- a/src/libAtomVM/otp_net.c
+++ b/src/libAtomVM/otp_net.c
@@ -106,7 +106,7 @@ static term eai_errno_to_term(int err, GlobalContext *glb)
  * @param inner_addr IP address  that will be stored in both address and addr
  *             entries of the map
  * @param global the global context
- * @returrn the getaddrinfo result item term
+ * @return the getaddrinfo result item term
  * @param heap the heap to create terms in, should have sufficient free space
  * @details This function is called in a loop to create optimized maps that
  * share keys.

--- a/src/libAtomVM/otp_socket.h
+++ b/src/libAtomVM/otp_socket.h
@@ -56,6 +56,7 @@ void otp_socket_init(GlobalContext *global);
  *
  * @param socket_term   the term with the socket
  * @param otp_socket    on output, the socket resource
+ * @param ctx           the current context
  * @return true in case of success
  */
 bool term_to_otp_socket(term socket_term, struct SocketResource **otp_socket, Context *ctx);
@@ -71,7 +72,7 @@ bool term_is_otp_socket(term socket_term);
 /**
  * @brief Send data to a socket (without blocking)
  *
- * @param otp_socket    the socket resource
+ * @param socket        the socket resource
  * @param buf           buffer to send
  * @param len           number of bytes
  * @param dest          destination address or invalid term for sendto/send
@@ -82,7 +83,7 @@ ssize_t socket_send(struct SocketResource *socket, const uint8_t *buf, size_t le
 /**
  * @brief Read data from a socket.
  *
- * @param otp_socket    the socket resource
+ * @param socket        the socket resource
  * @param buf           buffer to store data
  * @param len           number of bytes
  * @param flags         flags passed to recvfrom

--- a/src/libAtomVM/resources.h
+++ b/src/libAtomVM/resources.h
@@ -89,8 +89,8 @@ static inline void resource_type_destroy(struct ResourceType *resource_type)
  *
  * This function calls `sys_unregister_select_event`.
  *
- * @param select_event the event to notify
- * @param is_write if the event was selected for reading
+ * @param event the event to notify
+ * @param is_read if the event was selected for reading
  * @param is_write if the event was selected for writing
  * @param global the global context
  * @return true if the event was found


### PR DESCRIPTION
Fixes missing and miss matched parameter names in libAtomVM doxygen comments.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
