### PR TITLE
Improve ESP32-C6 support

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -63,6 +63,9 @@
 #elif CONFIG_IDF_TARGET_ESP32C3
 // only one user SPI bus, no VSPI
 #define HSPI_HOST   SPI2_HOST
+#elif (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)) && CONFIG_IDF_TARGET_ESP32C6
+// only one user SPI bus, no VSPI
+#define HSPI_HOST   SPI2_HOST
 #endif
 
 struct SPIDevice

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -92,6 +92,9 @@ static const char *const esp32_atom = "\x5" "esp32";
 static const char *const esp32_s2_atom = "\x8" "esp32_s2";
 static const char *const esp32_s3_atom = "\x8" "esp32_s3";
 static const char *const esp32_c3_atom = "\x8" "esp32_c3";
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+static const char *const esp32_c6_atom = "\x8" "esp32_c6";
+#endif
 #endif
 static const char *const emb_flash_atom = "\x9" "emb_flash";
 static const char *const bgn_atom = "\x3" "bgn";
@@ -485,6 +488,10 @@ static term get_model(Context *ctx, esp_chip_model_t model)
             return globalcontext_make_atom(ctx->global, esp32_s3_atom);
         case CHIP_ESP32C3:
             return globalcontext_make_atom(ctx->global, esp32_c3_atom);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+        case CHIP_ESP32C6:
+            return globalcontext_make_atom(ctx->global, esp32_c6_atom);
+#endif
         default:
             return UNDEFINED_ATOM;
     }


### PR DESCRIPTION
Return the right model number and define HSPI macro also for it.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
