### PR TITLE
.gitignore esp32/managed_components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ src/platforms/esp32/build/**
 src/platforms/esp32/build/**/*.d
 src/platforms/esp32/test/build/**
 src/platforms/esp32/components/**
+src/platforms/esp32/managed_components/**
 src/platforms/esp32/sdkconfig
 !src/platforms/esp32/components/avm_builtins/
 !src/platforms/esp32/components/avm_builtins/**


### PR DESCRIPTION
in src/platforms/esp32/ using:

idf.py add-dependency "espressif/esp32-camera"

or similar will use a managed_components folder for the downloaded dependencies.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
