### PR TITLE
Support "extended" x registers (16-1023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `binary_to_term` checks atom encoding validity, and fix latin1 support (when non-ASCII chars are
 used)
 - ESP32: fixed bug in `gpio:set_pin_mode/2` and `gpio:set_direction/3` that would accept any atom for the mode parameter without an error.
+- Support to function with 10 or more parameters
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 used)
 - ESP32: fixed bug in `gpio:set_pin_mode/2` and `gpio:set_direction/3` that would accept any atom for the mode parameter without an error.
 - Support to function with 10 or more parameters
+- Very unlikely but possible corruption caused by generated code that uses 16 live registers
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for utf8 encoding to `*_to_atom` and `atom_to_*` functions
 - `binary_to_atom/1` and `atom_to_binary/1` that default to utf8 (they were introduced with OTP23)
 - Added Pico cmake option `AVM_WAIT_BOOTSEL_ON_EXIT` (default `ON`) to allow tools to use automated `BOOTSEL` mode after main application exits
+- Support for code that makes use of more than 16 live registers, such as functions with > 16
+parameters and complex pattern matchings.
 
 ### Fixed
 

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -43,6 +43,7 @@
 #define BYTES_PER_TERM (TERM_BITS / 8)
 
 static struct ResourceMonitor *context_monitors_handle_terminate(Context *ctx);
