### PR TITLE
Implement ets:lookup_element/3

### DIFF
--- a/libs/estdlib/src/ets.erl
+++ b/libs/estdlib/src/ets.erl
@@ -28,6 +28,7 @@
     new/2,
     insert/2,
     lookup/2,
+    lookup_element/3,
     delete/2
 ]).
 
@@ -75,6 +76,19 @@ insert(_Table, _Entry) ->
 %%-----------------------------------------------------------------------------
 -spec lookup(Table :: table(), Key :: term()) -> [tuple()].
 lookup(_Table, _Key) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Table a reference to the ets table
+%% @param   Key the key used to lookup one or more entries
+%% @param   Pos index of the element to retrieve (1-based)
+%% @returns the Pos:nth element of entry in a set, or a list of entries, if the
+%% table permits
+%% @doc Look up an element from an entry in an ets table.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec lookup_element(Table :: table(), Key :: term(), Pos :: pos_integer()) -> term().
+lookup_element(_Table, _Key, _Pos) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/src/libAtomVM/ets.h
+++ b/src/libAtomVM/ets.h
@@ -55,7 +55,9 @@ typedef enum EtsErrorCode
     EtsTableNameInUse,
     EtsPermissionDenied,
     EtsBadEntry,
-    EtsAllocationFailure
+    EtsAllocationFailure,
+    EtsEntryNotFound,
+    EtsBadPosition
 } EtsErrorCode;
 struct Ets
 {
@@ -73,6 +75,7 @@ void ets_delete_owned_tables(struct Ets *ets, int32_t process_id, GlobalContext 
 
 EtsErrorCode ets_insert(term ref, term entry, Context *ctx);
 EtsErrorCode ets_lookup(term ref, term key, term *ret, Context *ctx);
+EtsErrorCode ets_lookup_element(term ref, term key, size_t pos, term *ret, Context *ctx);
 EtsErrorCode ets_delete(term ref, term key, term *ret, Context *ctx);
 
 #ifdef __cplusplus

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -123,6 +123,7 @@ erts_debug:flat_size/1, &flat_size_nif
 ets:new/2, &ets_new_nif
 ets:insert/2, &ets_insert_nif
 ets:lookup/2, &ets_lookup_nif
+ets:lookup_element/3, &ets_lookup_element_nif
 ets:delete/2, &ets_delete_nif
 atomvm:add_avm_pack_binary/2, &atomvm_add_avm_pack_binary_nif
 atomvm:add_avm_pack_file/2, &atomvm_add_avm_pack_file_nif

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -30,6 +30,7 @@ start() ->
     ok = test_private_access(),
     ok = test_protected_access(),
     ok = test_public_access(),
+    ok = test_lookup_element(),
 
     0.
 
@@ -341,3 +342,13 @@ echo(Term) ->
         T ->
             T
     end.
+
+test_lookup_element() ->
+    Tid = ets:new(test_lookup_element, []),
+    true = ets:insert(Tid, {foo, tapas}),
+    foo = ets:lookup_element(Tid, foo, 1),
+    tapas = ets:lookup_element(Tid, foo, 2),
+    expect_failure(fun() -> ets:lookup_element(Tid, bar, 1) end),
+    expect_failure(fun() -> ets:lookup_element(Tid, foo, 3) end),
+    expect_failure(fun() -> ets:lookup_element(Tid, foo, 0) end),
+    ok.


### PR DESCRIPTION
Mentioned in #887, required to port gleam/mist.
Implementation is in C as initially designed by @fadushin, which saves a little bit memory as we don't need to copy the whole entry.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
