### PR TITLE
Update eps32 workflows to new esp-idf versions

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -38,8 +38,8 @@ jobs:
         idf-version:
          - 'v4.4.7'
          - 'v5.0.6'
-         - 'v5.1.3'
-         - 'v5.2.1'
+         - 'v5.1.4'
+         - 'v5.2.2'
 
         exclude:
         - esp-idf-target: "esp32c3"
@@ -47,7 +47,7 @@ jobs:
         - esp-idf-target: "esp32c3"
           idf-version: 'v5.0.6'
         - esp-idf-target: "esp32c3"
-          idf-version: 'v5.1.3'
+          idf-version: 'v5.1.4'
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        idf-version: ["5.1.3"]
+        idf-version: ["5.1.4"]
         cc: ["clang-10"]
         cxx: ["clang++-10"]
         cflags: ["-O3"]


### PR DESCRIPTION
This updates the ESP32 workflows from ESP-IDF v5.2.1 to v5.2.2, and v5.1.3 to v5.1.4.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
