### PR TITLE
Prevent user-supplied callbacks from blocking network gen_server

### DIFF
--- a/libs/eavmlib/src/network.erl
+++ b/libs/eavmlib/src/network.erl
@@ -355,9 +355,12 @@ maybe_callback0(_Key, undefined) ->
     ok;
 maybe_callback0(Key, Config) ->
     case proplists:get_value(Key, Config) of
-        undefined -> ok;
-        Pid when is_pid(Pid) -> Pid ! Key;
-        Fun -> Fun()
+        undefined ->
+            ok;
+        Pid when is_pid(Pid) ->
+            Pid ! Key;
+        Fun when is_function(Fun) ->
+            spawn(fun() -> Fun() end)
     end.
 
 %% @private
@@ -365,9 +368,12 @@ maybe_callback1(_KeyArg, undefined) ->
     ok;
 maybe_callback1({Key, Arg} = Msg, Config) ->
     case proplists:get_value(Key, Config) of
-        undefined -> ok;
-        Pid when is_pid(Pid) -> Pid ! Msg;
-        Fun -> Fun(Arg)
+        undefined ->
+            ok;
+        Pid when is_pid(Pid) ->
+            Pid ! Msg;
+        Fun when is_function(Fun) ->
+            spawn(fun() -> Fun(Arg) end)
     end.
 
 %% @private


### PR DESCRIPTION
User-supplied callback functions should be called in their own spawned processes, so that if they don't terminate or take too long to run, they do not block the network gen_server.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
