### PR TITLE
Add support for setting network AP channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simple http client, that can be used for different use case such as downloading OTA updates
 - Elixir support for `Keyword.merge` `Keyword.take` `Keyword.pop(!)` `Keyword.keyword?` `Keyword.has_key?` functions.
 - Support for ESP32-H2
+- Support for setting channel used by network driver wifi access point.
 
 ### Changed
 

--- a/doc/src/network-programming-guide.md
+++ b/doc/src/network-programming-guide.md
@@ -111,10 +111,13 @@ The `<ap-properties>` property list may contain the following entries:
 
 * `{ssid, string() | binary()}`  The SSID to which the device should connect.
 * `{psk, string() | binary()}` The password required to authenticate to the network, if required.  Note that this password must be a minimum of 8 characters.
+* `{ap_channel, wifi_channel()}` The channel the access point should use.
 
 If the SSID is omitted in configuration, the SSID name `atomvm-<hexmac>` will be created, where `<hexmac>` is the hexadecimal representation of the factory-assigned MAC address of the device.  This name should be sufficiently unique to disambiguate it from other reachable ESP32 devices, but it may also be difficult to read or remember.
 
 If the password is omitted, then an _open network_ will be created, and a warning will be printed to the console.  Otherwise, the AP network will be started using WPA+WPA2 authentication.
+
+If the channel is omitted the default chanel for esp32 is `1`. This setting is only used while a device is operation is AP mode only. If `ap_channel` is configured, it will be temporarily changed to match the associated access point if AP + STA mode is used and the station is associated with an access point. This is a hardware limitation due to the modem radio only being able to operate on a single channel (frequency) at a time.
 
 The [`network:start/1`](./apidocs/erlang/eavmlib/network.md#start1) will immediately return `{ok, Pid}`, where `Pid` is the process id of the network server, if the network was properly initialized, or `{error, Reason}`, if there was an error in configuration.  However, the application may want to wait for the device to to be ready to accept connections from other devices, or to be notified when other devices connect to this AP.
 

--- a/libs/eavmlib/src/network.erl
+++ b/libs/eavmlib/src/network.erl
@@ -62,6 +62,59 @@
 -type sta_config() :: {sta, [sta_config_property()]}.
 
 -type mac() :: binary().
+-type ghz24_channel() :: 1..14.
+% This is the global 2.4 Ghz WiFI channel range, check your local jurisdiction for allowed channels in your geographic region.
+
+-type ghz5_20mhz_channel() ::
+    32
+    | 36
+    | 40
+    | 44
+    | 48
+    | 52
+    | 56
+    | 60
+    | 64
+    | 68
+    | 96
+    | 104
+    | 108
+    | 112
+    | 116
+    | 120
+    | 122
+    | 128
+    | 132
+    | 136
+    | 140
+    | 144
+    | 149
+    | 153
+    | 157
+    | 161
+    | 165
+    | 169
+    | 173
+    | 177.
+% This is the global 5 Ghz WiFI channel range when using 20Mhz bandwidth channels, check your local jurisdiction for allowed channels in your geographic region.
+
+-type ghz5_40mhz_channel() ::
+    38 | 46 | 54 | 62 | 102 | 110 | 118 | 126 | 134 | 142 | 151 | 159 | 167 | 175.
+% This is the global 5 Ghz WiFI channel range when using 40Mhz bandwidth channels, check your local jurisdiction for allowed channels in your geographic region.
+
+-type ghz5_80mhz_channel() :: 42 | 58 | 74 | 90 | 106 | 122 | 138 | 155 | 171.
+% This is the global 5 Ghz WiFI channel range when using 80Mhz bandwidth channels, check your local jurisdiction for allowed channels in your geographic region.
+
+-type ghz5_160mhz_channel() :: 50 | 82 | 114 | 163.
+% This is the global 5 Ghz WiFI channel range when using 160Mhz bandwidth channels, check your local jurisdiction for allowed channels in your geographic region.
+
+-type wifi_channel() ::
+    ghz24_channel()
+    | ghz5_20mhz_channel()
+    | ghz5_40mhz_channel()
+    | ghz5_80mhz_channel()
+    | ghz5_160mhz_channel().
+-type ap_channel_cfg() :: {ap_channel, wifi_channel()}.
 -type ap_ssid_hidden_config() :: {ap_ssid_hidden, boolean()}.
 -type ap_max_connections_config() :: {ap_max_connections, non_neg_integer()}.
 -type ap_started_config() :: {ap_started, fun(() -> term())}.
@@ -71,6 +124,7 @@
 -type ap_config_property() ::
     ssid_config()
     | psk_config()
+    | ap_channel_cfg()
     | ap_ssid_hidden_config()
     | ap_max_connections_config()
     | ap_started_config()

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -61,6 +61,7 @@
 #define PORT_REPLY_SIZE (TUPLE_SIZE(2) + REF_SIZE)
 
 static const char *const ap_atom = ATOM_STR("\x2", "ap");
+static const char *const ap_channel_atom = ATOM_STR("\xA", "ap_channel");
 static const char *const ap_sta_connected_atom = ATOM_STR("\x10", "ap_sta_connected");
 static const char *const ap_sta_disconnected_atom = ATOM_STR("\x13", "ap_sta_disconnected");
 static const char *const ap_sta_ip_assigned_atom = ATOM_STR("\x12", "ap_sta_ip_assigned");
@@ -449,6 +450,7 @@ static wifi_config_t *get_ap_wifi_config(term ap_config, GlobalContext *global)
     }
     term ssid_term = interop_kv_get_value(ap_config, ssid_atom, global);
     term pass_term = interop_kv_get_value(ap_config, psk_atom, global);
