### PR TITLE
Fix two warnings on esp32

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -63,7 +63,7 @@ static void gpio_driver_init(GlobalContext *global);
 
 #ifdef CONFIG_AVM_ENABLE_GPIO_PORT_DRIVER
 static NativeHandlerResult consume_gpio_mailbox(Context *ctx);
-static void IRAM_ATTR gpio_isr_handler(void *arg);
+static void gpio_isr_handler(void *arg);
 
 static Context *gpio_driver_create_port(GlobalContext *global, term opts);
 #endif

--- a/src/platforms/esp32/components/avm_builtins/i2c_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/i2c_driver.c
@@ -675,7 +675,6 @@ void i2c_driver_release(term i2c_port, GlobalContext *global)
         return;
     }
 
-    struct I2CData *i2c_data = ctx->platform_data;
     NativeHandlerResult close_result = i2c_driver_unref(ctx);
     if (close_result == NativeTerminate) {
         mailbox_send_term_signal(ctx, KillSignal, NORMAL_ATOM);


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
