### PR TITLE
Add os_type and os_version keys to erlang:system_info/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for setting channel used by network driver wifi access point.
 - Support for `maps:iterator/2` and `~kp` with `io_lib:format/2` that were introduced with OTP26.
 - Support for `erlang:apply/2`
+- Added support for `erlang:system_info/1` keys `os_type` and `os_version`.
 
 ### Changed
 
@@ -67,9 +68,6 @@ OTP. Since active mode is not supported right now, `active` must be explicitly s
 
 - Added experimental optimized GC mode that makes use of C realloc instead of copying data around,
 it can be enabled with `-DENABLE_REALLOC_GC=On`.
-- ESP32: new keys for `erlang:system_info/1` to retrieve esp-idf semantic version info:
-  * `esp_idf_semantic` returns a tuple `{Major :: integer(), Minor :: integer(), Patch :: integer()}`
-  * `esp_idf_major`, `esp_idf_minor`, `esp_idf_patch` return individual integers
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ OTP. Since active mode is not supported right now, `active` must be explicitly s
 
 - Added experimental optimized GC mode that makes use of C realloc instead of copying data around,
 it can be enabled with `-DENABLE_REALLOC_GC=On`.
+- ESP32: new keys for `erlang:system_info/1` to retrieve esp-idf semantic version info:
+  * `esp_idf_semantic` returns a tuple `{Major :: integer(), Minor :: integer(), Patch :: integer()}`
+  * `esp_idf_major`, `esp_idf_minor`, `esp_idf_patch` return individual integers
 
 ### Fixed
 

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -1067,6 +1067,10 @@ You can request ESP32-specific information using using the following input atoms
 * `esp32_minimum_free_size` Returns the smallest ever free space available in the ESP32 heap since boot, this will tell you how close you have come to running out of free memory.
 * `esp32_chip_info` Returns map of the form `#{features := Features, cores := Cores, revision := Revision, model := Model}`, where `Features` is a list of features enabled in the chip, from among the following atoms: `[emb_flash, bgn, ble, bt]`; `Cores` is the number of CPU cores on the chip; `Revision` is the chip version; and `Model` is one of the following atoms: `esp32`, `esp32_s2`, `esp32_s3`, `esp32_c3`, etc.
 * `esp_idf_version` Return the IDF SDK version, as a string.
