### PR TITLE
Improve connection management for esp32 network driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `network:sta_connect/0,1` and `network:sta_disconnect/0` to ESP32 network driver.
 - Added option to set a custom callback for esp32 network driver
 `disconnected` events
+- Added `network:sta_status/0` to get the current connection state of the sta interface.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added missing `ledc` functions for esp32 platform
 - Added support for Elixir GenServer and Supervisor.
 - Added support for 10 new STM32 families by switching to STM32 official SDK
+- Added `network:sta_connect/0,1` and `network:sta_disconnect/0` to ESP32 network driver.
+- Added option to set a custom callback for esp32 network driver
+`disconnected` events
 
 ### Changed
 
@@ -94,6 +97,8 @@ instead `badarg`.
 - Badarg error return from calling crypto:crypto_one_time with invalid arguments now matches OTP24+.
 - When function head doesn't match, function arguments are now in stacktrace
 - Function arguments are added to stacktrace also for some NIFs, when one of the arguments is badarg
+- Using a custom callback for STA disconnected events in esp32 network driver will stop automatic re-connect,
+allowing applications to use scan results or other means to decide when and where to connect.
 
 ### Fixed
 

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -121,10 +121,10 @@ static inline term make_atom(GlobalContext *global, AtomString atom_str)
 static term tuple_from_addr(Heap *heap, uint32_t addr)
 {
     term terms[4];
-    terms[0] = term_from_int32((addr >> 24) & 0xFF);
-    terms[1] = term_from_int32((addr >> 16) & 0xFF);
-    terms[2] = term_from_int32((addr >> 8) & 0xFF);
-    terms[3] = term_from_int32(addr & 0xFF);
+    terms[0] = term_from_int((addr >> 24) & 0xFF);
+    terms[1] = term_from_int((addr >> 16) & 0xFF);
+    terms[2] = term_from_int((addr >> 8) & 0xFF);
+    terms[3] = term_from_int(addr & 0xFF);
 
     return port_heap_create_tuple_n(heap, 4, terms);
 }

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -754,8 +754,6 @@ static void start_network(Context *ctx, term pid, term ref, term config)
             goto cleanup1;
         } else {
             ESP_LOGI(TAG, "STA mode configured");
-            free(sta_wifi_config);
-            sta_wifi_config = NULL;
         }
     }
 
@@ -771,8 +769,6 @@ static void start_network(Context *ctx, term pid, term ref, term config)
             goto cleanup1;
         } else {
             ESP_LOGI(TAG, "AP mode configured");
-            free(ap_wifi_config);
-            ap_wifi_config = NULL;
         }
     }
 
@@ -807,6 +803,7 @@ static void start_network(Context *ctx, term pid, term ref, term config)
     // Done -- send an ok so the FSM can proceed
     //
     port_send_reply(ctx, pid, ref, OK_ATOM);
+    goto cleanup;
 
 cleanup0:
     free(sta_wifi_config);

--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -62,6 +62,7 @@ compile_erlang(test_esp_partition)
 compile_erlang(test_esp_timer_get_time)
 compile_erlang(test_file)
 compile_erlang(test_wifi_example)
+compile_erlang(test_wifi_managed)
 compile_erlang(test_list_to_atom)
 compile_erlang(test_list_to_binary)
 compile_erlang(test_md5)
