### PR TITLE
Factorize REGISTER_* macros and logic for ports and nifs

### DIFF
--- a/src/libAtomVM/portnifloader.c
+++ b/src/libAtomVM/portnifloader.c
@@ -1,0 +1,85 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2019-2022 Davide Bettio <davide@uninstall.it>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include "portnifloader.h"
+
+#include <string.h>
+
+struct PortDriverDefListItem *port_driver_list;
+struct NifCollectionDefListItem *nif_collection_list;
+
+void port_driver_init_all(GlobalContext *global)
+{
+    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
+        if (item->def->port_driver_init_cb) {
+            item->def->port_driver_init_cb(global);
+        }
+    }
+}
+
+void port_driver_destroy_all(GlobalContext *global)
+{
+    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
+        if (item->def->port_driver_destroy_cb) {
+            item->def->port_driver_destroy_cb(global);
+        }
+    }
+}
+
+Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts)
+{
+    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
+        if (strcmp(port_name, item->def->port_driver_name) == 0) {
+            return item->def->port_driver_create_port_cb(global, opts);
+        }
+    }
+
+    return NULL;
+}
+
+void nif_collection_init_all(GlobalContext *global)
+{
+    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
+        if (item->def->nif_collection_init_cb) {
+            item->def->nif_collection_init_cb(global);
+        }
+    }
+}
+
+void nif_collection_destroy_all(GlobalContext *global)
+{
+    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
+        if (item->def->nif_collection_destroy_cb) {
+            item->def->nif_collection_destroy_cb(global);
+        }
+    }
+}
+
+const struct Nif *nif_collection_resolve_nif(const char *name)
+{
+    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
+        const struct Nif *res = item->def->nif_collection_resolve_nif_cb(name);
+        if (res) {
+            return res;
+        }
+    }
+
+    return NULL;
+}

--- a/src/libAtomVM/portnifloader.h
+++ b/src/libAtomVM/portnifloader.h
@@ -1,0 +1,108 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2019-2022 Davide Bettio <davide@uninstall.it>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _PORTNIFLOADER_H_
+#define _PORTNIFLOADER_H_
+
+#include "context.h"
+#include "globalcontext.h"
+#include "nifs.h"
+
+#define REGISTER_PORT_DRIVER(NAME, INIT_CB, DESTROY_CB, CREATE_CB)    \
+    struct PortDriverDef NAME##_port_driver_def = {                   \
+        .port_driver_name = #NAME,                                    \
+        .port_driver_init_cb = INIT_CB,                               \
+        .port_driver_destroy_cb = DESTROY_CB,                         \
+        .port_driver_create_port_cb = CREATE_CB                       \
+    };                                                                \
+                                                                      \
+    struct PortDriverDefListItem NAME##_port_driver_def_list_item = { \
+        .def = &NAME##_port_driver_def                                \
+    };                                                                \
+                                                                      \
+    __attribute__((constructor)) void NAME##register_port_driver()    \
+    {                                                                 \
+        NAME##_port_driver_def_list_item.next = port_driver_list;     \
+        port_driver_list = &NAME##_port_driver_def_list_item;         \
+    }
+
+#define REGISTER_NIF_COLLECTION(NAME, INIT_CB, DESTROY_CB, RESOLVE_NIF_CB)  \
+    struct NifCollectionDef NAME##_nif_collection_def = {                   \
+        .nif_collection_init_cb = INIT_CB,                                  \
+        .nif_collection_destroy_cb = DESTROY_CB,                            \
+        .nif_collection_resolve_nif_cb = RESOLVE_NIF_CB                     \
+    };                                                                      \
+                                                                            \
+    struct NifCollectionDefListItem NAME##_nif_collection_def_list_item = { \
+        .def = &NAME##_nif_collection_def                                   \
+    };                                                                      \
+                                                                            \
+    __attribute__((constructor)) void NAME##_nif()                          \
+    {                                                                       \
+        NAME##_nif_collection_def_list_item.next = nif_collection_list;     \
+        nif_collection_list = &NAME##_nif_collection_def_list_item;         \
+    }
+
+typedef void (*port_driver_init_t)(GlobalContext *global);
+typedef void (*port_driver_destroy_t)(GlobalContext *global);
+typedef Context *(*port_driver_create_port_t)(GlobalContext *global, term opts);
+
+struct PortDriverDef
+{
+    const char *port_driver_name;
+    const port_driver_init_t port_driver_init_cb;
+    const port_driver_destroy_t port_driver_destroy_cb;
+    const port_driver_create_port_t port_driver_create_port_cb;
+};
+
+struct PortDriverDefListItem
+{
+    struct PortDriverDefListItem *next;
+    const struct PortDriverDef *const def;
+};
+
+typedef void (*nif_collection_init_t)(GlobalContext *global);
+typedef void (*nif_collection_destroy_t)(GlobalContext *global);
+typedef const struct Nif *(*nif_collection_resolve_nif_t)(const char *name);
+
+struct NifCollectionDef
+{
+    const nif_collection_init_t nif_collection_init_cb;
+    const nif_collection_destroy_t nif_collection_destroy_cb;
+    const nif_collection_resolve_nif_t nif_collection_resolve_nif_cb;
+};
+
+struct NifCollectionDefListItem
+{
+    struct NifCollectionDefListItem *next;
+    const struct NifCollectionDef *const def;
+};
+
+extern struct PortDriverDefListItem *port_driver_list;
+extern struct NifCollectionDefListItem *nif_collection_list;
+
+void port_driver_init_all(GlobalContext *global);
+void port_driver_destroy_all(GlobalContext *global);
+Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts);
+void nif_collection_init_all(GlobalContext *global);
+void nif_collection_destroy_all(GlobalContext *global);
+const struct Nif *nif_collection_resolve_nif(const char *name);
+
+#endif

