### PR TITLE
Documentation workflows fix

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -12,7 +12,7 @@ name: Build Docs
 on:
   # Triggers the workflow on push request and tag events on master branch
   pull_request:
-    tag:
+    tags:
       - '**'
     branches:
       - 'master'

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -16,6 +16,7 @@ on:
       - '**'
     branches:
       - 'master'
+      - 'release-**'
     paths:
       - '.github/workflows/**'
       - 'CMakeLists.txt'

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -16,6 +16,7 @@ on:
       - '**'
     branches:
       - 'master'
+      - 'release-**'
     paths:
       - '.github/workflows/publish-docs.yaml'
       - 'CMakeLists.txt'


### PR DESCRIPTION
Fixes two bugs in the documentation workflows that prevented them from running in some cases where they should be run.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
