### PR TITLE
Corrections to edocs

### DIFF
--- a/libs/eavmlib/src/atomvm.erl
+++ b/libs/eavmlib/src/atomvm.erl
@@ -178,7 +178,7 @@ add_avm_pack_file(_AVMPath, _Options) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
-%% @param   name the AVM name.
+%% @param   Name the AVM name.
 %% @param   Options Options, as a property list.
 %% @returns `ok | error'
 %% @doc     Close previously opened AVM binary from your application.

--- a/libs/eavmlib/src/emscripten.erl
+++ b/libs/eavmlib/src/emscripten.erl
@@ -298,7 +298,7 @@ run_script(_Script) ->
 %% is run on the main thread. If `async', the script is run asynchronously, i.e.
 %% the caller does not wait for completion. Only applies if `main_thread' is specified.
 %% @returns ok
--spec run_script(iodata(), [run_script_opt()]) -> ok.
+-spec run_script(_Script :: iodata(), _Options :: [run_script_opt()]) -> ok.
 run_script(_Script, _Options) ->
     erlang:nif_error(undefined).
 
@@ -324,7 +324,7 @@ promise_resolve(_Promise) ->
 %% 'no_proc'. Likewise if the Promise is garbage collected by the Erlang VM.
 %% @param _Promise Opaque promise resource
 %% @param _Value Value to send to Javascript, must be an integer or a string.
--spec promise_resolve(promise(), integer() | iodata()) -> ok.
+-spec promise_resolve(_Promise :: promise(), _Value :: integer() | iodata()) -> ok.
 promise_resolve(_Promise, _Value) ->
     erlang:nif_error(undefined).
 
@@ -337,7 +337,7 @@ promise_reject(_Promise) ->
 %% This is similar to `promise_resolve' except the promise is rejected.
 %% @param _Promise Opaque promise resource
 %% @param _Value Value to send to Javascript, must be an integer or a string.
--spec promise_reject(promise(), integer() | iodata()) -> ok.
+-spec promise_reject(_Promise :: promise(), _Value :: integer() | iodata()) -> ok.
 promise_reject(_Promise, _Value) ->
     erlang:nif_error(undefined).
 
@@ -383,7 +383,10 @@ register_keypress_callback(_Target, _Options) ->
 %% @param _Target target to register keypress on
 %% @param _Options options for event handling
 %% @param _UserData user data passed back
--spec register_keypress_callback(html5_target(), register_options(), any()) -> register_result().
+-spec register_keypress_callback(
+    _Target :: html5_target(), _Options :: register_options(), _UserData :: any()
+) ->
+    register_result().
 register_keypress_callback(_Target, _Options, _UserData) ->
     erlang:nif_error(undefined).
 
@@ -405,7 +408,7 @@ register_keypress_callback(_Target, _Options, _UserData) ->
 %%
 %% @param _TargetOrHandle Target or handle
 %% @returns ok or an error
--spec unregister_keypress_callback(html5_target() | listener_handle()) ->
+-spec unregister_keypress_callback(_TargetOrHandle :: html5_target() | listener_handle()) ->
     ok | {error, register_error_reason()}.
 unregister_keypress_callback(_TargetOrHandle) ->
     erlang:nif_error(undefined).

--- a/libs/eavmlib/src/emscripten.erl
+++ b/libs/eavmlib/src/emscripten.erl
@@ -316,9 +316,9 @@ promise_resolve(_Promise) ->
 %% '''
 %% and if an Erlang process is registered as `some_proc`, then the process
 %% will receive a message:
-%% ```
+%% <pre><code>
 %% {emscripten, {call, Promise, <<"message">>}}
-%% '''
+%% </code></pre>
 %% and the Javascript caller will wait until `promise_resolve' or `promise_reject'
 %% is called. If the process doesn't exist, the promise will be rejected with
 %% 'no_proc'. Likewise if the Promise is garbage collected by the Erlang VM.

