### PR TITLE
ssl options handling fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Stacktraces are included by default on Pico devices.
+- Changed ssl default from `{active, false}` to `{active, true}` in order to have same behavior as
+OTP. Since active mode is not supported right now, `active` must be explicitly set to false:
+`ssl:connect(..., ..., [{active, false}, ...])`, otherwise it will crash.
 
 ## [0.6.1] - 2024-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix invalid read after free in ssl code, see also issue
 [#1115](https://github.com/atomvm/AtomVM/issues/1115).
 - Fix semantic of `ssl:recv(Socket, 0)` to return all available bytes, matching what OTP does.
+- Fix `binary` option handling in `ssl:connect/3` so `binary` can be used instead of
+`{binary, true}`.
 
 ### Changed
 - Stacktraces are included by default on Pico devices.

--- a/libs/estdlib/src/ssl.erl
+++ b/libs/estdlib/src/ssl.erl
@@ -216,6 +216,8 @@ process_options(SSLContext, SSLConfig, [{verify, verify_none} | Tail]) ->
     process_options(SSLContext, SSLConfig, Tail);
 process_options(SSLContext, SSLConfig, [{binary, true} | Tail]) ->
     process_options(SSLContext, SSLConfig, Tail);
+process_options(SSLContext, SSLConfig, [binary | Tail]) ->
+    process_options(SSLContext, SSLConfig, Tail);
 process_options(SSLContext, SSLConfig, [{active, false} | Tail]) ->
     process_options(SSLContext, SSLConfig, Tail).
 

--- a/libs/estdlib/src/ssl.erl
+++ b/libs/estdlib/src/ssl.erl
@@ -166,6 +166,7 @@ connect(Socket, TLSOptions) ->
     ok = ?MODULE:nif_set_bio(SSLContext, Socket),
     SSLConfig = ?MODULE:nif_config_init(),
     ok = ?MODULE:nif_config_defaults(SSLConfig, client, stream),
+    {active, false} = proplists:lookup(active, TLSOptions),
     process_options(SSLContext, SSLConfig, TLSOptions),
     CtrDrbg = gen_server:call(?MODULE, get_ctr_drbg),
     ok = ?MODULE:nif_conf_rng(SSLConfig, CtrDrbg),


### PR DESCRIPTION
Make it closer to OTP default behavior.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
