### PR TITLE
Fix scheduler issues with non-SMP builds for Esp32 platform

### DIFF
--- a/src/libAtomVM/scheduler.c
+++ b/src/libAtomVM/scheduler.c
@@ -321,6 +321,8 @@ static void scheduler_make_ready(Context *ctx)
     if (waiting_scheduler) {
         sys_signal(global);
     }
+#elif defined(AVM_TASK_DRIVER_ENABLED)
+    sys_signal(global);
 #endif
 }
 
@@ -372,7 +374,7 @@ void scheduler_terminate(Context *ctx)
 void scheduler_stop_all(GlobalContext *global)
 {
     global->scheduler_stop_all = true;
-#ifndef AVM_NO_SMP
+#if !defined(AVM_NO_SMP) || defined(AVM_TASK_DRIVER_ENABLED)
     sys_signal(global);
 #endif
 }
@@ -403,6 +405,8 @@ void scheduler_set_timeout(Context *ctx, avm_int64_t timeout)
     if (glb->waiting_scheduler) {
         sys_signal(glb);
     }
+#elif defined(AVM_TASK_DRIVER_ENABLED)
+    sys_signal(glb);
 #endif
 }
 

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -756,7 +756,7 @@ static NativeHandlerResult do_receive_data(Context *ctx)
             term_put_tuple_element(active_tuple, 4, recv_data);
         }
         globalcontext_send_message(ctx->global, socket_data->controlling_process_pid, active_tuple);
-        TRACE("sent received to active process (pid=%d): ", socket_data->controlling_process_pid);
+        TRACE("sent received to active process (pid=%d): ", (int) socket_data->controlling_process_pid);
         #ifdef ENABLE_TRACE
             term_display(stdout, active_tuple, ctx);
         #endif
@@ -766,7 +766,7 @@ static NativeHandlerResult do_receive_data(Context *ctx)
         term_put_tuple_element(ok_tuple, 0, OK_ATOM);
         term_put_tuple_element(ok_tuple, 1, recv_term);
         do_send_passive_reply(ctx, socket_data, ok_tuple);
-        TRACE("sent received to passive caller (pid=%d): ", socket_data->passive_receiver_process_pid);
+        TRACE("sent received to passive caller (pid=%d): ", (int) socket_data->passive_receiver_process_pid);
         #ifdef ENABLE_TRACE
             term_display(stdout, ok_tuple, ctx);
         #endif


### PR DESCRIPTION
Posting messages from a listener did not break out of the sys_poll_events loop on non-SMP builds. Pico is not affected because sys_poll_events doesn't loop.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