+* `esp_idf_semantic` Returns a tuple containing `{Major :: integer(), Minor :: integer(), Patch :: integer()}`.
+* `esp_idf_major` Returns the major version number as an integer.
+* `esp_idf_minor` Returns the minor version number as an integer.
+* `esp_idf_patch` Returns the patch version number as an integer.
 
 For example,
 

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -612,6 +612,8 @@ For more information about Erlang external term format, consult the [Erlang Docu
 
 You can obtain system information about the AtomVM virtual machine via the [`erlang:system_info/1`](./apidocs/erlang/estdlib/erlang.md#system_info1) function, which takes an atom parameter designating the desired datum.  Allowable parameters include
 
+* `os_type` The operating system or runtime environment.
+* `os_version` The sematic version of the currently running operating system or runtime environment.
 * `process_count` The number of processes running in the system.
 * `port_count` The number of ports running in the system.
 * `atom_count` The number of atoms allocated in the system.
@@ -1067,10 +1069,6 @@ You can request ESP32-specific information using using the following input atoms
 * `esp32_minimum_free_size` Returns the smallest ever free space available in the ESP32 heap since boot, this will tell you how close you have come to running out of free memory.
 * `esp32_chip_info` Returns map of the form `#{features := Features, cores := Cores, revision := Revision, model := Model}`, where `Features` is a list of features enabled in the chip, from among the following atoms: `[emb_flash, bgn, ble, bt]`; `Cores` is the number of CPU cores on the chip; `Revision` is the chip version; and `Model` is one of the following atoms: `esp32`, `esp32_s2`, `esp32_s3`, `esp32_c3`, etc.
 * `esp_idf_version` Return the IDF SDK version, as a string.
-* `esp_idf_semantic` Returns a tuple containing `{Major :: integer(), Minor :: integer(), Patch :: integer()}`.
-* `esp_idf_major` Returns the major version number as an integer.
-* `esp_idf_minor` Returns the minor version number as an integer.
-* `esp_idf_patch` Returns the patch version number as an integer.
 
 For example,
 

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -248,6 +248,8 @@ process_info(_Pid, _Key) ->
 %%
 %% The following keys are supported on all platforms:
 %% <ul>
+%%      <li><b>os_type</b> tuple containing `{Osfamily :: atom(), Osname (or IDE) :: atom()}'</li>
+%%      <li><b>os_version</b> operating system sematic version `{Major :: integer(), Minor :: integer(), Patch :: integer()}'</li>
 %%      <li><b>process_count</b> the number of processes running in the node (integer)</li>
 %%      <li><b>port_count</b> the number of ports running in the node (integer)</li>
 %%      <li><b>atom_count</b> the number of atoms currently allocated (integer)</li>

--- a/src/platforms/rp2040/src/lib/CMakeLists.txt
+++ b/src/platforms/rp2040/src/lib/CMakeLists.txt
@@ -20,6 +20,8 @@
 
 cmake_minimum_required (VERSION 3.13)
 
+include(${PICO_SDK_PATH}/pico_sdk_version.cmake)
+
 set(HEADER_FILES
     gpiodriver.h
     platform_defaultatoms.h
@@ -43,6 +45,10 @@ set(
     PLATFORM_LIB_SUFFIX
     ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
 )
+
+add_compile_definitions(OS_VERSION_MAJOR=${PICO_SDK_VERSION_MAJOR})
+add_compile_definitions(OS_VERSION_MINOR=${PICO_SDK_VERSION_MINOR})
+add_compile_definitions(OS_VERSION_PATCH=${PICO_SDK_VERSION_REVISION})
 
 add_library(libAtomVM${PLATFORM_LIB_SUFFIX} STATIC ${SOURCE_FILES} ${HEADER_FILES})
 target_compile_features(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC c_std_11)

--- a/src/platforms/rp2040/src/lib/sys.c
+++ b/src/platforms/rp2040/src/lib/sys.c
@@ -314,8 +314,26 @@ Context *sys_create_port(GlobalContext *glb, const char *port_name, term opts)
 
 term sys_get_info(Context *ctx, term key)
 {
-    UNUSED(ctx);
-    UNUSED(key);
+    if (globalcontext_is_term_equal_to_atom_string(ctx->global, key, ATOM_STR("\x7", "os_type"))) {
+        if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
+            return OUT_OF_MEMORY_ATOM;
+        }
+        term os = term_alloc_tuple(2, &ctx->heap);
+        term_put_tuple_element(os, 0, globalcontext_make_atom(ctx->global, ATOM_STR("\x6", "rp2040")));
+        term_put_tuple_element(os, 1, globalcontext_make_atom(ctx->global, ATOM_STR("\x8", "pico-sdk")));
+
+        return os;
+    }
+    if (globalcontext_is_term_equal_to_atom_string(ctx->global, key, ATOM_STR("\xA", "os_version"))) {
+        if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(3)) != MEMORY_GC_OK)) {
+            return OUT_OF_MEMORY_ATOM;
+        }
+        term os_ver = term_alloc_tuple(3, &ctx->heap);
+        term_put_tuple_element(os_ver, 0, term_from_int32(OS_VERSION_MAJOR));
+        term_put_tuple_element(os_ver, 1, term_from_int32(OS_VERSION_MINOR));
+        term_put_tuple_element(os_ver, 2, term_from_int32(OS_VERSION_PATCH));
+        return os_ver;
+    }
     return UNDEFINED_ATOM;
 }
 

--- a/src/platforms/stm32/CMakeLists.txt
+++ b/src/platforms/stm32/CMakeLists.txt
@@ -104,4 +104,7 @@ include(cmake/libopencm3.cmake)
 # Include additional compilation flags
 include(cmake/compile-flags.cmake)
 
+# Include version_from_git
+include(cmake/version_from_git.cmake)
+
 add_subdirectory(src)

