### PR TITLE
Fix issue with multiple links creation (#1193)

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -405,6 +405,8 @@ static struct ResourceMonitor *context_monitors_handle_terminate(Context *ctx)
                     }
 
                     term exited_pid = term_from_local_process_id(ctx->process_id);
+                    // Process table should be locked before context_unlink is
+                    // called. This is done in calling function context_destroy.
                     context_unlink(target, exited_pid);
                     // Prepare the message on ctx's heap which will be freed afterwards.
                     term info_tuple = term_alloc_tuple(3, &ctx->heap);

--- a/tests/erlang_tests/trap_exit_flag.erl
+++ b/tests/erlang_tests/trap_exit_flag.erl
@@ -35,12 +35,14 @@ test_nocatch() ->
     Pid = spawn_opt(fun proc/0, []),
     erlang:link(Pid),
     erlang:link(Pid),
-    {links,[Pid]} = erlang:process_info(MyPid,links),
+    {links, LinkedPids1} = erlang:process_info(MyPid, links),
+    1 = no_of_linked_pids(Pid, LinkedPids1),
     Pid ! do_throw,
     ok =
         receive
             {'EXIT', Pid, {{nocatch, test}, EL}} when is_list(EL) ->
-                {links,[]} = erlang:process_info(MyPid,links),
+                {links, LinkedPids2} = erlang:process_info(MyPid, links),
+                0 = no_of_linked_pids(Pid, LinkedPids2),
                 ok;
             Other ->
                 {unexpected, Other}
@@ -81,3 +83,6 @@ proc() ->
         exit_normally ->
             ok
     end.
+
+no_of_linked_pids(Pid, L) ->
+    erlang:length([X || X <- L, X =:= Pid]).

--- a/tests/erlang_tests/trap_exit_flag.erl
+++ b/tests/erlang_tests/trap_exit_flag.erl
@@ -31,12 +31,16 @@ start() ->
     0.
 
 test_nocatch() ->
+    MyPid = self(),
     Pid = spawn_opt(fun proc/0, []),
     erlang:link(Pid),
+    erlang:link(Pid),
+    {links,[Pid]} = erlang:process_info(MyPid,links),
     Pid ! do_throw,
     ok =
         receive
             {'EXIT', Pid, {{nocatch, test}, EL}} when is_list(EL) ->
+                {links,[]} = erlang:process_info(MyPid,links),
                 ok;
             Other ->
                 {unexpected, Other}


### PR DESCRIPTION
Fix for issue #1193
If link is called several times for the same pid, multiple links are created.
Also remove link if a process exits and a linked process traps the EXIT message.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
