### PR TITLE
Add required call to psa_crypto_init for TLS 1.3

### DIFF
--- a/src/libAtomVM/otp_ssl.c
+++ b/src/libAtomVM/otp_ssl.c
@@ -39,6 +39,10 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/ssl.h>
 
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+#include <psa/crypto.h>
+#endif
+
 // #define ENABLE_TRACE
 #include <trace.h>
 
@@ -300,6 +304,14 @@ static term nif_ssl_init(Context *ctx, int argc, term argv[])
     enif_release_resource(rsrc_obj);
 
     mbedtls_ssl_init(&rsrc_obj->context);
+
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+    psa_status_t status = psa_crypto_init();
+    if (UNLIKELY(status != PSA_SUCCESS)) {
+        AVM_LOGW(TAG, "Failed to initialize PSA %s:%i.\n", __FILE__, __LINE__);
+        RAISE_ERROR(BADARG_ATOM);
+    }
+#endif
 
     return obj;
 }


### PR DESCRIPTION
Fixes at least the test crash on macOS reported in #1129

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
