### PR TITLE
Fix CI failures related to macos-latest starting to be macos-14 (arm64)

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-13"]
+        os: ["macos-13", "macos-14"]
         otp: ["24", "25", "26"]
 
     steps:
@@ -68,19 +68,19 @@ jobs:
     - name: "Build: run cmake"
       working-directory: build
       run: |
-        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
+        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:/opt/homebrew/opt/erlang@${{ matrix.otp }}/bin:$PATH"
         cmake -DAVM_WARNINGS_ARE_ERRORS=ON -G Ninja ..
 
     - name: "Build: run ninja"
       working-directory: build
       run: |
-        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
+        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:/opt/homebrew/opt/erlang@${{ matrix.otp }}/bin:$PATH"
         ninja
 
     - name: "Build: run dialyzer"
       working-directory: build
       run: |
-        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
+        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:/opt/homebrew/opt/erlang@${{ matrix.otp }}/bin:$PATH"
         ninja dialyzer
 
     # Test
@@ -127,7 +127,7 @@ jobs:
     - name: "Install and smoke test"
       working-directory: build
       run: |
-        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:$PATH"
+        export PATH="/usr/local/opt/erlang@${{ matrix.otp }}/bin:/opt/homebrew/opt/erlang@${{ matrix.otp }}/bin:$PATH"
         sudo ninja install
         atomvm examples/erlang/hello_world.avm
         atomvm -v

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -65,17 +65,18 @@ jobs:
           otp: "26"
           container: erlang:26
 
-        - os: "macos-latest"
+        # This is ARM64
+        - os: "macos-14"
           otp: "24"
-          path_prefix: "/usr/local/opt/erlang@24/bin:"
+          path_prefix: "/opt/homebrew/opt/erlang@24/bin:"
 
-        - os: "macos-latest"
+        - os: "macos-14"
           otp: "25"
-          path_prefix: "/usr/local/opt/erlang@25/bin:"
+          path_prefix: "/opt/homebrew/opt/erlang@25/bin:"
 
-        - os: "macos-latest"
+        - os: "macos-14"
           otp: "26"
-          path_prefix: "/usr/local/bin:"
+          path_prefix: "/opt/homebrew/opt/erlang@26/bin:"
     steps:
     # Setup
     - name: "Checkout repo"


### PR DESCRIPTION
Also extend matrix to test on both macos-13 (amd64) and macos-14 (arm64)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
