### PR TITLE
Refactor pid/ref/fun_to_list and fix erlang:display/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix bug in `erlang:ref_to_list/1` and `erlang:display/1`: the unique integer was truncated on some
 32-bit architectures
+- Stop hardcoding `erl_eval` as module name in both display and fun_to_list
+- Correctly display and convert to list funs such as `fun m:f/a`
 
 ## [0.6.0] - 2024-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix bug in `erlang:ref_to_list/1`, the unique integer was truncated on some 32-bit architectures
+- Fix bug in `erlang:ref_to_list/1` and `erlang:display/1`: the unique integer was truncated on some
+32-bit architectures
 
 ## [0.6.0] - 2024-03-05
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2272,16 +2272,7 @@ static term nif_erlang_integer_to_list_2(Context *ctx, int argc, term argv[])
     char integer_string[integer_string_len];
     lltoa(int_value, base, integer_string);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, integer_string_len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-    }
-
-    term prev = term_nil();
-    for (int i = integer_string_len - 1; i >= 0; i--) {
-        prev = term_list_prepend(term_from_int11(integer_string[i]), prev, &ctx->heap);
-    }
-
-    return prev;
+    return make_list_from_ascii_buf((uint8_t *) integer_string, integer_string_len, ctx);
 }
 
 static int format_float(term value, int scientific, int decimals, int compact, char *out_buf, int outbuf_len)
