### PR TITLE
Make rp2040 wait for usb serial timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `binary_to_atom/1` and `atom_to_binary/1` that default to utf8 (they were introduced with OTP23)
 - Added Pico cmake option `AVM_WAIT_BOOTSEL_ON_EXIT` (default `ON`) to allow tools to use automated `BOOTSEL` mode after main application exits
 - Use UTF-8 encoding for atoms when using `erlang:term_to_binary/1`, in conformance with OTP-26
+- Pico: Wait for USB serial connection `cmake` configuration option `AVM_USB_WAIT_SECONDS` added with 20 second default.
 
 ### Fixed
 

--- a/src/platforms/rp2040/src/CMakeLists.txt
+++ b/src/platforms/rp2040/src/CMakeLists.txt
@@ -43,6 +43,12 @@ endif()
 
 if (AVM_WAIT_FOR_USB_CONNECT)
     target_compile_definitions(AtomVM PRIVATE PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS=-1)
+elseif (AVM_USB_WAIT_SECONDS)
+    math(EXPR WAIT_FOR_USB_TIMEOUT "1000 * ${AVM_USB_WAIT_SECONDS}")
+    message(STATUS "Wait for USB serial connection timeout ${WAIT_FOR_USB_TIMEOUT} ms")
+    target_compile_definitions(AtomVM PRIVATE PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS=${WAIT_FOR_USB_TIMEOUT})
+else()
+    target_compile_definitions(AtomVM PRIVATE PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS=20000)
 endif()
 
 if (AVM_WAIT_BOOTSEL_ON_EXIT)


### PR DESCRIPTION
Adds Pico `cmake` configuration option `AVM_USB_WAIT_SECONDS` to set a timeout to wait for USB serial connection before starting the application.

This will allow for release builds that will wait for a console connection, but eventually timeout and run the aplication.  This allows testing `blinky` and network applications without requiring opening a console connection to the device, while still waiting a reasonable ammount of time for the user to make a console connection to the serial to see the output of applications like `hello_world`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
