### PR TITLE
ESP32 CI: Bump QEMU to 9.0.0 & bump pytest(-embedded)

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -82,9 +82,9 @@ jobs:
       if: runner.arch != 'ARM64' && runner.os == 'Linux' && matrix.esp-idf-target == 'esp32'
       run: |
         set -eu
-        QEMU_VER=esp-develop-8.2.0-20240122
-        QEMU_XTENSA_DIST=qemu-xtensa-softmmu-esp_develop_8.2.0_20240122-x86_64-linux-gnu.tar.xz
-        QEMU_XTENSA_SHA256=e7c72ef5705ad1444d391711088c8717fc89f42e9bf6d1487f9c2a326b8cfa83
+        QEMU_VER=esp-develop-9.0.0-20240606
+        QEMU_XTENSA_DIST=qemu-xtensa-softmmu-esp_develop_9.0.0_20240606-x86_64-linux-gnu.tar.xz
+        QEMU_XTENSA_SHA256=071d117c44a6e9a1bc8664ab63b592d3e17ceb779119dcb46c59571a4a7a88c9
         wget --no-verbose https://github.com/espressif/qemu/releases/download/${QEMU_VER}/${QEMU_XTENSA_DIST}
         echo "${QEMU_XTENSA_SHA256} *${QEMU_XTENSA_DIST}" | sha256sum --check --strict -
         tar -xf ${QEMU_XTENSA_DIST} -C /opt && rm ${QEMU_XTENSA_DIST}
@@ -93,9 +93,9 @@ jobs:
       if: runner.arch != 'ARM64' && runner.os == 'Linux' && matrix.esp-idf-target == 'esp32c3'
       run: |
         set -eu
-        QEMU_VER=esp-develop-8.2.0-20240122
-        QEMU_RISCV32_DIST=qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-x86_64-linux-gnu.tar.xz
-        QEMU_RISCV32_SHA256=95ac86d7b53bf98b5ff19c33aa926189b849f5a0daf8f41e160bc86c5e31abd4
+        QEMU_VER=esp-develop-9.0.0-20240606
+        QEMU_RISCV32_DIST=qemu-riscv32-softmmu-esp_develop_9.0.0_20240606-x86_64-linux-gnu.tar.xz
+        QEMU_RISCV32_SHA256=47120e826cfec7180db8cb611a7a4aed2e9b2191c2a739194f8ce085e63cdd8d
         wget --no-verbose https://github.com/espressif/qemu/releases/download/${QEMU_VER}/${QEMU_RISCV32_DIST}
         echo "${QEMU_RISCV32_SHA256} *${QEMU_RISCV32_DIST}" | sha256sum --check --strict -
         tar -xf ${QEMU_RISCV32_DIST} -C /opt && rm ${QEMU_RISCV32_DIST}
@@ -104,9 +104,9 @@ jobs:
       if: runner.arch == 'ARM64' && runner.os == 'Linux' && matrix.esp-idf-target == 'esp32'
       run: |
         set -eu
-        QEMU_VER=esp-develop-8.2.0-20240122
-        QEMU_XTENSA_DIST=qemu-xtensa-softmmu-esp_develop_8.2.0_20240122-aarch64-linux-gnu.tar.xz
-        QEMU_XTENSA_SHA256=77c83f2772f7d9b0c770722c2cebf3625d21d8eddbccfea6816f3d8f4982ea86
+        QEMU_VER=esp-develop-9.0.0-20240606
+        QEMU_XTENSA_DIST=qemu-xtensa-softmmu-esp_develop_9.0.0_20240606-aarch64-linux-gnu.tar.xz
+        QEMU_XTENSA_SHA256=43552f32b303a6820d0d9551903e54fc221aca98ccbd04e5cbccbca881548008
         wget --no-verbose https://github.com/espressif/qemu/releases/download/${QEMU_VER}/${QEMU_XTENSA_DIST}
         echo "${QEMU_XTENSA_SHA256} *${QEMU_XTENSA_DIST}" | sha256sum --check --strict -
         tar -xf ${QEMU_XTENSA_DIST} -C /opt && rm ${QEMU_XTENSA_DIST}
