### PR TITLE
Fix issue with multiple links creation (#1193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ in ESP-IDF Kconfig options.
 
 - Fix bug (with code compiled with OTP-21) with binary pattern matching: the fix introduced with
 `02411048` was not completely right, and it was converting match context to bogus binaries.
+- Fix creation of multiple links for the same process and not removing link at trapped exits.
+See issue [#1193](https://github.com/atomvm/AtomVM/issues/1193).
 
 ## [0.6.2] - 25-05-2024
 

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -402,10 +402,14 @@ static struct ResourceMonitor *context_monitors_handle_terminate(Context *ctx)
                         AVM_ABORT();
                     }
 
+                    term exited_pid = term_from_local_process_id(ctx->process_id);
+                    // Process table should be locked before context_unlink is
+                    // called. This is done in calling function context_destroy.
+                    context_unlink(target, exited_pid);
                     // Prepare the message on ctx's heap which will be freed afterwards.
                     term info_tuple = term_alloc_tuple(3, &ctx->heap);
                     term_put_tuple_element(info_tuple, 0, EXIT_ATOM);
-                    term_put_tuple_element(info_tuple, 1, term_from_local_process_id(ctx->process_id));
+                    term_put_tuple_element(info_tuple, 1, exited_pid);
                     term_put_tuple_element(info_tuple, 2, ctx->exit_reason);
                     mailbox_send(target, info_tuple);
                 } else {
@@ -444,7 +448,15 @@ static struct ResourceMonitor *context_monitors_handle_terminate(Context *ctx)
 
 int context_link(Context *ctx, term link_pid)
 {
-    struct Monitor *monitor = malloc(sizeof(struct Monitor));
+    struct ListHead *item;
+    struct Monitor *monitor;
+    LIST_FOR_EACH (item, &ctx->monitors_head) {
+        monitor = GET_LIST_ENTRY(item, struct Monitor, monitor_list_head);
+        if ((monitor->monitor_obj == link_pid) && (monitor->ref_ticks == 0)) {
+            return 0;
+        }
+    }
+    monitor = malloc(sizeof(struct Monitor));
     if (IS_NULL_PTR(monitor)) {
         return -1;
     }

--- a/tests/erlang_tests/trap_exit_flag.erl
+++ b/tests/erlang_tests/trap_exit_flag.erl
@@ -31,12 +31,18 @@ start() ->
     0.
 
 test_nocatch() ->
+    MyPid = self(),
     Pid = spawn_opt(fun proc/0, []),
     erlang:link(Pid),
+    erlang:link(Pid),
+    {links, LinkedPids1} = erlang:process_info(MyPid, links),
+    1 = no_of_linked_pids(Pid, LinkedPids1),
     Pid ! do_throw,
     ok =
         receive
             {'EXIT', Pid, {{nocatch, test}, EL}} when is_list(EL) ->
+                {links, LinkedPids2} = erlang:process_info(MyPid, links),
+                0 = no_of_linked_pids(Pid, LinkedPids2),
                 ok;
             Other ->
                 {unexpected, Other}
@@ -77,3 +83,6 @@ proc() ->
         exit_normally ->
             ok
     end.
+
+no_of_linked_pids(Pid, L) ->
+    erlang:length([X || X <- L, X =:= Pid]).


### PR DESCRIPTION
Fix for issue https://github.com/atomvm/AtomVM/issues/1193
If link is called several times for the same pid, multiple links are created.
Also remove link if a process exits and a linked process traps the EXIT message.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
