### PR TITLE
Handle wifi event 40 on ESP-IDF v5.2 builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.3] - Unreleased
 
+### Changed
+
+- ESP32 network driver messages for event 40 (home channel change events) are now suppressed, but the
+details for the channel changes can be observed in the console log if "debug" level logging is enabled
+in ESP-IDF Kconfig options.
+
 ### Fixed
 
 - Fix bug (with code compiled with OTP-21) with binary pattern matching: the fix introduced with

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -289,6 +289,14 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
                 break;
             }
 
+#if ESP_IDF_VERSION_MAJOR >= 5 && ESP_IDF_VERSION_MINOR >= 2
+            case WIFI_EVENT_HOME_CHANNEL_CHANGE: {
+                wifi_event_home_channel_change_t *chan_data = (wifi_event_home_channel_change_t *) event_data;
+                ESP_LOGD(TAG, "WIFI_EVENT home channel changed from %u to %u.", chan_data->old_chan, chan_data->new_chan);
+                break;
+            }
+#endif
+
             default:
                 ESP_LOGI(TAG, "Unhandled wifi event: %" PRIi32 ".", event_id);
                 break;


### PR DESCRIPTION
ESP-IDF version 5.2 introdued a new event (40), which indicates a home channel change when devices are connected in station mode. These informational events are not very useful for applications to act on, as this is expected when a station connects to a new access point, or when the access point instructs connected devices to change to a different channel. Rather than confuse application developers with log messages for an unhandled event 40, by default these events now do nothing, but if debug level logging is enabled in ESP-IDF Kconfig setting an informative debug log entry will be printed on the console.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
