### PR TITLE
Fix Pico and STM32 CI

### DIFF
--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   pico:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         board: ["pico", "pico_w"]
@@ -39,6 +39,9 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
+
+    - name: "apt update"
+      run: sudo apt update
 
     - name: "Install deps"
       run: sudo apt install -y cmake gperf ninja-build gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib erlang-base erlang-dialyzer

--- a/.github/workflows/stm32-build.yaml
+++ b/.github/workflows/stm32-build.yaml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   stm32:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/cache@v3
       id: builddeps-cache
@@ -62,6 +62,9 @@ jobs:
         git clone https://github.com/libopencm3/libopencm3.git -b v0.8.0
         cd libopencm3
         make
+
+    - name: "apt update"
+      run: sudo apt update
 
     - name: "Install deps"
       run: sudo apt install -y cmake gperf


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
