### PR TITLE
Prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-03-05
+
+### Fixed
+
+- Fix a bug that broke sockets on ESP32-C3 and other single core ESP32 devices, that may also
+cause other issues. The bug has been introduced with messages from tasks change between beta.1
+and rc.0
+
 ## [0.6.0-rc.0] - 2024-03-03
 
 ### Added

--- a/version.cmake
+++ b/version.cmake
@@ -1,7 +1,7 @@
 #
 # This file is part of AtomVM.
 #
-# Copyright 2022 Davide Bettio <davide@uninstall.it>
+# Copyright 2022-2024 Davide Bettio <davide@uninstall.it>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,5 +19,5 @@
 #
 
 # Please, keep also in sync src/libAtomVM/atomvm_version.h
-set(ATOMVM_BASE_VERSION "0.6.0-rc.0")
+set(ATOMVM_BASE_VERSION "0.6.0")
 set(ATOMVM_DEV FALSE)


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
