### PR TITLE
Fix STM32 cmake bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ it can be enabled with `-DENABLE_REALLOC_GC=On`.
 32-bit architectures
 - Stop hardcoding `erl_eval` as module name in both display and fun_to_list
 - Correctly display and convert to list funs such as `fun m:f/a`
+- Fixed bug in STM32 cmake that could cause builds with multiple jobs to fail due to incorrect artifact dependency
 
 ## [0.6.0] - 2024-03-05
 

--- a/src/platforms/stm32/cmake/libopencm3.cmake
+++ b/src/platforms/stm32/cmake/libopencm3.cmake
@@ -184,7 +184,7 @@ macro(add_executable _name)
             ${bin} ALL
             COMMAND ${ARM_OBJCOPY} -Obinary ${elf_in} ${bin_out}
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-            DEPENDS ${elf}
+            DEPENDS ${elf_in}
         )
 
         message("------------Output Locations------------")


### PR DESCRIPTION
The cmake file /src/platforms/stm32/cmake/libopencm3.cmake had the `arm_objcopy` dependency incorrect. This could lead to build failures if enough parallel build jobs we given, allowing the job to run before the elf file was created.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