@@ -115,9 +115,9 @@ jobs:
       if: runner.arch == 'ARM64' && runner.os == 'Linux' && matrix.esp-idf-target == 'esp32c3'
       run: |
         set -eu
-        QEMU_VER=esp-develop-8.2.0-20240122
-        QEMU_RISCV32_DIST=qemu-riscv32-softmmu-esp_develop_8.2.0_20240122-aarch64-linux-gnu.tar.xz
-        QEMU_RISCV32_SHA256=4089f7958f753779e5b4c93fe2469d62850a1f209b0bda8b75d55fe4a61ca39b
+        QEMU_VER=esp-develop-9.0.0-20240606
+        QEMU_RISCV32_DIST=qemu-riscv32-softmmu-esp_develop_9.0.0_20240606-aarch64-linux-gnu.tar.xz
+        QEMU_RISCV32_SHA256=3b6221a8b1881d2c9b9fa0b0bf8d7065c84153d2a54e429307bde9feae235c27
         wget --no-verbose https://github.com/espressif/qemu/releases/download/${QEMU_VER}/${QEMU_RISCV32_DIST}
         echo "${QEMU_RISCV32_SHA256} *${QEMU_RISCV32_DIST}" | sha256sum --check --strict -
         tar -xf ${QEMU_RISCV32_DIST} -C /opt && rm ${QEMU_RISCV32_DIST}
@@ -126,11 +126,11 @@ jobs:
       run: |
         set -e
         . $IDF_PATH/export.sh
-        pip install pytest==8.0.2 \
-            pytest-embedded==1.8.1 \
-            pytest-embedded-serial-esp==1.8.1 \
-            pytest-embedded-idf==1.8.1 \
-            pytest-embedded-qemu==1.8.1
+        pip install pytest==8.2.2 \
+            pytest-embedded==1.10.3 \
+            pytest-embedded-serial-esp==1.10.3 \
+            pytest-embedded-idf==1.10.3 \
+            pytest-embedded-qemu==1.10.3
 
     - name: Build ESP32 tests using idf.py
       working-directory: ./src/platforms/esp32/test/

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -177,10 +177,8 @@ TEST_CASE("test_esp_partition", "[test_run]")
     TEST_ASSERT(term_to_int(ret_value) == 0);
 }
 
-// avoid: assert failed: sdmmc_ll_get_card_clock_div /IDF/components/hal/esp32/include/hal/sdmmc_ll.h:203 (hw->clksrc.card1 == 1)
-// pending https://github.com/espressif/qemu/commit/fe80b1870651ef1227bffd7d4151aa2ce4bcf65f released
-// due to assert fix in 5.2+ https://github.com/espressif/esp-idf/commit/263e39c32b447f7832744f2458f13abbfe2033a9
-#if (ESP_IDF_VERSION_MAJOR < 5 || (ESP_IDF_VERSION_MAJOR <= 5 && ESP_IDF_VERSION_MINOR < 2)) && !CONFIG_IDF_TARGET_ESP32C3
+// qemu SDMMC works all esp-idf versions for esp32 - still no support c3.
+#if !CONFIG_IDF_TARGET_ESP32C3
 TEST_CASE("test_file", "[test_run]")
 {
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
@@ -494,14 +492,11 @@ TEST_CASE("test_ssl", "[test_run]")
     TEST_ASSERT(ret_value == OK_ATOM);
 }
 
-// Works C3 on local runs, but fails GH actions
-#if !CONFIG_IDF_TARGET_ESP32C3
 TEST_CASE("test_rtc_slow", "[test_run]")
 {
     term ret_value = avm_test_case("test_rtc_slow.beam");
     TEST_ASSERT(term_to_int(ret_value) == 0);
 }
-#endif
 
 // Works C3 on local runs, but fails GH actions
 #if ESP_IDF_VERSION_MAJOR >= 5 && !CONFIG_IDF_TARGET_ESP32C3


### PR DESCRIPTION
QEMU was updated upstream: https://github.com/espressif/qemu/releases/tag/esp-develop-9.0.0-20240606

Resolves the sd card test issue for 5.2.x - and rtc_slow test for c3.

Enables future work on esp32s3 testing - though it currently seems to lack an openeth implementation, thus requiring multiple test to be disabled and fragmenting code. So esp32s3 support slated for future work.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
