### PR TITLE
Fix binary pattern matching with OTP-21 compiled code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.3] - Unreleased
 
+### Fixed
+
+- Fix bug (with code compiled with OTP-21) with binary pattern matching: the fix introduced with
+`02411048` was not completely right, and it was converting match context to bogus binaries.
+
 ## [0.6.2] - 25-05-2024
 
 ### Added

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -5045,9 +5045,12 @@ wait_timeout_trap_handler:
 
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("bs_context_to_binary/1, dreg=%c%i\n", T_DEST_REG_GC_SAFE(dreg));
+                    // TODO: bs_context_to_binary should rather overwrite the match state with
+                    // the result of the conversion
                     term src = READ_DEST_REGISTER_GC_SAFE(dreg);
                     term bin;
                     if (term_is_match_state(src)) {
+                        term_match_state_restore_start_offset(src);
                         avm_int_t offset = term_get_match_state_offset(src);
                         if (offset == 0) {
                             bin = term_get_match_state_binary(src);


### PR DESCRIPTION
Binary pattern matching was not working properly due to a bug in `bs_context_to_binary` implementation.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
