### PR TITLE
Adds guards `is_even` and `is_odd` to `Integer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for DragonFly BSD (generic_unix platform).
+- Added guards `is_even` and `is_odd` to the `Integer` module
 
 ### Fixed
 

--- a/libs/exavmlib/lib/Integer.ex
+++ b/libs/exavmlib/lib/Integer.ex
@@ -25,6 +25,12 @@ defmodule Integer do
   This is not a full implementation of the Elixir Integer module.
   """
 
+  import Bitwise
+
+  defguard is_odd(integer) when is_integer(integer) and (integer &&& 1) == 1
+
+  defguard is_even(integer) when is_integer(integer) and (integer &&& 1) == 0
+
   def floor_div(dividend, divisor) do
     if dividend * divisor < 0 and rem(dividend, divisor) != 0 do
       div(dividend, divisor) - 1


### PR DESCRIPTION
Adds guards `is_even` and `is_odd` to `Integer` using `Bitwise`

Fixes #428.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
