### PR TITLE
Fix undef error when a function is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ in ESP-IDF Kconfig options.
 `02411048` was not completely right, and it was converting match context to bogus binaries.
 - Fix creation of multiple links for the same process and not removing link at trapped exits.
 See issue [#1193](https://github.com/atomvm/AtomVM/issues/1193).
+- Fix error that is raised when a function is undefined
 
 ## [0.6.2] - 25-05-2024
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1116,10 +1116,12 @@ static void destroy_extended_registers(Context *ctx, unsigned int live)
         } else {                                                        \
             fun_module = globalcontext_get_module(ctx->global, module_name); \
             if (IS_NULL_PTR(fun_module)) {                              \
+                SET_ERROR(UNDEF_ATOM);                                  \
                 HANDLE_ERROR();                                         \
             }                                                           \
             label = module_search_exported_function(fun_module, function_name, fun_arity, glb); \
             if (UNLIKELY(label == 0)) {                                 \
+                SET_ERROR(UNDEF_ATOM);                                  \
                 HANDLE_ERROR();                                         \
             }                                                           \
         }                                                               \
@@ -5108,11 +5110,13 @@ wait_timeout_trap_handler:
                     Module *target_module = globalcontext_get_module(ctx->global, module_name);
                     if (IS_NULL_PTR(target_module)) {
                         pc = orig_pc;
+                        SET_ERROR(UNDEF_ATOM);
                         HANDLE_ERROR();
                     }
                     int target_label = module_search_exported_function(target_module, function_name, arity, glb);
                     if (target_label == 0) {
                         pc = orig_pc;
+                        SET_ERROR(UNDEF_ATOM);
                         HANDLE_ERROR();
                     }
                     ctx->cp = module_address(mod->module_index, pc - code);
@@ -5164,10 +5168,12 @@ wait_timeout_trap_handler:
                 } else {
                     Module *target_module = globalcontext_get_module(ctx->global, module_name);
                     if (IS_NULL_PTR(target_module)) {
+                        SET_ERROR(UNDEF_ATOM);
                         HANDLE_ERROR();
                     }
                     int target_label = module_search_exported_function(target_module, function_name, arity, glb);
                     if (target_label == 0) {
+                        SET_ERROR(UNDEF_ATOM);
                         HANDLE_ERROR();
                     }
                     JUMP_TO_LABEL(target_module, target_label);

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -178,6 +178,7 @@ compile_erlang(test_system_info)
 compile_erlang(test_binary_to_term)
 compile_erlang(test_selective_receive)
 compile_erlang(test_timeout_not_integer)
+compile_erlang(test_undef)
 
 compile_erlang(test_funs0)
 compile_erlang(test_funs1)
@@ -637,6 +638,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_binary_to_term.beam
     test_selective_receive.beam
     test_timeout_not_integer.beam
+    test_undef.beam
 
     test_funs0.beam
     test_funs1.beam

--- a/tests/erlang_tests/test_undef.erl
+++ b/tests/erlang_tests/test_undef.erl
@@ -1,0 +1,73 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_undef).
+
+-export([
+    start/0, test_undef_apply/1, test_undef_apply_last/1, test_undef_call/1, apply_last/2, call/1
+]).
+
+start() ->
+    ok = test_undef_apply(test_undef_module),
+    ok = test_undef_apply(?MODULE),
+    ok = test_undef_apply_last(test_undef_module),
+    ok = test_undef_apply_last(?MODULE),
+    ok = test_undef_call(test_undef_module),
+    ok = test_undef_call(?MODULE),
+    0.
+
+test_undef_apply(Module) ->
+    % At least with OTP27 compiler, this compiles to:
+    % {apply,0}.
+    try
+        Module:undef_function(),
+        {unexpected, ok}
+    catch
+        error:undef -> ok;
+        T:V -> {unexpected, T, V}
+    end.
+
+test_undef_apply_last(Module) ->
+    try
+        apply_last(Module, undef_function),
+        {unexpected, ok}
+    catch
+        error:undef -> ok;
+        T:V -> {unexpected, T, V}
+    end.
+
+apply_last(Module, Func) ->
+    % At least with OTP27 compiler, this compiles to:
+    % {apply_last,0,0}.
+    Module:Func().
+
+test_undef_call(Module) ->
+    try
+        call(fun Module:undef_function/0),
+        {unexpected, ok}
+    catch
+        error:undef -> ok;
+        T:V -> {unexpected, T, V}
+    end.
+
+call(Fun) ->
+    % At least with OTP27 compiler, this compiles to:
+    % {apply_last,0,0}.
+    Fun().

--- a/tests/test.c
+++ b/tests/test.c
@@ -358,6 +358,7 @@ struct Test tests[] = {
     TEST_CASE(test_binary_to_term),
     TEST_CASE(test_selective_receive),
     TEST_CASE(test_timeout_not_integer),
+    TEST_CASE(test_undef),
     TEST_CASE(test_bs),
     TEST_CASE(test_bs_int),
     TEST_CASE(test_bs_int_unaligned),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
