### PR TITLE
release-notes: add esp32-C6 as supported soc

### DIFF
--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -58,6 +58,7 @@ AtomVM currently supports the following [Espressif ESP SoCs](https://www.espress
 | [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf) | ✅ |
 | [ESP32c2](https://www.espressif.com/sites/default/files/documentation/esp32-c2_datasheet_en.pdf) | ✅ |
 | [ESP32c3](https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf) | ✅ |
+| [ESP32c6](https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf) | ✅ |
 | [ESP32h2](https://www.espressif.com/sites/default/files/documentation/esp32-h2_datasheet_en.pdf) | ✅ |
 | [ESP32s2](https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf) | ✅ |
 | [ESP32s3](https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf) | ✅ |


### PR DESCRIPTION
missed landing it with https://github.com/atomvm/AtomVM/pull/1184

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later