### PR TITLE
Add new function to obtain connection RSSI info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a number of functions to proplists module, such as `delete/2`, `from/to_map/1`, etc...
 - Add `esp:deep_sleep_enable_gpio_wakeup/2` to allow wakeup from deep sleep for ESP32C3 and ESP32C6.
 - Obtain RSSI of the current connection with `network:sta_rssi/0` on ESP32.
+- Pico-W support for `network:sta_rssi/0`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added guards `is_even` and `is_odd` to the `Integer` module
 - Add a number of functions to proplists module, such as `delete/2`, `from/to_map/1`, etc...
 - Add `esp:deep_sleep_enable_gpio_wakeup/2` to allow wakeup from deep sleep for ESP32C3 and ESP32C6.
+- Obtain RSSI of the current connection with `network:sta_rssi/0` on ESP32.
 
 ### Fixed
 

--- a/doc/src/network-programming-guide.md
+++ b/doc/src/network-programming-guide.md
@@ -99,6 +99,8 @@ case network:wait_for_sta(Config, 15000) of
 end
 ```
 
+To obtain the signal strength (in decibels) of the connection to the associated access point use [`network:sta_rssi/0`](./apidocs/erlang/eavmlib/network.md#sta_rssi0).
+
 ## AP mode
 
 In AP mode, the ESP32 starts a WiFi network to which other devices (laptops, mobile devices, other ESP32 devices, etc) can connect.  The ESP32 will create an IPv4 network, and will assign itself the address `192.168.4.1`.  Devices that attach to the ESP32 in AP mode will be assigned sequential addresses in the `192.168.4.0/24` range, e.g., `192.168.4.2`, `192.168.4.3`, etc.

--- a/src/platforms/rp2040/src/lib/gpiodriver.c
+++ b/src/platforms/rp2040/src/lib/gpiodriver.c
@@ -24,6 +24,9 @@
 #include <string.h>
 
 #include <hardware/gpio.h>
+#ifdef LIB_PICO_CYW43_ARCH
+#include <pico/cyw43_arch.h>
+#endif
 
 #include "defaultatoms.h"
 #include "interop.h"


### PR DESCRIPTION
These changes add support for both ESP32 and Pico-W to obtain the current signal strength (in decibels) of the connection to the associated access point using `network:sta_rssi/0`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