--- a/libs/eavmlib/src/esp.erl
+++ b/libs/eavmlib/src/esp.erl
@@ -157,7 +157,10 @@ sleep_get_wakeup_cause() ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
-%% @returns Configure ext0 wakeup
+%% @doc Configure gpio wakeup from deep sleep
+%% @param   Pin number of the pin to use as wakeup event
+%% @param   Level is the state to trigger a wakeup
+%% @returns `ok | error'
 %% @end
 %%-----------------------------------------------------------------------------
 -spec sleep_enable_ext0_wakeup(Pin :: pos_integer(), Level :: 0..1) -> ok | error.
@@ -165,10 +168,25 @@ sleep_enable_ext0_wakeup(_Pin, _Level) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
-%% @returns Configure ext1 wakeup
+%% @doc Configure multiple gpio pins for wakeup from deep sleep
+%% @param   Mask bit mask of GPIO numbers which will cause wakeup
+%% @param   Mode used to determine wakeup events
+%%
+%%     The available modes are:
+%% <table>
+%%   <tr> <th>Mode</th> <th>Description</th> </tr>
+%%   <tr> <td>`0'</td> <td>WAKEUP_ALL_LOW</td></tr>
+%%   <tr> <td>`1'</td> <td>WAKEUP_ANY_HIGH (When chip is ESP32-S2, ESP32-S3, ESP32-C6 or ESP32-H2)</td></tr>
+%%   <tr> <td>`2'</td> <td>WAKEUP_ANY_LOW</td></tr>
+%%   <tr> <td>`3'</td> <td>WAKEUP_ANY_HIGH</td></tr>
+%% </table>
+%%
+%% Note: The operation of these modes can vary with builds from previous versions
+%% of the ESP-IDF. The modes described here are valid for AtomVM built with ESP-IDF-v5.1.x.
+%% @returns `ok | error'
 %% @end
 %%-----------------------------------------------------------------------------
--spec sleep_enable_ext1_wakeup(Mask :: non_neg_integer(), Mode :: 0..1) -> ok | error.
+-spec sleep_enable_ext1_wakeup(Mask :: non_neg_integer(), Mode :: 0..3) -> ok | error.
 sleep_enable_ext1_wakeup(_Mask, _Mode) ->
     erlang:nif_error(undefined).
 

--- a/libs/eavmlib/src/gpio.erl
+++ b/libs/eavmlib/src/gpio.erl
@@ -25,7 +25,8 @@
 %% (General Purpose Input and Output) pins.
 %%
 %% Note: `-type pin()' used in this driver refers to a pin number on Espressif
-%% chips, or a tuple {GPIO_BANK, PIN} for stm32 chips.
+%% chips and normal Raspberry Pi Pico pins, or a tuple {GPIO_BANK, PIN} for STM32
+%% chips and the "extra" GPIOs available on the Pico-W.
 %% @end
 %%-----------------------------------------------------------------------------
 -module(gpio).

--- a/libs/eavmlib/src/gpio.erl
+++ b/libs/eavmlib/src/gpio.erl
@@ -197,7 +197,7 @@ set_direction(GPIO, Pin, Direction) ->
 %%-----------------------------------------------------------------------------
 %% @param   GPIO pid that was returned from `gpio:start/0'
 %% @param   Pin number of the pin to write
-%% @param   Desired output level to set
+%% @param   Level the desired output level to set
 %% @returns ok | error | {error, Reason}
 %% @doc     Set GPIO digital output level
 %%
@@ -443,7 +443,7 @@ deep_sleep_hold_dis() ->
 
 %%-----------------------------------------------------------------------------
 %% @param   Pin number of the pin to write
-%% @param   Desired output level to set
+%% @param   Level the desired output level to set
 %% @returns ok | error | {error, Reason}
 %% @doc     Set GPIO digital output level
 %%

--- a/libs/eavmlib/src/pico.erl
+++ b/libs/eavmlib/src/pico.erl
@@ -37,7 +37,7 @@
 %%          The datetime can be obtained through bif erlang:localtime()
 %% @end
 %%-----------------------------------------------------------------------------