--- a/src/platforms/esp32/components/avm_sys/CMakeLists.txt
+++ b/src/platforms/esp32/components/avm_sys/CMakeLists.txt
@@ -30,6 +30,7 @@ set(AVM_SYS_COMPONENT_SRCS
     "../../../../libAtomVM/otp_net.c"
     "../../../../libAtomVM/otp_socket.c"
     "../../../../libAtomVM/otp_ssl.c"
+    "../../../../libAtomVM/portnifloader.c"
 )
 
 if (IDF_VERSION_MAJOR GREATER_EQUAL 5)

--- a/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
+++ b/src/platforms/esp32/components/avm_sys/include/esp32_sys.h
@@ -42,41 +42,7 @@
 #endif
 
 #include "sys.h"
-
-#define REGISTER_PORT_DRIVER(NAME, INIT_CB, DESTROY_CB, CREATE_CB)    \
-    struct PortDriverDef NAME##_port_driver_def = {                   \
-        .port_driver_name = #NAME,                                    \
-        .port_driver_init_cb = INIT_CB,                               \
-        .port_driver_destroy_cb = DESTROY_CB,                         \
-        .port_driver_create_port_cb = CREATE_CB                       \
-    };                                                                \
-                                                                      \
-    struct PortDriverDefListItem NAME##_port_driver_def_list_item = { \
-        .def = &NAME##_port_driver_def                                \
-    };                                                                \
-                                                                      \
-    __attribute__((constructor)) void NAME##register_port_driver()    \
-    {                                                                 \
-        NAME##_port_driver_def_list_item.next = port_driver_list;     \
-        port_driver_list = &NAME##_port_driver_def_list_item;         \
-    }
-
-#define REGISTER_NIF_COLLECTION(NAME, INIT_CB, DESTROY_CB, RESOLVE_NIF_CB)  \
-    struct NifCollectionDef NAME##_nif_collection_def = {                   \
-        .nif_collection_init_cb = INIT_CB,                                  \
-        .nif_collection_destroy_cb = DESTROY_CB,                            \
-        .nif_collection_resolve_nif_cb = RESOLVE_NIF_CB                     \
-    };                                                                      \
-                                                                            \
-    struct NifCollectionDefListItem NAME##_nif_collection_def_list_item = { \
-        .def = &NAME##_nif_collection_def                                   \
-    };                                                                      \
-                                                                            \
-    __attribute__((constructor)) void NAME##register_nif_collection()       \
-    {                                                                       \
-        NAME##_nif_collection_def_list_item.next = nif_collection_list;     \
-        nif_collection_list = &NAME##_nif_collection_def_list_item;         \
-    }
+#include "portnifloader.h"
 
 #define EVENT_DESCRIPTORS_COUNT 16
 
