### PR TITLE
Update Release Notes with newly supported esp32 chipsets

### DIFF
--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -56,7 +56,9 @@ AtomVM currently supports the following [Espressif ESP SoCs](https://www.espress
 | Espressif SoCs | AtomVM support |
 |------------------------------|----------------|
 | [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) | ✅ |
+| [ESP32c2](https://www.espressif.com/sites/default/files/documentation/esp32-c2_datasheet_en.pdf) | ✅ |
 | [ESP32c3](https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf) | ✅ |
+| [ESP32h2](https://www.espressif.com/sites/default/files/documentation/esp32-h2_datasheet_en.pdf) | ✅ |
 | [ESP32s2](https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf) | ✅ |
 | [ESP32s3](https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf) | ✅ |
 
@@ -66,8 +68,8 @@ AtomVM currently supports the following versions of ESP-IDF:
 |------------------------------|----------------|
 | ESP-IDF [v4.4](https://docs.espressif.com/projects/esp-idf/en/v4.4.7/esp32/get-started/index.html) | ✅ |
 | ESP-IDF [v5.0](https://docs.espressif.com/projects/esp-idf/en/v5.0.6/esp32/get-started/index.html) | ✅ |
-| ESP-IDF [v5.1](https://docs.espressif.com/projects/esp-idf/en/v5.1.3/esp32/get-started/index.html) | ✅ |
-| ESP-IDF [v5.2](https://docs.espressif.com/projects/esp-idf/en/v5.2.1/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.1](https://docs.espressif.com/projects/esp-idf/en/v5.1.4/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.2](https://docs.espressif.com/projects/esp-idf/en/v5.2.2/esp32/get-started/index.html) | ✅ |
 
 Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.  We recommend you to use the latest subminor (patch) versions for source builds. You can check the current version used for testing in the [esp32-build.yaml](https://github.com/atomvm/AtomVM/actions/workflows/esp32-build.yaml) workflow.
 


### PR DESCRIPTION
Adds ESP32-C2 and ESP32-H2 to the supported esp32 SOCs in the Release Notes.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
