### PR TITLE
Update ESP32 platform sntp API calls

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -530,10 +530,10 @@ static void maybe_set_sntp(term sntp_config, GlobalContext *global)
         char *host = interop_term_to_string(interop_kv_get_value(sntp_config, host_atom, global), &ok);
         if (LIKELY(ok)) {
             // do not free(sntp)
-            sntp_setoperatingmode(SNTP_OPMODE_POLL);
-            sntp_setservername(0, host);
+            esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
+            esp_sntp_setservername(0, host);
             sntp_set_time_sync_notification_cb(time_sync_notification_cb);
-            sntp_init();
+            esp_sntp_init();
             ESP_LOGI(TAG, "SNTP initialized with host set to %s", host);
         } else {
             ESP_LOGE(TAG, "Unable to locate sntp host in configuration");


### PR DESCRIPTION
This fixes deprication warnings for `sntp_setoperatingmode`, `esp_sntp_setservername` and `esp_sntp_init` by updating to the new replacement functions. This will hopefully get `sntp` callbacks working on esp32c6, but I don't have the hardware to test that model yet.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