--spec rtc_set_datetime(calendar:datetime()) -> ok.
+-spec rtc_set_datetime(Datetime :: calendar:datetime()) -> ok.
 rtc_set_datetime(_Datetime) ->
     erlang:nif_error(undefined).
 

--- a/libs/eavmlib/src/pico.erl
+++ b/libs/eavmlib/src/pico.erl
@@ -33,6 +33,7 @@
 ]).
 
 %%-----------------------------------------------------------------------------
+%% @param   Datetime `calendar:datetime()' to set rtc clock.
 %% @doc     Set the datetime on the RTC.
 %%          The datetime can be obtained through bif erlang:localtime()
 %% @end

--- a/libs/eavmlib/src/port.erl
+++ b/libs/eavmlib/src/port.erl
@@ -23,7 +23,7 @@
 %% @doc AtomVM port driver APIs
 %%
 %% This module contains functions that are intended to be used by drivers that
-%% rely on a `port' interface rather than `niffs'.
+%% rely on a `port' interface rather than `nifs'.
 %%
 %% The port driver should be initialized with:
 %% `open_port({spawn, "Name"}, Param)'

--- a/libs/eavmlib/src/port.erl
+++ b/libs/eavmlib/src/port.erl
@@ -41,7 +41,7 @@
 -export([call/2, call/3]).
 
 %%-----------------------------------------------------------------------------
-%% @param   Pid Pid to which to send messages
+%% @param   Port Pid to which to send messages
 %% @param   Message the message to send
 %% @returns term() | {error, Reason}.
 %% @doc     Send a message to a given port driver pid.
@@ -50,12 +50,12 @@
 %% return a term or `{error, Reason}'.
 %% @end
 %%-----------------------------------------------------------------------------
--spec call(Pid :: pid(), Message :: term()) -> term().
+-spec call(Port :: pid(), Message :: term()) -> term().
 call(Port, Message) ->
     call(Port, Message, infinity).
 
 %%-----------------------------------------------------------------------------
-%% @param   Pid Pid to which to send messages
+%% @param   Port Pid to which to send messages
 %% @param   Message the message to send
 %% @param   Timeout the timeout value in milliseconds
 %% @returns term() | {error, Reason}.
@@ -65,7 +65,7 @@ call(Port, Message) ->
 %% a term or `{error, Reason}', or`{error, timeout}' if the TimeoutMs is reached first.
 %% @end
 %%-----------------------------------------------------------------------------
--spec call(Pid :: pid(), Message :: term(), Timeout :: timeout()) -> term() | {error, timeout}.
+-spec call(Port :: pid(), Message :: term(), Timeout :: timeout()) -> term() | {error, timeout}.
 call(Port, Message, Timeout) ->
     MonitorRef = monitor(port, Port),
     Port ! {'$call', {self(), MonitorRef}, Message},

--- a/libs/eavmlib/src/port.erl
+++ b/libs/eavmlib/src/port.erl
@@ -50,7 +50,7 @@
 %% return a term or `{error, Reason}'.
 %% @end
 %%-----------------------------------------------------------------------------
--spec call(pid(), Message :: term()) -> term().
+-spec call(Pid :: pid(), Message :: term()) -> term().
 call(Port, Message) ->
     call(Port, Message, infinity).
 
@@ -65,7 +65,7 @@ call(Port, Message) ->
 %% a term or `{error, Reason}', or`{error, timeout}' if the TimeoutMs is reached first.
 %% @end
 %%-----------------------------------------------------------------------------
--spec call(pid(), Message :: term(), Timeout :: timeout()) -> term() | {error, timeout}.
+-spec call(Pid :: pid(), Message :: term(), Timeout :: timeout()) -> term() | {error, timeout}.
 call(Port, Message, Timeout) ->
     MonitorRef = monitor(port, Port),
     Port ! {'$call', {self(), MonitorRef}, Message},

--- a/libs/estdlib/src/calendar.erl
+++ b/libs/estdlib/src/calendar.erl
@@ -113,9 +113,10 @@ date_to_gregorian_days(Year, M, D) when
     Era * 146097 + DoE + 60.
 
 %%-----------------------------------------------------------------------------
