### PR TITLE
Fix C++ compilation

### DIFF
--- a/src/libAtomVM/atom.h
+++ b/src/libAtomVM/atom.h
@@ -28,12 +28,12 @@
 #ifndef _ATOM_H_
 #define _ATOM_H_
 
+#include <stdint.h>
+#include <stdlib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
-#include <stdlib.h>
 
 /**
  * @details no-op macro: just syntax sugar for avoiding mistakes or clang-format dividing atoms in multiple

--- a/src/libAtomVM/atom_table.h
+++ b/src/libAtomVM/atom_table.h
@@ -25,6 +25,10 @@
 
 #include "atom.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define ATOM_TABLE_NOT_FOUND -1
 #define ATOM_TABLE_ALLOC_FAIL -2
 
@@ -62,5 +66,9 @@ bool atom_table_is_atom_ref_ascii(struct AtomTable *table, atom_ref_t atom);
 void atom_table_write_bytes(struct AtomTable *table, atom_ref_t atom, size_t buf_len, void *outbuf);
 void atom_table_write_cstring(
     struct AtomTable *table, atom_ref_t atom, size_t buf_len, char *outbuf);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/atomshashtable.h
+++ b/src/libAtomVM/atomshashtable.h
@@ -21,11 +21,11 @@
 #ifndef _ATOMSHASHTABLE_H_
 #define _ATOMSHASHTABLE_H_
 
+#include "atom.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "atom.h"
 
 #ifndef AVM_NO_SMP
 #ifndef TYPEDEF_RWLOCK

--- a/src/libAtomVM/avmpack.h
+++ b/src/libAtomVM/avmpack.h
@@ -26,15 +26,15 @@
 #ifndef _AVMPACK_H_
 #define _AVMPACK_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "globalcontext.h"
 #include "list.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define END_OF_FILE 0
 #define BEAM_START_FLAG 1

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -26,16 +26,16 @@
 #ifndef _BIF_H_
 #define _BIF_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 
 #include "atom.h"
 #include "context.h"
 #include "exportedfunction.h"
 #include "module.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define MAX_BIF_NAME_LEN 260
 

--- a/src/libAtomVM/bitstring.h
+++ b/src/libAtomVM/bitstring.h
@@ -22,14 +22,14 @@
 #ifndef _BITSTRING_H_
 #define _BITSTRING_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "term.h"
 
 #include <stdbool.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifdef __ORDER_LITTLE_ENDIAN__
     #define READ_16LE_UNALIGNED(ptr) \

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -28,16 +28,16 @@
 #ifndef _CONTEXT_H_
 #define _CONTEXT_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "globalcontext.h"
 #include "list.h"
 #include "mailbox.h"
 #include "smp.h"
 #include "term.h"
 #include "timer_list.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct Module;
 

--- a/src/libAtomVM/debug.h
+++ b/src/libAtomVM/debug.h
@@ -28,11 +28,11 @@
 #ifndef _DEBUG_H_
 #define _DEBUG_H_
 
+#include "context.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "context.h"
 
 /**
  * @brief Print a repreentation of the context to stderr.

--- a/src/libAtomVM/defaultatoms.h
+++ b/src/libAtomVM/defaultatoms.h
@@ -21,11 +21,11 @@
 #ifndef _DEFAULTATOMS_H_
 #define _DEFAULTATOMS_H_
 
+#include "globalcontext.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "globalcontext.h"
 
 #define FALSE_ATOM_INDEX 0
 #define TRUE_ATOM_INDEX 1

--- a/src/libAtomVM/dictionary.h
+++ b/src/libAtomVM/dictionary.h
@@ -21,12 +21,12 @@
 #ifndef _DICTIONARY_H_
 #define _DICTIONARY_H_
 
+#include "list.h"
+#include "term.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "list.h"
-#include "term.h"
 
 typedef enum
 {

--- a/src/libAtomVM/erl_nif_priv.h
+++ b/src/libAtomVM/erl_nif_priv.h
@@ -21,12 +21,12 @@
 #ifndef _ERL_NIF_PRIV_H_
 #define _ERL_NIF_PRIV_H_
 
+#include "context.h"
+#include "memory.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "context.h"
-#include "memory.h"
 
 struct ErlNifEnv
 {

--- a/src/libAtomVM/externalterm.h
+++ b/src/libAtomVM/externalterm.h
@@ -28,11 +28,11 @@
 #ifndef _EXTERNALTERM_H_
 #define _EXTERNALTERM_H_
 
+#include "term.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "term.h"
 
 enum ExternalTermResult
 {

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -28,10 +28,6 @@
 #ifndef _GLOBALCONTEXT_H_
 #define _GLOBALCONTEXT_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 
 #include "atom.h"
@@ -43,6 +39,10 @@ extern "C" {
 #include "synclist.h"
 #include "term.h"
 #include "timer_list.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define INVALID_PROCESS_ID 0
 

--- a/src/libAtomVM/iff.h
+++ b/src/libAtomVM/iff.h
@@ -28,11 +28,11 @@
 #ifndef _IFF_H_
 #define _IFF_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /** UTF-8 Atoms table section */
 #define AT8U 0

