### PR TITLE
Include stacktraces on rp2040 port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix invalid read after free in ssl code, see also issue
 [#1115](https://github.com/atomvm/AtomVM/issues/1115).
 
+### Changed
+- Stacktraces are included by default on Pico devices.
+
 ## [0.6.1] - 2024-04-17
 
 ### Added

--- a/src/platforms/rp2040/CMakeLists.txt
+++ b/src/platforms/rp2040/CMakeLists.txt
@@ -54,6 +54,7 @@ option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
 option(AVM_WAIT_FOR_USB_CONNECT "Wait for USB connection before starting" OFF)
 option(AVM_WAIT_BOOTSEL_ON_EXIT "Wait in BOOTSEL rather than shutdown on exit" ON)
 option(AVM_REBOOT_ON_NOT_OK "Reboot Pico if result is not ok" OFF)
+option(AVM_CREATE_STACKTRACES "Create stacktraces" ON)
 
 set(AVM_DISABLE_TASK_DRIVER ON FORCE)
 


### PR DESCRIPTION
Adds stacktraces to the rp2040 port by default. Like other ports they may be excluded by the cmake option `-DAVM_CREATE_STACKTRACES=off`.

Closes #1107

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
