### PR TITLE
Fix error in documentation table of contents

### DIFF
--- a/doc/src/api-reference-documentation.rst
+++ b/doc/src/api-reference-documentation.rst
@@ -2,7 +2,6 @@
 ..
 .. SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 
-
 API Reference Documentation
 =========================================
 
@@ -54,12 +53,10 @@ etest
    apidocs/erlang/etest/*
 
 =========================================
-AtomVM 'C' Internal Libraries
+AtomVM 'C' APIs
 =========================================
 
 .. toctree::
    :maxdepth: 1
 
-   c_api_docs
-
-[`libAtomVM  (Doxygen theme) <_static/libatomvm/index.html>`_]
+   apidocs/libatomvm/index


### PR DESCRIPTION
One file was missed during the recent documentation updates. This fixes the table of contents to match links changed in other updates, including the link to the no longer duplicated doxygen html content.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
