### PR TITLE
Fix unknown opcode report

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -4508,7 +4508,7 @@ wait_timeout_trap_handler:
                         }
                         src = x_regs[live];
                     #endif
-                    TRACE("bs_start_match3/4, fail=%i src=0x%lx live=%u dreg=%c%i\n", fail, src, live, T_DEST_REG_UNSAFE(dreg));
+                    TRACE("bs_start_match3/4, fail=%i src=0x%lx live=%u dreg=%c%i\n", fail, src, live, T_DEST_REG_GC_SAFE(dreg));
                     if (!(term_is_binary(src) || term_is_match_state(src))) {
                         WRITE_REGISTER_GC_SAFE(dreg, src);
                         pc = mod->labels[fail];
@@ -6925,7 +6925,7 @@ bs_match_jump_to_fail:
 #endif
 
             default:
-                printf("Undecoded opcode: %i\n", *pc);
+                printf("Undecoded opcode: %i\n", pc[-1]);
                 #ifdef IMPL_EXECUTE_LOOP
                     fprintf(stderr, "failed at %" PRIuPTR "\n", pc - code);
                 #endif


### PR DESCRIPTION
PC is now offset by 1 and unknown opcode error string should report the unimplemented opcode. Most known is 149 which is on_load (see #995)

Also fix trace code so it compiles.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