--- a/src/libAtomVM/interop.h
+++ b/src/libAtomVM/interop.h
@@ -21,12 +21,12 @@
 #ifndef _INTEROP_H_
 #define _INTEROP_H_
 
+#include "context.h"
+#include "term.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "context.h"
-#include "term.h"
 
 typedef enum
 {

--- a/src/libAtomVM/list.h
+++ b/src/libAtomVM/list.h
@@ -21,6 +21,10 @@
 #ifndef _LIST_H_
 #define _LIST_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief gets a pointer to the struct that contains a certain list head
  *
@@ -91,5 +95,9 @@ static inline struct ListHead *list_last(struct ListHead *head)
 {
     return head->prev;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/listeners.h
+++ b/src/libAtomVM/listeners.h
@@ -49,6 +49,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Add an event listener to the set of polled events.
  *
@@ -151,3 +155,7 @@ void sys_listener_destroy(struct ListHead *item)
     free(listener);
 }
 #endif /* DOXYGEN_SKIP_SECTION */
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -29,10 +29,6 @@
 #ifndef _MAILBOX_H_
 #define _MAILBOX_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 
 #include "list.h"
@@ -48,6 +44,10 @@ extern "C" {
 #define ATOMIC _Atomic
 #else
 #define ATOMIC
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 struct Context;

--- a/src/libAtomVM/memory.h
+++ b/src/libAtomVM/memory.h
@@ -21,20 +21,20 @@
 #ifndef _MEMORY_H_
 #define _MEMORY_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "erl_nif.h"
-#include "term_typedef.h"
-#include "utils.h"
-
 // #define DEBUG_HEAP_ALLOC
 
 #include <stdint.h>
 #include <stdlib.h>
 #ifdef DEBUG_HEAP_ALLOC
 #include <stdio.h>
+#endif
+
+#include "erl_nif.h"
+#include "term_typedef.h"
+#include "utils.h"
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 #define HEAP_NEED_GC_SHRINK_THRESHOLD_COEFF 64

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -28,10 +28,6 @@
 #ifndef _MODULE_H_
 #define _MODULE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -43,6 +39,10 @@ extern "C" {
 #include "globalcontext.h"
 #include "term.h"
 #include "valueshashtable.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef AVM_NO_SMP
 

--- a/src/libAtomVM/nifs.h
+++ b/src/libAtomVM/nifs.h
@@ -26,13 +26,13 @@
 #ifndef _NIFS_H_
 #define _NIFS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "atom.h"
 #include "context.h"
 #include "exportedfunction.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define VALIDATE_VALUE(value, verify_function) \
     if (UNLIKELY(!verify_function((value)))) { \

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -41,14 +41,17 @@
     #include "stacktrace.h"
 #endif
 
+//#define ENABLE_TRACE
+#include "trace.h"
+
 // These constants can be used to reduce the size of the VM for a specific
 // range of compiler versions
 #define MINIMUM_OTP_COMPILER_VERSION 21
 #define MAXIMUM_OTP_COMPILER_VERSION 26
 
-//#define ENABLE_TRACE
-
-#include "trace.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define COMPACT_LITERAL 0
 #define COMPACT_INTEGER 1
@@ -7007,3 +7010,7 @@ terminate_context:
 #endif
 
 #undef DECODE_COMPACT_TERM
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/libAtomVM/otp_crypto.h
+++ b/src/libAtomVM/otp_crypto.h
@@ -21,11 +21,11 @@
 #ifndef _OTP_CRYPTO_H_
 #define _OTP_CRYPTO_H_
 
+#include <nifs.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <nifs.h>
 
 const struct Nif *otp_crypto_nif_get_nif(const char *nifname);
 

--- a/src/libAtomVM/otp_net.h
+++ b/src/libAtomVM/otp_net.h
@@ -21,12 +21,12 @@
 #ifndef _OTP_NET_H_
 #define _OTP_NET_H_
 
+#include <globalcontext.h>
+#include <nifs.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <globalcontext.h>
-#include <nifs.h>
 
 const struct Nif *otp_net_nif_get_nif(const char *nifname);
 void otp_net_init(GlobalContext *global);

--- a/src/libAtomVM/otp_socket.h
+++ b/src/libAtomVM/otp_socket.h
@@ -21,13 +21,13 @@
 #ifndef _OTP_SOCKET_H_
 #define _OTP_SOCKET_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <globalcontext.h>
 #include <nifs.h>
 #include <otp_socket_platform.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #if !defined(OTP_SOCKET_BSD) && !defined(OTP_SOCKET_LWIP)
 #if HAVE_SOCKET && HAVE_SELECT

--- a/src/libAtomVM/otp_ssl.h
+++ b/src/libAtomVM/otp_ssl.h
@@ -21,12 +21,12 @@
 #ifndef _OTP_SSL_H_
 #define _OTP_SSL_H_
 
+#include <globalcontext.h>
+#include <nifs.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <globalcontext.h>
-#include <nifs.h>
 
 const struct Nif *otp_ssl_nif_get_nif(const char *nifname);
 void otp_ssl_init(GlobalContext *global);

--- a/src/libAtomVM/overflow_helpers.h
+++ b/src/libAtomVM/overflow_helpers.h
@@ -21,6 +21,14 @@
 #ifndef _OVERFLOW_HELPERS_H_
 #define _OVERFLOW_HELPERS_H_
 
+#include "term.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef __GNUC__
 #if __GNUC__ >= 5
     #define BUILTIN_ADD_OVERFLOW __builtin_add_overflow
@@ -59,9 +67,6 @@
 #define BUILTIN_ADD_OVERFLOW atomvm_add_overflow
 #define BUILTIN_ADD_OVERFLOW_INT atomvm_add_overflow_int
 #define BUILTIN_ADD_OVERFLOW_INT64 atomvm_add_overflow_int64
-
-#include "term.h"
-#include <stdint.h>
 
 static inline int atomvm_add_overflow(avm_int_t a, avm_int_t b, avm_int_t *res)
 {
@@ -120,9 +125,6 @@ static inline int atomvm_sub_overflow_int64(avm_int64_t a, avm_int64_t b, avm_in
 #define BUILTIN_MUL_OVERFLOW_INT atomvm_mul_overflow_int
 #define BUILTIN_MUL_OVERFLOW_INT64 atomvm_mul_overflow_int64
 
-#include "term.h"
-#include <stdint.h>
-
 static inline int atomvm_mul_overflow_int(avm_int_t a, avm_int_t b, avm_int_t *res)
 {
     avm_int64_t mul = (avm_int64_t) a * (avm_int64_t) b;
@@ -157,6 +159,10 @@ static inline int atomvm_mul_overflow(avm_int_t a, avm_int_t b, avm_int_t *res)
     #else
         #error "Unsupported AVM_INT_MAX size"
     #endif
+}
+#endif
+
+#ifdef __cplusplus
 }
 #endif
 

--- a/src/libAtomVM/platform_nifs.h
+++ b/src/libAtomVM/platform_nifs.h
@@ -21,12 +21,12 @@
 #ifndef _PLATFORM_NIFS_H_
 #define _PLATFORM_NIFS_H_
 
+#include "exportedfunction.h"
+#include "module.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "exportedfunction.h"
-#include "module.h"
 
 /**
  * @brief    Returns the Nif assocatiated with a nif name.

--- a/src/libAtomVM/port.h
+++ b/src/libAtomVM/port.h
@@ -21,15 +21,15 @@
 #ifndef _PORT_H_
 #define _PORT_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "context.h"
 #include "defaultatoms.h"
 #include "globalcontext.h"
 #include "memory.h"
 #include "term.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // Sometimes ports need to send messages while not executed in a given ctx
 // (typically event handlers), so the helpers are available with a Heap

--- a/src/libAtomVM/posix_nifs.h
+++ b/src/libAtomVM/posix_nifs.h
@@ -26,13 +26,13 @@
 #ifndef _POSIX_NIFS_H_
 #define _POSIX_NIFS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "exportedfunction.h"
 #include "globalcontext.h"
 #include "term.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #if HAVE_OPEN && HAVE_CLOSE
 extern const ErlNifResourceTypeInit posix_fd_resource_type_init;

--- a/src/libAtomVM/refc_binary.h
+++ b/src/libAtomVM/refc_binary.h
@@ -21,10 +21,6 @@
 #ifndef _REFC_BINARY_H_
 #define _REFC_BINARY_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdlib.h>
 
@@ -40,6 +36,10 @@ extern "C" {
 #define ATOMIC _Atomic
 #else
 #define ATOMIC
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 #ifndef TYPEDEF_CONTEXT

--- a/src/libAtomVM/scheduler.h
+++ b/src/libAtomVM/scheduler.h
@@ -28,12 +28,12 @@
 #ifndef _SCHEDULER_H_
 #define _SCHEDULER_H_
 
+#include "context.h"
+#include "globalcontext.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "context.h"
-#include "globalcontext.h"
 
 #define DEFAULT_REDUCTIONS_AMOUNT 1024
 

--- a/src/libAtomVM/smp.h
+++ b/src/libAtomVM/smp.h
@@ -29,10 +29,6 @@
 #ifndef _SMP_H_
 #define _SMP_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
 #define CLANG_THREAD_SANITIZE_SAFE __attribute__((no_sanitize("thread")))
@@ -67,6 +63,10 @@ extern "C" {
 #else
 #define ATOMIC
 #endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 #ifndef TYPEDEF_MUTEX

--- a/src/libAtomVM/stacktrace.h
+++ b/src/libAtomVM/stacktrace.h
@@ -21,13 +21,13 @@
 #ifndef _STACKTRACE_H_
 #define _STACKTRACE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "context.h"
 #include "module.h"
 #include "term.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 term stacktrace_create_raw(Context *ctx, Module *mod, int current_offset, term exception_class);
 /**

--- a/src/libAtomVM/synclist.h
+++ b/src/libAtomVM/synclist.h
@@ -21,12 +21,17 @@
 #ifndef _SYNCLIST_H_
 #define _SYNCLIST_H_
 
-#include "list.h"
 #include <stdio.h>
+
+#include "list.h"
 
 #ifndef AVM_NO_SMP
 
 #include "smp.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef TYPEDEF_RWLOCK
 #define TYPEDEF_RWLOCK
@@ -109,6 +114,10 @@ static inline int synclist_is_empty(struct SyncList *synclist)
     synclist_unlock(synclist);
     return result;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #else
 

--- a/src/libAtomVM/sys.h
+++ b/src/libAtomVM/sys.h
@@ -30,15 +30,15 @@
 #ifndef _SYS_H_
 #define _SYS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "globalcontext.h"
 #include "module.h"
 
 #include <stdint.h>
 #include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct AVMPackData;
 

--- a/src/libAtomVM/sys_mbedtls.h
+++ b/src/libAtomVM/sys_mbedtls.h
@@ -24,6 +24,10 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // On SMP builds, mbedtls_entropy_context or mbedtls_ctr_drbg_context can be
 // accessed from several scheduler threads at once through calls to functions
 // such as `mbedtls_ctr_drbg_random` that may call a function on
@@ -74,5 +78,9 @@ mbedtls_ctr_drbg_context *sys_mbedtls_get_ctr_drbg_context_lock(GlobalContext *g
  * @param global the global context
  */
 void sys_mbedtls_ctr_drbg_context_unlock(GlobalContext *global);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/tempstack.h
+++ b/src/libAtomVM/tempstack.h
@@ -24,6 +24,10 @@
 #include "term_typedef.h"
 #include "utils.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum
 {
     TempStackOk = 0,
@@ -114,5 +118,9 @@ static inline term temp_stack_pop(struct TempStack *temp_stack)
 
     return value;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -28,10 +28,6 @@
 #ifndef _TERM_H_
 #define _TERM_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -43,6 +39,10 @@ extern "C" {
 #include "utils.h"
 
 #include "term_typedef.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define TERM_BOXED_VALUE_TAG 0x2
 #define TERM_INTEGER_TAG 0xF

--- a/src/libAtomVM/timer_list.h
+++ b/src/libAtomVM/timer_list.h
@@ -21,14 +21,14 @@
 #ifndef _TIMER_LIST_H_
 #define _TIMER_LIST_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdint.h>
 
 #include "list.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct TimerListItem;
 typedef void(timer_list_callback_t)(struct TimerListItem *);

--- a/src/libAtomVM/utils.h
+++ b/src/libAtomVM/utils.h
@@ -28,6 +28,14 @@
 #ifndef _UTILS_H_
 #define _UTILS_H_
 
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     #ifdef __GNUC__
         #define READ_32_ALIGNED(ptr) \
@@ -190,7 +198,6 @@
 #define RAND_MODULO 31
 #endif
 
-#include <stdlib.h>
 static inline void *rand_fail_malloc(unsigned long malloc_size)
 {
     return ((rand() % RAND_MODULO) == 0) ? 0L : malloc(malloc_size);
@@ -207,7 +214,6 @@ static inline void *rand_fail_calloc(int n, unsigned long alloc_size)
 #endif
 
 #ifdef AVM_VERBOSE_ABORT
-#include <stdio.h>
 #define AVM_ABORT()                                                           \
     {                                                                         \
         fprintf(stderr, "Abort in file %s at line %i\n", __FILE__, __LINE__); \
@@ -297,8 +303,6 @@ static inline __attribute__((always_inline)) func_ptr_t cast_void_to_func_ptr(vo
  * It makes use of offsetof() from stddef.h.
  */
 
-#include <stddef.h>
-
 #define CONTAINER_OF(ptr, type, member) \
     ((type *) (((char *) (ptr)) - offsetof(type, member)))
 
@@ -321,6 +325,10 @@ static inline __attribute__((always_inline)) func_ptr_t cast_void_to_func_ptr(vo
         __builtin_unreachable()
 #else
     #define UNREACHABLE(...)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif


### PR DESCRIPTION
With ESP-IDF 5.2, some headers do not tolerate being included from an extern "C" block. To avoid any similar issue, all includes are moved outside of these blocks, thus fixing compilation of C++ code including our headers.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
