### PR TITLE
Workaround issue with verify_none and TLS 1.3

### DIFF
--- a/src/libAtomVM/otp_ssl.c
+++ b/src/libAtomVM/otp_ssl.c
@@ -447,6 +447,16 @@ static term nif_ssl_conf_authmode(Context *ctx, int argc, term argv[])
 
     mbedtls_ssl_conf_authmode(&rsrc_obj->config, authmode);
 
+    // MBEDTLS_SSL_VERIFY_NONE and MBEDTLS_SSL_VERIFY_OPTIONAL do not work with TLS 1.3
+    // https://github.com/Mbed-TLS/mbedtls/issues/7075
+    if (authmode != MBEDTLS_SSL_VERIFY_REQUIRED) {
+#if MBEDTLS_VERSION_NUMBER >= 0x03020000
+        mbedtls_ssl_conf_max_tls_version(&rsrc_obj->config, MBEDTLS_SSL_VERSION_TLS1_2);
+#else
+        mbedtls_ssl_conf_max_version(&rsrc_obj->config, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
+#endif
+    }
+
     return OK_ATOM;
 }
 

--- a/tests/libs/estdlib/test_ssl.erl
+++ b/tests/libs/estdlib/test_ssl.erl
@@ -61,33 +61,33 @@ test_start_twice() ->
     ok = ssl:start().
 
 test_connect_close() ->
-    {ok, SSLSocket} = ssl:connect("atomvm.net", 443, [{verify, verify_none}, {active, false}]),
+    {ok, SSLSocket} = ssl:connect("www.atomvm.net", 443, [{verify, verify_none}, {active, false}]),
     ok = ssl:close(SSLSocket).
 
 test_connect_error() ->
-    {error, _Error} = ssl:connect("atomvm.net", 80, [{verify, verify_none}, {active, false}]),
+    {error, _Error} = ssl:connect("www.atomvm.net", 80, [{verify, verify_none}, {active, false}]),
     ok.
 
 test_send_recv() ->
-    {ok, SSLSocket} = ssl:connect("atomvm.net", 443, [
+    {ok, SSLSocket} = ssl:connect("www.atomvm.net", 443, [
         {verify, verify_none}, {active, false}, {binary, true}
     ]),
     UserAgent = erlang:system_info(machine),
     ok = ssl:send(SSLSocket, [
-        <<"GET / HTTP/1.1\r\nHost: atomvm.net\r\nUser-Agent: ">>, UserAgent, <<"\r\n\r\n">>
+        <<"GET / HTTP/1.1\r\nHost: www.atomvm.net\r\nUser-Agent: ">>, UserAgent, <<"\r\n\r\n">>
     ]),
-    {ok, <<"HTTP/1.1">>} = ssl:recv(SSLSocket, 8),
+    {ok, <<"HTTP/1.1 200 OK">>} = ssl:recv(SSLSocket, 15),
     ok = ssl:close(SSLSocket),
     ok.
 
 test_send_recv_zero() ->
-    {ok, SSLSocket} = ssl:connect("atomvm.net", 443, [
+    {ok, SSLSocket} = ssl:connect("www.atomvm.net", 443, [
         {verify, verify_none}, {active, false}, {binary, true}
     ]),
     UserAgent = erlang:system_info(machine),
     ok = ssl:send(SSLSocket, [
-        <<"GET / HTTP/1.1\r\nHost: atomvm.net\r\nUser-Agent: ">>, UserAgent, <<"\r\n\r\n">>
+        <<"GET / HTTP/1.1\r\nHost: www.atomvm.net\r\nUser-Agent: ">>, UserAgent, <<"\r\n\r\n">>
     ]),
-    {ok, <<"HTTP/1.1", _/binary>>} = ssl:recv(SSLSocket, 0),
+    {ok, <<"HTTP/1.1 200 OK", _/binary>>} = ssl:recv(SSLSocket, 0),
     ok = ssl:close(SSLSocket),
     ok.


### PR DESCRIPTION
There is a limitation in current versions of mbed-tls where verify none is not compatible with TLS 1.3. As a workaround, downgrade TLS to 1.2 shall the user specify verify none.

Also improve ssl test by using a TLS 1.3 server (www.atomvm.net).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
