### PR TITLE
CI: ESP32: update 5.0.4 to 5.0.6, 5.1.2 to 5.1.3

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -36,8 +36,8 @@ jobs:
       matrix:
         idf-version:
         - '4.4.6'
-        - '5.0.4'
-        - '5.1.2'
+        - '5.0.6'
+        - '5.1.3'
 
     steps:
     - name: Checkout repo
@@ -68,7 +68,7 @@ jobs:
             gcc g++ zlib1g-dev
 
     - name: Install qemu binary from espressif/qemu
-      if: matrix.idf-version != '5.1.2'
+      if: matrix.idf-version != '5.1.3'
       run: |
         set -eu
         QEMU_VER=esp-develop-20220919

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        idf-version: ["5.1.2"]
+        idf-version: ["5.1.3"]
         cc: ["clang-10"]
         cxx: ["clang++-10"]
         cflags: ["-O3"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ used)
 
 - `binary_to_atom/2` validates utf8 strings
 - `*_to_atom` and `atom_to_*` properly convert latin1 (not just ASCII) to utf8 and viceversa
+- ESP32: use esp-idf v5.1.3 for building release binaries
 
 ## [0.6.0-beta.0] - 2024-02-08
 

--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -547,7 +547,7 @@ AtomVM supports extensions to the VM via the implementation of custom native fun
 
 ```{seealso}
 For more information about building components for the IDF SDK, consult the
-[IDF SDK Build System](https://docs.espressif.com/projects/esp-idf/en/v5.1.2/esp32/api-guides/build-system.html)
+[IDF SDK Build System](https://docs.espressif.com/projects/esp-idf/en/v5.1.3/esp32/api-guides/build-system.html)
 documentation.
 ```
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