--- a/src/platforms/stm32/cmake/version_from_git.cmake
+++ b/src/platforms/stm32/cmake/version_from_git.cmake
@@ -1,0 +1,58 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2024 Winford (Uncle  Grumpy) <winford@object.stream>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+function( version_from_git )
+
+  # Find Git
+  find_package(Git)
+  if(!Git_FOUND)
+    message( FATAL_ERROR "Git not found" )
+  endif(!Git_FOUND)
+
+  # Git tag
+  execute_process(
+    COMMAND           "${GIT_EXECUTABLE}" describe --exact-match
+    WORKING_DIRECTORY "${LIBOPENCM3_DIR}"
+    RESULT_VARIABLE   git_result
+    OUTPUT_VARIABLE   git_tag
+    ERROR_VARIABLE    git_error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+  if( NOT git_result EQUAL 0 )
+    message( FATAL_ERROR "Failed to execute Git: ${git_error}" )
+  endif()
+
+  if( git_tag MATCHES "^v([0-9]+)[.]([0-9]+)[.]([0-9]+).*$" )
+    set( ide_version_major "${CMAKE_MATCH_1}" )
+    set( ide_version_minor "${CMAKE_MATCH_2}" )
+    set( ide_version_patch "${CMAKE_MATCH_3}" )
+  else()
+    set( ide_version_major "undefined" )
+    set( ide_version_minor "undefined" )
+    set( ide_version_patch "undefined" )
+  endif()
+
+  # Set parent scope variables
+  set( IDE_VERSION_MAJOR ${ide_version_major} PARENT_SCOPE)
+  set( IDE_VERSION_MINOR ${ide_version_minor} PARENT_SCOPE)
+  set( IDE_VERSION_PATCH ${ide_version_patch} PARENT_SCOPE)
+
+endfunction( version_from_git )

--- a/src/platforms/stm32/src/lib/CMakeLists.txt
+++ b/src/platforms/stm32/src/lib/CMakeLists.txt
@@ -21,6 +21,7 @@
 cmake_minimum_required (VERSION 3.13)
 project (libAtomVMPlatformSTM32)
 
+
 set(HEADER_FILES
     avm_devcfg.h
     avm_log.h
@@ -40,6 +41,11 @@ set(
     PLATFORM_LIB_SUFFIX
     ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
 )
+
+version_from_git()
+add_compile_definitions(OS_VERSION_MAJOR=${IDE_VERSION_MAJOR})
+add_compile_definitions(OS_VERSION_MINOR=${IDE_VERSION_MINOR})
+add_compile_definitions(OS_VERSION_PATCH=${IDE_VERSION_PATCH})
 
 add_library(libAtomVM${PLATFORM_LIB_SUFFIX} ${SOURCE_FILES} ${HEADER_FILES})
 target_compile_features(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC c_std_11)

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -295,8 +295,26 @@ Context *sys_create_port(GlobalContext *glb, const char *driver_name, term opts)
 
 term sys_get_info(Context *ctx, term key)
 {
-    UNUSED(ctx);
-    UNUSED(key);
+    if (globalcontext_is_term_equal_to_atom_string(ctx->global, key, ATOM_STR("\x7", "os_type"))) {
+        if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
+            return OUT_OF_MEMORY_ATOM;
+        }
+        term os = term_alloc_tuple(2, &ctx->heap);
+        term_put_tuple_element(os, 0, globalcontext_make_atom(ctx->global, ATOM_STR("\x3", "stm32")));
+        term_put_tuple_element(os, 1, globalcontext_make_atom(ctx->global, ATOM_STR("\x7", "opencm3")));
+
+        return os;
+    }
+    if (globalcontext_is_term_equal_to_atom_string(ctx->global, key, ATOM_STR("\xA", "os_version"))) {
+        if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(3)) != MEMORY_GC_OK)) {
+            return OUT_OF_MEMORY_ATOM;
+        }
+        term os_ver = term_alloc_tuple(3, &ctx->heap);
+        term_put_tuple_element(os_ver, 0, term_from_int32(OS_VERSION_MAJOR));
+        term_put_tuple_element(os_ver, 1, term_from_int32(OS_VERSION_MINOR));
+        term_put_tuple_element(os_ver, 2, term_from_int32(OS_VERSION_PATCH));
+        return os_ver;
+    }
     return UNDEFINED_ATOM;
 }
 


### PR DESCRIPTION
Adds support for `erlang:system_info/1` keys `os_type` and `os_version` for obtaining a conveniently parse-able semantic version of the operating system (or runtime environment) the VM is running on.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
