### PR TITLE
Fix ESP32 `gpio:set_pin_mode/2` input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32: fix i2c_driver_acquire and i2c_driver_release functions, that were working only once.
 - Sending messages to registered processes using the `!` operator now works.
 - Fixed bug in `OP_SEND` that would accept sending a message to any integer or term without raising an error.
+- ESP32: fixed bug in `gpio:set_pin_mode/2` and `gpio:set_direction/3` that would accept any atom for the mode parameter without an error.
 
 ### Changed
 

--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -140,11 +140,11 @@ static inline term gpio_set_pin_mode(Context *ctx, term gpio_num_term, term mode
 {
     int gpio_num = term_to_int(gpio_num_term);
 
-    gpio_mode_t mode = interop_atom_term_select_int(pin_mode_table, mode_term, ctx->global);
+    avm_int_t mode = interop_atom_term_select_int(pin_mode_table, mode_term, ctx->global);
     if (UNLIKELY(mode < 0)) {
         return ERROR_ATOM;
     }
-    esp_err_t result = gpio_set_direction(gpio_num, mode);
+    esp_err_t result = gpio_set_direction(gpio_num, (gpio_mode_t) mode);
 
     if (UNLIKELY(result != ESP_OK)) {
         return ERROR_ATOM;


### PR DESCRIPTION
Fixes a bug that caused the driver to silently accept any atom as a valid mode parameter, and return `ok` without causing an error.

closes #1064

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
