### PR TITLE
Export missing types in esp module

### DIFF
--- a/libs/eavmlib/src/esp.erl
+++ b/libs/eavmlib/src/esp.erl
@@ -120,6 +120,8 @@
 
 -export_type(
     [
+        esp_reset_reason/0,
+        esp_wakeup_cause/0,
         esp_partition/0,
         esp_partition_type/0,
         esp_partition_subtype/0,


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
