### PR TITLE
Update `byte_size/1` and `bit_size/1` bifs to implement OTP-18987

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 details for the channel changes can be observed in the console log if "debug" level logging is enabled
 in ESP-IDF Kconfig options.
 - Default size of ESP32 RTC slow memory from 4086 to 4096, except on ESP32-H2 where it's 3072
+- Update `byte_size/1` and `bit_size/1` to implement OTP27 match context reuse optimization OTP-18987.
 
 ### Fixed
 

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -27,6 +27,7 @@
 #include "defaultatoms.h"
 #include "dictionary.h"
 #include "overflow_helpers.h"
+#include "term.h"
 #include "trace.h"
 #include "utils.h"
 
@@ -68,18 +69,36 @@ term bif_erlang_byte_size_1(Context *ctx, int live, term arg1)
 {
     UNUSED(live);
 
-    VALIDATE_VALUE(arg1, term_is_binary);
+    size_t len;
 
-    return term_from_int32(term_binary_size(arg1));
+    if (term_is_match_state(arg1)) {
+        avm_int_t offset = term_get_match_state_offset(arg1);
+        term src_bin = term_get_match_state_binary(arg1);
+        len = term_binary_size(src_bin) - offset / 8;
+    } else {
+        VALIDATE_VALUE(arg1, term_is_binary);
+        len = term_binary_size(arg1);
+    }
+
+    return term_from_int32(len);
 }
 
 term bif_erlang_bit_size_1(Context *ctx, int live, term arg1)
 {
     UNUSED(live);
 
-    VALIDATE_VALUE(arg1, term_is_binary);
+    size_t len;
 
-    return term_from_int32(term_binary_size(arg1) * 8);
+    if (term_is_match_state(arg1)) {
+        avm_int_t offset = term_get_match_state_offset(arg1);
+        term src_bin = term_get_match_state_binary(arg1);
+        len = term_binary_size(src_bin) * 8 - offset;
+    } else {
+        VALIDATE_VALUE(arg1, term_is_binary);
+        len = term_binary_size(arg1) * 8;
+    }
+
+    return term_from_int32(len);
 }
 
 term bif_erlang_is_atom_1(Context *ctx, term arg1)

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -446,6 +446,7 @@ compile_erlang(sexp_lexer)
 compile_erlang(test_function_exported)
 compile_erlang(test_list_to_tuple)
 
+compile_erlang(bs_context_byte_size)
 compile_erlang(bs_context_to_binary_with_offset)
 compile_erlang(bs_restore2_start_offset)
 compile_erlang(test_refc_binaries)
@@ -910,6 +911,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_function_exported.beam
     test_list_to_tuple.beam
 
+    bs_context_byte_size.beam
     bs_context_to_binary_with_offset.beam
     bs_restore2_start_offset.beam
     bs_append_extra_words.beam

--- a/tests/erlang_tests/bs_context_byte_size.erl
+++ b/tests/erlang_tests/bs_context_byte_size.erl
@@ -1,0 +1,61 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(bs_context_byte_size).
+
+-export([start/0, decode/2, decode_bit_size/2]).
+
+start() ->
+    {0, <<>>} = decode(0, undefined),
+    {0, <<1>>} = decode(
+        42, <<0, 0, 0, 0, 0, 0, 0, 0, 1>>
+    ),
+    {0, <<1, 2>>} = decode(
+        42, <<0, 0, 0, 0, 0, 0, 0, 0, 1, 2>>
+    ),
+    {42, <<1, 2, 3>>} = decode(
+        42, <<0, 0, 0, 0, 0, 0, 0, 42, 1, 2, 3>>
+    ),
+    {42, <<1, 2, 3, 4, 5, 6, 7, 8>>} = decode(
+        42, <<0, 0, 0, 0, 0, 0, 0, 42, 1, 2, 3, 4, 5, 6, 7, 8>>
+    ),
+    {42, <<>>} = decode(
+        42, <<0, 0, 0, 0, 0, 0, 0, 42, 1, 2, 3, 4, 5, 6, 7, 8, 9>>
+    ),
+    {42, <<1, 2, 3, 4, 5, 6, 7, 8>>} = decode_bit_size(
+        42, <<0, 0, 0, 0, 0, 0, 0, 42, 1, 2, 3, 4, 5, 6, 7, 8>>
+    ),
+    {42, <<>>} = decode_bit_size(
+        42, <<0, 0, 0, 0, 0, 0, 0, 42, 1, 2, 3, 4, 5, 6, 7, 8, 9>>
+    ),
+    {42, <<>>} = decode(
+        42, <<0, 0, 0, 0, 0, 0, 0, 43, 1, 2, 3>>
+    ),
+    0.
+
+decode(Now, <<BootTime:64, Bin/binary>>) when BootTime =< Now andalso byte_size(Bin) =< 8 ->
+    {BootTime, Bin};
+decode(Now, _) ->
+    {Now, <<>>}.
+
+decode_bit_size(Now, <<BootTime:64, Bin/binary>>) when BootTime =< Now andalso bit_size(Bin) < 65 ->
+    {BootTime, Bin};
+decode_bit_size(Now, _) ->
+    {Now, <<>>}.

--- a/tests/test.c
+++ b/tests/test.c
@@ -467,6 +467,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(test_function_exported, 7),
     TEST_CASE_EXPECTED(test_list_to_tuple, 69),
 
+    TEST_CASE(bs_context_byte_size),
     TEST_CASE_EXPECTED(bs_context_to_binary_with_offset, 42),
     TEST_CASE_EXPECTED(bs_restore2_start_offset, 823),
 


### PR DESCRIPTION
Update `byte_size/1` and `bit_size/1` so they accept a match context as a parameter to implement an optimization introduced with OTP 27.0 as OTP-18987.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
