### PR TITLE
Fix bug in ESP32 gpio:stop/0 and gpio:close/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32: fix i2c_driver_acquire and i2c_driver_release functions, that were working only once.
 - Sending messages to registered processes using the `!` operator now works.
 - Fixed bug in `OP_SEND` that would accept sending a message to any integer or term without raising an error.
+- ESP32: fixed bug in `gpio:stop/0` and `gpio:close/1` that would cause the VM to crash.
 
 ## [0.6.0-beta.0] - 2024-02-08
 

--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -275,7 +275,7 @@ static term gpiodriver_close(Context *ctx)
             struct GPIOListenerData *gpio_listener = GET_LIST_ENTRY(item, struct GPIOListenerData, gpio_listener_list_head);
             gpio_num = gpio_listener->gpio;
             list_remove(&gpio_listener->gpio_listener_list_head);
-            list_remove(&gpio_listener->listener.listeners_list_head);
+            sys_unregister_listener(ctx->global, &gpio_listener->listener);
             free(gpio_listener);
 
             gpio_set_intr_type(gpio_num, GPIO_INTR_DISABLE);
@@ -287,6 +287,7 @@ static term gpiodriver_close(Context *ctx)
         }
     }
 
+    ctx->platform_data = NULL;
     globalcontext_unregister_process(glb, gpio_atom_index);
     free(gpio_data);
 

--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -235,6 +235,11 @@ Context *gpio_driver_create_port(GlobalContext *global, term opts)
     Context *ctx = context_new(global);
 
     struct GPIOData *gpio_data = malloc(sizeof(struct GPIOData));
+    if (IS_NULL_PTR(gpio_data)) {
+        ESP_LOGE(TAG, "Not enough free memory to initialize GPIO port driver!");
+        scheduler_terminate(ctx);
+        return NULL;
+    }
     list_init(&gpio_data->gpio_listeners);
 
     ctx->native_handler = consume_gpio_mailbox;


### PR DESCRIPTION
This fixes the bug that causes the VM to crash when the GPIO port driver is stopped on the ESP32 platform (issue #816). Also adds missing `NULL` check when the `GPIOData` struct is malloc'd.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
