### PR TITLE
Fix semantic of `ssl:recv(Socket, 0)` to return all available bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix invalid read after free in ssl code, see also issue
 [#1115](https://github.com/atomvm/AtomVM/issues/1115).
+- Fix semantic of `ssl:recv(Socket, 0)` to return all available bytes, matching what OTP does.
 
 ### Changed
 - Stacktraces are included by default on Pico devices.

--- a/tests/libs/estdlib/test_ssl.erl
+++ b/tests/libs/estdlib/test_ssl.erl
@@ -53,6 +53,7 @@ test_ssl() ->
     ok = test_connect_close(),
     ok = test_connect_error(),
     ok = test_send_recv(),
+    ok = test_send_recv_zero(),
     ok = ssl:stop(),
     ok.
 
@@ -76,5 +77,17 @@ test_send_recv() ->
         <<"GET / HTTP/1.1\r\nHost: atomvm.net\r\nUser-Agent: ">>, UserAgent, <<"\r\n\r\n">>
     ]),
     {ok, <<"HTTP/1.1">>} = ssl:recv(SSLSocket, 8),
+    ok = ssl:close(SSLSocket),
+    ok.
+
+test_send_recv_zero() ->
+    {ok, SSLSocket} = ssl:connect("atomvm.net", 443, [
+        {verify, verify_none}, {active, false}, {binary, true}
+    ]),
+    UserAgent = erlang:system_info(machine),
+    ok = ssl:send(SSLSocket, [
+        <<"GET / HTTP/1.1\r\nHost: atomvm.net\r\nUser-Agent: ">>, UserAgent, <<"\r\n\r\n">>
+    ]),
+    {ok, <<"HTTP/1.1", _/binary>>} = ssl:recv(SSLSocket, 0),
     ok = ssl:close(SSLSocket),
     ok.


### PR DESCRIPTION
This matches OTP behavior.
Fix #1147

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
