### PR TITLE
Added a limited implementation of the OTP ets interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.7.0-alpha.0] - Unreleased
+
+### Added
+- Added a limited implementation of the OTP `ets` interface
+
 ## [0.6.0] - 2024-03-05
 
 ### Fixed

--- a/libs/estdlib/src/CMakeLists.txt
+++ b/libs/estdlib/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(ERLANG_MODULES
     code
     crypto
     erts_debug
+    ets
     gen_event
     gen_server
     gen_statem

--- a/libs/estdlib/src/ets.erl
+++ b/libs/estdlib/src/ets.erl
@@ -1,0 +1,89 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%%-----------------------------------------------------------------------------
+%% @doc A limited implementation of the Erlang/OTP `ets' module.
+%% @end
+%%-----------------------------------------------------------------------------
+-module(ets).
+
+-export([
+    new/2,
+    insert/2,
+    lookup/2,
+    delete/2
+]).
+
+-export_type([
+    table/0,
+    options/0,
+    table_type/0,
+    access_type/0
+]).
+
+-opaque table() :: atom | reference().
+-type table_type() :: set.
+-type access_type() :: private | protected | public.
+-type option() :: table_type() | {keypos, non_neg_integer()} | access_type().
+-type options() :: [option()].
+
+%%-----------------------------------------------------------------------------
+%% @param   Name the ets table name
+%% @param   Options the options used to create the table
+%% @returns A new ets table
+%% @doc Create a new ets table.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec new(Name :: atom(), Options :: options()) -> table().
+new(_Name, _Options) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Table a reference to the ets table
+%% @param   Entry the entry to insert
+%% @returns true; otherwise, an error is raised if arguments are bad
+%% @doc Insert an entry into an ets table.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec insert(Table :: table(), Entry :: tuple()) -> true.
+insert(_Table, _Entry) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Table a reference to the ets table
+%% @param   Key the key used to lookup one or more entries
+%% @returns the entry in a set, or a list of entries, if the table permits
+%% @doc Look up an entry in an ets table.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec lookup(Table :: table(), Key :: term()) -> [tuple()].
+lookup(_Table, _Key) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Table a reference to the ets table
+%% @param   Key the key used to lookup one or more entries to delete
+%% @returns true; otherwise, an error is raised if arguments are bad
+%% @doc Delete an entry from an ets table.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec delete(Table :: table(), Key :: term()) -> true.
+delete(_Table, _Key) ->
+    erlang:nif_error(undefined).

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -34,6 +34,8 @@ set(HEADER_FILES
     dictionary.h
     erl_nif.h
     erl_nif_priv.h
+    ets.h
+    ets_hashtable.h
     exportedfunction.h
     externalterm.h
     globalcontext.h
@@ -80,6 +82,8 @@ set(SOURCE_FILES
     debug.c
     defaultatoms.c
     dictionary.c
+    ets.c
+    ets_hashtable.c
     externalterm.c
     globalcontext.c
     iff.c

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -182,6 +182,8 @@ void context_destroy(Context *ctx)
         free(ctx->platform_data);
     }
 
+    ets_delete_owned_tables(&ctx->global->ets, ctx->process_id, ctx->global);
+
     free(ctx);
 }
 

--- a/src/libAtomVM/ets.c
+++ b/src/libAtomVM/ets.c
@@ -1,0 +1,348 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2024 Fred Dushin <fred@dushin.nt>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include "ets.h"
+
+#include "context.h"
+#include "defaultatoms.h"
+#include "ets_hashtable.h"
+#include "list.h"
+#include "memory.h"
+
+#ifndef AVM_NO_SMP
+#define SMP_RDLOCK(table) smp_rwlock_rdlock(table->lock)
+#define SMP_WRLOCK(table) smp_rwlock_wrlock(table->lock)
+#define SMP_UNLOCK(table) smp_rwlock_unlock(table->lock)
+#else
+#define SMP_RDLOCK(table)
+#define SMP_WRLOCK(table)
+#define SMP_UNLOCK(table)
+#endif
+
+#ifndef AVM_NO_SMP
+#ifndef TYPEDEF_RWLOCK
+#define TYPEDEF_RWLOCK
+typedef struct RWLock RWLock;
+#endif
+#endif
+
+struct EtsTable
+{
+    struct ListHead head;
+    uint64_t ref_ticks;
+    term name;
+    bool is_named;
+    int32_t owner_process_id;
+    size_t keypos;
+    EtsTableType table_type;
+    // In the future, we might support rb-trees for sorted sets
+    // For this MVP, we only support unsorted sets
+    struct EtsHashTable *hashtable;
+    EtsAccessType access_type;
+
+#ifndef AVM_NO_SMP
+    RWLock *lock;
+#endif
+};
+typedef enum TableAccessType
+{
+    TableAccessNone,
+    TableAccessRead,
+    TableAccessWrite
+} TableAccessType;
+
+static void ets_delete_all_tables(struct Ets *ets, GlobalContext *global);
+
+static void ets_add_table(struct Ets *ets, struct EtsTable *ets_table)
+{
+    struct ListHead *ets_tables_list = synclist_wrlock(&ets->ets_tables);
+
+    list_append(ets_tables_list, &ets_table->head);
+
+    synclist_unlock(&ets->ets_tables);
+}
+
+static struct EtsTable *ets_get_table_by_ref(struct Ets *ets, uint64_t ref, TableAccessType access_type)
+{
+    struct ListHead *ets_tables_list = synclist_rdlock(&ets->ets_tables);
+    struct ListHead *item;
+    struct EtsTable *ret = NULL;
+    LIST_FOR_EACH (item, ets_tables_list) {
+        struct EtsTable *table = GET_LIST_ENTRY(item, struct EtsTable, head);
+        if (table->ref_ticks == ref) {
+            switch (access_type) {
+                case TableAccessRead:
+                    SMP_RDLOCK(table);
+                    break;
+                case TableAccessWrite:
+                    SMP_WRLOCK(table);
+                    break;
+                default:
+                    break;
+            }
+            ret = table;
+            break;
+        }
+    }
+    synclist_unlock(&ets->ets_tables);
+    return ret;
+}
+
+static struct EtsTable *ets_get_table_by_name(struct Ets *ets, term name, TableAccessType access_type)
+{
+    struct ListHead *ets_tables_list = synclist_rdlock(&ets->ets_tables);
+    struct ListHead *item;
+    struct EtsTable *ret = NULL;
+    LIST_FOR_EACH (item, ets_tables_list) {
+        struct EtsTable *table = GET_LIST_ENTRY(item, struct EtsTable, head);
+        if (table->is_named && table->name == name) {
+            switch (access_type) {
+                case TableAccessRead:
+                    SMP_RDLOCK(table);
+                    break;
+                case TableAccessWrite:
+                    SMP_WRLOCK(table);
+                    break;
+                default:
+                    break;
+            }
+            ret = table;
+            break;
+        }
+    }
+    synclist_unlock(&ets->ets_tables);
+    return ret;
+}
+
+void ets_init(struct Ets *ets)
+{
+    synclist_init(&ets->ets_tables);
+}
+
+void ets_destroy(struct Ets *ets, GlobalContext *global)
+{
+    ets_delete_all_tables(ets, global);
+    synclist_destroy(&ets->ets_tables);
+}
+
+EtsErrorCode ets_create_table(term name, bool is_named, EtsTableType table_type, EtsAccessType access_type, size_t keypos, term *ret, Context *ctx)
+{
+    if (is_named) {
+        struct EtsTable *ets_table = ets_get_table_by_name(&ctx->global->ets, name, TableAccessNone);
+        if (ets_table != NULL) {
+            return EtsTableNameInUse;
+        }
+    }
+
+    struct EtsTable *ets_table = malloc(sizeof(struct EtsTable));
+    if (IS_NULL_PTR(ets_table)) {
+        return EtsAllocationFailure;
+    }
+
+    list_init(&ets_table->head);
+
+    ets_table->name = name;
+    ets_table->is_named = is_named;
+    ets_table->access_type = access_type;
+
+    ets_table->table_type = table_type;
+    struct EtsHashTable *hashtable = ets_hashtable_new();
+    if (IS_NULL_PTR(hashtable)) {
+        free(ets_table);
+        return EtsAllocationFailure;
+    }
+    ets_table->hashtable = hashtable;
+
+    ets_table->owner_process_id = ctx->process_id;
+
+    uint64_t ref_ticks = globalcontext_get_ref_ticks(ctx->global);
+    ets_table->ref_ticks = ref_ticks;
+
+    ets_table->keypos = keypos;
+
+#ifndef AVM_NO_SMP
+    ets_table->lock = smp_rwlock_create();
+#endif
+
+    if (is_named) {
+        *ret = name;
+    } else {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, REF_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            ets_hashtable_destroy(hashtable, ctx->global);
+            free(ets_table);
+            return EtsAllocationFailure;
+        }
+        *ret = term_from_ref_ticks(ref_ticks, &ctx->heap);
+    }
+
+    ets_add_table(&ctx->global->ets, ets_table);
+
+    return EtsOk;
+}
+
+static void ets_table_destroy(struct EtsTable *table, GlobalContext *global)
+{
+    SMP_WRLOCK(table);
+    ets_hashtable_destroy(table->hashtable, global);
+    SMP_UNLOCK(table);
+
+#ifndef AVM_NO_SMP
+    smp_rwlock_destroy(table->lock);
+#endif
+
+    free(table);
+}
+
+typedef bool (*ets_table_filter_pred)(struct EtsTable *table, void *data);
+
+static void ets_delete_tables_internal(struct Ets *ets, ets_table_filter_pred pred, void *data, GlobalContext *global)
+{
+    struct ListHead *ets_tables_list = synclist_wrlock(&ets->ets_tables);
+    struct ListHead *item;
+    struct ListHead *tmp;
+    MUTABLE_LIST_FOR_EACH (item, tmp, ets_tables_list) {
+        struct EtsTable *table = GET_LIST_ENTRY(item, struct EtsTable, head);
+        if (pred(table, data)) {
+            list_remove(&table->head);
+            ets_table_destroy(table, global);
+        }
+    }
+    synclist_unlock(&ets->ets_tables);
+}
+
+static bool equal_process_id_pred(struct EtsTable *table, void *data)
+{
+    int32_t *process_id = (int32_t *) data;
+    return table->owner_process_id == *process_id;
+}
+
+void ets_delete_owned_tables(struct Ets *ets, int32_t process_id, GlobalContext *global)
+{
+    ets_delete_tables_internal(ets, equal_process_id_pred, &process_id, global);
+}
+
+static bool true_pred(struct EtsTable *table, void *data)
+{
+    UNUSED(table);
+    UNUSED(data);
+
+    return true;
+}
+
+static void ets_delete_all_tables(struct Ets *ets, GlobalContext *global)
+{
+    ets_delete_tables_internal(ets, true_pred, NULL, global);
+}
+
+EtsErrorCode ets_insert(term ref, term entry, Context *ctx)
+{
+    struct EtsTable *ets_table = term_is_atom(ref) ? ets_get_table_by_name(&ctx->global->ets, ref, TableAccessWrite) : ets_get_table_by_ref(&ctx->global->ets, term_to_ref_ticks(ref), TableAccessWrite);
+    if (ets_table == NULL) {
+        return EtsTableNotFound;
+    }
+
+    if (ets_table->access_type != EtsAccessPublic && ets_table->owner_process_id != ctx->process_id) {
+        SMP_UNLOCK(ets_table);
+        return EtsPermissionDenied;
+    }
+
+    if ((size_t) term_get_tuple_arity(entry) < (ets_table->keypos + 1)) {
+        SMP_UNLOCK(ets_table);
+        return EtsBadEntry;
+    }
+
+    Heap *heap = malloc(sizeof(Heap));
+    if (IS_NULL_PTR(heap)) {
+        SMP_UNLOCK(ets_table);
+        return EtsAllocationFailure;
+    }
+    size_t size = (size_t) memory_estimate_usage(entry);
+    if (memory_init_heap(heap, size) != MEMORY_GC_OK) {
+        free(heap);
+        SMP_UNLOCK(ets_table);
+        return EtsAllocationFailure;
+    }
+
+    term new_entry = memory_copy_term_tree(heap, entry);
+    term key = term_get_tuple_element(new_entry, (int) ets_table->keypos);
+
+    EtsErrorCode ret = EtsOk;
+    EtsHashtableErrorCode res = ets_hashtable_insert(ets_table->hashtable, key, new_entry, EtsHashtableAllowOverwrite, heap, ctx->global);
+    if (UNLIKELY(res != EtsHashtableOk)) {
+        ret = EtsAllocationFailure;
+    }
+
+    SMP_UNLOCK(ets_table);
+
+    return ret;
+}
+
+EtsErrorCode ets_lookup(term ref, term key, term *ret, Context *ctx)
+{
+    struct EtsTable *ets_table = term_is_atom(ref) ? ets_get_table_by_name(&ctx->global->ets, ref, TableAccessRead) : ets_get_table_by_ref(&ctx->global->ets, term_to_ref_ticks(ref), TableAccessRead);
+    if (ets_table == NULL) {
+        return EtsTableNotFound;
+    }
+
+    if (ets_table->access_type == EtsAccessPrivate && ets_table->owner_process_id != ctx->process_id) {
+        SMP_UNLOCK(ets_table);
+        return EtsPermissionDenied;
+    }
+
+    term res = ets_hashtable_lookup(ets_table->hashtable, key, ets_table->keypos, ctx->global);
+
+    if (term_is_nil(res)) {
+        *ret = term_nil();
+    } else {
+
+        size_t size = (size_t) memory_estimate_usage(res);
+        // alocate [object]
+        if (UNLIKELY(memory_ensure_free_opt(ctx, size + CONS_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            SMP_UNLOCK(ets_table);
+            return EtsAllocationFailure;
+        }
+        term new_res = memory_copy_term_tree(&ctx->heap, res);
+        *ret = term_list_prepend(new_res, term_nil(), &ctx->heap);
+    }
+    SMP_UNLOCK(ets_table);
+
+    return EtsOk;
+}
+
+EtsErrorCode ets_delete(term ref, term key, term *ret, Context *ctx)
+{
+    struct EtsTable *ets_table = term_is_atom(ref) ? ets_get_table_by_name(&ctx->global->ets, ref, TableAccessRead) : ets_get_table_by_ref(&ctx->global->ets, term_to_ref_ticks(ref), TableAccessRead);
+    if (ets_table == NULL) {
+        return EtsTableNotFound;
+    }
+
+    if (ets_table->access_type != EtsAccessPublic && ets_table->owner_process_id != ctx->process_id) {
+        SMP_UNLOCK(ets_table);
+        return EtsPermissionDenied;
+    }
+
+    bool _res = ets_hashtable_remove(ets_table->hashtable, key, ets_table->keypos, ctx->global);
+    UNUSED(_res);
+
+    SMP_UNLOCK(ets_table);
+    *ret = TRUE_ATOM;
+
+    return EtsOk;
+}

--- a/src/libAtomVM/ets.h
+++ b/src/libAtomVM/ets.h
@@ -1,0 +1,82 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2024 Fred Dushin <fred@dushin.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _ETS_H_
+#define _ETS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct Context;
+struct GlobalContext;
+
+#include "list.h"
+#include "synclist.h"
+#include "term.h"
+
+// N.B. Only EtsTableSet currently supported
+typedef enum EtsTableType
+{
+    EtsTableSet,
+    EtsTableOrderedSet,
+    EtsTableBag,
+    EtsTableDuplicateBag
+} EtsTableType;
+
+typedef enum EtsAccessType
+{
+    EtsAccessPrivate,
+    EtsAccessProtected,
+    EtsAccessPublic
+} EtsAccessType;
+
+typedef enum EtsErrorCode
+{
+    EtsOk,
+    EtsTableNotFound,
+    EtsTableNameInUse,
+    EtsPermissionDenied,
+    EtsBadEntry,
+    EtsAllocationFailure
+} EtsErrorCode;
+struct Ets
+{
+    // TODO Using a list imposes O(len(ets_tables)) cost
+    // on lookup, so in the future we may want to consider
+    // a table or map instead of a list.
+    struct SyncList ets_tables;
+};
+
+void ets_init(struct Ets *ets);
+void ets_destroy(struct Ets *ets, GlobalContext *global);
+
+EtsErrorCode ets_create_table(term name, bool is_named, EtsTableType table_type, EtsAccessType access_type, size_t keypos, term *ret, Context *ctx);
+void ets_delete_owned_tables(struct Ets *ets, int32_t process_id, GlobalContext *global);
+
+EtsErrorCode ets_insert(term ref, term entry, Context *ctx);
+EtsErrorCode ets_lookup(term ref, term key, term *ret, Context *ctx);
+EtsErrorCode ets_delete(term ref, term key, term *ret, Context *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libAtomVM/ets_hashtable.c
+++ b/src/libAtomVM/ets_hashtable.c
@@ -1,0 +1,333 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2024 Fred Dushin <fred@dushin.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include "ets_hashtable.h"
+
+#include "smp.h"
+#include "term.h"
+#include "utils.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+// #define TRACE_ENABLED
+#include "trace.h"
+
+struct HNode
+{
+    struct HNode *next;
+    term key;
+    term entry;
+    Heap *heap;
+};
+
+static uint32_t hash_term(term t, GlobalContext *global);
+
+struct EtsHashTable *ets_hashtable_new()
+{
+    struct EtsHashTable *htable = malloc(sizeof(struct EtsHashTable));
+    if (IS_NULL_PTR(htable)) {
+        return NULL;
+    }
+
+    memset(htable->buckets, 0, NUM_BUCKETS * sizeof(struct HNode *));
+    htable->capacity = NUM_BUCKETS;
+
+    return htable;
+}
+
+void ets_hashtable_destroy(struct EtsHashTable *hash_table, GlobalContext *global)
+{
+    for (size_t i = 0; i < hash_table->capacity; ++i) {
+        struct HNode *node = hash_table->buckets[i];
+        while (node != 0) {
+            memory_destroy_heap(node->heap, global);
+            struct HNode *next_node = node->next;
+            free(node);
+            node = next_node;
+        }
+    }
+}
+
+#ifdef TRACE_ENABLED
+static void print_info(struct EtsHashTable *hash_table)
+{
+    fprintf(stderr, "============\n");
+    for (size_t i = 0; i < hash_table->capacity; ++i) {
+        size_t len = 0;
+        struct HNode *node = hash_table->buckets[i];
+        while (node) {
+            node = node->next;
+            ++len;
+        }
+        fprintf(stderr, "len bucket[%zu]: %zu\n", i, len);
+    }
+}
+#endif
+
+EtsHashtableErrorCode ets_hashtable_insert(struct EtsHashTable *hash_table, term key, term entry, EtsHashtableOptions opts, Heap *heap, GlobalContext *global)
+{
+    uint32_t hash = hash_term(key, global);
+    uint32_t index = hash % hash_table->capacity;
+
+#ifdef TRACE_ENABLED
+    fprintf(stderr, "hash=%u index=%i key=", hash, index);
+    term_fprint(stderr, key, global);
+    fprintf(stderr, "\n");
+#endif
+
+    struct HNode *node = hash_table->buckets[index];
+    if (node) {
+        while (1) {
+            if (term_compare(key, node->key, TermCompareExact, global) == TermEquals) {
+                if (opts & EtsHashtableAllowOverwrite) {
+                    node->entry = entry;
+                    memory_destroy_heap(node->heap, global);
+                    node->heap = heap;
+                    return EtsHashtableOk;
+                } else {
+                    return EtsHashtableFailure;
+                }
+            }
+
+            if (node->next) {
+                node = node->next;
+            } else {
+                break;
+            }
+        }
+    }
+
+    struct HNode *new_node = malloc(sizeof(struct HNode));
+    if (IS_NULL_PTR(new_node)) {
+        return EtsHashtableError;
+    }
+    new_node->next = NULL;
+    new_node->key = key;
+    new_node->entry = entry;
+    new_node->heap = heap;
+
+    if (node) {
+        node->next = new_node;
+    } else {
+        hash_table->buckets[index] = new_node;
+    }
+
+#ifdef TRACE_ENABLED
+    print_info(hash_table);
+#endif
+
+    return EtsHashtableOk;
+}
+
+term ets_hashtable_lookup(struct EtsHashTable *hash_table, term key, size_t keypos, GlobalContext *global)
+{
+    uint32_t hash = hash_term(key, global);
+    uint32_t index = hash % hash_table->capacity;
+
+    const struct HNode *node = hash_table->buckets[index];
+    while (node) {
+        term key_to_compare = term_get_tuple_element(node->entry, keypos);
+        if (term_compare(key, key_to_compare, TermCompareExact, global) == TermEquals) {
+            return node->entry;
+        }
+        node = node->next;
+    }
+
+    return term_nil();
+}
+
+bool ets_hashtable_remove(struct EtsHashTable *hash_table, term key, size_t keypos, GlobalContext *global)
+{
+    uint32_t hash = hash_term(key, global);
+    uint32_t index = hash % hash_table->capacity;
+
+    struct HNode *node = hash_table->buckets[index];
+    struct HNode *prev_node = NULL;
+    while (node) {
+        term key_to_compare = term_get_tuple_element(node->entry, keypos);
+        if (term_compare(key, key_to_compare, TermCompareExact, global) == TermEquals) {
+
+            memory_destroy_heap(node->heap, global);
+            struct HNode *next_node = node->next;
+            free(node);
+
+            if (prev_node != NULL) {
+                prev_node->next = next_node;
+            } else {
+                hash_table->buckets[index] = next_node;
+            }
+            return true;
+        } else {
+            prev_node = node;
+            node = node->next;
+        }
+    }
+
+    return false;
+}
+
+//
+// hash function
+//
+// Conceptually similar to (but not identical to) the `make_hash` algorithm described in
+// https://github.com/erlang/otp/blob/cbd1378ee1fde835e55614bac9290b281bafe49a/erts/emulator/beam/utils.c#L644
+//
+// Also described in character folding algorithm (PJW Hash)
+// https://en.wikipedia.org/wiki/Hash_function#Character_folding
+//
+// TODO: implement erlang:phash2 using the OTP algorithm
+//
+
+// some large (close to 2^24) primes taken from
+// http://compoasso.free.fr/primelistweb/page/prime/liste_online_en.php
+
+#define LARGE_PRIME_INITIAL 16777259
+#define LARGE_PRIME_ATOM 16777643
+#define LARGE_PRIME_INTEGER 16777781
+#define LARGE_PRIME_FLOAT 16777973
+#define LARGE_PRIME_PID 16778147
+#define LARGE_PRIME_REF 16778441
+#define LARGE_PRIME_BINARY 16780483
+#define LARGE_PRIME_TUPLE 16778821
+#define LARGE_PRIME_LIST 16779179
+#define LARGE_PRIME_MAP 16779449
+
+static uint32_t hash_atom(term t, int32_t h, GlobalContext *global)
+{
+    AtomString atom_str = (uint8_t *) globalcontext_atomstring_from_term(global, t);
+    size_t len = atom_string_len(atom_str);
+    const uint8_t *data = (const uint8_t *) atom_string_data(atom_str);
+    for (size_t i = 0; i < len; ++i) {
+        h = h * LARGE_PRIME_ATOM + data[i];
+    }
+    return h * LARGE_PRIME_ATOM;
+}
+
+static uint32_t hash_integer(term t, int32_t h, GlobalContext *global)
+{
+    UNUSED(global);
+    uint64_t n = (uint64_t) term_maybe_unbox_int64(t);
+    while (n) {
+        h = h * LARGE_PRIME_INTEGER + (n & 0xFF);
+        n >>= 8;
+    }
+    return h * LARGE_PRIME_INTEGER;
+}
+
+static uint32_t hash_float(term t, int32_t h, GlobalContext *global)
+{
+    UNUSED(global);
+    avm_float_t f = term_to_float(t);
+    uint8_t *data = (uint8_t *) &f;
+    size_t len = sizeof(float);
+    for (size_t i = 0; i < len; ++i) {
+        h = h * LARGE_PRIME_FLOAT + data[i];
+    }
+    return h * LARGE_PRIME_FLOAT;
+}
+
+static uint32_t hash_pid(term t, int32_t h, GlobalContext *global)
+{
+    UNUSED(global);
+    uint32_t n = (uint32_t) term_to_local_process_id(t);
+    while (n) {
+        h = h * LARGE_PRIME_PID + (n & 0xFF);
+        n >>= 8;
+    }
+    return h * LARGE_PRIME_PID;
+}
+
+static uint32_t hash_reference(term t, int32_t h, GlobalContext *global)
+{
+    UNUSED(global);
+    uint64_t n = term_to_ref_ticks(t);
+    while (n) {
+        h = h * LARGE_PRIME_REF + (n & 0xFF);
+        n >>= 8;
+    }
+    return h * LARGE_PRIME_REF;
+}
+
+static uint32_t hash_binary(term t, int32_t h, GlobalContext *global)
+{
+    UNUSED(global);
+    size_t len = (size_t) term_binary_size(t);
+    uint8_t *data = (uint8_t *) term_binary_data(t);
+    for (size_t i = 0; i < len; ++i) {
+        h = h * LARGE_PRIME_BINARY + data[i];
+    }
+    return h * LARGE_PRIME_BINARY;
+}
+
+static uint32_t hash_term_incr(term t, int32_t h, GlobalContext *global)
+{
+    if (term_is_atom(t)) {
+        return hash_atom(t, h, global);
+    } else if (term_is_any_integer(t)) {
+        return hash_integer(t, h, global);
+    } else if (term_is_float(t)) {
+        return hash_float(t, h, global);
+    } else if (term_is_pid(t)) {
+        return hash_pid(t, h, global);
+    } else if (term_is_reference(t)) {
+        return hash_reference(t, h, global);
+    } else if (term_is_binary(t)) {
+        return hash_binary(t, h, global);
+    } else if (term_is_tuple(t)) {
+        size_t arity = term_get_tuple_arity(t);
+        for (size_t i = 0; i < arity; ++i) {
+            term elt = term_get_tuple_element(t, (int) i);
+            h = h * LARGE_PRIME_TUPLE + hash_term_incr(elt, h, global);
+        }
+        return h * LARGE_PRIME_TUPLE;
+    } else if (term_is_list(t)) {
+        while (!term_is_nonempty_list(t)) {
+            term elt = term_get_list_head(t);
+            h = h * LARGE_PRIME_LIST + hash_term_incr(elt, h, global);
+            t = term_get_list_tail(t);
+            if (term_is_nil(t)) {
+                h = h * LARGE_PRIME_LIST;
+                break;
+            } else if (!term_is_list(t)) {
+                h = h * LARGE_PRIME_LIST + hash_term_incr(elt, h, global);
+                break;
+            }
+        }
+        return h * LARGE_PRIME_TUPLE;
+    } else if (term_is_map(t)) {
+        size_t size = term_get_map_size(t);
+        for (size_t i = 0; i < size; ++i) {
+            term key = term_get_map_key(t, (avm_uint_t) i);
+            h = h * LARGE_PRIME_MAP + hash_term_incr(key, h, global);
+            term value = term_get_map_value(t, (avm_uint_t) i);
+            h = h * LARGE_PRIME_MAP + hash_term_incr(value, h, global);
+        }
+        return h * LARGE_PRIME_MAP;
+    } else {
+        fprintf(stderr, "hash_term: unsupported term type\n");
+        return h;
+    }
+}
+
+static uint32_t hash_term(term t, GlobalContext *global)
+{
+    return hash_term_incr(t, LARGE_PRIME_INITIAL, global);
+}

--- a/src/libAtomVM/ets_hashtable.h
+++ b/src/libAtomVM/ets_hashtable.h
@@ -1,0 +1,63 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2024 Fred Dushin <fred@dushin.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _ETS_HASHTABLE_H_
+#define _ETS_HASHTABLE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "globalcontext.h"
+#include "term.h"
+#include <stdlib.h>
+
+#define NUM_BUCKETS 16
+
+struct EtsHashTable
+{
+    size_t capacity;
+    struct HNode *buckets[NUM_BUCKETS];
+};
+
+typedef enum EtsHashtableOptions
+{
+    EtsHashtableAllowOverwrite = 1
+} EtsHashtableOptions;
+
+typedef enum EtsHashtableErrorCode
+{
+    EtsHashtableOk = 0,
+    EtsHashtableFailure,
+    EtsHashtableError
+} EtsHashtableErrorCode;
+
+struct EtsHashTable *ets_hashtable_new();
+void ets_hashtable_destroy(struct EtsHashTable *hash_table, GlobalContext *global);
+
+EtsHashtableErrorCode ets_hashtable_insert(struct EtsHashTable *hash_table, term key, term entry, EtsHashtableOptions opts, Heap *heap, GlobalContext *global);
+term ets_hashtable_lookup(struct EtsHashTable *hash_table, term key, size_t keypos, GlobalContext *global);
+bool ets_hashtable_remove(struct EtsHashTable *hash_table, term key, size_t keypos, GlobalContext *global);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -82,6 +82,8 @@ GlobalContext *globalcontext_new()
     synclist_init(&glb->resource_types);
     synclist_init(&glb->select_events);
 
+    ets_init(&glb->ets);
+
     glb->last_process_id = 0;
 
     glb->atom_table = atom_table_new();
@@ -199,6 +201,8 @@ COLD_FUNC void globalcontext_destroy(GlobalContext *glb)
         free((void *) select_event);
     }
     synclist_destroy(&glb->select_events);
+
+    ets_destroy(&glb->ets, glb);
 
     // Destroy refc binaries including resources
     // (this list should be empty if resources were properly refcounted)

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -37,6 +37,7 @@ extern "C" {
 #include "atom.h"
 #include "atom_table.h"
 #include "erl_nif.h"
+#include "ets.h"
 #include "list.h"
 #include "mailbox.h"
 #include "smp.h"
@@ -105,6 +106,8 @@ struct GlobalContext
     struct SyncList listeners;
     struct SyncList resource_types;
     struct SyncList select_events;
+
+    struct Ets ets;
 
     int32_t last_process_id;
 

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -120,6 +120,10 @@ erlang:group_leader/2, &group_leader_nif
 erlang:get_module_info/1, &get_module_info_nif
 erlang:get_module_info/2, &get_module_info_nif
 erts_debug:flat_size/1, &flat_size_nif
+ets:new/2, &ets_new_nif
+ets:insert/2, &ets_insert_nif
+ets:lookup/2, &ets_lookup_nif
+ets:delete/2, &ets_delete_nif
 atomvm:add_avm_pack_binary/2, &atomvm_add_avm_pack_binary_nif
 atomvm:add_avm_pack_file/2, &atomvm_add_avm_pack_file_nif
 atomvm:close_avm_pack/2, &atomvm_close_avm_pack_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -495,6 +495,7 @@ compile_erlang(test_utf8_atoms)
 compile_erlang(twentyone_param_function)
 compile_erlang(complex_list_match_xregs)
 compile_erlang(twentyone_param_fun)
+compile_erlang(test_ets)
 
 add_custom_target(erlang_test_modules DEPENDS
     code_load_files
@@ -956,4 +957,5 @@ add_custom_target(erlang_test_modules DEPENDS
     twentyone_param_function.beam
     complex_list_match_xregs.beam
     twentyone_param_fun.beam
+    test_ets.beam
 )

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -1,0 +1,343 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_ets).
+
+-export([start/0]).
+
+start() ->
+    ok = test_basic(),
+    ok = test_named_table(),
+    ok = test_keypos(),
+    ok = test_key_types(),
+    ok = test_private_access(),
+    ok = test_protected_access(),
+    ok = test_public_access(),
+
+    0.
+
+test_basic() ->
+    test_basic([]).
+
+test_named_table() ->
+    test_basic([named_table]).
+
+test_basic(Options) ->
+    {ok, Tid} = run_test(fun test_basic_fun/2, Options),
+
+    %%
+    %% The table should no longer exist
+    %%
+    sleep(25),
+    ok = expect_failure(
+        fun() ->
+            ets:lookup(Tid, foo)
+        end
+    ),
+    ok.
+
+test_basic_fun(Pid, Options) ->
+    expect_failure(fun() -> ets:new([isnt, an, atom], []) end),
+    expect_failure(fun() -> ets:new(bad_options, not_a_list) end),
+
+    Tid = ets:new(test, Options),
+
+    %% check name in use
+    case member(named_table, Options) of
+        true ->
+            expect_failure(fun() -> ets:new(test, Options) end),
+            %% you can still create an un-named table with the same name
+            _Tid = ets:new(test, []);
+        _ ->
+            _Tid = ets:new(test, [])
+    end,
+
+    [] = ets:lookup(Tid, foo),
+    true = ets:insert(Tid, {foo, bar}),
+    [{foo, bar}] = ets:lookup(Tid, foo),
+
+    [] = ets:lookup(Tid, does_not_exist),
+
+    true = ets:insert(Tid, {foo, tapas}),
+    [{foo, tapas}] = ets:lookup(Tid, foo),
+
+    true = ets:delete(Tid, does_not_exist),
+    [] = ets:lookup(Tid, does_not_exist),
+    true = ets:delete(Tid, foo),
+    [] = ets:lookup(Tid, foo),
+
+    true = ets:insert(Tid, {foo, bar}),
+    true = ets:insert(Tid, {gnu, gnat}),
+    true = ets:insert(Tid, {bar, tapas}),
+
+    true = ets:delete(Tid, foo),
+    [{gnu, gnat}] = ets:lookup(Tid, gnu),
+    [{bar, tapas}] = ets:lookup(Tid, bar),
+    true = ets:delete(Tid, gnu),
+    [{bar, tapas}] = ets:lookup(Tid, bar),
+    [] = ets:lookup(Tid, gnu),
+    true = ets:delete(Tid, bar),
+    [] = ets:lookup(Tid, bar),
+
+    [] = ets:lookup(Tid, #{some => structured, key => [a, b, c]}),
+    true = ets:insert(Tid, {#{some => structured, key => [a, b, c]}, bar}),
+    [{#{some := structured, key := [a, b, c]}, bar}] = ets:lookup(Tid, #{
+        some => structured, key => [a, b, c]
+    }),
+
+    expect_failure(fun() -> ets:insert(Tid, {}) end),
+    expect_failure(fun() -> ets:insert(Tid, not_a_tuple) end),
+    expect_failure(fun() -> ets:insert([isnt, a, table, reference], {foo, bar}) end),
+    expect_failure(fun() -> ets:lookup([isnt, a, table, reference], foo) end),
+    expect_failure(fun() -> ets:delete([isnt, a, table, reference], foo) end),
+
+    Pid ! {ok, Tid}.
+
+test_keypos() ->
+    ok = run_test(fun test_keypos_fun/2, []),
+    ok.
+
+test_keypos_fun(Pid, _Options) ->
+    expect_failure(fun() -> ets:new(bad_keypos, -1) end),
+
+    Tid = ets:new(test, [{keypos, 2}]),
+
+    true = ets:insert(Tid, {foo, bar}),
+    true = ets:insert(Tid, {gnu, gnat}),
+    true = ets:insert(Tid, {bar, tapas}),
+
+    [{foo, bar}] = ets:lookup(Tid, bar),
+    [{gnu, gnat}] = ets:lookup(Tid, gnat),
+    [{bar, tapas}] = ets:lookup(Tid, tapas),
+
+    expect_failure(fun() -> ets:insert(Tid, {}) end),
+    expect_failure(fun() -> ets:insert(Tid, {arity_1}) end),
+
+    Pid ! ok.
+
+test_key_types() ->
+    ok = run_test(fun test_key_types_fun/2, []),
+    ok.
+
+test_key_types_fun(Pid, _Options) ->
+    Tid = ets:new(test, []),
+    EchoServer = spawn_opt(fun echo_server/0, []),
+    register(echo, EchoServer),
+
+    ok = test_key_insert_lookup(
+        Tid,
+        some_atom
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        12345
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        0
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        -12345
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        3.14159365
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        self()
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        erlang:make_ref()
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        <<"fubar">>
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        <<"">>
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        {some_atom, 1234}
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        [a, b, c, self(), 3.1415265]
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        [a | b]
+    ),
+    ok = test_key_insert_lookup(
+        Tid,
+        #{
+            some_atom => {a, b, c},
+            #{another => "map"} => erlang:make_ref(),
+            <<1, 2, 3, 4>> => <<-4, -3, -2, -1>>
+        }
+    ),
+
+    EchoServer ! halt,
+
+    Pid ! ok.
+
+test_key_insert_lookup(Tid, Key) ->
+    true = ets:insert(Tid, {Key, value}),
+    [{Key, value}] = ets:lookup(Tid, echo(Key)),
+    ok.
+
+test_private_access() ->
+    Self = self(),
+    Pid = spawn_opt(fun() -> test_access_fun(Self, [private]) end, []),
+
+    Pid ! get_table,
+    Tid =
+        receive
+            {table, T} ->
+                T
+        after 1000 ->
+            error(timeout_wait_for_table)
+        end,
+
+    ok = expect_failure(
+        fun() -> ets:insert(Tid, {gnu, gnat}) end
+    ),
+    ok = expect_failure(
+        fun() -> ets:lookup(Tid, foo) end
+    ),
+
+    Pid ! halt,
+    ok.
+
+test_protected_access() ->
+    Self = self(),
+    Pid = spawn_opt(fun() -> test_access_fun(Self, [protected]) end, []),
+
+    Pid ! get_table,
+    Tid =
+        receive
+            {table, T} ->
+                T
+        after 1000 ->
+            error(timeout_wait_for_table)
+        end,
+
+    ok = expect_failure(
+        fun() -> ets:insert(Tid, {gnu, gnat}) end
+    ),
+    [{foo, bar}] = ets:lookup(Tid, foo),
+
+    Pid ! halt,
+    ok.
+
+test_public_access() ->
+    Self = self(),
+    Pid = spawn_opt(fun() -> test_access_fun(Self, [public]) end, []),
+
+    Pid ! get_table,
+    Tid =
+        receive
+            {table, T} ->
+                T
+        after 1000 ->
+            error(timeout_wait_for_table)
+        end,
+
+    true = ets:insert(Tid, {gnu, gnat}),
+    [{foo, bar}] = ets:lookup(Tid, foo),
+
+    Pid ! halt,
+    ok.
+
+test_access_fun(Pid, Options) ->
+    Tid = ets:new(test, Options),
+
+    true = ets:insert(Tid, {foo, bar}),
+
+    receive
+        get_table ->
+            Pid ! {table, Tid}
+    end,
+
+    receive
+        halt ->
+            ok
+    end.
+
+run_test(Fun, Options) ->
+    Self = self(),
+    spawn_opt(fun() -> Fun(Self, Options) end, []),
+    wait_for_test_result().
+
+wait_for_test_result() ->
+    receive
+        Result ->
+            Result
+    after 1000 ->
+        {error, timeout_waiting_for_test_result}
+    end.
+
+expect_failure(Fun) ->
+    expect_failure(Fun, error, badarg).
+
+expect_failure(Fun, Class, Error) ->
+    try
+        Fun(),
+        fail
+    catch
+        Class:Error ->
+            ok;
+        OtherClass:OtherError ->
+            {fail, OtherClass, OtherError}
+    end.
+
+sleep(Ms) ->
+    receive
+    after Ms ->
+        ok
+    end.
+
+member(_Element, []) ->
+    false;
+member(Element, [Element | _]) ->
+    true;
+member(Element, [_ | Tail]) ->
+    member(Element, Tail).
+
+echo_server() ->
+    receive
+        {echo, Term, Pid} ->
+            Pid ! Term,
+            echo_server();
+        halt ->
+            ok
+    end.
+
+echo(Term) ->
+    EchoServer = whereis(echo),
+    EchoServer ! {echo, Term, self()},
+    receive
+        T ->
+            T
+    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -527,6 +527,7 @@ struct Test tests[] = {
     TEST_CASE(complex_list_match_xregs),
     TEST_CASE(twentyone_param_fun),
 
+    TEST_CASE(test_ets),
     // TEST CRASHES HERE: TEST_CASE(memlimit),
 
     { NULL, 0, false, false }


### PR DESCRIPTION
This PR implements a small subset of the OTP `ets` interface.

The following `ets` functions are supported:

* `ets:new/2`
* `ets:insert/2`
* `ets:lookup/2`
* `ets:delete/2`

The following parameters to `ets:new/2` are supported:

* `is_named`
* `{keypos, I :: non_neg_integer()}`
* `private` | `protected` | `public` access types

Only the `set` table type is supported.

This limited functionality allows users to define ETS tables and share term data between processes in a manner that is more efficient than using message passing with a process.  The likely initial users of this feature will be the logging subsystem, as well as parts of the (forthcoming) application support, for storing application environment settings.

This PR provides a partial implementation of issue #887.  Subsequent PRs can add additional features from this issue.

For information about the OTP `ets` interface, see https://www.erlang.org/doc/man/ets.  This implementation attempts to be API-compatible with the OTP implementation.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