+    term channel_term = interop_kv_get_value(ap_config, ap_channel_atom, global);
 
     //
     // Check parameters
@@ -481,6 +483,10 @@ static wifi_config_t *get_ap_wifi_config(term ap_config, GlobalContext *global)
             return NULL;
         }
     }
+    uint8_t channel = 0;
+    if (!term_is_invalid_term(channel_term)) {
+        channel = term_to_uint8(channel_term);
+    }
 
     //
     // Allocate wifi_config and check variable sizes
@@ -512,6 +518,9 @@ static wifi_config_t *get_ap_wifi_config(term ap_config, GlobalContext *global)
     if (!IS_NULL_PTR(psk)) {
         strcpy((char *) wifi_config->ap.password, psk);
         free(psk);
+    }
+    if (channel != 0) {
+        wifi_config->ap.channel = channel;
     }
 
     wifi_config->ap.authmode = IS_NULL_PTR(psk) ? WIFI_AUTH_OPEN : WIFI_AUTH_WPA_WPA2_PSK;

--- a/src/platforms/rp2040/src/lib/networkdriver.c
+++ b/src/platforms/rp2040/src/lib/networkdriver.c
@@ -41,6 +41,7 @@
 #define PORT_REPLY_SIZE (TUPLE_SIZE(2) + REF_SIZE)
 
 static const char *const ap_atom = ATOM_STR("\x2", "ap");
+static const char *const ap_channel_atom = ATOM_STR("\xA", "ap_channel");
 static const char *const ap_sta_connected_atom = ATOM_STR("\x10", "ap_sta_connected");
 static const char *const ap_sta_disconnected_atom = ATOM_STR("\x13", "ap_sta_disconnected");
 static const char *const ap_started_atom = ATOM_STR("\xA", "ap_started");
@@ -382,6 +383,7 @@ static term start_ap(term ap_config, GlobalContext *global)
 {
     term ssid_term = interop_kv_get_value(ap_config, ssid_atom, global);
     term pass_term = interop_kv_get_value(ap_config, psk_atom, global);
+    term channel_term = interop_kv_get_value(ap_config, ap_channel_atom, global);
 
     //
     // Check parameters
@@ -407,6 +409,13 @@ static term start_ap(term ap_config, GlobalContext *global)
         if (!ok) {
             free(ssid);
             return BADARG_ATOM;
+        }
+    }
+    uint32_t channel = 0;
+    if (!term_is_invalid_term(channel_term)) {
+        channel = term_to_int32(channel_term);
+        if (channel != 0) {
+            cyw43_wifi_ap_set_channel(&cyw43_state, channel);
         }
     }
 


### PR DESCRIPTION
These changes add support for setting the channel used in access point mode, for both esp32 and rp2040 network drivers.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
