### PR TITLE
Fix missing configuration in `doc/conf.py.in`

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -101,6 +101,7 @@ breathe_domain_by_extension = {
 breathe_use_project_refids = True
 
 myst_heading_anchors = 5
+myst_enable_extensions = ['colon_fence']
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
I missed a configuration option when reworking the recent documentation PRs. This setting is needed to propery render doxygen content in the published html documentation.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
