### PR TITLE
Force smp for all esp32

### DIFF
--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -150,18 +150,9 @@ else()
     if(HAVE_PLATFORM_SMP_H)
         target_compile_definitions(libAtomVM PUBLIC HAVE_PLATFORM_SMP_H)
     endif()
-    include(CheckCSourceCompiles)
-    check_c_source_compiles("
-        #include <stdatomic.h>
-        int main() {
-            _Static_assert(ATOMIC_POINTER_LOCK_FREE == 2, \"Expected ATOMIC_POINTER_LOCK_FREE to be equal to 2\");
-        }
-    " ATOMIC_POINTER_LOCK_FREE_IS_TWO)
-    if (NOT ATOMIC_POINTER_LOCK_FREE_IS_TWO AND NOT HAVE_PLATFORM_SMP_H)
+    if (NOT HAVE_PLATFORM_SMP_H)
         if (NOT STDATOMIC_INCLUDE)
             message(FATAL_ERROR "stdatomic.h cannot be found, you need to disable SMP on this platform or provide platform_smp.h and define HAVE_PLATFORM_SMP_H")
-        else()
-            message(FATAL_ERROR "Platform doesn't support atomic pointers, you need to disable SMP or provide platform_smp.h and define HAVE_PLATFORM_SMP_H")
         endif()
     endif()
 endif()

--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -33,12 +33,6 @@ set(HAVE_SOCKET 1 CACHE INTERNAL "Have symbol socket" FORCE)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules")
 
-# Disable SMP with esp32 socs that have only one core
-if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32c6|esp32h2")
-    message("Disabling SMP as selected target only has one core")
-    set(AVM_DISABLE_SMP YES FORCE)
-endif()
-
 project(atomvm-esp32)
 
 # esp-idf does not use compile_feature but instead sets version in
@@ -52,7 +46,11 @@ if (-std=gnu99 IN_LIST c_compile_options )
 endif()
 
 # Options that make sense for this platform
+
+# Some AtomVM components might not work when SMP is disabled, such as the network driver that sends
+# messages from other threads.
 option(AVM_DISABLE_SMP "Disable SMP." OFF)
+
 option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
 option(AVM_CREATE_STACKTRACES "Create stacktraces" ON)


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