@@ -116,55 +82,12 @@ struct ESP32PlatformData
     bool random_is_initialized;
 };
 
-typedef void (*port_driver_init_t)(GlobalContext *global);
-typedef void (*port_driver_destroy_t)(GlobalContext *global);
-typedef Context *(*port_driver_create_port_t)(GlobalContext *global, term opts);
-
-struct PortDriverDef
-{
-    const char *port_driver_name;
-    const port_driver_init_t port_driver_init_cb;
-    const port_driver_destroy_t port_driver_destroy_cb;
-    const port_driver_create_port_t port_driver_create_port_cb;
-};
-
-struct PortDriverDefListItem
-{
-    struct PortDriverDefListItem *next;
-    const struct PortDriverDef *const def;
-};
-
-typedef void (*nif_collection_init_t)(GlobalContext *global);
-typedef void (*nif_collection_destroy_t)(GlobalContext *global);
-typedef const struct Nif *(*nif_collection_resolve_nif_t)(const char *name);
-
-struct NifCollectionDef
-{
-    const nif_collection_init_t nif_collection_init_cb;
-    const nif_collection_destroy_t nif_collection_destroy_cb;
-    const nif_collection_resolve_nif_t nif_collection_resolve_nif_cb;
-};
-
-struct NifCollectionDefListItem
-{
-    struct NifCollectionDefListItem *next;
-    const struct NifCollectionDef *const def;
-};
-
-extern struct PortDriverDefListItem *port_driver_list;
-extern struct NifCollectionDefListItem *nif_collection_list;
-
 extern QueueSetHandle_t event_set;
 extern QueueHandle_t event_queue;
 void esp32_sys_queue_init();
 
 void socket_init(Context *ctx, term opts);
 
-void port_driver_init_all(GlobalContext *global);
-void port_driver_destroy_all(GlobalContext *global);
-void nif_collection_init_all(GlobalContext *global);
-void nif_collection_destroy_all(GlobalContext *global);
-const struct Nif *nif_collection_resolve_nif(const char *name);
 term esp_err_to_term(GlobalContext *glb, esp_err_t status);
 
 const void *esp32_sys_mmap_partition(

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -68,8 +68,6 @@
 
 #define TAG "sys"
 
-static Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts);
-
 static void *select_thread_loop(void *);
 static void select_thread_signal(struct ESP32PlatformData *platform);
 
@@ -97,9 +95,6 @@ static const char *const features_atom = "\x8" "features";
 static const char *const model_atom = "\x5" "model";
 static const char *const revision_atom = "\x8" "revision";
 // clang-format on
-
-struct PortDriverDefListItem *port_driver_list;
-struct NifCollectionDefListItem *nif_collection_list;
 
 QueueHandle_t event_queue = NULL;
 QueueSetHandle_t event_set = NULL;
@@ -545,65 +540,6 @@ term sys_get_info(Context *ctx, term key)
         return term_from_string((const uint8_t *) str, n, &ctx->heap);
     }
     return UNDEFINED_ATOM;
-}
-
-void port_driver_init_all(GlobalContext *global)
-{
-    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
-        if (item->def->port_driver_init_cb) {
-            item->def->port_driver_init_cb(global);
-        }
-    }
-}
-
-void port_driver_destroy_all(GlobalContext *global)
-{
-    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
-        if (item->def->port_driver_destroy_cb) {
-            item->def->port_driver_destroy_cb(global);
-        }
-    }
-}
-
-static Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts)
-{
-    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
-        if (strcmp(port_name, item->def->port_driver_name) == 0) {
-            return item->def->port_driver_create_port_cb(global, opts);
-        }
-    }
-
-    return NULL;
-}
-
-void nif_collection_init_all(GlobalContext *global)
-{
-    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
-        if (item->def->nif_collection_init_cb) {
-            item->def->nif_collection_init_cb(global);
-        }
-    }
-}
-
-void nif_collection_destroy_all(GlobalContext *global)
-{
-    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
-        if (item->def->nif_collection_destroy_cb) {
-            item->def->nif_collection_destroy_cb(global);
-        }
-    }
-}
-
-const struct Nif *nif_collection_resolve_nif(const char *name)
-{
-    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
-        const struct Nif *res = item->def->nif_collection_resolve_nif_cb(name);
-        if (res) {
-            return res;
-        }
-    }
-
-    return NULL;
 }
 
 void event_listener_add_to_polling_set(struct EventListener *listener, GlobalContext *global)

