### PR TITLE
Fix missing validation in rp2040 gpio driver `pull` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ used)
 - ESP32: fixed bug in `gpio:set_pin_mode/2` and `gpio:set_direction/3` that would accept any atom for the mode parameter without an error.
 - ESP32: GPIO driver fix bug that would accept invalid `pull` direction, and silently set `pull` direction to `floating` without issuing an error.
 - ESP32: fixed bug in gpio driver that would accept invalid pin numbers (either negative, or too large)
+- RP2040: fixed bug in `gpio:set_pin_pull/2` that would accept any parameter as a valid `pull` mode.
 
 ### Changed
 

--- a/src/platforms/rp2040/src/lib/gpiodriver.c
+++ b/src/platforms/rp2040/src/lib/gpiodriver.c
@@ -52,7 +52,7 @@ static const AtomStringIntPair pull_mode_table[] = {
     { ATOM_STR("\x4", "down"), AtomVMRP2040GPIOPullDown },
     { ATOM_STR("\x7", "up_down"), AtomVMRP2040GPIOPullUp | AtomVMRP2040GPIOPullDown },
     { ATOM_STR("\x8", "floating"), AtomVMRP2040GPIOFloating },
-    SELECT_INT_DEFAULT(AtomVMRP2040GPIOFloating)
+    SELECT_INT_DEFAULT(-1)
 };
 
 enum gpio_pin_level
@@ -123,6 +123,9 @@ static term nif_gpio_set_pin_pull(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
     int pull_mode = interop_atom_term_select_int(pull_mode_table, argv[1], ctx->global);
+    if (UNLIKELY(pull_mode < 0)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
     gpio_set_pulls(gpio_num, pull_mode & AtomVMRP2040GPIOPullUp, pull_mode & AtomVMRP2040GPIOPullDown);
     return OK_ATOM;
 }


### PR DESCRIPTION
Fixes a bug in `gpio:set_pin_pull/2` that would accept any parameter as a valid `pull` mode.

Closes #1069

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