-%% @param   DateTime
-%% @returns Days    number of days
-%% @doc     Computes the number of gregorian days starting with year 0 and ending at the specified date.
+%% @param   DateTime the date and time to convert to seconds
+%% @returns Seconds number of seconds
+%% @doc     Computes the number of gregorian seconds starting with year 0 and ending
+%% at the specified date and time.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec datetime_to_gregorian_seconds(DateTime :: datetime()) -> integer().
@@ -158,7 +159,7 @@ day_of_the_week(Y, M, D) ->
 %%-----------------------------------------------------------------------------
 %% @param   Time the time, as an integer, in the specified unit
 %% @param   TimeUnit the time unit
-%% @param   The date and time (in UTC) converted from the specified time and time unit
+%% @returns DateTime The date and time (in UTC) converted from the specified time and time unit
 %% @doc     Convert an integer time value to a date and time in UTC.
 %% @end
 %%-----------------------------------------------------------------------------

--- a/libs/estdlib/src/calendar.erl
+++ b/libs/estdlib/src/calendar.erl
@@ -129,7 +129,7 @@ datetime_to_gregorian_seconds({Date, {Hour, Minute, Second}}) when
 
 %%-----------------------------------------------------------------------------
 %% @equiv day_of_the_week(Y, M, D)
-%% @param   Date the date for which to retreive the weekday
+%% @param   Date the date for which to retrieve the weekday
 %% @returns Weekday day of the week
 %% @doc     Computes the day of the week from the specified date tuple {Year, Month, Day}.
 %%          Returns the day of the week as 1: Monday, 2: Tuesday, and so on.

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -925,6 +925,7 @@ demonitor(_Monitor) ->
 
 %%-----------------------------------------------------------------------------
 %% @param   Monitor reference of monitor to remove
+%% @param   Options options list
 %% @returns `true'
 %% @doc     Remove a monitor, with options.
 %% If `flush', monitor messages are flushed and guaranteed to not be received.

--- a/libs/estdlib/src/gen_statem.erl
+++ b/libs/estdlib/src/gen_statem.erl
@@ -21,7 +21,7 @@
 %%-----------------------------------------------------------------------------
 %% @doc An implementation of the Erlang/OTP gen_statem interface.
 %%
-%% This module implements a strict susbset of the Erlang/OTP gen_statem
+%% This module implements a strict subset of the Erlang/OTP gen_statem
 %% interface, supporting operations for local creation and management of
 %% gen_statem instances.
 %%

--- a/libs/estdlib/src/gen_statem.erl
+++ b/libs/estdlib/src/gen_statem.erl
@@ -169,6 +169,8 @@ stop(ServerRef) ->
 
 %%-----------------------------------------------------------------------------
 %% @param   ServerRef a reference to the gen_statem acquired via start
+%% @param   Reason the reason to supply for stopping
+%% @param   Timeout maximum time to wait for shutdown
 %% @returns ok, if the gen_statem stopped; {error, Reason}, otherwise.
 %% @doc     Stop a previously started gen_statem instance.
 %%

--- a/libs/estdlib/src/gen_tcp.erl
+++ b/libs/estdlib/src/gen_tcp.erl
@@ -172,7 +172,7 @@ listen(Port, Options) ->
     end.
 
 %%-----------------------------------------------------------------------------
-%% @param   ListenSocket the listening socket.
+%% @param   Socket the listening socket.
 %% @returns a connection-based (tcp) socket that can be used for reading and writing
 %% @doc     Accept a connection on a listening socket.
 %% @end
@@ -188,7 +188,7 @@ accept({?GEN_TCP_MONIKER, Socket, Module}) ->
     end.
 
 %%-----------------------------------------------------------------------------
-%% @param   ListenSocket the listening socket.
+%% @param   Socket the listening socket.
 %% @param   Timeout amount of time in milliseconds to wait for a connection
 %% @returns a connection-based (tcp) socket that can be used for reading and writing
 %% @doc     Accept a connection on a listening socket.