--- a/src/platforms/rp2040/src/lib/CMakeLists.txt
+++ b/src/platforms/rp2040/src/lib/CMakeLists.txt
@@ -26,6 +26,7 @@ set(HEADER_FILES
     platform_smp.h
     rp2040_sys.h
     ../../../../libAtomVM/otp_crypto.h
+    ../../../../libAtomVM/portnifloader.h
 )
 
 set(SOURCE_FILES
@@ -37,6 +38,7 @@ set(SOURCE_FILES
     smp.c
     sys.c
     ../../../../libAtomVM/otp_crypto.c
+    ../../../../libAtomVM/portnifloader.c
 )
 
 set(

--- a/src/platforms/rp2040/src/lib/rp2040_sys.h
+++ b/src/platforms/rp2040/src/lib/rp2040_sys.h
@@ -35,45 +35,11 @@
 
 #pragma GCC diagnostic pop
 
+#include "portnifloader.h"
 #include "sys.h"
 
 // Because pico sdk uses -gc-section, it is required to add -Wl,-u NAME_nif
 // to make sure a given module nif or port are linked in.
-
-#define REGISTER_PORT_DRIVER(NAME, INIT_CB, DESTROY_CB, CREATE_CB)    \
-    struct PortDriverDef NAME##_port_driver_def = {                   \
-        .port_driver_name = #NAME,                                    \
-        .port_driver_init_cb = INIT_CB,                               \
-        .port_driver_destroy_cb = DESTROY_CB,                         \
-        .port_driver_create_port_cb = CREATE_CB                       \
-    };                                                                \
-                                                                      \
-    struct PortDriverDefListItem NAME##_port_driver_def_list_item = { \
-        .def = &NAME##_port_driver_def                                \
-    };                                                                \
-                                                                      \
-    __attribute__((constructor)) void NAME##register_port_driver()    \
-    {                                                                 \
-        NAME##_port_driver_def_list_item.next = port_driver_list;     \
-        port_driver_list = &NAME##_port_driver_def_list_item;         \
-    }
-
-#define REGISTER_NIF_COLLECTION(NAME, INIT_CB, DESTROY_CB, RESOLVE_NIF_CB)  \
-    struct NifCollectionDef NAME##_nif_collection_def = {                   \
-        .nif_collection_init_cb = INIT_CB,                                  \
-        .nif_collection_destroy_cb = DESTROY_CB,                            \
-        .nif_collection_resolve_nif_cb = RESOLVE_NIF_CB                     \
-    };                                                                      \
-                                                                            \
-    struct NifCollectionDefListItem NAME##_nif_collection_def_list_item = { \
-        .def = &NAME##_nif_collection_def                                   \
-    };                                                                      \
-                                                                            \
-    __attribute__((constructor)) void NAME##_nif()                          \
-    {                                                                       \
-        NAME##_nif_collection_def_list_item.next = nif_collection_list;     \
-        nif_collection_list = &NAME##_nif_collection_def_list_item;         \
-    }
 
 #define EVENT_QUEUE_LEN 16
 
@@ -128,49 +94,5 @@ struct RP2040PlatformData
     mbedtls_ctr_drbg_context random_ctx;
     bool random_is_initialized;
 };
-
-typedef void (*port_driver_init_t)(GlobalContext *global);
-typedef void (*port_driver_destroy_t)(GlobalContext *global);
-typedef Context *(*port_driver_create_port_t)(GlobalContext *global, term opts);
-
-struct PortDriverDef
-{
-    const char *port_driver_name;
-    const port_driver_init_t port_driver_init_cb;
-    const port_driver_destroy_t port_driver_destroy_cb;
-    const port_driver_create_port_t port_driver_create_port_cb;
-};
-
-struct PortDriverDefListItem
-{
-    struct PortDriverDefListItem *next;
-    const struct PortDriverDef *const def;
-};
-
-typedef void (*nif_collection_init_t)(GlobalContext *global);
-typedef void (*nif_collection_destroy_t)(GlobalContext *global);
-typedef const struct Nif *(*nif_collection_resolve_nif_t)(const char *name);
-
-struct NifCollectionDef
-{
-    const nif_collection_init_t nif_collection_init_cb;
-    const nif_collection_destroy_t nif_collection_destroy_cb;
-    const nif_collection_resolve_nif_t nif_collection_resolve_nif_cb;
-};
-
-struct NifCollectionDefListItem
-{
-    struct NifCollectionDefListItem *next;
-    const struct NifCollectionDef *const def;
-};
-
-extern struct PortDriverDefListItem *port_driver_list;
-extern struct NifCollectionDefListItem *nif_collection_list;
-
-void port_driver_init_all(GlobalContext *global);
-void port_driver_destroy_all(GlobalContext *global);
-void nif_collection_init_all(GlobalContext *global);
-void nif_collection_destroy_all(GlobalContext *global);
-const struct Nif *nif_collection_resolve_nif(const char *name);
 
 #endif

