### PR TITLE
Add all Esp32-xx BOOTLOADER_OFFSET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0-rc.0] - Unreleased
 
+### Added
+
+- `BOOTLOADER_OFFSET` for all current Esp32 models.
+
+### Fixed
+
+- `BOOTLOADER_OFFSET` was incorrect for Esp32-C6 and Esp32-S2.
+
+### Changed
+
 ## [0.6.0-beta.1] - 2024-02-28
 
 ### Added

--- a/src/platforms/esp32/tools/CMakeLists.txt
+++ b/src/platforms/esp32/tools/CMakeLists.txt
@@ -23,15 +23,24 @@ project (ReleaseEsp32)
 
 ## Build image tools for target chip
 
+# BOOTLOADER_OFFSET
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/bootloader.html
+
 set(BOOTLOADER_OFFSET "0x1000")
-if(${CONFIG_IDF_TARGET} STREQUAL "esp32s3")
+if( ${CONFIG_IDF_TARGET} STREQUAL "esp32s2")
+    set(BOOTLOADER_OFFSET "0x1000")
+elseif(${CONFIG_IDF_TARGET} STREQUAL "esp32s3")
+    set(BOOTLOADER_OFFSET "0x0")
+elseif(${CONFIG_IDF_TARGET} STREQUAL "esp32c2")
     set(BOOTLOADER_OFFSET "0x0")
 elseif(${CONFIG_IDF_TARGET} STREQUAL "esp32c3")
     set(BOOTLOADER_OFFSET "0x0")
 elseif(${CONFIG_IDF_TARGET} STREQUAL "esp32c6")
     set(BOOTLOADER_OFFSET "0x0")
-elseif( ${CONFIG_IDF_TARGET} STREQUAL "esp32s2")
+elseif(${CONFIG_IDF_TARGET} STREQUAL "esp32h2")
     set(BOOTLOADER_OFFSET "0x0")
+elseif(${CONFIG_IDF_TARGET} STREQUAL "esp32p4")
+    set(BOOTLOADER_OFFSET "0x2000")
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mkimage.config.in ${CMAKE_BINARY_DIR}/mkimage.config)


### PR DESCRIPTION
Decided to add all BOOTLOADER_OFFSET - and not only correcting the incorrect S2 one..

Obviously the conditional could be refactored, but seems preferably to explicitly list/config the various devices.

Release image didn't boot Esp32-S2.

`"Bootloader is located at the address 0x1000 in the flash."`
https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/bootloader.html

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
