### PR TITLE
Simplify conditional macros and clarify mbedtls entropy locks

### DIFF
--- a/src/libAtomVM/sys_mbedtls.h
+++ b/src/libAtomVM/sys_mbedtls.h
@@ -24,14 +24,54 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
 
+// On SMP builds, mbedtls_entropy_context or mbedtls_ctr_drbg_context can be
+// accessed from several scheduler threads at once through calls to functions
+// such as `mbedtls_ctr_drbg_random` that may call a function on
+// mbedtls_entropy_context. So they need to be protected by a mutex.
+//
+// On non-SMP builds, we don't need any lock because all calls we make to
+// mbedtls_ctr_drbg* functions are done from the scheduler thread itself.
+
+/**
+ * @brief get and acquire lock on mbedtls_entropy_context.
+ * @details this function must be called from a scheduler thread (nif,
+ * native handler, listener) to access the entropy context and should be
+ * balanced by `sys_mbedtls_entropy_context_unlock`.
+ * On non-SMP builds, there is no lock as there is only one scheduler.
+ *
+ * @param global the global context
+ */
 mbedtls_entropy_context *sys_mbedtls_get_entropy_context_lock(GlobalContext *global);
+
+/**
+ * @brief release lock on mbedtls_entropy_context.
+ *
+ * @param global the global context
+ */
 void sys_mbedtls_entropy_context_unlock(GlobalContext *global);
+
+/**
+ * @brief invoke `mbedtls_entropy_func`
+ * @details unless MBEDTLS_THREADING_C is defined, this function must acquire
+ * the entropy mutex to call `mbedtls_entropy_func`.
+ */
 int sys_mbedtls_entropy_func(void *entropy, unsigned char *buf, size_t size);
 
+/**
+ * @brief get and acquire lock on mbedtls_ctr_drbg_context.
+ * @details this function must be called from a scheduler thread (nif,
+ * native handler, listener) to access the random context and should be
+ * balanced by `sys_mbedtls_ctr_drbg_context_unlock`.
+ * On non-SMP builds, there is no lock as there is only one scheduler.
+ *
+ * @warning do not call this function when already owning the entropy context
+ */
 mbedtls_ctr_drbg_context *sys_mbedtls_get_ctr_drbg_context_lock(GlobalContext *global);
 
 /**
- * @warning do not call this function when already owning the entropy context
+ * @brief release lock on mbedtls_ctr_drbg_context.
+ *
+ * @param global the global context
  */
 void sys_mbedtls_ctr_drbg_context_unlock(GlobalContext *global);
 

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -799,16 +799,12 @@ term esp_err_to_term(GlobalContext *glb, esp_err_t status)
 
 int sys_mbedtls_entropy_func(void *entropy, unsigned char *buf, size_t size)
 {
-#ifndef MBEDTLS_THREADING_C
-#ifndef AVM_NO_SMP
+#if !defined(MBEDTLS_THREADING_C) && !defined(AVM_NO_SMP)
     struct ESP32PlatformData *platform
         = CONTAINER_OF(entropy, struct ESP32PlatformData, entropy_ctx);
     SMP_MUTEX_LOCK(platform->entropy_mutex);
-#endif
     int result = mbedtls_entropy_func(entropy, buf, size);
-#ifndef AVM_NO_SMP
     SMP_MUTEX_UNLOCK(platform->entropy_mutex);
-#endif
 
     return result;
 #else


### PR DESCRIPTION
There is no lock on non-SMP builds.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
