### PR TITLE
Add support for esp32c2

### DIFF
--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -42,7 +42,7 @@ jobs:
         otp: ["24"]
         elixir_version: ["1.11"]
         compiler_pkgs: ["clang-10"]
-        soc: ["esp32", "esp32c3", "esp32s2", "esp32s3", "esp32c6"]
+        soc: ["esp32", "esp32c2", "esp32c3", "esp32s2", "esp32s3", "esp32c6"]
 
     env:
       CC: ${{ matrix.cc }}

--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -34,7 +34,7 @@ set(HAVE_SOCKET 1 CACHE INTERNAL "Have symbol socket" FORCE)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules")
 
 # Disable SMP with esp32 socs that have only one core
-if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32c6|esp32h2")
+if (${IDF_TARGET} MATCHES "esp32s2|esp32c2|esp32c3|esp32c6|esp32h2")
     message("Disabling SMP as selected target only has one core")
     set(AVM_DISABLE_SMP YES FORCE)
     set(HAVE_PLATFORM_ATOMIC_H ON)

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -63,6 +63,9 @@
 #elif CONFIG_IDF_TARGET_ESP32C3
 // only one user SPI bus, no VSPI
 #define HSPI_HOST   SPI2_HOST
+#elif (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)) && CONFIG_IDF_TARGET_ESP32C2
+// only one user SPI bus, no VSPI
+#define HSPI_HOST   SPI2_HOST
 #elif (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)) && CONFIG_IDF_TARGET_ESP32C6
 // only one user SPI bus, no VSPI
 #define HSPI_HOST   SPI2_HOST

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -83,6 +83,9 @@ static const char *const esp_idf_version_atom = "\xF" "esp_idf_version";
 static const char *const esp32_atom = "\x5" "esp32";
 static const char *const esp32_s2_atom = "\x8" "esp32_s2";
 static const char *const esp32_s3_atom = "\x8" "esp32_s3";
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+static const char *const esp32_c2_atom = "\x8" "esp32_c2";
+#endif
 static const char *const esp32_c3_atom = "\x8" "esp32_c3";
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
 static const char *const esp32_c6_atom = "\x8" "esp32_c6";
@@ -476,6 +479,10 @@ static term get_model(Context *ctx, esp_chip_model_t model)
             return globalcontext_make_atom(ctx->global, esp32_s2_atom);
         case CHIP_ESP32S3:
             return globalcontext_make_atom(ctx->global, esp32_s3_atom);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+        case CHIP_ESP32C2:
+            return globalcontext_make_atom(ctx->global, esp32_c2_atom);
+#endif
         case CHIP_ESP32C3:
             return globalcontext_make_atom(ctx->global, esp32_c3_atom);
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
