### PR TITLE
Keyword.ex: merge/2 take/2 pop/pop! and helper fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Simple http client, that can be used for different use case such as downloading OTA updates
+- Elixir support for `Keyword.merge` `Keyword.take` `Keyword.pop(!)` `Keyword.keyword?` `Keyword.has_key?` functions.
 
 ### Changed
 


### PR DESCRIPTION
Keyword.pop is needed for Elixir.GenServer.

rest of the functions is often used for config/starting genservers in elixir land - and minimum needed for running eg https://github.com/elixir-circuits on atomvm (when Elixir.GenServer is available).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
