### PR TITLE
Improve release notes for ESP32 support

### DIFF
--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -64,9 +64,9 @@ AtomVM currently supports the following versions of ESP-IDF:
 
 | IDF SDK supported versions | AtomVM support |
 |------------------------------|----------------|
-| ESP-IDF [v4.4](https://docs.espressif.com/projects/esp-idf/en/v4.4.6/esp32/get-started/index.html) | ✅ |
-| ESP-IDF [v5.0](https://docs.espressif.com/projects/esp-idf/en/v5.0.4/esp32/get-started/index.html) | ✅ |
-| ESP-IDF [v5.1](https://docs.espressif.com/projects/esp-idf/en/v5.1.1/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v4.4.7](https://docs.espressif.com/projects/esp-idf/en/v4.4.7/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.0.6](https://docs.espressif.com/projects/esp-idf/en/v5.0.6/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.1.3](https://docs.espressif.com/projects/esp-idf/en/v5.1.3/esp32/get-started/index.html) | ✅ |
 
 Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.
 

--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -69,7 +69,7 @@ AtomVM currently supports the following versions of ESP-IDF:
 | ESP-IDF [v5.1](https://docs.espressif.com/projects/esp-idf/en/v5.1.3/esp32/get-started/index.html) | ✅ |
 | ESP-IDF [v5.2](https://docs.espressif.com/projects/esp-idf/en/v5.2.1/esp32/get-started/index.html) | ✅ |
 
-Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.  Also, please check [`idf-version` on esp32-build.yaml](https://github.com/atomvm/AtomVM/blob/main/.github/workflows/esp32-build.yaml#L38) for the current versions including subminor number used in the CI build.
+Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.  We recommend you to use the latest subminor (patch) versions for source builds. You can check the current version used for testing in the [esp32-build.yaml](https://github.com/atomvm/AtomVM/actions/workflows/esp32-build.yaml) workflow.
 
 ### STM32 Support
 

--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -67,6 +67,7 @@ AtomVM currently supports the following versions of ESP-IDF:
 | ESP-IDF [v4.4.7](https://docs.espressif.com/projects/esp-idf/en/v4.4.7/esp32/get-started/index.html) | ✅ |
 | ESP-IDF [v5.0.6](https://docs.espressif.com/projects/esp-idf/en/v5.0.6/esp32/get-started/index.html) | ✅ |
 | ESP-IDF [v5.1.3](https://docs.espressif.com/projects/esp-idf/en/v5.1.3/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.2.1](https://docs.espressif.com/projects/esp-idf/en/v5.2.1/esp32/get-started/index.html) | ✅ |
 
 Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.
 

--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -64,12 +64,12 @@ AtomVM currently supports the following versions of ESP-IDF:
 
 | IDF SDK supported versions | AtomVM support |
 |------------------------------|----------------|
-| ESP-IDF [v4.4.7](https://docs.espressif.com/projects/esp-idf/en/v4.4.7/esp32/get-started/index.html) | ✅ |
-| ESP-IDF [v5.0.6](https://docs.espressif.com/projects/esp-idf/en/v5.0.6/esp32/get-started/index.html) | ✅ |
-| ESP-IDF [v5.1.3](https://docs.espressif.com/projects/esp-idf/en/v5.1.3/esp32/get-started/index.html) | ✅ |
-| ESP-IDF [v5.2.1](https://docs.espressif.com/projects/esp-idf/en/v5.2.1/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v4.4](https://docs.espressif.com/projects/esp-idf/en/v4.4.7/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.0](https://docs.espressif.com/projects/esp-idf/en/v5.0.6/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.1](https://docs.espressif.com/projects/esp-idf/en/v5.1.3/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.2](https://docs.espressif.com/projects/esp-idf/en/v5.2.1/esp32/get-started/index.html) | ✅ |
 
-Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.  Also, please check [`idf-version` of the CI build target](https://github.com/atomvm/AtomVM/blob/main/.github/workflows/esp32-build.yaml#L38).
+Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.  Also, please check [`idf-version` on esp32-build.yaml](https://github.com/atomvm/AtomVM/blob/main/.github/workflows/esp32-build.yaml#L38) for the current versions including subminor number used in the CI build.
 
 ### STM32 Support
 

--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -69,7 +69,7 @@ AtomVM currently supports the following versions of ESP-IDF:
 | ESP-IDF [v5.1.3](https://docs.espressif.com/projects/esp-idf/en/v5.1.3/esp32/get-started/index.html) | ✅ |
 | ESP-IDF [v5.2.1](https://docs.espressif.com/projects/esp-idf/en/v5.2.1/esp32/get-started/index.html) | ✅ |
 
-Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.
+Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.  Also, please check [`idf-version` of the CI build target](https://github.com/atomvm/AtomVM/blob/main/.github/workflows/esp32-build.yaml#L38).
 
 ### STM32 Support
 


### PR DESCRIPTION
This PR tries to include the subminor number of ESP-IDF supported versions because it is sensitive to build firmware for the ESP32 family. Also, v5.2 (v5.2.1) is covered at this time, so this has been added.
Moreover, I added link to target `idf-version` on [esp32-build.yaml](https://github.com/atomvm/AtomVM/blob/main/.github/workflows/esp32-build.yaml#L38). As future development progresses, the information in this table may diverge from the CI build target numbers, but I expect that users can follow this link to the latest status.

This will close #1168

---
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