--- a/src/platforms/stm32/src/lib/CMakeLists.txt
+++ b/src/platforms/stm32/src/lib/CMakeLists.txt
@@ -27,6 +27,7 @@ set(HEADER_FILES
     gpio_driver.h
     stm_sys.h
     ../../../../libAtomVM/platform_nifs.h
+    ../../../../libAtomVM/portnifloader.h
     ../../../../libAtomVM/sys.h
 )
 
@@ -34,6 +35,7 @@ set(SOURCE_FILES
     gpio_driver.c
     platform_nifs.c
     sys.c
+    ../../../../libAtomVM/portnifloader.c
 )
 
 set(

--- a/src/platforms/stm32/src/lib/stm_sys.h
+++ b/src/platforms/stm32/src/lib/stm_sys.h
@@ -21,6 +21,7 @@
 #define _STM_SYS_H_
 
 #include <interop.h>
+#include <portnifloader.h>
 #include <sys.h>
 
 #define STM32_ATOM globalcontext_make_atom(ctx->global, ATOM_STR("\x5", "stm32"))
@@ -52,41 +53,6 @@
 #define __isb asm __volatile__("isb" :: \
                                    : "memory");
 
-#define REGISTER_PORT_DRIVER(NAME, INIT_CB, DESTROY_CB, CREATE_CB)    \
-    struct PortDriverDef NAME##_port_driver_def = {                   \
-        .port_driver_name = #NAME,                                    \
-        .port_driver_init_cb = INIT_CB,                               \
-        .port_driver_destroy_cb = DESTROY_CB,                         \
-        .port_driver_create_port_cb = CREATE_CB                       \
-    };                                                                \
-                                                                      \
-    struct PortDriverDefListItem NAME##_port_driver_def_list_item = { \
-        .def = &NAME##_port_driver_def                                \
-    };                                                                \
-                                                                      \
-    __attribute__((constructor)) void NAME##register_port_driver()    \
-    {                                                                 \
-        NAME##_port_driver_def_list_item.next = port_driver_list;     \
-        port_driver_list = &NAME##_port_driver_def_list_item;         \
-    }
-
-#define REGISTER_NIF_COLLECTION(NAME, INIT_CB, DESTROY_CB, RESOLVE_NIF_CB)  \
-    struct NifCollectionDef NAME##_nif_collection_def = {                   \
-        .nif_collection_init_cb = INIT_CB,                                  \
-        .nif_collection_destroy_cb = DESTROY_CB,                            \
-        .nif_collection_resolve_nif_cb = RESOLVE_NIF_CB                     \
-    };                                                                      \
-                                                                            \
-    struct NifCollectionDefListItem NAME##_nif_collection_def_list_item = { \
-        .def = &NAME##_nif_collection_def                                   \
-    };                                                                      \
-                                                                            \
-    __attribute__((constructor)) void NAME##register_nif_collection()       \
-    {                                                                       \
-        NAME##_nif_collection_def_list_item.next = nif_collection_list;     \
-        nif_collection_list = &NAME##_nif_collection_def_list_item;         \
-    }
-
 #ifdef LIBOPENCM3_GPIO_COMMON_F24_H
 #define GPIO_CLOCK_LIST                                                                                                         \
     {                                                                                                                           \
@@ -110,54 +76,6 @@ struct STM32PlatformData
 {
     struct ListHead locked_pins;
 };
-
-typedef void (*port_driver_init_t)(GlobalContext *global);
-typedef void (*port_driver_destroy_t)(GlobalContext *global);
-typedef Context *(*port_driver_create_port_t)(GlobalContext *global, term opts);
-
-struct PortDriverDef
-{
-    const char *port_driver_name;
-    const port_driver_init_t port_driver_init_cb;
-    const port_driver_destroy_t port_driver_destroy_cb;
-    const port_driver_create_port_t port_driver_create_port_cb;
-};
-
-struct PortDriverDefListItem
-{
-    struct PortDriverDefListItem *next;
-    const struct PortDriverDef *const def;
-};
-
-typedef void (*nif_collection_init_t)(GlobalContext *global);
-typedef void (*nif_collection_destroy_t)(GlobalContext *global);
-typedef const struct Nif *(*nif_collection_resolve_nif_t)(const char *name);
-
-struct NifCollectionDef
-{
-    const nif_collection_init_t nif_collection_init_cb;
-    const nif_collection_destroy_t nif_collection_destroy_cb;
-    const nif_collection_resolve_nif_t nif_collection_resolve_nif_cb;
-};
-
-struct NifCollectionDefListItem
-{
-    struct NifCollectionDefListItem *next;
-    const struct NifCollectionDef *const def;
-};
-
-extern struct PortDriverDefListItem *port_driver_list;
-extern struct NifCollectionDefListItem *nif_collection_list;
-
-void sys_enable_core_periph_clocks(void);
-bool sys_lock_pin(GlobalContext *glb, uint32_t gpio_bank, uint16_t pin_num);
-
-void port_driver_init_all(GlobalContext *global);
-void port_driver_destroy_all(GlobalContext *global);
-
-const struct Nif *nif_collection_resolve_nif(const char *name);
-void nif_collection_init_all(GlobalContext *global);
-void nif_collection_destroy_all(GlobalContext *global);
 
 void sys_init_icache(void);
 void sys_enable_flash_cache(void);

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -41,11 +41,6 @@
 #define TAG "sys"
 #define RESERVE_STACK_SIZE 4096U
 
-static Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts);
-
-struct PortDriverDefListItem *port_driver_list;
-struct NifCollectionDefListItem *nif_collection_list;
-
 /* These functions are needed to fix a hard fault when using malloc in devices with sram spanning
  * multiple chips
  */
