### PR TITLE
Prepare v0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.1] - Unreleased
+## [0.6.1] - 2024-04-17
 
 ### Added
 
@@ -18,6 +18,8 @@ it can be enabled with `-DENABLE_REALLOC_GC=On`.
 - Stop hardcoding `erl_eval` as module name in both display and fun_to_list
 - Correctly display and convert to list funs such as `fun m:f/a`
 - Fixed bug in STM32 cmake that could cause builds with multiple jobs to fail due to incorrect artifact dependency
+- Fix crash on macOS due to missing call to `psa_crypto_init` for TLS 1.3
+- Fix crypto test on rp2040
 
 ## [0.6.0] - 2024-03-05
 

--- a/version.cmake
+++ b/version.cmake
@@ -20,4 +20,4 @@
 
 # Please, keep also in sync src/libAtomVM/atomvm_version.h
 set(ATOMVM_BASE_VERSION "0.6.1")
-set(ATOMVM_DEV TRUE)
+set(ATOMVM_DEV FALSE)


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