--- a/libs/estdlib/src/gen_udp.erl
+++ b/libs/estdlib/src/gen_udp.erl
@@ -69,7 +69,7 @@ open(PortNum) ->
     open(PortNum, []).
 
 %%-----------------------------------------------------------------------------
-%% @param   Port the port number to bind to.  Specify 0 to use an OS-assigned
+%% @param   PortNum the port number to bind to.  Specify 0 to use an OS-assigned
 %%          port number, which can then be retrieved via the inet:port/1
 %%          function.
 %% @param   Options A list of configuration parameters.
@@ -98,7 +98,7 @@ open(PortNum, Options) ->
 %%-----------------------------------------------------------------------------
 %% @param   Socket the socket over which to send a packet
 %% @param   Address the target address to which to send the packet
-%% @param   Port    the port on target address to which to send the packet
+%% @param   PortNum the port on target address to which to send the packet
 %% @param   Packet  the packet of data to send
 %% @returns ok | {error, Reason}
 %% @doc     Send a packet over a UDP socket to a target address/port.

--- a/libs/estdlib/src/gen_udp.erl
+++ b/libs/estdlib/src/gen_udp.erl
@@ -153,7 +153,7 @@ recv({?GEN_UDP_MONIKER, Socket, Module}, Length, Timeout) ->
 %% @doc     Close the socket.
 %% @end
 %%-----------------------------------------------------------------------------
--spec close(inet:socket()) -> ok.
+-spec close(Socket :: inet:socket()) -> ok.
 close({?GEN_UDP_MONIKER, Socket, Module}) ->
     Module:close(Socket).
 

--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -306,7 +306,7 @@ keyreplace(K, I, [H | T], L, NewTuple, NewList) ->
 
 %%-----------------------------------------------------------------------------
 %% @param   Fun the function to apply
-%% @param   Accum0 the initial accumulator
+%% @param   Acc0 the initial accumulator
 %% @param   List the list over which to fold
 %% @returns the result of folding Fun over L
 %% @doc     Fold over a list of terms, from left to right, applying Fun(E, Accum)

--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -464,6 +464,7 @@ seq(From, To) when is_integer(From) andalso is_integer(To) andalso From =< To ->
 %%
 %% @end
 %%-----------------------------------------------------------------------------
+-spec seq(From :: integer(), To :: integer(), Incr :: integer()) -> list().
 seq(From, To, Incr) when
     (not is_integer(From) orelse not is_integer(To) orelse not is_integer(Incr)) orelse
         (To < (From - Incr) andalso Incr > 0) orelse

--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -22,7 +22,7 @@
 %%-----------------------------------------------------------------------------
 %% @doc An implementation of the Erlang/OTP lists interface.
 %%
-%% This module implements a strict susbset of the Erlang/OTP lists
+%% This module implements a strict subset of the Erlang/OTP lists
 %% interface.
 %% @end
 %%-----------------------------------------------------------------------------
@@ -125,7 +125,7 @@ delete(E, [H | T], Accum) ->
 %% @returns the elements of L in reverse order
 %% @equiv lists:reverse(L, [])
 %% @doc Erlang/OTP implementation of this function actually handles few simple
-%% cases and calls lists:reverse/2 for the more genertic case. Consequently,
+%% cases and calls `lists:reverse/2' for the more generic case. Consequently,
 %% calling `lists:reverse/1' without a list or with an improper list of two
 %% elements will fail with a function clause exception on Erlang/OTP and with a
 %% badarg exception with this implementation.
@@ -139,7 +139,7 @@ reverse(_L) ->
 %% @param   L the list to reverse
 %% @param   T the tail to append to the reversed list
 %% @returns the elements of L in reverse order followed by T
-%% @doc     Reverse the elements of L, folled by T.
+%% @doc     Reverse the elements of L, followed by T.
 %% If T is not a list or not a proper list, it is appended anyway and the result
 %% will be an improper list.
 %%

--- a/libs/estdlib/src/socket.erl
+++ b/libs/estdlib/src/socket.erl
@@ -445,7 +445,7 @@ sendto(Socket, Data, Dest) ->
 
 %%-----------------------------------------------------------------------------
 %% @param   Socket the socket
