### PR TITLE
Fix isolation of esp32 networking tests

### DIFF
--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -90,7 +90,7 @@ static esp_netif_t *eth_start(void)
         .stack = ESP_NETIF_NETSTACK_DEFAULT_ETH
     };
     esp_netif_t *netif = esp_netif_new(&netif_config);
-    assert(netif);
+    TEST_ASSERT(netif != NULL);
     free(desc);
 
     eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
@@ -208,10 +208,11 @@ TEST_CASE("test_file", "[test_run]")
     sdmmc_card_print_info(stdout, card);
 
     term ret_value = avm_test_case("test_file.beam");
-    TEST_ASSERT(ret_value == OK_ATOM);
 
     esp_vfs_fat_sdcard_unmount(mount_point, card);
     ESP_LOGI(TAG, "Card unmounted");
+
+    TEST_ASSERT(ret_value == OK_ATOM);
 }
 
 TEST_CASE("test_list_to_binary", "[test_run]")
@@ -390,9 +391,10 @@ TEST_CASE("test_select", "[test_run]")
     ESP_ERROR_CHECK(esp_vfs_register("/pipe", &pipefs, NULL));
 
     term ret_value = avm_test_case("test_select.beam");
-    TEST_ASSERT(ret_value == OK_ATOM);
 
     esp_vfs_unregister("/pipe");
+
+    TEST_ASSERT(ret_value == OK_ATOM);
 }
 
 TEST_CASE("test_time_and_processes", "[test_run]")
@@ -438,10 +440,11 @@ TEST_CASE("test_net", "[test_run]")
     }
 
     term ret_value = avm_test_case("test_net.beam");
-    TEST_ASSERT(ret_value == OK_ATOM);
 
     ESP_LOGI(TAG, "Stopping network\n");
     eth_stop(eth_netif);
+
+    TEST_ASSERT(ret_value == OK_ATOM);
 }
 
 TEST_CASE("test_socket", "[test_run]")
@@ -458,10 +461,11 @@ TEST_CASE("test_socket", "[test_run]")
     }
 
     term ret_value = avm_test_case("test_socket.beam");
-    TEST_ASSERT(term_to_int(ret_value) == 0);
 
     ESP_LOGI(TAG, "Stopping network\n");
     eth_stop(eth_netif);
+
+    TEST_ASSERT(term_to_int(ret_value) == 0);
 }
 
 TEST_CASE("test_ssl", "[test_run]")
@@ -478,10 +482,11 @@ TEST_CASE("test_ssl", "[test_run]")
     }
 
     term ret_value = avm_test_case("test_ssl.beam");
-    TEST_ASSERT(ret_value == OK_ATOM);
 
     ESP_LOGI(TAG, "Stopping network\n");
     eth_stop(eth_netif);
+
+    TEST_ASSERT(ret_value == OK_ATOM);
 }
 
 TEST_CASE("test_rtc_slow", "[test_run]")


### PR DESCRIPTION
Move assert of result of erlang test code after tearing down networking.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
