### PR TITLE
Fix beam CI on macOS

### DIFF
--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -66,16 +66,16 @@ jobs:
           container: erlang:26
 
         - os: "macos-latest"
-          otp: "23"
-          path_prefix: "/usr/local/opt/erlang@23/bin:"
-
-        - os: "macos-latest"
           otp: "24"
           path_prefix: "/usr/local/opt/erlang@24/bin:"
 
         - os: "macos-latest"
           otp: "25"
           path_prefix: "/usr/local/opt/erlang@25/bin:"
+
+        - os: "macos-latest"
+          otp: "26"
+          path_prefix: "/usr/local/bin:"
     steps:
     # Setup
     - name: "Checkout repo"


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
