### PR TITLE
Fix `gen_tcp` and `ssl` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `binary` option handling in `ssl:connect/3` so `binary` can be used instead of
 `{binary, true}`.
 - Fix scheduling of trapped process that were wrongly immediately rescheduled before being signaled.
+- Fix `gen_tcp` and `ssl` types.
 
 ### Changed
 - Stacktraces are included by default on Pico devices.

--- a/libs/estdlib/src/gen_tcp.erl
+++ b/libs/estdlib/src/gen_tcp.erl
@@ -59,6 +59,8 @@
 -type connect_option() :: option().
 -type packet() :: string() | binary().
 
+-export_type([reason/0, option/0, listen_option/0, connect_option/0, packet/0]).
+
 -include("inet-priv.hrl").
 
 %%-----------------------------------------------------------------------------

--- a/libs/estdlib/src/ssl.erl
+++ b/libs/estdlib/src/ssl.erl
@@ -67,15 +67,20 @@
 -export_type([
     sslsocket/0,
     host/0,
-    hostname/0
+    hostname/0,
+    socket_option/0,
+    tls_client_option/0
 ]).
 
 -type host() :: hostname() | ip_address().
 -type hostname() :: string().
 -type ip_address() :: inet:ip_address().
--type tls_client_option() :: client_option().
+
+-type socket_option() :: gen_tcp:connect_option() | gen_tcp:listen_option().
+-type tls_client_option() :: client_option() | socket_option().
 -type client_option() ::
-    {server_name_indication, sni()}.
+    {server_name_indication, sni()} | {verify, verify_none}.
+
 -type sni() :: hostname() | disabled.
 -type reason() :: any().
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
