### PR TITLE
Fix scheduling of trapped processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix semantic of `ssl:recv(Socket, 0)` to return all available bytes, matching what OTP does.
 - Fix `binary` option handling in `ssl:connect/3` so `binary` can be used instead of
 `{binary, true}`.
+- Fix scheduling of trapped process that were wrongly immediately rescheduled before being signaled.
 
 ### Changed
 - Stacktraces are included by default on Pico devices.

--- a/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
+++ b/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
@@ -158,8 +158,6 @@ extern QueueSetHandle_t event_set;
 extern QueueHandle_t event_queue;
 void esp32_sys_queue_init();
 
-void sys_event_listener_init(EventListener *listener, void *sender, event_handler_t handler, void *data);
-
 void socket_init(Context *ctx, term opts);
 
 void port_driver_init_all(GlobalContext *global);


### PR DESCRIPTION
Fixes #1150 

Also remove prototype for a function that does not exist.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