@@ -2429,16 +2420,7 @@ static term nif_erlang_float_to_list(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-    }
-
-    term prev = term_nil();
-    for (int i = len - 1; i >= 0; i--) {
-        prev = term_list_prepend(term_from_int11(float_buf[i]), prev, &ctx->heap);
-    }
-
-    return prev;
+    return make_list_from_ascii_buf((uint8_t *) float_buf, len, ctx);
 }
 
 static term nif_erlang_list_to_binary_1(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -22,21 +22,12 @@
 #define _GNU_SOURCE
 #endif
 
-// used to be required before C11 for PRI* format macros
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-// stdio.h must be included before of inttypes.h to avoid a bug in newlib (observed on RPi 2040)
-// that makes PRIu64 unavailable
-#include <stdint.h>
-#include <stdio.h>
-
-#include <inttypes.h>
+#include "nifs.h"
 
 #include <errno.h>
 #include <fenv.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 #include <time.h>
 
@@ -64,8 +55,6 @@
 #include "term.h"
 #include "unicode.h"
 #include "utils.h"
-
-#include "nifs.h"
 
 #define MAX_NIF_NAME_LEN 260
 #define FLOAT_BUF_SIZE 64
@@ -3119,12 +3108,12 @@ static term nif_erlang_pid_to_list(Context *ctx, int argc, term argv[])
     term t = argv[0];
     VALIDATE_VALUE(t, term_is_pid);
 
-    // 2^32 = 4294967296 (10 chars)
-    // 6 chars of static text + '\0'
-    char buf[17];
-    snprintf(buf, 17, "<0.%" PRIu32 ".0>", term_to_local_process_id(t));
-
-    int str_len = strnlen(buf, 17);
+    char buf[PID_AS_CSTRING_LEN];
+    int str_len = term_snprint(buf, PID_AS_CSTRING_LEN, t, ctx->global);
+    if (UNLIKELY(str_len < 0)) {
+        // TODO: change to internal error or something like that
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
 
     if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
@@ -3144,13 +3133,12 @@ static term nif_erlang_ref_to_list(Context *ctx, int argc, term argv[])
     term t = argv[0];
     VALIDATE_VALUE(t, term_is_reference);
 
-    // 2^64 = 18446744073709551616 (20 chars)
-    // 12 chars of static text + '\0'
-    char buf[33];
-    uint64_t ref_ticks = term_to_ref_ticks(t);
-    snprintf(buf, 33, "#Ref<0.0.0.%" PRIu64 ">", ref_ticks);
-
-    int str_len = strnlen(buf, 33);
+    char buf[REF_AS_CSTRING_LEN];
+    int str_len = term_snprint(buf, REF_AS_CSTRING_LEN, t, ctx->global);
+    if (UNLIKELY(str_len < 0)) {
+        // TODO: change to internal error or something like that
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
 
     if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
@@ -3170,24 +3158,27 @@ static term nif_erlang_fun_to_list(Context *ctx, int argc, term argv[])
     term t = argv[0];
     VALIDATE_VALUE(t, term_is_function);
 
-    const term *boxed_value = term_to_const_term_ptr(t);
-    Module *fun_module = (Module *) boxed_value[1];
-    uint32_t fun_index = boxed_value[2];
+    // when using NULL, required buffer size will be returned
+    int str_len = term_snprint(NULL, 0, t, ctx->global);
+    if (UNLIKELY(str_len < 0)) {
+        // TODO: change to internal error or something like that
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    int buf_len = str_len + 1;
 
-    // char-len(address) + char-len(32-bit-num) + 16 + '\0' = 47
-    // 20                  10
-    const char *format =
-    #ifdef __clang__
-            "#Fun<erl_eval.%lu.%llu>";
-    #else
-            "#Fun<erl_eval.%lu.%llu>";
-    #endif
-    char buf[47];
-    snprintf(buf, 47, format, fun_index, (unsigned long) fun_module);
-
-    int str_len = strnlen(buf, 47);
+    char *buf = malloc(buf_len);
+    if (IS_NULL_PTR(buf)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    int ret = term_snprint(buf, buf_len, t, ctx->global);
+    if (UNLIKELY(ret < 0)) {
+        // TODO: change to internal error or something like that
+        free(buf);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
 
     if (UNLIKELY(memory_ensure_free_opt(ctx, str_len * 2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        free(buf);
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -3195,6 +3186,8 @@ static term nif_erlang_fun_to_list(Context *ctx, int argc, term argv[])
     for (int i = str_len - 1; i >= 0; i--) {
         prev = term_list_prepend(term_from_int11(buf[i]), prev, &ctx->heap);
     }
+    free(buf);
+
     return prev;
 }
 

--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -189,7 +189,8 @@ int term_funprint(PrinterFun *fun, term t, const GlobalContext *global)
             return ret;
         }
     } else if (term_is_pid(t)) {
-        return fun->print(fun, "<0.%" PRIu32 ".0>", term_to_local_process_id(t));
+        int32_t process_id = term_to_local_process_id(t);
+        return fun->print(fun, "<0.%" PRIu32 ".0>", process_id);
 
     } else if (term_is_function(t)) {
         const term *boxed_value = term_to_const_term_ptr(t);
@@ -326,13 +327,10 @@ int term_funprint(PrinterFun *fun, term t, const GlobalContext *global)
         return ret;
 
     } else if (term_is_reference(t)) {
-        const char *format =
-#ifdef __clang__
-        "#Ref<0.0.0.%llu>";
-#else
-        "#Ref<0.0.0.%lu>";
-#endif
-        return fun->print(fun, format, term_to_ref_ticks(t));
+        uint64_t ref_ticks = term_to_ref_ticks(t);
+
+        // Update also REF_AS_CSTRING_LEN when changing this format string
+        return fun->print(fun, "#Ref<0.0.0.%" PRIu64 ">", ref_ticks);
 
     } else if (term_is_boxed_integer(t)) {
         int size = term_boxed_size(t);

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -546,6 +546,26 @@ static inline int term_is_function(term t)
 }
 
 /**
+ * @brief Checks if a term is an external fun
+ *
+ * @details Returns true if a term is an external fun such as "fun m:f/a", otherwise false.
+ * @param t the term that will be checked.
+ * @return true if check succeeds, false otherwise.
+ */
+static inline bool term_is_external_fun(term t)
+{
+    if (term_is_function(t)) {
+        const term *boxed_value = term_to_const_term_ptr(t);
+        term index_or_function = boxed_value[2];
+        if (term_is_atom(index_or_function)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * @brief Checks if a term is a saved CP
  *
  * @details Returns 1 if a term is a saved continuation pointer, otherwise 0.

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -527,11 +527,12 @@ static inline int term_is_reference(term t)
 }
 
 /**
- * @brief Checks if a term is a function
+ * @brief Checks if a term is a fun
  *
  * @details Returns 1 if a term is a fun, otherwise 0.
  * @param t the term that will be checked.
  * @return 1 if check succeeds, 0 otherwise.
+ * @deprecated renamed to term_is_fun.
  */
 static inline int term_is_function(term t)
 {
@@ -546,6 +547,19 @@ static inline int term_is_function(term t)
 }
 
 /**
+ * @brief Checks if a term is a fun
+ *
+ * @details Returns true if a term is a fun, otherwise false.
+ * @param t the term that will be checked.
+ * @return true if check succeeds, false otherwise.
+ */
+
+static inline bool term_is_fun(term t)
+{
+    return term_is_function(t) != 0;
+}
+
+/**
  * @brief Checks if a term is an external fun
  *
  * @details Returns true if a term is an external fun such as "fun m:f/a", otherwise false.
@@ -554,7 +568,7 @@ static inline int term_is_function(term t)
  */
 static inline bool term_is_external_fun(term t)
 {
-    if (term_is_function(t)) {
+    if (term_is_fun(t)) {
         const term *boxed_value = term_to_const_term_ptr(t);
         term index_or_function = boxed_value[2];
         if (term_is_atom(index_or_function)) {

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -111,6 +111,14 @@ extern "C" {
 
 #define TERM_FROM_ATOM_INDEX(atom_index) ((atom_index << 6) | 0xB)
 
+// 2^64 = 18446744073709551616 (20 chars)
+// "#Ref<0.0.0." ">\0" (13 chars)
+#define REF_AS_CSTRING_LEN 33
+
+// 2^32 = 4294967296 (10 chars)
+// "<0." ".0>\0" (7 chars)
+#define PID_AS_CSTRING_LEN 17
+
 #ifndef TYPEDEF_GLOBALCONTEXT
 #define TYPEDEF_GLOBALCONTEXT
 typedef struct GlobalContext GlobalContext;

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -496,6 +496,8 @@ compile_erlang(twentyone_param_function)
 compile_erlang(complex_list_match_xregs)
 compile_erlang(twentyone_param_fun)
 
+compile_erlang(test_fun_to_list)
+
 add_custom_target(erlang_test_modules DEPENDS
     code_load_files
 
@@ -956,4 +958,6 @@ add_custom_target(erlang_test_modules DEPENDS
     twentyone_param_function.beam
     complex_list_match_xregs.beam
     twentyone_param_fun.beam
+
+    test_fun_to_list.beam
 )

--- a/tests/erlang_tests/test_fun_to_list.erl
+++ b/tests/erlang_tests/test_fun_to_list.erl
@@ -1,0 +1,90 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+% WARNING: renaming this module will break the test
+-module(test_fun_to_list).
+-export([start/0, make_fun/0, make_fun/1, get_fun_bytes/0, fun_to_bin/1]).
+
+start() ->
+    <<"#Fun<test_fun_to_list.", Rest1/binary>> = ?MODULE:fun_to_bin(?MODULE:make_fun()),
+    <<"#Fun<test_fun_to_list.", Rest2/binary>> = ?MODULE:fun_to_bin(?MODULE:make_fun(42)),
+
+    [Id1, LastTok1] = binary:split(Rest1, <<".">>),
+    [Uniq1, <<"">>] = binary:split(LastTok1, <<">">>),
+    _ = erlang:binary_to_integer(Id1),
+    _ = erlang:binary_to_integer(Uniq1),
+
+    [Id2, LastTok2] = binary:split(Rest2, <<".">>),
+    [Uniq2, <<"">>] = binary:split(LastTok2, <<">">>),
+
+    _ = erlang:binary_to_integer(Id2),
+    _ = erlang:binary_to_integer(Uniq2),
+
+    <<"fun erlang:integer_to_list/1">> = ?MODULE:fun_to_bin(
+        erlang:binary_to_term(erlang:list_to_binary(?MODULE:get_fun_bytes()))
+    ),
+
+    0.
+
+make_fun() ->
+    P = self(),
+    fun() -> P ! foo end.
+
+make_fun(N) ->
+    P = self(),
+    fun(X) -> P ! N + X end.
+
+get_fun_bytes() ->
+    [
+        131,
+        113,
+        100,
+        0,
+        6,
+        101,
+        114,
+        108,
+        97,
+        110,
+        103,
+        100,
+        0,
+        15,
+        105,
+        110,
+        116,
+        101,
+        103,
+        101,
+        114,
+        95,
+        116,
+        111,
+        95,
+        108,
+        105,
+        115,
+        116,
+        97,
+        1
+    ].
+
+fun_to_bin(Fun) ->
+    erlang:list_to_binary(erlang:fun_to_list(Fun)).

--- a/tests/test.c
+++ b/tests/test.c
@@ -527,6 +527,8 @@ struct Test tests[] = {
     TEST_CASE(complex_list_match_xregs),
     TEST_CASE(twentyone_param_fun),
 
+    TEST_CASE(test_fun_to_list),
+
     // TEST CRASHES HERE: TEST_CASE(memlimit),
 
     { NULL, 0, false, false }


### PR DESCRIPTION
Remove code duplication that there was between `pid`/`ref`/`fun_to_list` and fix `erlang:display/1`.

Also fix `erlang:display/1` with refs and funs too.

This PR makes also some code deduplication, introducing a couple of heleprs useful when converting a buffer of characters to a list. So `atom`/`integer`/`float_to_list` have been changed to make use of it.

This change is related to #1112 and #1113 (the fix merged with #1113 was not enough due to some duplicated code having the same issue).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
