### PR TITLE
Fix select on non-SMP Esp32 builds

### DIFF
--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -157,6 +157,11 @@ if(HAVE_PLATFORM_ATOMIC_H)
     target_compile_definitions(libAtomVM PUBLIC HAVE_PLATFORM_ATOMIC_H)
 endif()
 
+# Platforms that run select in a task must set this option
+if(AVM_SELECT_IN_TASK)
+    target_compile_definitions(libAtomVM PUBLIC AVM_SELECT_IN_TASK)
+endif()
+
 include(CheckIncludeFile)
 CHECK_INCLUDE_FILE(stdatomic.h STDATOMIC_INCLUDE)
 include(CheckCSourceCompiles)

--- a/src/libAtomVM/resources.h
+++ b/src/libAtomVM/resources.h
@@ -84,6 +84,9 @@ static inline void resource_type_destroy(struct ResourceType *resource_type)
  * if a select event was selected and the read or write flag was set.
  * It modifies the select_event object so the notification is only sent once.
  *
+ * The function can also be called from a select task loop if
+ * `AVM_SELECT_IN_TASK` is defined.
+ *
  * It is not an error to call this function with an event that is not in the
  * list.
  *
@@ -102,6 +105,10 @@ bool select_event_notify(ErlNifEvent event, bool is_read, bool is_write, GlobalC
  * events marked for close.
  * @details Convenience function that can be called by `sys_poll_events` and
  * iterates on events to be closed and count them.
+ *
+ * The function can also be called from a select task loop if
+ * `AVM_SELECT_IN_TASK` is defined.
+ *
  * @param select_events list of events, with a write lock
  * @param read on output number of events with read = 1, can be NULL
  * @param write on output number of events with write = 1, can be NULL

--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -40,6 +40,9 @@ if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32c6|esp32h2")
     set(HAVE_PLATFORM_ATOMIC_H ON)
 endif()
 
+# On Esp32, select is run in a loop in a dedicated task
+set(AVM_SELECT_IN_TASK ON)
+
 project(atomvm-esp32)
 
 # esp-idf does not use compile_feature but instead sets version in

--- a/src/platforms/esp32/test/CMakeLists.txt
+++ b/src/platforms/esp32/test/CMakeLists.txt
@@ -52,6 +52,9 @@ if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32c6|esp32h2")
     set(HAVE_PLATFORM_ATOMIC_H ON)
 endif()
 
+# On Esp32, select is run in a loop in a dedicated task
+set(AVM_SELECT_IN_TASK ON)
+
 project(atomvm-esp32-test)
 
 # esp-idf does not use compile_feature but instead sets version in


### PR DESCRIPTION
On Esp32, select is implemented with a FreeRTOS task. It should use the new task API to properly signal the scheduler on non-SMP builds.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
