### PR TITLE
Fixed setting DHCP hostname in STA+AP mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `BOOTLOADER_OFFSET` was incorrect for Esp32-C6 and Esp32-S2.
+- Fixed a bug that would fail to set DHCP hostname in STA+AP mode on all ESP32 platforms.
 
 ### Changed
 


### PR DESCRIPTION
This PR fixes a bug that would cause the DHCP hostname to not get properly set when the device is configured in STA+AP mode.  As a consequence, the default DHCP hostname (`espressif`) would be used, which would obviously be problematic on a network running multiple IoT devices.

With this fix, the DCHP hostname is properly set, both in AP and STA modes, and in fact can be set differently in config, if desired.

Closes #1084.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
