### PR TITLE
Disable SMP on ESP32-C6

### DIFF
--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -34,7 +34,7 @@ set(HAVE_SOCKET 1 CACHE INTERNAL "Have symbol socket" FORCE)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules")
 
 # Disable SMP with esp32 socs that have only one core
-if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32h2")
+if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32c6|esp32h2")
     message("Disabling SMP as selected target only has one core")
     set(AVM_DISABLE_SMP YES FORCE)
 endif()


### PR DESCRIPTION
This change brings the build of the ESP32c6 image in-line with other uni-processor ESP32 class MCUs, making

* the ESP32c6 consistent with other builds
* Benefitting from a small performance improvement (1.3x) in the ping pong speed test, with negligible improvement in other perf tests.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