+static void destroy_extended_registers(Context *ctx, unsigned int live);
 
 Context *context_new(GlobalContext *glb)
 {
@@ -61,6 +62,7 @@ Context *context_new(GlobalContext *glb)
     ctx->e = ctx->heap.heap_end;
 
     context_clean_registers(ctx, 0);
+    list_init(&ctx->extended_x_regs);
 
     ctx->fr = NULL;
 
@@ -151,6 +153,7 @@ void context_destroy(Context *ctx)
     // Any other process released our mailbox, so we can clear it.
     mailbox_destroy(&ctx->mailbox, &ctx->heap);
 
+    destroy_extended_registers(ctx, 0);
     free(ctx->fr);
 
     memory_destroy_heap(&ctx->heap, ctx->global);

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -76,6 +76,8 @@ enum HeapGrowthStrategy
 
 // Max number of x(N) & fr(N) registers
 // BEAM sets this to 1024.
+// x regs have an additional register that is used for storing an additional working element
+// so the number of registers is MAX_REG + 1, but only MAX_REG are addressable as x registers
 #define MAX_REG 16
 
 struct Context
@@ -84,7 +86,7 @@ struct Context
     GlobalContext *global;
     Heap heap;
     term *e;
-    term x[MAX_REG];
+    term x[MAX_REG + 1];
 
     struct ListHead processes_list_head;
 

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -87,6 +87,7 @@ struct Context
     Heap heap;
     term *e;
     term x[MAX_REG + 1];
+    struct ListHead extended_x_regs;
 
     struct ListHead processes_list_head;
 
@@ -167,6 +168,13 @@ struct ResourceMonitor
 {
     struct Monitor base;
     struct ListHead resource_list_head;
+};
+
+struct ExtendedRegister
+{
+    struct ListHead head;
+    unsigned int index;
+    term value;
 };
 
 /**

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -264,6 +264,13 @@ static enum MemoryGCResult memory_gc(Context *ctx, size_t new_size, size_t num_r
         entry->value = memory_shallow_copy_term(old_root_fragment, entry->value, &ctx->heap.heap_ptr, true);
     }
 
+    TRACE("- Running copy GC on process extended registers\n");
+    LIST_FOR_EACH (item, &ctx->extended_x_regs) {
+        struct ExtendedRegister *ext_reg = GET_LIST_ENTRY(item, struct ExtendedRegister, head);
+        ext_reg->value = memory_shallow_copy_term(
+            old_root_fragment, ext_reg->value, &ctx->heap.heap_ptr, true);
+    }
+
     TRACE("- Running copy GC on exit reason\n");
     ctx->exit_reason = memory_shallow_copy_term(old_root_fragment, ctx->exit_reason, &ctx->heap.heap_ptr, true);
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -791,7 +791,8 @@ const struct Nif *nifs_get(AtomString module, AtomString function, int arity)
 
     int function_name_len = atom_string_len(function);
     if (UNLIKELY((arity > 9) || (module_name_len + function_name_len + 4 > MAX_NIF_NAME_LEN))) {
-        AVM_ABORT();
+        // In AtomVM NIFs are limited to 9 parameters
+        return NULL;
     }
     memcpy(nifname + module_name_len + 1, atom_string_data(function), function_name_len);
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -492,6 +492,10 @@ compile_erlang(test_atomvm_random)
 compile_erlang(float_decode)
 compile_erlang(test_utf8_atoms)
 
+compile_erlang(twentyone_param_function)
+compile_erlang(complex_list_match_xregs)
+compile_erlang(twentyone_param_fun)
+
 add_custom_target(erlang_test_modules DEPENDS
     code_load_files
 
@@ -946,5 +950,10 @@ add_custom_target(erlang_test_modules DEPENDS
     test_atomvm_random.beam
 
     float_decode.beam
+
     test_utf8_atoms.beam
+
+    twentyone_param_function.beam
+    complex_list_match_xregs.beam
+    twentyone_param_fun.beam
 )

--- a/tests/erlang_tests/complex_list_match_xregs.erl
+++ b/tests/erlang_tests/complex_list_match_xregs.erl
@@ -1,0 +1,56 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(complex_list_match_xregs).
+-export([start/0, test_a/1, list_a/0, list_b/0, list_c/0]).
+
+start() ->
+    {ok, {"first", "list"}} = ?MODULE:test_a(?MODULE:list_a()),
+    {x, $o} = ?MODULE:test_a(?MODULE:list_b()),
+    ok_baz = ?MODULE:test_a(?MODULE:list_c()),
+    0.
+
+test_a(["This", "is", _, _, _, _, _, "baz", "baar"]) ->
+    error_a;
+test_a(["This", "is", _, _, "foo", _, _, "baz"]) ->
+    ok_baz;
+test_a(["This", "is", "baz", _, _, _, _, "baz"]) ->
+    error_c;
+test_a(["This", "is", "not" | _Tail]) ->
+    error_d;
+test_a(["This", "is", _, N, _, W]) ->
+    {ok, {N, W}};
+test_a(["This" | Tail]) ->
+    {foo, "This", Tail};
+test_a([[$F, X, $o | Tail], Tail]) ->
+    {x, X};
+test_a([[$F, Y, $o | _Tail1], _Tail2]) ->
+    {x, Y};
+test_a(List) ->
+    {error, List}.
+
+list_a() ->
+    ["This", "is", "the", "first", "test", "list"].
+
+list_b() ->
+    [[$F, $o, $o, "bar"], "bar"].
+
+list_c() ->
+    ["This", "is", "aaa", "bbb", "foo", "ccc", "ddd", "baz"].

--- a/tests/erlang_tests/twentyone_param_fun.erl
+++ b/tests/erlang_tests/twentyone_param_fun.erl
@@ -1,0 +1,80 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(twentyone_param_fun).
+-export([start/0, sum_mul/3, id/1, g/18]).
+
+start() ->
+    {X, Fun} = ?MODULE:g(20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37),
+    Ref = erlang:make_ref(),
+    {A, Ref2} = Fun(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, Ref),
+    {B, Ref} = Fun(
+        1, 2, 3, 40, 50, 60, 70, 80, 90, 100, 110, 120, 13, 14, 15, 16, 17, 18, 19, X, Ref2
+    ),
+    1337 - (A + B).
+
+g(C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, D, C11, C12, C13, C14, C15, C16, C17) when
+    is_integer(C17)
+->
+    Fun =
+        (fun(
+            P1,
+            P2,
+            P3,
+            P4,
+            P5,
+            P6,
+            P7,
+            P8,
+            P9,
+            P10,
+            P11,
+            P12,
+            P13,
+            P14,
+            P15,
+            P16,
+            P17,
+            P18,
+            P19,
+            P20,
+            Ref
+        ) when is_reference(Ref) ->
+            Sum =
+                ?MODULE:sum_mul(P1 - C1, P2, 1) +
+                    ?MODULE:sum_mul(P3, P4 - C2, 2) +
+                    ?MODULE:sum_mul(P5 - C3, P6, 3) +
+                    ?MODULE:sum_mul(P5, P6 - C4, 4) +
+                    ?MODULE:sum_mul(P7 - C5, P8, 5) +
+                    ?MODULE:sum_mul(P9, P10 - C6, 6) +
+                    ?MODULE:sum_mul(P11 - C7, P12, 7) +
+                    ?MODULE:sum_mul(P13 - C9, P14 - C8, 8) +
+                    ?MODULE:sum_mul(P15 - C10, P16 - C11, 9) +
+                    ?MODULE:sum_mul(P17 - C13, P18 - C12, 10) +
+                    ?MODULE:sum_mul(P19 - C14, P20 - C15, 11) + C16 - C17,
+            {?MODULE:id(Sum), ?MODULE:id(Ref)}
+        end),
+    {D, Fun}.
+
+sum_mul(A, B, C) ->
+    (A + B) * C.
+
+id(X) ->
+    X.

--- a/tests/erlang_tests/twentyone_param_function.erl
+++ b/tests/erlang_tests/twentyone_param_function.erl
@@ -1,0 +1,58 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(twentyone_param_function).
+-export([start/0, f/21, sum_mul/3, id/1, get_mf/0]).
+
+start() ->
+    Ref = erlang:make_ref(),
+    {M, F} = ?MODULE:get_mf(),
+    {A, Ref2} = f(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, Ref),
+    {B, Ref} = ?MODULE:f(
+        1, 2, 3, 40, 50, 60, 70, 80, 90, 100, 110, 120, 13, 14, 15, 16, 17, 18, 19, 20, Ref2
+    ),
+    {C, Ref} = M:F(
+        -1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15, 16, -17, 18, -19, 20, Ref
+    ),
+    A + B + C - 7417.
+
+f(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, Ref) ->
+    Sum =
+        ?MODULE:sum_mul(P1, P2, 1) +
+            ?MODULE:sum_mul(P3, P4, 2) +
+            ?MODULE:sum_mul(P5, P6, 3) +
+            ?MODULE:sum_mul(P5, P6, 4) +
+            ?MODULE:sum_mul(P7, P8, 5) +
+            ?MODULE:sum_mul(P9, P10, 6) +
+            ?MODULE:sum_mul(P11, P12, 7) +
+            ?MODULE:sum_mul(P13, P14, 8) +
+            ?MODULE:sum_mul(P15, P16, 9) +
+            ?MODULE:sum_mul(P17, P18, 10) +
+            ?MODULE:sum_mul(P19, P20, 11),
+    {?MODULE:id(Sum), ?MODULE:id(Ref)}.
+
+sum_mul(A, B, C) ->
+    (A + B) * C.
+
+id(X) ->
+    X.
+
+get_mf() ->
+    {?MODULE, f}.

--- a/tests/test.c
+++ b/tests/test.c
@@ -520,7 +520,13 @@ struct Test tests[] = {
 #endif
 
     TEST_CASE(float_decode),
+
     TEST_CASE(test_utf8_atoms),
+
+    TEST_CASE(twentyone_param_function),
+    TEST_CASE(complex_list_match_xregs),
+    TEST_CASE(twentyone_param_fun),
+
     // TEST CRASHES HERE: TEST_CASE(memlimit),
 
     { NULL, 0, false, false }


### PR DESCRIPTION
This PR is focused into removing 2 main limitations:
1. Functions can have any number of parameters
2. Up to 1023 live x registers are supported

This restriction has been easily workarounded so far, but removing this limitation closes a gap that makes development smoother.

Since so far everything worked nicely with just 16 registers, this implementation threats "extended x registers" as an uncommon case, so using them is way slower, but still possible, while reducing memory footprint to bare minimum.

There is still a limitation: NIFs with more than 16 parameters are still not allowed, but this limitation will be likely stay unnoticed.

This PR also fixes an unlikely corruption when having exactly 16 live registers, and enables support of more than > 16 typed y registers (I never observed any crash due to this limitation).

See also for #943 for an alternative approach, decoding is based on Paul's work from that PR.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
