### PR TITLE
Prepare v0.6.0 beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0-beta.1] - Unreleased
+## [0.6.0-beta.1] - 2024-02-28
 
 ### Added
 

--- a/version.cmake
+++ b/version.cmake
@@ -19,4 +19,4 @@
 #
 
 set(ATOMVM_BASE_VERSION "0.6.0-beta.1")
-set(ATOMVM_DEV TRUE)
+set(ATOMVM_DEV FALSE)


### PR DESCRIPTION
This PR prepares v0.6.0-beta.1 release.

Following devices have been tested:
- ESP32: OK
- ESP32-S3: VM crash with default dev mode app
- ESP32-C3: default dev mod app fails (likely a manual testing issue)
- ESP32-C6: OK

- RPi2040 Wireless: OK

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