@@ -83,6 +84,7 @@ set(erlang_test_beams
     test_esp_timer_get_time.beam
     test_file.beam
     test_wifi_example.beam
+    test_wifi_managed.beam
     test_list_to_atom.beam
     test_list_to_binary.beam
     test_md5.beam

--- a/src/platforms/esp32/test/main/test_erl_sources/test_wifi_managed.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_wifi_managed.erl
@@ -1,0 +1,148 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Peter M <petermm@gmail.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_wifi_managed).
+
+-export([start/0]).
+
+start() ->
+    case verify_platform(atomvm:platform()) of
+        ok ->
+            ok = test_managed_start(),
+            ok = test_managed_connect(),
+            ok = test_sta_status_lifecycle(),
+            ok = test_disconnect_and_reconnect(),
+            ok = test_connect_new_ap(),
+            network:stop(),
+            ok;
+        Error ->
+            Error
+    end.
+
+%% Test starting the network driver in managed mode (no immediate connection)
+test_managed_start() ->
+    Self = self(),
+    Config =
+        [
+            {sta, [
+                managed,
+                {connected, fun() -> Self ! sta_connected end},
+                {got_ip, fun(IpInfo) -> Self ! {got_ip, IpInfo} end},
+                {disconnected, fun() -> Self ! sta_disconnected end}
+            ]},
+            {sntp, [{host, "time.aws.com"}, {synchronized, fun sntp_synchronized/1}]}
+        ],
+    case network:start(Config) of
+        {ok, _Pid} ->
+            io:format("Managed network started.~n"),
+            %% In managed mode, sta_status should be disconnected (not connecting)
+            disconnected = network:sta_status(),
+            io:format("test_managed_start OK.~n"),
+            ok;
+        Error ->
+            Error
+    end.
+
+%% Test connecting to an AP using sta_connect/1
+test_managed_connect() ->
+    %% Status should still be disconnected before connect
+    disconnected = network:sta_status(),
+    ok =
+        network:sta_connect([
+            {ssid, "Wokwi-GUEST"},
+            {psk, ""},
+            {sntp, [{host, "pool.ntp.org"}, {synchronized, fun sntp_synchronized/1}]}
+        ]),
+    %% After initiating connect, status should be connecting
+    Status = network:sta_status(),
+    case Status of
+        connecting ->
+            ok;
+        associated ->
+            ok;
+        connected ->
+            ok;
+        Other ->
+            error({unexpected_sta_status, Other})
+    end,
+    case wait_for_ip(20000) of
+        ok -> ok;
+        E -> error({waiting_for_ip, E})
+    end,
+    connected = network:sta_status(),
+    io:format("test_managed_connect OK.~n"),
+    ok.
+
+%% Test the full sta_status lifecycle
+test_sta_status_lifecycle() ->
+    %% We should be connected from previous test
+    connected = network:sta_status(),
+    io:format("test_sta_status_lifecycle OK.~n"),
+    ok.
+
+%% Test disconnecting and reconnecting to the same AP
+test_disconnect_and_reconnect() ->
+    ok = network:sta_disconnect(),
+    ok = wait_for_disconnect(5000),
+    disconnected = network:sta_status(),
+    %% Reconnect using sta_connect/0 (reconnect to last AP)
+    ok = network:sta_connect(),
+    ok = wait_for_ip(20000),
+    connected = network:sta_status(),
+    io:format("test_disconnect_and_reconnect OK.~n"),
+    ok.
+
+%% Test connecting to a new AP using sta_connect/1 with sta_config
+test_connect_new_ap() ->
+    ok = network:sta_disconnect(),
+    ok = wait_for_disconnect(5000),
+    disconnected = network:sta_status(),
+    %% Connect again with explicit config
+    ok = network:sta_connect([{ssid, "Wokwi-GUEST"}, {psk, ""}]),
+    ok = wait_for_ip(20000),
+    connected = network:sta_status(),
+    io:format("test_connect_new_ap OK.~n"),
+    ok.
+
+sntp_synchronized({TVSec, TVUsec}) ->
+    io:format("Synchronized time with SNTP server. TVSec=~p TVUsec=~p~n", [TVSec, TVUsec]).
+
+verify_platform(esp32) ->
+    ok;
+verify_platform(Platform) ->
+    {error, {unsupported_platform, Platform}}.
+
+wait_for_ip(Timeout) ->
+    receive
+        {got_ip, IpInfo} ->
+            io:format("Got IP: ~p~n", [IpInfo]),
+            ok
+    after Timeout ->
+        {error, timeout}
+    end.
+
+wait_for_disconnect(Timeout) ->
+    receive
+        sta_disconnected ->
+            io:format("STA disconnected.~n"),
+            ok
+    after Timeout ->
+        {error, timeout}
+    end.

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -613,6 +613,12 @@ TEST_CASE("test_wifi_example", "[test_run]")
     term ret_value = avm_test_case("test_wifi_example.beam");
     TEST_ASSERT(ret_value == OK_ATOM);
 }
+
+TEST_CASE("test_wifi_managed", "[test_run]")
+{
+    term ret_value = avm_test_case("test_wifi_managed.beam");
+    TEST_ASSERT(ret_value == OK_ATOM);
+}
 #endif
 
 // Works C3 on local runs, but fails GH actions


### PR DESCRIPTION
This PR adds the ability to stop a connection to an access point, and to start a connection to a new, or the last configured access point. The driver can also enable STA mode without performing an initial connection by supplying the `managed` atom in the STA configuration and omitting the `ssid` and `psk` settings. Combined with the network scan feature in #1165 this gives the esp32 platform the ability to act as a roaming device, and connect to any known wifi networks found after performing a wifi scan. The `disconnected` event callback can be used to override the default automatic re-connect action of the driver, and a network scan or other means may now be used to determine if, when, and which access point to connect to.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
