### PR TITLE
Implement lists:keytake/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simple http client, that can be used for different use case such as downloading OTA updates
 - Elixir support for `Keyword.merge` `Keyword.take` `Keyword.pop(!)` `Keyword.keyword?` `Keyword.has_key?` functions.
 - Support for ESP32-H2
+- lists:keytake/3 implemented.
 
 ### Changed
 

--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -3,6 +3,7 @@
 %
 % Copyright 2017-2023 Fred Dushin <fred@dushin.net>
 % split/2 function Copyright Ericsson AB 1996-2023.
+% keytake/3 function Copyright Ericsson AB 1996-2024.
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -40,6 +41,7 @@
     keyfind/3,
     keymember/3,
     keyreplace/4,
+    keytake/3,
     foldl/3,
     foldr/3,
     all/2,
@@ -303,6 +305,33 @@ keyreplace(K, I, [H | T], L, NewTuple, NewList) when is_tuple(H) andalso is_tupl
     end;
 keyreplace(K, I, [H | T], L, NewTuple, NewList) ->
     keyreplace(K, I, T, L, NewTuple, [H | NewList]).
+
+%%-----------------------------------------------------------------------------
+%% @param   Key         the key to match
+%% @param   N           the position in the tuple to compare (1..tuple_size)
+%% @param   TupleList1  the list of tuples from which to find the element
+%% @returns `{value, Tuple, TupleList2}' if such a tuple is found, otherwise `false'.
+%%          `TupleList2' is a copy of `TupleList1' where the first
+%%          occurrence of `Tuple' has been removed.
+%% @doc     Searches the list of tuples `TupleList1' for a tuple whose `N'th element
+%%          compares equal to `Key'.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec keytake(Key, N, TupleList1) -> {value, Tuple, TupleList2} | false when
+    Key :: term(),
+    N :: pos_integer(),
+    TupleList1 :: [tuple()],
+    TupleList2 :: [tuple()],
+    Tuple :: tuple().
+keytake(Key, N, L) when is_integer(N), N > 0 ->
+    keytake(Key, N, L, []).
+
+keytake(Key, N, [H | T], L) when element(N, H) == Key ->
+    {value, H, lists:reverse(L, T)};
+keytake(Key, N, [H | T], L) ->
+    keytake(Key, N, T, [H | L]);
+keytake(_K, _N, [], _L) ->
+    false.
 
 %%-----------------------------------------------------------------------------
 %% @param   Fun the function to apply

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -31,6 +31,7 @@ test() ->
     ok = test_keyfind(),
     ok = test_keydelete(),
     ok = test_keyreplace(),
+    ok = test_keytake(),
     ok = test_foldl(),
     ok = test_foldr(),
     ok = test_all(),
@@ -103,6 +104,19 @@ test_keyreplace() ->
         {a, x},
         []
     ]),
+    ok.
+
+test_keytake() ->
+    List1 = [{name, "Joe"}, {name, "Robert"}, {name, "Mike"}],
+    ?ASSERT_MATCH(
+        lists:keytake("Joe", 2, List1), {value, {name, "Joe"}, [{name, "Robert"}, {name, "Mike"}]}
+    ),
+    ?ASSERT_MATCH(
+        lists:keytake("Robert", 2, List1),
+        {value, {name, "Robert"}, [{name, "Joe"}, {name, "Mike"}]}
+    ),
+    ?ASSERT_MATCH(lists:keytake("Joe", 1, List1), false),
+    ?ASSERT_MATCH(lists:keytake("Joe", 3, List1), false),
     ok.
 
 test_foldl() ->


### PR DESCRIPTION
Closes https://github.com/atomvm/AtomVM/issues/1159.

Carbon copy from https://github.com/erlang/otp/blob/0b1bab25dbabb6c19319f3373c5a6dfa74667210/lib/stdlib/src/lists.erl#L1252

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
