### PR TITLE
Support DragonFly BSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.2] - Unreleased
 
+### Added
+
+- Support for DragonFly BSD (generic_unix platform).
+
 ### Fixed
 
 - Fix invalid read after free in ssl code, see also issue

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ option(COVERAGE "Build for code coverage" OFF)
 
 if((${CMAKE_SYSTEM_NAME} STREQUAL "Darwin") OR
    (${CMAKE_SYSTEM_NAME} STREQUAL "Linux") OR
-   (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD"))
+   (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD") OR
+   (${CMAKE_SYSTEM_NAME} STREQUAL "DragonFly"))
     add_subdirectory(src/platforms/generic_unix)
 else()
     message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")

--- a/README.Md
+++ b/README.Md
@@ -15,7 +15,7 @@ AtomVM implements from scratch a minimal Erlang VM that supports a subset of Erl
 Supported Platforms
 ===================
 
-* Linux, macOS, FreeBSD ([generic unix](src/platforms/generic_unix))
+* Linux, macOS, FreeBSD, DragonFly ([generic unix](src/platforms/generic_unix))
 * ESP32 SoC (with IDF/FreeRTOS, see [README.ESP32.Md](README.ESP32.Md))
 * STM32 MCUs (with LibOpenCM3, see [README.STM32.Md](README.STM32.Md))
 * Raspberry Pi Pico (see [README.PICO.Md](README.PICO.Md))
@@ -76,7 +76,7 @@ $ ./src/AtomVM ./tests/libs/alisp/test_alisp.avm
 
 Complete [Build Instructions](https://www.atomvm.net/doc/main/build-instructions.html) are
 available in the documentation for
-[Generic UNIX](https://www.atomvm.net/doc/main/build-instructions.html) (Linux, MacOS, FreeBSD),
+[Generic UNIX](https://www.atomvm.net/doc/main/build-instructions.html) (Linux, MacOS, FreeBSD, DragonFly),
 [ESP32](https://www.atomvm.net/doc/main/build-instructions.html#building-for-esp32),
 [STM32](https://www.atomvm.net/doc/main/build-instructions.html#building-for-stm32),
 [Raspberry Pi Pico](https://www.atomvm.net/doc/main/build-instructions.html#building-for-raspberry-pi-pico)

--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -81,7 +81,7 @@ The `src` directory is broken up into the core platform-independent AtomVM libra
 
 ## Building for Generic UNIX
 
-The following instructions apply to unix-like environments, including Linux, FreeBSD, and MacOS.
+The following instructions apply to unix-like environments, including Linux, FreeBSD, DragonFly and MacOS.
 
 ```{hint}
 The Generic UNIX is useful for running and testing simple AtomVM programs.  Not all of the AtomVM

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -218,7 +218,10 @@ if(AVM_CREATE_STACKTRACES)
 endif()
 
 # Automatically use zlib if present to load .beam files
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+if ((${CMAKE_SYSTEM_NAME} STREQUAL "Darwin") OR
+    (${CMAKE_SYSTEM_NAME} STREQUAL "Linux") OR
+    (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD") OR
+    (${CMAKE_SYSTEM_NAME} STREQUAL "DragonFly"))
     find_package(ZLIB)
     if (ZLIB_FOUND)
         target_compile_definitions(libAtomVM PRIVATE WITH_ZLIB)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,7 +69,8 @@ set(
 
 if((${CMAKE_SYSTEM_NAME} STREQUAL "Darwin") OR
    (${CMAKE_SYSTEM_NAME} STREQUAL "Linux") OR
-   (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD"))
+   (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD") OR
+   (${CMAKE_SYSTEM_NAME} STREQUAL "DragonFly"))
     target_include_directories(test-erlang PRIVATE ../src/platforms/generic_unix/lib)
     target_include_directories(test-enif PRIVATE ../src/platforms/generic_unix/lib)
     target_include_directories(test-mailbox PRIVATE ../src/platforms/generic_unix/lib)

--- a/tools/packbeam/CMakeLists.txt
+++ b/tools/packbeam/CMakeLists.txt
@@ -39,7 +39,8 @@ endif (ZLIB_FOUND)
 
 if((${CMAKE_SYSTEM_NAME} STREQUAL "Darwin") OR
    (${CMAKE_SYSTEM_NAME} STREQUAL "Linux") OR
-   (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD"))
+   (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD") OR
+   (${CMAKE_SYSTEM_NAME} STREQUAL "DragonFly"))
     target_include_directories(PackBEAM PRIVATE ../../src/platforms/generic_unix/lib)
 else()
     message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")


### PR DESCRIPTION
All tests pass given cmake is configured with
-DMBEDTLS_ROOT_DIR=/usr/local.

Likely, to support the two other BSDs NetBSD and OpenBSD, their respective identifiers would have to be added there as well.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