@@ -327,63 +322,4 @@ void sys_init_icache()
     // Force a final resync and clear of the instruction pipeline
     __dsb;
     __isb;
-}
-
-void port_driver_init_all(GlobalContext *global)
-{
-    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
-        if (item->def->port_driver_init_cb) {
-            item->def->port_driver_init_cb(global);
-        }
-    }
-}
-
-void port_driver_destroy_all(GlobalContext *global)
-{
-    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
-        if (item->def->port_driver_destroy_cb) {
-            item->def->port_driver_destroy_cb(global);
-        }
-    }
-}
-
-static Context *port_driver_create_port(const char *port_name, GlobalContext *global, term opts)
-{
-    for (struct PortDriverDefListItem *item = port_driver_list; item != NULL; item = item->next) {
-        if (strcmp(port_name, item->def->port_driver_name) == 0) {
-            return item->def->port_driver_create_port_cb(global, opts);
-        }
-    }
-
-    return NULL;
-}
-
-void nif_collection_init_all(GlobalContext *global)
-{
-    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
-        if (item->def->nif_collection_init_cb) {
-            item->def->nif_collection_init_cb(global);
-        }
-    }
-}
-
-void nif_collection_destroy_all(GlobalContext *global)
-{
-    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
-        if (item->def->nif_collection_destroy_cb) {
-            item->def->nif_collection_destroy_cb(global);
-        }
-    }
-}
-
-const struct Nif *nif_collection_resolve_nif(const char *name)
-{
-    for (struct NifCollectionDefListItem *item = nif_collection_list; item != NULL; item = item->next) {
-        const struct Nif *res = item->def->nif_collection_resolve_nif_cb(name);
-        if (res) {
-            return res;
-        }
-    }
-
-    return NULL;
 }


### PR DESCRIPTION
esp32, rp2040 and stm32 all use the same logic to use .ctor runtime to register drivers and nifs collections.

Also use the smaller constructor name for nifs of RP2040 on other platforms to maintain compatibility as RP2040 builds have to explicitely list nifs so they are not gc'd. EPS32 is unaffected as enabling of nifs is done through menuconfig.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
