### PR TITLE
Fix missing AVM_DISABLE_SMP for esp32c2 in test

### DIFF
--- a/src/platforms/esp32/test/CMakeLists.txt
+++ b/src/platforms/esp32/test/CMakeLists.txt
@@ -46,7 +46,7 @@ set(HAVE_SOCKET ON)
 set(HAVE_SOCKET 1 CACHE INTERNAL "Have symbol socket" FORCE)
 
 # Disable SMP with esp32 socs that have only one core
-if (${IDF_TARGET} MATCHES "esp32s2|esp32c3|esp32c6|esp32h2")
+if (${IDF_TARGET} MATCHES "esp32s2|esp32c2|esp32c3|esp32c6|esp32h2")
     message("Disabling SMP as selected target only has one core")
     set(AVM_DISABLE_SMP YES FORCE)
     set(HAVE_PLATFORM_ATOMIC_H ON)


### PR DESCRIPTION
Missed it in https://github.com/atomvm/AtomVM/pull/1164

No CI supports the c2 currently, so absolutely no hurry - just for good measure.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
