### PR TITLE
Fix incompatibility of test_crypto test with Pico

### DIFF
--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -13,6 +13,7 @@ on:
       - 'CMakeLists.txt'
       - 'libs/**'
       - 'src/platforms/rp2040/**'
+      - 'src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl'
       - 'src/libAtomVM/**'
   pull_request:
     paths:
@@ -20,6 +21,7 @@ on:
       - 'CMakeLists.txt'
       - 'libs/**'
       - 'src/platforms/rp2040/**'
+      - 'src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl'
       - 'src/libAtomVM/**'
 
 permissions:

--- a/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_crypto.erl
@@ -23,7 +23,11 @@
 
 start() ->
     Sysinfo = erlang:system_info(esp32_chip_info),
-    Model = maps:get(model, Sysinfo),
+    Model =
+        if
+            is_map(Sysinfo) -> maps:get(model, Sysinfo);
+            true -> undefined
+        end,
     ok = test_hash(),
     ok = test_crypto_one_time(),
     ok = test_available_ciphers(Model),


### PR DESCRIPTION
Fixes the pico test part reported in #1129

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
