### PR TITLE
Fix C++ compilation for ets headers

### DIFF
--- a/src/libAtomVM/ets.h
+++ b/src/libAtomVM/ets.h
@@ -21,16 +21,16 @@
 #ifndef _ETS_H_
 #define _ETS_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 struct Context;
 struct GlobalContext;
 
 #include "list.h"
 #include "synclist.h"
 #include "term.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // N.B. Only EtsTableSet currently supported
 typedef enum EtsTableType

--- a/src/libAtomVM/ets_hashtable.h
+++ b/src/libAtomVM/ets_hashtable.h
@@ -21,13 +21,13 @@
 #ifndef _ETS_HASHTABLE_H_
 #define _ETS_HASHTABLE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "globalcontext.h"
 #include "term.h"
 #include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define NUM_BUCKETS 16
 


### PR DESCRIPTION
This PR depends on #1158.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
