### PR TITLE
Fix documentation typo that casues functions to not be rendered

### DIFF
--- a/doc/src/atomvm-internals.md
+++ b/doc/src/atomvm-internals.md
@@ -162,7 +162,7 @@ Drivers can send messages from event callbacks typically called from FreeRTOS ta
 
 ````{only} html
 >:::{doxygenfunction} globalcontext_send_message
->
+
 >:::{doxygenfunction} globalcontext_send_message_from_task
 ````
 


### PR DESCRIPTION
Remove a stray block indent that prevented two function in the same
"````{only} html" block to be left out of the rendered documentation.

When multiple :::{doxygen} directives are given in the same
"````{only} html" block they need to be separated by an empty newline.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
