### PR TITLE
Conditionally include `memory_realloc_heap_root` in build

### DIFF
--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -77,6 +77,7 @@ void memory_init_heap_root_fragment(Heap *heap, HeapFragment *root, size_t size)
     heap->heap_end = heap->heap_start + size;
 }
 
+#ifdef ENABLE_REALLOC_GC
 static inline enum MemoryGCResult memory_realloc_heap_root(Heap *heap, size_t size)
 {
     uintptr_t used_size = heap->heap_ptr - heap->heap_start;
@@ -90,6 +91,7 @@ static inline enum MemoryGCResult memory_realloc_heap_root(Heap *heap, size_t si
     heap->heap_end = heap->heap_start + size;
     return MEMORY_GC_OK;
 }
+#endif
 
 static inline enum MemoryGCResult memory_heap_alloc_new_fragment(Heap *heap, size_t size)
 {


### PR DESCRIPTION
For build that do not have `ENABLE_REALLOC_GC` defined the function `memory_realloc_heap_root` is unused, which emmits warnings, that elevate to build failures in the build and test on MacOS workflow.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
