### PR TITLE
ESP32: enable jump tables for libAtomVM for Xtensa devices

### DIFF
--- a/src/platforms/esp32/components/libatomvm/CMakeLists.txt
+++ b/src/platforms/esp32/components/libatomvm/CMakeLists.txt
@@ -29,4 +29,7 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../../../libAtomVM" "libAtomVM"
 target_link_libraries(${COMPONENT_LIB}
     INTERFACE libAtomVM "-u platform_nifs_get_nif" "-u platform_defaultatoms_init")
 
+if ((IDF_VERSION_MAJOR GREATER_EQUAL 5) AND (${IDF_TARGET} MATCHES "^esp32$|esp32s2|esp32s3"))
+    target_compile_options("libAtomVM" PRIVATE -fjump-tables -ftree-switch-conversion)
+endif ()
 target_compile_features(${COMPONENT_LIB} INTERFACE c_std_11)


### PR DESCRIPTION
Starting from a certain point jump tables are disabled since they are not compatible with moving code to IRAM.
Enable that again for libAtomVM since we are not moving code to IRAM for it.

See also:
https://github.com/espressif/esp-idf/commit/c02aa6d0ae6599ec703c17afb3a774cfba0b1ee3

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
