### PR TITLE
Allow sending messages directly from driver (FreeRTOS) tasks

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -88,7 +88,7 @@ jobs:
         - arch: "arm32v5"
           platform: "arm/v5"
           cflags: "-O2 -mthumb -mthumb-interwork -march=armv4t"
-          cmake_opts: "-DAVM_DISABLE_SMP=On"
+          cmake_opts: "-DAVM_DISABLE_SMP=On -DAVM_DISABLE_TASK_DRIVER=On"
           tag: "stretch"
           sources: |
             deb [trusted=yes] http://archive.debian.org/debian/ stretch-backports main

--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -218,6 +218,15 @@ jobs:
         docker run --network host -v $PWD:/mnt -w /mnt cypress/included:12.17.1 --browser chrome
         killall AtomVM
 
+    - name: "Publish screenshots of failures"
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: cypress-screenshots
+        path: |
+            src/platforms/emscripten/tests/cypress/screenshots/**/*.png
+        retention-days: 7
+
     - name: "Rename and write sha256sum (web)"
       if: startsWith(github.ref, 'refs/tags/')
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `BOOTLOADER_OFFSET` for all current Esp32 models.
+- Added API to send messages from FreeRTOS tasks or pthreads, typically to
+easily support integration with Esp32 callbacks
 
 ### Fixed
 
