### PR TITLE
Fix arm32v5 build-linux-artifacts

### DIFF
--- a/.github/workflows/build-linux-artifacts.yaml
+++ b/.github/workflows/build-linux-artifacts.yaml
@@ -70,7 +70,7 @@ jobs:
           docker_image: "arm32v5/debian"
           platform: "arm/v5"
           cflags: "-mthumb -mthumb-interwork -march=armv4t"
-          cmake_opts: "-DAVM_DISABLE_SMP=On"
+          cmake_opts: "-DAVM_DISABLE_SMP=On -DAVM_DISABLE_TASK_DRIVER=On"
           tag: "stretch"
           sources: |
             deb [trusted=yes] http://archive.debian.org/debian/ stretch-backports main


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
