### PR TITLE
Warn during ESP32 builds if esp32boot.avm is not found

### DIFF
--- a/src/platforms/esp32/tools/CMakeLists.txt
+++ b/src/platforms/esp32/tools/CMakeLists.txt
@@ -62,3 +62,7 @@ file(COPY ${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/flash.sh
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 )
 
+if (NOT EXISTS ../../../../build/libs/esp32boot/esp32boot.avm)
+    message(WARNING "A generic_unix build must be done first in the top level AtomVM/build directory! \n\
+    Consult https://www.atomvm.net/doc/main/build-instructions.html for build instructions.")
+endif()


### PR DESCRIPTION
To help users avoid problems using ./build/mkimage.sh from the esp32 directory a warning is emitted if esp32boot.avm cannot be found from a previous generic_unix build during configuration. This warning contains a link to the complete Build Instructions. This easy to miss step was responsible for some confusion that was recently discussed and solved on erlangforums.com.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