@@ -16,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug that would fail to set DHCP hostname in STA+AP mode on all ESP32 platforms.
 - ESP32-S3: crash in network driver caused by a smaller stack size for scheduler threads, when
 calling `esp_wifi_init()`. See also issue [#1059](https://github.com/atomvm/AtomVM/issues/1059).
+- Fixed Esp32 network driver on non-SMP builds
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(Elixir)
 
 option(AVM_DISABLE_FP "Disable floating point support." OFF)
 option(AVM_DISABLE_SMP "Disable SMP." OFF)
+option(AVM_DISABLE_TASK_DRIVER "Disable task driver support." OFF)
 option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
 option(AVM_RELEASE "Build an AtomVM release" OFF)

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -6,6 +6,13 @@
 
 # AtomVM Update Instructions
 
+## v0.6.0-beta.1 -> v0.6.0-rc.0
+
+- Drivers that send messages from Esp32 callbacks should use new functions
+`port_send_message_from_task`, `globalcontext_send_message_from_task` or
+`memory_destroy_heap_from_task` instead of `port_send_message`,
+`globalcontext_send_message` and `memory_destroy_heap`.
+
 ## v0.6.0-alpha.2 -> v0.6.0-beta.0
 
 - Registers are no longer preserved by GC by default when invoking nifs, as part of the fix

--- a/doc/src/apidocs/libatomvm/functions.rst
+++ b/doc/src/apidocs/libatomvm/functions.rst
@@ -98,6 +98,7 @@ Functions
 .. doxygenfunction:: globalcontext_process_exists
 .. doxygenfunction:: globalcontext_register_process
 .. doxygenfunction:: globalcontext_send_message
+.. doxygenfunction:: globalcontext_send_message_from_task
 .. doxygenfunction:: globalcontext_send_message_nolock
 .. doxygenfunction:: globalcontext_unregister_process
 .. doxygenfunction:: iff_is_valid_beam

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -144,25 +144,35 @@ endif()
 
 if (AVM_DISABLE_SMP)
     target_compile_definitions(libAtomVM PUBLIC AVM_NO_SMP)
-else()
-    include(CheckIncludeFile)
-    CHECK_INCLUDE_FILE(stdatomic.h STDATOMIC_INCLUDE)
-    if(HAVE_PLATFORM_SMP_H)
-        target_compile_definitions(libAtomVM PUBLIC HAVE_PLATFORM_SMP_H)
-    endif()
-    include(CheckCSourceCompiles)
-    check_c_source_compiles("
-        #include <stdatomic.h>
-        int main() {
-            _Static_assert(ATOMIC_POINTER_LOCK_FREE == 2, \"Expected ATOMIC_POINTER_LOCK_FREE to be equal to 2\");
-        }
-    " ATOMIC_POINTER_LOCK_FREE_IS_TWO)
-    if (NOT ATOMIC_POINTER_LOCK_FREE_IS_TWO AND NOT HAVE_PLATFORM_SMP_H)
-        if (NOT STDATOMIC_INCLUDE)
-            message(FATAL_ERROR "stdatomic.h cannot be found, you need to disable SMP on this platform or provide platform_smp.h and define HAVE_PLATFORM_SMP_H")
-        else()
-            message(FATAL_ERROR "Platform doesn't support atomic pointers, you need to disable SMP or provide platform_smp.h and define HAVE_PLATFORM_SMP_H")
-        endif()
+endif()
+if (NOT AVM_DISABLE_TASK_DRIVER)
+    target_compile_definitions(libAtomVM PUBLIC AVM_TASK_DRIVER_ENABLED)
+endif()
+
+if(HAVE_PLATFORM_SMP_H)
+    target_compile_definitions(libAtomVM PUBLIC HAVE_PLATFORM_SMP_H)
+endif()
+if(HAVE_PLATFORM_ATOMIC_H)
+    target_compile_definitions(libAtomVM PUBLIC HAVE_PLATFORM_ATOMIC_H)
+endif()
+
+include(CheckIncludeFile)
+CHECK_INCLUDE_FILE(stdatomic.h STDATOMIC_INCLUDE)
+include(CheckCSourceCompiles)
+check_c_source_compiles("
+    #include <stdatomic.h>
+    int main() {
+        _Static_assert(ATOMIC_POINTER_LOCK_FREE == 2, \"Expected ATOMIC_POINTER_LOCK_FREE to be equal to 2\");
+    }
+" ATOMIC_POINTER_LOCK_FREE_IS_TWO)
+if (ATOMIC_POINTER_LOCK_FREE_IS_TWO)
+    target_compile_definitions(libAtomVM PUBLIC HAVE_ATOMIC)
+endif()
+if (NOT ATOMIC_POINTER_LOCK_FREE_IS_TWO AND NOT (HAVE_PLATFORM_ATOMIC_H OR (AVM_DISABLE_SMP AND AVM_DISABLE_TASK_DRIVER)))
+    if (NOT STDATOMIC_INCLUDE)
+        message(FATAL_ERROR "stdatomic.h cannot be found, you need to provide platform_atomic.h and define HAVE_PLATFORM_ATOMIC_H or alternatively pass AVM_DISABLE_SMP and AVM_DISABLE_TASK_DRIVER")
+    else()
+        message(FATAL_ERROR "Platform doesn't support atomic pointers, you need to provide platform_atomic.h and define HAVE_PLATFORM_ATOMIC_H or alternatively pass AVM_DISABLE_SMP and AVM_DISABLE_TASK_DRIVER")
     endif()
 endif()
 

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -35,6 +35,15 @@
 #include "term.h"
 #include "utils.h"
 
+#ifdef HAVE_PLATFORM_ATOMIC_H
+#include "platform_atomic.h"
+#else
+#if defined(HAVE_ATOMIC)
+#include <stdatomic.h>
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_INT atomic_compare_exchange_weak
+#endif
+#endif
+
 #define IMPL_EXECUTE_LOOP
 #include "opcodesswitch.h"
 #undef IMPL_EXECUTE_LOOP
@@ -235,7 +244,7 @@ void context_update_flags(Context *ctx, int mask, int value) CLANG_THREAD_SANITI
     enum ContextFlags desired;
     do {
         desired = (expected & mask) | value;
-    } while (!ATOMIC_COMPARE_EXCHANGE_WEAK(&ctx->flags, &expected, desired));
+    } while (!ATOMIC_COMPARE_EXCHANGE_WEAK_INT(&ctx->flags, &expected, desired));
 #else
     ctx->flags = (ctx->flags & mask) | value;
 #endif

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2858,7 +2858,7 @@ static term nif_erlang_system_flag(Context *ctx, int argc, term argv[])
             argv[1] = BADARG_ATOM;
             return term_invalid_term();
         }
-        while (!ATOMIC_COMPARE_EXCHANGE_WEAK(&ctx->global->online_schedulers, &old_value, new_value)) {};
+        while (!ATOMIC_COMPARE_EXCHANGE_WEAK_INT(&ctx->global->online_schedulers, &old_value, new_value)) {};
         return term_from_int32(old_value);
     }
 #else

--- a/src/libAtomVM/otp_socket.c
+++ b/src/libAtomVM/otp_socket.c
@@ -59,6 +59,8 @@
 // #define ENABLE_TRACE
 #include <trace.h>
 
+#define TAG "otp_socket"
+
 // Check some LWIP options
 #if OTP_SOCKET_LWIP
 #if !TCP_LISTEN_BACKLOG

--- a/src/libAtomVM/otp_ssl.c
+++ b/src/libAtomVM/otp_ssl.c
@@ -42,6 +42,8 @@
 // #define ENABLE_TRACE
 #include <trace.h>
 
+#define TAG "otp_ssl"
+
 #ifndef MBEDTLS_PRIVATE
 #define MBEDTLS_PRIVATE(member) member
 #endif

--- a/src/libAtomVM/port.c
+++ b/src/libAtomVM/port.c
@@ -36,6 +36,14 @@ void port_send_message_nolock(GlobalContext *glb, term pid, term msg)
     globalcontext_send_message_nolock(glb, local_process_id, msg);
 }
 
+#ifdef AVM_TASK_DRIVER_ENABLED
+void port_send_message_from_task(GlobalContext *glb, term pid, term msg)
+{
+    int local_process_id = term_to_local_process_id(pid);
+    globalcontext_send_message_from_task(glb, local_process_id, NormalMessage, msg);
+}
+#endif
+
 void port_ensure_available(Context *ctx, size_t size)
 {
     if (context_avail_free_memory(ctx) < size) {

--- a/src/libAtomVM/port.h
+++ b/src/libAtomVM/port.h
@@ -71,8 +71,39 @@ static inline term port_create_reply(Context *ctx, term ref, term payload)
 {
     return port_heap_create_reply(&ctx->heap, ref, payload);
 }
+
+/**
+ * @brief Send a message to a given pid. This function must be called from
+ * a driver's native handler.
+ *
+ * @param glb the global context
+ * @param pid the pid of the process to send a message to.
+ * @param msg the message to send.
+ */
 void port_send_message(GlobalContext *glb, term pid, term msg);
+
+/**
+ * @brief Send a message to a given pid. This function must be called from
+ * a driver's native handler after a target context has been locked.
+ *
+ * @param glb the global context
+ * @param pid the pid of the process to send a message to.
+ * @param msg the message to send.
+ */
 void port_send_message_nolock(GlobalContext *glb, term pid, term msg);
+
+#ifdef AVM_TASK_DRIVER_ENABLED
+/**
+ * @brief Send a message to a given pid. This function can be called from
+ * a driver's task, such as an event callback.
+ *
+ * @param glb the global context
+ * @param pid the pid of the process to send a message to.
+ * @param msg the message to send.
+ */
+void port_send_message_from_task(GlobalContext *glb, term pid, term msg);
+#endif
+
 void port_ensure_available(Context *ctx, size_t size);
 
 // Helper to send a message from NIFs or from the native handler.

--- a/src/libAtomVM/refc_binary.h
+++ b/src/libAtomVM/refc_binary.h
@@ -30,7 +30,17 @@ extern "C" {
 
 #include "list.h"
 #include "resources.h"
-#include "smp.h"
+
+#ifdef HAVE_PLATFORM_ATOMIC_H
+#include "platform_atomic.h"
+#endif
+
+#if defined(HAVE_ATOMIC) && !defined(__cplusplus)
+#include <stdatomic.h>
+#define ATOMIC _Atomic
+#else
+#define ATOMIC
+#endif
 
 #ifndef TYPEDEF_CONTEXT
 #define TYPEDEF_CONTEXT

--- a/src/libAtomVM/scheduler.h
+++ b/src/libAtomVM/scheduler.h
@@ -61,10 +61,20 @@ void scheduler_init_ready(Context *c);
 
 /**
  * @brief Signal a process that a message was inserted in the mailbox.
+ * @details Cannot be called from a foreign task or from ISR.
  *
  * @param c the process context.
  */
 void scheduler_signal_message(Context *c);
+
+#ifdef AVM_TASK_DRIVER_ENABLED
+/**
+ * @brief Signal a process that a message was inserted in the mailbox.
+ * @details Must only be called while global->processes_spinlock is acquired.
+ * @param c the process context.
+ */
+void scheduler_signal_message_from_task(Context *c);
+#endif
 
 /**
  * @brief Signal a process that it was killed.

--- a/src/libAtomVM/synclist.h
+++ b/src/libAtomVM/synclist.h
@@ -56,6 +56,14 @@ static inline struct ListHead *synclist_rdlock(struct SyncList *synclist)
     return &synclist->head;
 }
 
+static inline struct ListHead *synclist_tryrdlock(struct SyncList *synclist)
+{
+    if (smp_rwlock_tryrdlock(synclist->lock)) {
+        return &synclist->head;
+    }
+    return NULL;
+}
+
 static inline struct ListHead *synclist_wrlock(struct SyncList *synclist)
 {
     smp_rwlock_wrlock(synclist->lock);
@@ -107,6 +115,7 @@ static inline int synclist_is_empty(struct SyncList *synclist)
 #define SyncList ListHead
 #define synclist_init(list) list_init(list)
 #define synclist_rdlock(list) list
+#define synclist_tryrdlock(list) list
 #define synclist_wrlock(list) list
 #define synclist_nolock(list) list
 #define synclist_unlock(list) UNUSED(list)

--- a/src/libAtomVM/sys.h
+++ b/src/libAtomVM/sys.h
@@ -175,23 +175,22 @@ void sys_unregister_listener(GlobalContext *global, EventListener *listener);
  */
 void sys_listener_destroy(struct ListHead *item);
 
-#ifndef AVM_NO_SMP
-
+#if !defined(AVM_NO_SMP) || defined(AVM_TASK_DRIVER_ENABLED)
 /**
  * @brief Interrupt the wait in `sys_poll_events`.
  *
  * @details This function should signal the thread that is waiting in
- * `sys_poll_events` so it returns before the timeout. It is only used
- * for SMP builds.
+ * `sys_poll_events` so it returns before the timeout. It is mostly used for
+ * SMP builds, but also to abort sleep from driver callbacks on FreeRTOS.
  *
  * Please note that this function may be called while no thread is waiting in
  * sys_poll_events and this should have no effect. This function is called in
- * scheduler loop (internal function `scheduler_run0`).
+ * scheduler loop (internal function `scheduler_run0`) and when scheduling
+ * processes.
  *
  * @param glb the global context.
  */
 void sys_signal(GlobalContext *glb);
-
 #endif
 
 enum OpenAVMResult sys_open_avm_from_file(

--- a/src/platforms/emscripten/src/lib/sys.c
+++ b/src/platforms/emscripten/src/lib/sys.c
@@ -108,7 +108,7 @@ static void htmlevent_user_data_dtor(ErlNifEnv *caller_env, void *obj)
 {
     struct HTMLEventUserDataResource *htmlevent_user_data_rsrc = (struct HTMLEventUserDataResource *) obj;
     if (!term_is_invalid_term(htmlevent_user_data_rsrc->user_data)) {
-        memory_sweep_mso_list(htmlevent_user_data_rsrc->storage[STORAGE_MSO_LIST_INDEX], caller_env->global);
+        memory_sweep_mso_list(htmlevent_user_data_rsrc->storage[STORAGE_MSO_LIST_INDEX], caller_env->global, false);
         htmlevent_user_data_rsrc->user_data = term_invalid_term();
     }
     free(htmlevent_user_data_rsrc->target_element_str);
@@ -482,7 +482,7 @@ static void sys_process_emscripten_message(GlobalContext *glb, struct Emscripten
             }
             globalcontext_send_message(glb, message_html_event->target_pid, message_term);
             END_WITH_STACK_HEAP(heap, glb)
-            memory_sweep_mso_list(message_html_event->message_heap->mso_list, glb);
+            memory_sweep_mso_list(message_html_event->message_heap->mso_list, glb, false);
             memory_destroy_heap_fragment(message_html_event->message_heap);
         } break;
 

--- a/src/platforms/emscripten/tests/cypress/e2e/examples.spec.cy.js
+++ b/src/platforms/emscripten/tests/cypress/e2e/examples.spec.cy.js
@@ -185,8 +185,12 @@ describe("emscripten HTML5 Events", () => {
     cy.get("#click-checkbox").click();
     cy.get("#input-field").click({ x: 2, y: 2 });
     cy.get("#event-1 td.event-type").should("contain", "click");
-    cy.get("#event-1 td.event-map").should("contain", "target_x => 2");
-    cy.get("#event-1 td.event-map").should("contain", "target_y => 2");
+    // Could be offset by 1
+    // Maybe related: https://github.com/cypress-io/cypress/issues/20802
+    cy.get("#event-1 td.event-map").should(($eventMap) => {
+        const eventMapText = $eventMap.text();
+        expect(eventMapText).to.match(/target_x => [23]/).and.match(/target_y => [23]/);
+    });
     cy.get("#event-1 td.event-user-data").should(
       "contain",
       "click -- input field",

--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -37,6 +37,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules
 if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32c6|esp32h2")
     message("Disabling SMP as selected target only has one core")
     set(AVM_DISABLE_SMP YES FORCE)
+    set(HAVE_PLATFORM_ATOMIC_H ON)
 endif()
 
 project(atomvm-esp32)

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -126,7 +126,7 @@ static void send_term(Heap *heap, struct ClientData *data, term t)
     term_put_tuple_element(msg, 1, t);
 
     // Pid ! {Ref, T}
-    port_send_message(data->global, term_from_local_process_id(data->owner_process_id), msg);
+    port_send_message_from_task(data->global, term_from_local_process_id(data->owner_process_id), msg);
 }
 
 static void send_got_ip(struct ClientData *data, esp_netif_ip_info_t *info)
@@ -319,6 +319,7 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
         switch (event_id) {
 
             case SNTP_EVENT_BASE_SYNC: {
+                ESP_LOGI(TAG, "SNTP_EVENT_BASE_SYNC received.");
                 send_sntp_sync(data, (struct timeval *) event_data);
                 break;
             }

--- a/src/platforms/esp32/components/avm_sys/include/otp_socket_platform.h
+++ b/src/platforms/esp32/components/avm_sys/include/otp_socket_platform.h
@@ -27,8 +27,6 @@ extern "C" {
 
 #include <esp_log.h>
 
-#define TAG "otp_socket"
-
 #define AVM_LOGD(tag, format, ...) \
     ;
 

--- a/src/platforms/esp32/components/avm_sys/platform_atomic.h
+++ b/src/platforms/esp32/components/avm_sys/platform_atomic.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of AtomVM.
  *
- * Copyright 2023 by Fred Dushin <fred@dushin.net>
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,24 +18,14 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
-#ifndef __OTP_SOCKET_PLATFORM_H__
-#define __OTP_SOCKET_PLATFORM_H__
+#ifndef _PLATFORM_ATOMIC_H
+#define _PLATFORM_ATOMIC_H
 
-#include <stdbool.h>
-#include <stdio.h>
+#include <stdatomic.h>
 
-#define AVM_LOGD(tag, format, ...) \
-    ;
+// We always rely on esp-idf implementation of atomic_compare_exchange_weak
 
-#define AVM_LOGI(tag, format, ...) \
-    fprintf(stderr, "I %s: " format " (%s:%i)\n", tag, ##__VA_ARGS__, __FILE__, __LINE__);
-
-#define AVM_LOGW(tag, format, ...) \
-    fprintf(stderr, "W %s: " format " (%s:%i)\n", tag, ##__VA_ARGS__, __FILE__, __LINE__);
-
-#define AVM_LOGE(tag, format, ...) \
-    fprintf(stderr, "E %s: " format " (%s:%i)\n", tag, ##__VA_ARGS__, __FILE__, __LINE__);
-
-bool otp_socket_platform_supports_peek();
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_PTR(object, expected, desired) \
+    atomic_compare_exchange_weak(object, expected, desired)
 
 #endif

--- a/src/platforms/esp32/components/libatomvm/CMakeLists.txt
+++ b/src/platforms/esp32/components/libatomvm/CMakeLists.txt
@@ -26,6 +26,11 @@ option(AVM_PEDANTIC_WARNINGS "Pedantic compiler warnings" OFF)
 
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../../../libAtomVM" "libAtomVM")
 
+# Add directory with platform_atomic.h if we mean to use it
+if (HAVE_PLATFORM_ATOMIC_H)
+    target_include_directories(libAtomVM PUBLIC ../avm_sys/)
+endif()
+
 target_link_libraries(${COMPONENT_LIB}
     INTERFACE libAtomVM "-u platform_nifs_get_nif" "-u platform_defaultatoms_init")
 

--- a/src/platforms/esp32/test/CMakeLists.txt
+++ b/src/platforms/esp32/test/CMakeLists.txt
@@ -46,9 +46,10 @@ set(HAVE_SOCKET ON)
 set(HAVE_SOCKET 1 CACHE INTERNAL "Have symbol socket" FORCE)
 
 # Disable SMP with esp32 socs that have only one core
-if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32h2")
+if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32c6|esp32h2")
     message("Disabling SMP as selected target only has one core")
     set(AVM_DISABLE_SMP YES FORCE)
+    set(HAVE_PLATFORM_ATOMIC_H ON)
 endif()
 
 project(atomvm-esp32-test)

--- a/src/platforms/generic_unix/lib/smp.c
+++ b/src/platforms/generic_unix/lib/smp.c
@@ -21,6 +21,7 @@
 #include "smp.h"
 
 #ifndef AVM_NO_SMP
+#include <errno.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -195,6 +196,18 @@ void smp_rwlock_rdlock(RWLock *lock)
     if (UNLIKELY(pthread_rwlock_rdlock(&lock->lock))) {
         AVM_ABORT();
     }
+}
+
+bool smp_rwlock_tryrdlock(RWLock *lock)
+{
+    int r = pthread_rwlock_tryrdlock(&lock->lock);
+    if (r == EBUSY) {
+        return false;
+    }
+    if (UNLIKELY(r)) {
+        AVM_ABORT();
+    }
+    return true;
 }
 
 void smp_rwlock_wrlock(RWLock *lock)

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -70,14 +70,6 @@
 // Platform uses listeners
 #include "listeners.h"
 
-#ifndef AVM_NO_SMP
-#define SMP_MUTEX_LOCK(mtx) smp_mutex_lock(mtx)
-#define SMP_MUTEX_UNLOCK(mtx) smp_mutex_unlock(mtx)
-#else
-#define SMP_MUTEX_LOCK(mtx)
-#define SMP_MUTEX_UNLOCK(mtx)
-#endif
-
 #ifdef DYNLOAD_PORT_DRIVERS
 #include <dlfcn.h>
 
@@ -355,7 +347,7 @@ void sys_poll_events(GlobalContext *glb, int timeout_ms) CLANG_THREAD_SANITIZE_S
 #endif
 }
 
-#ifndef AVM_NO_SMP
+#if !defined(AVM_NO_SMP) || defined(AVM_TASK_DRIVER_ENABLED)
 void sys_signal(GlobalContext *glb)
 {
     struct GenericUnixPlatformData *platform = glb->platform_data;

--- a/src/platforms/rp2040/CMakeLists.txt
+++ b/src/platforms/rp2040/CMakeLists.txt
@@ -55,6 +55,8 @@ option(AVM_WAIT_FOR_USB_CONNECT "Wait for USB connection before starting" OFF)
 option(AVM_WAIT_BOOTSEL_ON_EXIT "Wait in BOOTSEL rather than shutdown on exit" ON)
 option(AVM_REBOOT_ON_NOT_OK "Reboot Pico if result is not ok" OFF)
 
+set(AVM_DISABLE_TASK_DRIVER ON FORCE)
+
 set(
     PLATFORM_LIB_SUFFIX
     ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}

--- a/src/platforms/rp2040/src/CMakeLists.txt
+++ b/src/platforms/rp2040/src/CMakeLists.txt
@@ -28,11 +28,12 @@ if(CMAKE_COMPILER_IS_GNUCC)
     target_compile_options(AtomVM PRIVATE -Wall -pedantic -Wextra)
 endif()
 
-# libAtomVM needs to find Pico's platform_smp.h header
+# libAtomVM needs to find Pico's platform_smp.h and platform_atomic.h headers
 set(HAVE_PLATFORM_SMP_H ON)
+set(HAVE_PLATFORM_ATOMIC_H ON)
 add_subdirectory(../../../libAtomVM libAtomVM)
 target_link_libraries(AtomVM PUBLIC libAtomVM)
-# Also add lib where platform_smp.h header is
+# Also add lib where platform_smp.h and platform_atomic headers are
 target_include_directories(libAtomVM PUBLIC lib)
 
 target_link_libraries(AtomVM PUBLIC hardware_regs pico_stdlib pico_binary_info)

--- a/src/platforms/rp2040/src/lib/otp_socket_platform.h
+++ b/src/platforms/rp2040/src/lib/otp_socket_platform.h
@@ -31,8 +31,6 @@
 
 #pragma GCC diagnostic pop
 
-#define TAG "otp_socket"
-
 #define AVM_LOGD(tag, format, ...) \
     ;
 

--- a/src/platforms/rp2040/src/lib/platform_atomic.h
+++ b/src/platforms/rp2040/src/lib/platform_atomic.h
@@ -1,0 +1,153 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _PLATFORM_ATOMIC_H
+#define _PLATFORM_ATOMIC_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+#include <pico/critical_section.h>
+
+#pragma GCC diagnostic pop
+
+#define ATOMIC
+
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_PTR(object, expected, desired) \
+    smp_atomic_compare_exchange_weak_ptr((void **) object, (void **) expected, (void *) desired)
+
+#define ATOMIC_COMPARE_EXCHANGE_WEAK_INT(object, expected, desired) \
+    smp_atomic_compare_exchange_weak_int((void *) object, (void *) expected, (uint64_t) desired, sizeof(desired))
+
+#ifndef AVM_NO_SMP
+static critical_section_t atomic_cas_section;
+#endif
+
+/**
+ * @brief Initialize structures of atomic functions
+ */
+static inline void atomic_init()
+{
+#ifndef AVM_NO_SMP
+    critical_section_init(&atomic_cas_section);
+#endif
+}
+
+/**
+ * @brief Free structures for atomic functions
+ */
+static inline void atomic_free()
+{
+#ifndef AVM_NO_SMP
+    critical_section_deinit(&atomic_cas_section);
+#endif
+}
+
+static inline bool smp_atomic_compare_exchange_weak_ptr(void **object, void **expected, void *desired)
+{
+#ifndef AVM_NO_SMP
+    critical_section_enter_blocking(&atomic_cas_section);
+#else
+    uint32_t save = save_and_disable_interrupts();
+#endif
+
+    bool result;
+    result = *object == *expected;
+    if (result) {
+        *object = desired;
+    } else {
+        *expected = *object;
+    }
+#ifndef AVM_NO_SMP
+    critical_section_exit(&atomic_cas_section);
+#else
+    restore_interrupts(save);
+#endif
+    return result;
+}
+
+static inline bool smp_atomic_compare_exchange_weak_int(void *object, void *expected, uint64_t desired, size_t desired_len)
+{
+#ifndef AVM_NO_SMP
+    critical_section_enter_blocking(&atomic_cas_section);
+#else
+    uint32_t save = save_and_disable_interrupts();
+#endif
+
+    bool result;
+    switch (desired_len) {
+        case sizeof(uint64_t): {
+            uint64_t *object_ptr = (uint64_t *) object;
+            uint64_t *expected_ptr = (uint64_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+        case sizeof(uint32_t): {
+            uint32_t *object_ptr = (uint32_t *) object;
+            uint32_t *expected_ptr = (uint32_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+        case sizeof(uint16_t): {
+            uint16_t *object_ptr = (uint16_t *) object;
+            uint16_t *expected_ptr = (uint16_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+        case sizeof(uint8_t): {
+            uint8_t *object_ptr = (uint8_t *) object;
+            uint8_t *expected_ptr = (uint8_t *) expected;
+            result = *object_ptr == *expected_ptr;
+            if (result) {
+                *object_ptr = desired;
+            } else {
+                *expected_ptr = *object_ptr;
+            }
+            break;
+        }
+    }
+
+#ifndef AVM_NO_SMP
+    critical_section_exit(&atomic_cas_section);
+#else
+    restore_interrupts(save);
+#endif
+    return result;
+}
+
+#endif

--- a/src/platforms/rp2040/src/lib/smp.c
+++ b/src/platforms/rp2040/src/lib/smp.c
@@ -95,8 +95,7 @@ void smp_mutex_lock(Mutex *mtx)
 
 bool smp_mutex_trylock(Mutex *mtx)
 {
-    uint32_t owner;
-    return mutex_try_enter(&mtx->mutex, &owner);
+    return mutex_try_enter(&mtx->mutex, NULL);
 }
 
 void smp_mutex_unlock(Mutex *mtx)
@@ -147,6 +146,11 @@ void smp_rwlock_destroy(RWLock *lock)
 void smp_rwlock_rdlock(RWLock *lock)
 {
     mutex_enter_blocking(&lock->lock);
+}
+
+bool smp_rwlock_tryrdlock(RWLock *lock)
+{
+    return mutex_try_enter(&lock->lock, NULL);
 }
 
 void smp_rwlock_wrlock(RWLock *lock)

--- a/src/platforms/rp2040/tests/CMakeLists.txt
+++ b/src/platforms/rp2040/tests/CMakeLists.txt
@@ -31,10 +31,11 @@ if(CMAKE_COMPILER_IS_GNUCC)
     target_compile_options(rp2040_tests PRIVATE -Wall -pedantic -Wextra)
 endif()
 
-# libAtomVM needs to find Pico's platform_smp.h header
+# libAtomVM needs to find Pico's platform_smp.h and platform_atomic.h headers
 set(HAVE_PLATFORM_SMP_H ON)
+set(HAVE_PLATFORM_ATOMIC_H ON)
 target_link_libraries(rp2040_tests PUBLIC libAtomVM)
-# Also add lib where platform_smp.h header is
+# Also add lib where platform_smp.h and platform_atomic.h headers are
 target_include_directories(rp2040_tests PUBLIC ../src/lib)
 
 target_link_libraries(rp2040_tests PUBLIC hardware_regs pico_stdlib pico_binary_info unity)

--- a/src/platforms/stm32/CMakeLists.txt
+++ b/src/platforms/stm32/CMakeLists.txt
@@ -37,6 +37,7 @@ option(AVM_DISABLE_GPIO_NIFS "Disable GPIO nifs (input and output)" OFF)
 option(AVM_DISABLE_GPIO_PORT_DRIVER "Disable GPIO 'port' driver (input, output, and interrupts)" OFF)
 
 set(AVM_DISABLE_SMP ON FORCE)
+set(AVM_DISABLE_TASK_DRIVER ON FORCE)
 
 if (AVM_NEWLIB_NANO)
     set(LINKER_FLAGS "${LINKER_FLAGS} -specs=nano.specs")


### PR DESCRIPTION
Introduce and document new functions to send messages from a driver task, typically a callback on a platform with FreeRTOS.

While sending messages from such a task may work with SMP builds, it was not necessarily safe and it didn't work with non-SMP builds.

Introduce the required synchronization primitives that try and acquire locks.

Also fix ESP32 network driver to use these new functions as it was broken with non-SMP builds (e.g. ESP32C6).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
