### PR TITLE
Fix race condition in whereis_dead_process test

### DIFF
--- a/tests/erlang_tests/whereis_dead_process.erl
+++ b/tests/erlang_tests/whereis_dead_process.erl
@@ -34,8 +34,7 @@ test_two_names() ->
     test_names([foo, bar]).
 
 test_names(Names) ->
-    Pid = spawn_opt(fun() -> do_register(Names) end, []),
-    Monitor = monitor(process, Pid),
+    {Pid, Monitor} = spawn_opt(fun() -> do_register(Names) end, [monitor]),
     ok =
         receive
             {'DOWN', Monitor, process, Pid, _} -> ok


### PR DESCRIPTION
Fix a case where spawned process is already gone, thus making the test flappy.

See https://github.com/atomvm/AtomVM/actions/runs/9075615955/job/24936583233?pr=1156#step:13:1318

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
