### PR TITLE
Update documentation build system to reflect main branch rename

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -10,12 +10,13 @@ name: Build Docs
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push request and tag events on master branch
+  # Triggers the workflow on push request and tag events on main branch
   pull_request:
     tag:
       - '**'
     branches:
-      - 'master'
+      - 'main'
+      - 'release-*'
     paths:
       - '.github/workflows/**'
       - 'CMakeLists.txt'
@@ -36,7 +37,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/master' && github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/main' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -10,12 +10,13 @@ name: Publish Docs
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on pull request, tag events and pushes on master
+  # Triggers the workflow on pull request, tag events and pushes on main
   push:
     tags:
       - '**'
     branches:
-      - 'master'
+      - 'main'
+      - 'release-*'
     paths:
       - '.github/workflows/publish-docs.yaml'
       - 'CMakeLists.txt'

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -47,7 +47,7 @@ add_custom_target(edown-escript
 )
 
 # Get the version tree name, tag if this is a tagged commit, otherwise master.
-execute_process(COMMAND "bash" "-c" "tag=$(git for-each-ref --points-at=HEAD --format='%(refname:lstrip=2)' refs/tags); ( [ $tag ] && echo $tag ) || echo 'master'"
+execute_process(COMMAND "bash" "-c" "tag=$(git for-each-ref --points-at=HEAD --format='%(refname:lstrip=2)' refs/tags); ( [ $tag ] && echo $tag ) || echo 'main'"
                 OUTPUT_VARIABLE
                 DOC_TREE_VERSION
                 OUTPUT_STRIP_TRAILING_WHITESPACE )

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -166,11 +166,11 @@ versions = list()
 for tag in tag_list:
     versions.append(tag.name)
 
-versions.append('master')
+versions.append('main')
 if ((repo.head.object.hexsha) == (latest_tag.commit.hexsha)):
     current_version = latest_tag.name
 else:
-    current_version = 'master'
+    current_version = 'main'
 
 print("Sphinx config found documentation candidates: %r." % (versions))
 print("Sphinx config current version: %r." % (current_version))


### PR DESCRIPTION
Updates the workflows and navigation menu to reflect the recent rename of the `master` branch to `main`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
