### PR TITLE
Add esp-idf 5.3-beta2 to CI

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -40,6 +40,7 @@ jobs:
          - 'v5.0.6'
          - 'v5.1.4'
          - 'v5.2.2'
+         - 'v5.3-beta2'
 
         exclude:
         - esp-idf-target: "esp32c3"


### PR DESCRIPTION
Start testing against the 5.3-beta2 release, as suggested on telegram.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
