### PR TITLE
ESP32: use single precision floats for performance reasons

### DIFF
--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 
 # Options that make sense for this platform
 option(AVM_DISABLE_SMP "Disable SMP." OFF)
-option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
+option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." ON)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
 option(AVM_CREATE_STACKTRACES "Create stacktraces" ON)
 


### PR DESCRIPTION
Documentation says: "Avoid using double precision floating point arithmetic double. These calculations are emulated in software and are very slow. If possible then use an integer-based representation, or single-precision floating point."

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