-%% @param   Option the option
+%% @param   SocketOption the option
 %% @param   Value the option value
 %% @returns `{ok, Address}' if successful; `{error, Reason}', otherwise.
 %% @doc     Set a socket option.

--- a/libs/estdlib/src/unicode.erl
+++ b/libs/estdlib/src/unicode.erl
@@ -122,7 +122,7 @@ characters_to_binary(_Data, _InEncoding) ->
 %% for which this function merely returns an error tuple.</p>
 %% @param Data data to convert to UTF8
 %% @param InEncoding encoding of input data
-%% @param InEncoding output encoding
+%% @param OutEncoding output encoding
 %% @return an encoded binary or a tuple if conversion failed.
 -spec characters_to_binary(
     Data :: chardata() | latin1_chardata(), InEncoding :: encoding(), OutEncoding :: encoding()

--- a/libs/etest/src/etest.erl
+++ b/libs/etest/src/etest.erl
@@ -49,7 +49,7 @@
 %%          returns the atom fail.
 %% @end
 %%-----------------------------------------------------------------------------
--spec test(list(module())) -> ok | fail.
+-spec test(Tests :: list(module())) -> ok | fail.
 test(Tests) ->
     Results = [{Test, run_test(Test)} || Test <- Tests],
     case erlang:system_info(machine) of
@@ -65,7 +65,7 @@ test(Tests) ->
 %% @returns ok if X and Y unify; fail otherwise.
 %% @end
 %%-----------------------------------------------------------------------------
--spec assert_match(term(), term()) -> ok | fail.
+-spec assert_match(X :: term(), Y :: term()) -> ok | fail.
 assert_match(X, X) -> ok;
 assert_match(_, _) -> fail.
 
@@ -75,7 +75,7 @@ assert_match(_, _) -> fail.
 %% @returns ok if X and Y are equal; fail otherwise.
 %% @end
 %%-----------------------------------------------------------------------------
--spec assert_equals(term(), term()) -> ok | fail.
+-spec assert_equals(X :: term(), Y :: term()) -> ok | fail.
 assert_equals(X, Y) ->
     case X == Y of
         true -> ok;
@@ -87,7 +87,7 @@ assert_equals(X, Y) ->
 %% @returns ok if X is true; fail otherwise.
 %% @end
 %%-----------------------------------------------------------------------------
--spec assert_true(boolean()) -> ok | fail.
+-spec assert_true(X :: boolean()) -> ok | fail.
 assert_true(true) -> ok;
 assert_true(_) -> fail.
 
@@ -96,7 +96,7 @@ assert_true(_) -> fail.
 %% @returns ok if evaluating F results in Error being raised; fail, otherwise
 %% @end
 %%-----------------------------------------------------------------------------
--spec assert_exception(fun()) -> ok | fail.
+-spec assert_exception(F :: fun()) -> ok | fail.
 assert_exception(F) ->
     try
         F(),
@@ -112,7 +112,7 @@ assert_exception(F) ->
 %% raised; fail, otherwise
 %% @end
 %%-----------------------------------------------------------------------------
--spec assert_exception(fun(), Class :: throw | error | exit) -> ok | fail.
+-spec assert_exception(F :: fun(), Class :: throw | error | exit) -> ok | fail.
 assert_exception(F, Class) ->
     try
         F(),
@@ -130,7 +130,7 @@ assert_exception(F, Class) ->
 %% value E being raised; fail, otherwise
 %% @end
 %%-----------------------------------------------------------------------------
--spec assert_exception(fun(), Class :: throw | error | exit, E :: any()) -> ok | fail.
+-spec assert_exception(F :: fun(), Class :: throw | error | exit, E :: any()) -> ok | fail.
 assert_exception(F, Class, E) ->
     try
         F(),


### PR DESCRIPTION
Fixes missing parameters and miss matched parameters in specs that left many functions not having these included in the documentation. Corrects typos and incorrect information. Adds documentation for a few undocumented functions in modules that are otherwise fully documented.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
