### PR TITLE
Address several ESP32 network driver issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ instead
 - General inspect() compliance with Elixir behavior (but there are still some minor differences)
 - Fix several uses of free on prevously released memory on ESP32, under certain error condition using
 `network:start/1`, that would lead to a hard crash of the VM.
+- Fix a bug in ESP32 network driver where the low level driver was not being stopped and resoureces were not freed
+when `network:stop/0` was used, see issue [#643](https://github.com/atomvm/AtomVM/issues/643)
 
 ## [0.6.4] - 2024-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for directory listing using POSIX APIs: (`atomvm:posix_opendir/1`,
 `atomvm:posix_readdir/1`, `atomvm:posix_closedir/1`).
 - ESP32: add support for `esp_adc` ADC driver, with Erlang and Elixir examples
+- Add handler for ESP32 network driver STA mode `beacon_timeout` (event: 21), see issue
+[#1100](https://github.com/atomvm/AtomVM/issues/1100)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ instead
 - `unicode:characters_to_list`: fixed bogus out_of_memory error on some platforms such as ESP32
 - Fix crash in Elixir library when doing `inspect(:atom)`
 - General inspect() compliance with Elixir behavior (but there are still some minor differences)
+- Fix several uses of free on prevously released memory on ESP32, under certain error condition using
+`network:start/1`, that would lead to a hard crash of the VM.
 
 ## [0.6.4] - 2024-08-18
 

--- a/doc/src/network-programming-guide.md
+++ b/doc/src/network-programming-guide.md
@@ -46,6 +46,7 @@ Callback functions are optional, but are highly recommended for building robust 
 In addition, the following optional parameters can be specified to configure the AP network (ESP32 only):
 
 * `{dhcp_hostname, string()|binary()}` The DHCP hostname as which the device should register (`<<"atomvm-<hexmac>">>`, where `<hexmac>` is the hexadecimal representation of the factory-assigned MAC address of the device).
+* `{beacon_timeout, fun(() -> term())}` A callback function which will be called when the device does not receive a beacon frame from the connected access point during the "inactive time" (6 second default, currently not configurable).
 
 The following example illustrates initialization of the WiFi network in STA mode.  The example program will configure the network to connect to a specified network.  Events that occur during the lifecycle of the network will trigger invocations of the specified callback functions.
 

--- a/libs/eavmlib/src/network.erl
+++ b/libs/eavmlib/src/network.erl
@@ -386,6 +386,8 @@ handle_info(Msg, State) ->
 
 %% @hidden
 terminate(_Reason, _State) ->
+    Ref = make_ref(),
+    network_port ! {?SERVER, Ref, stop},
     ok.
 
 %%

--- a/libs/eavmlib/src/network.erl
+++ b/libs/eavmlib/src/network.erl
@@ -50,6 +50,7 @@
 
 -type dhcp_hostname_config() :: {dhcp_hostname, string() | binary()}.
 -type sta_connected_config() :: {connected, fun(() -> term())}.
+-type sta_beacon_timeout_config() :: {beacon_timeout, fun(() -> term())}.
 -type sta_disconnected_config() :: {disconnected, fun(() -> term())}.
 -type sta_got_ip_config() :: {got_ip, fun((ip_info()) -> term())}.
 -type sta_config_property() ::
@@ -57,6 +58,7 @@
     | psk_config()
     | dhcp_hostname_config()
     | sta_connected_config()
+    | sta_beacon_timeout_config()
     | sta_disconnected_config()
     | sta_got_ip_config().
 -type sta_config() :: {sta, [sta_config_property()]}.
@@ -357,6 +359,9 @@ handle_cast(_Msg, State) ->
 handle_info({Ref, sta_connected} = _Msg, #state{ref = Ref, config = Config} = State) ->
     maybe_sta_connected_callback(Config),
     {noreply, State};
+handle_info({Ref, sta_beacon_timeout} = _Msg, #state{ref = Ref, config = Config} = State) ->
+    maybe_sta_beacon_timeout_callback(Config),
+    {noreply, State};
 handle_info({Ref, sta_disconnected} = _Msg, #state{ref = Ref, config = Config} = State) ->
     maybe_sta_disconnected_callback(Config),
     {noreply, State};
@@ -397,6 +402,10 @@ terminate(_Reason, _State) ->
 %% @private
 maybe_sta_connected_callback(Config) ->
     maybe_callback0(connected, proplists:get_value(sta, Config)).
+
+%% @private
+maybe_sta_beacon_timeout_callback(Config) ->
+    maybe_callback0(beacon_timeout, proplists:get_value(sta, Config)).
 
 %% @private
 maybe_sta_disconnected_callback(Config) ->

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -744,7 +744,6 @@ static void start_network(Context *ctx, term pid, term ref, term config)
         if ((err = esp_wifi_set_config(ESP_IF_WIFI_AP, ap_wifi_config)) != ESP_OK) {
             ESP_LOGE(TAG, "Error setting AP mode config %d", err);
             free(ap_wifi_config);
-            free(sta_wifi_config);
             term error = port_create_error_tuple(ctx, term_from_int(err));
             port_send_reply(ctx, pid, ref, error);
             return;
@@ -753,12 +752,14 @@ static void start_network(Context *ctx, term pid, term ref, term config)
             free(ap_wifi_config);
         }
     }
+
+    //
+    // Start the configured interface(s)
+    //
     if ((err = esp_wifi_start()) != ESP_OK) {
         ESP_LOGE(TAG, "Error in esp_wifi_start %d", err);
         term error = port_create_error_tuple(ctx, term_from_int(err));
         port_send_reply(ctx, pid, ref, error);
-        free(ap_wifi_config);
-        free(sta_wifi_config);
         return;
     } else {
         ESP_LOGI(TAG, "WIFI started");


### PR DESCRIPTION
These changes close the following issues for the ESP32 network driver:
* [#643] When network:stop/0 is used the driver is now completely stopped and all resources are freed.
* [#1100] Adds a configurable event handler for STA beacon timeouts (Event: 21).
* Fixes several possible cases of double free() when using network:start/1.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
