### PR TITLE
Add support for eunit module

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -106,6 +106,12 @@ jobs:
       run: |
         ./tests/test-structs
 
+    - name: "Test: test_etest.avm"
+      timeout-minutes: 5
+      working-directory: build
+      run: |
+        ./src/AtomVM ./tests/libs/etest/test_etest.avm
+
     - name: "Test: test_estdlib.avm"
       timeout-minutes: 10
       working-directory: build

--- a/.github/workflows/build-and-test-on-freebsd.yaml
+++ b/.github/workflows/build-and-test-on-freebsd.yaml
@@ -106,6 +106,11 @@ jobs:
           ./tests/test-structs
 
           echo "%%"
+          echo "%% Running etest tests ..."
+          echo "%%"
+          ./src/AtomVM tests/libs/etest/test_etest.avm
+
+          echo "%%"
           echo "%% Running estdlib tests ..."
           echo "%%"
           ./src/AtomVM tests/libs/estdlib/test_estdlib.avm

--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -49,7 +49,7 @@ jobs:
         mkdir build_tests
         cd build_tests
         cmake .. -G Ninja -DAVM_WARNINGS_ARE_ERRORS=ON
-        ninja erlang_test_modules test_estdlib test_eavmlib test_alisp
+        ninja erlang_test_modules test_etest test_estdlib test_eavmlib test_alisp
 
     - name: Upload test modules
       uses: actions/upload-artifact@v4
@@ -159,6 +159,7 @@ jobs:
         cp ../build_tests/tests/erlang_tests/code_load/*.{avm,beam,hrl} tests/erlang_tests/code_load/ &&
         mkdir -p tests/erlang_tests/code_load/beams/ &&
         cp ../build_tests/tests/erlang_tests/code_load/beams/*.beam tests/erlang_tests/code_load/beams/ &&
+        cp ../build_tests/tests/libs/etest/*.avm tests/libs/etest/  &&
         cp ../build_tests/tests/libs/estdlib/*.avm tests/libs/estdlib/  &&
         cp ../build_tests/tests/libs/eavmlib/*.avm tests/libs/eavmlib/ &&
         cp ../build_tests/tests/libs/alisp/*.avm tests/libs/alisp/ &&
@@ -176,6 +177,7 @@ jobs:
         file ./tests/test-structs &&
         ./tests/test-structs &&
         file ./src/AtomVM &&
+        ./src/AtomVM tests/libs/etest/test_etest.avm &&
         ./src/AtomVM tests/libs/estdlib/test_estdlib.avm &&
         ./src/AtomVM tests/libs/eavmlib/test_eavmlib.avm &&
         ./src/AtomVM tests/libs/alisp/test_alisp.avm

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -351,6 +351,13 @@ jobs:
         ./tests/test-structs
         valgrind ./tests/test-structs
 
+    - name: "Test: test_etest.avm"
+      timeout-minutes: 5
+      working-directory: build
+      run: |
+        ./src/AtomVM ./tests/libs/etest/test_etest.avm
+        valgrind ./src/AtomVM ./tests/libs/etest/test_etest.avm
+
     - name: "Test: test_estdlib.avm"
       timeout-minutes: 5
       working-directory: build

--- a/.github/workflows/build-libraries.yaml
+++ b/.github/workflows/build-libraries.yaml
@@ -67,6 +67,20 @@ jobs:
       working-directory: build
       run: make dialyzer
 
+    - name: "Test: test_alisp.avm"
+      timeout-minutes: 5
+      working-directory: build
+      run: |
+        ./src/AtomVM ./tests/libs/etest/test_alisp.avm
+        valgrind ./src/AtomVM ./tests/libs/etest/test_alisp.avm
+
+    - name: "Test: test_etest.avm"
+      timeout-minutes: 5
+      working-directory: build
+      run: |
+        ./src/AtomVM ./tests/libs/etest/test_etest.avm
+        valgrind ./src/AtomVM ./tests/libs/etest/test_etest.avm
+
     - name: "Test: test_estdlib.avm"
       timeout-minutes: 10
       working-directory: build

--- a/.github/workflows/build-linux-artifacts.yaml
+++ b/.github/workflows/build-linux-artifacts.yaml
@@ -34,7 +34,7 @@ jobs:
         mkdir build_tests
         cd build_tests
         cmake .. -G Ninja -DAVM_WARNINGS_ARE_ERRORS=ON
-        ninja erlang_test_modules test_estdlib test_eavmlib test_alisp
+        ninja erlang_test_modules test_etest test_estdlib test_eavmlib test_alisp
 
     - name: Upload test modules
       uses: actions/upload-artifact@v4
@@ -226,6 +226,7 @@ jobs:
         file ./tests/test-structs &&
         ./tests/test-structs &&
         file ./src/AtomVM &&
+        ./src/AtomVM tests/libs/etest/test_etest.avm &&
         ./src/AtomVM tests/libs/estdlib/test_estdlib.avm &&
         ./src/AtomVM tests/libs/eavmlib/test_eavmlib.avm &&
         ./src/AtomVM tests/libs/alisp/test_alisp.avm &&

--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -74,7 +74,7 @@ jobs:
         set -eu
         apt update
         DEBIAN_FRONTEND=noninteractive apt install -y -q \
-            doxygen erlang-base erlang-dialyzer \
+            doxygen erlang-base erlang-dev erlang-dialyzer erlang-eunit \
             libglib2.0-0 libpixman-1-0 \
             gcc g++ zlib1g-dev libsdl2-2.0-0 libslirp0 libmbedtls-dev
 

--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -46,7 +46,11 @@ jobs:
       run: sudo apt update
 
     - name: "Install deps"
-      run: sudo apt install -y cmake gperf ninja-build gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib erlang-base erlang-dialyzer
+      run: |
+        sudo apt install -y \
+            cmake gperf ninja-build gcc-arm-none-eabi \
+            libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib \
+            erlang-base erlang-dev erlang-dialyzer erlang-eunit
 
     - name: Build
       shell: bash

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -143,3 +143,11 @@ jobs:
       run: |
         export PATH="${{ matrix.path_prefix }}$PATH"
         erl -pa tests/libs/estdlib/ -pa tests/libs/estdlib/beams/ -pa libs/etest/src/beams -s tests -s init stop -noshell
+
+    # Test
+    - name: "Run tests/libs/etest/test_eunit with OTP eunit"
+      timeout-minutes: 10
+      working-directory: build
+      run: |
+        export PATH="${{ matrix.path_prefix }}$PATH"
+        erl -pa tests/libs/etest/beams -s test_eunit test -s init stop -noshell

--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -47,7 +47,7 @@ jobs:
         cd build
         cmake .. -G Ninja -DAVM_WARNINGS_ARE_ERRORS=ON
         # test_eavmlib does not work with wasm due to http + ssl test
-        ninja AtomVM atomvmlib test_alisp hello_world run_script call_cast html5_events wasm_webserver
+        ninja AtomVM atomvmlib test_etest test_alisp hello_world run_script call_cast html5_events wasm_webserver
 
     - name: Upload AtomVM and test modules
       uses: actions/upload-artifact@v4
@@ -114,6 +114,7 @@ jobs:
         node src/AtomVM.js ../../../../build/tests/libs/alisp/test_alisp.avm
         # test_eavmlib does not work with wasm due to http + ssl test
         # node src/AtomVM.js ../../../../build/tests/libs/eavmlib/test_eavmlib.avm
+        node src/AtomVM.js ../../../../build/tests/libs/etest/test_etest.avm
 
     - name: "Rename and write sha256sum (node)"
       if: startsWith(github.ref, 'refs/tags/')

--- a/libs/etest/src/eunit.erl
+++ b/libs/etest/src/eunit.erl
@@ -1,0 +1,270 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%%-----------------------------------------------------------------------------
+%% @doc This modules provides an eunit-compatible API for AtomVM generating
+%% an output that can be parsed by dut.expect_unity_test_output
+%% @end
+%%-----------------------------------------------------------------------------
+-module(eunit).
+
+-export([
+    start/0,
+    test/1,
+    test/2
+]).
+
+-define(DEFAULT_TIMEOUT, 30000).
+
+-type option() :: exact_execution | {exact_execution, boolean()}.
+-type test() ::
+    fun(() -> term())
+    | atom()
+    | {module, atom()}
+    | {test, ModuleName :: atom(), FunctionName :: atom()}
+    | {Line :: pos_integer(), fun(() -> term())}
+    | {generator, GenFun :: fun(() -> test())}
+    | {generator, ModuleName :: atom(), FunctionName :: atom()}
+    | {Title :: string(), test()}
+    | [test()].
+
+-record(state, {
+    total = 0 :: non_neg_integer(),
+    failures = 0 :: non_neg_integer(),
+    runner = undefined :: undefined | pid(),
+    spawn = false :: boolean(),
+    timeout = ?DEFAULT_TIMEOUT :: timeout(),
+    instantiator_arg = undefined :: term()
+}).
+
+%% @equiv test(Tests, [])
+-spec test(test()) -> ok | {error, {failures, pos_integer()}}.
+test(Tests) -> test(Tests, []).
+
+%%-----------------------------------------------------------------------------
+%% @param   Tests tests or module to run tests from
+%% @param   Options options. If `exact_execution' is true and Tests is a module
+%%          name, tests from the module with _tests suffix are not collected.
+%% @returns ok if all of the tests pass, or the atom fail, if any of the tests
+%%          failed.
+%% @doc     Run tests print result using io:format in a format compatible with
+%%          `dut.expect_unity_test_output'.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec test(Tests :: test(), Options :: [option()]) -> ok | {error, {failures, pos_integer()}}.
+test(Tests, Options) ->
+    #state{total = Total, failures = Failures} = test(Tests, [], Options, #state{}),
+    Outcome =
+        case Failures of
+            0 -> "OK";
+            _ -> "FAIL"
+        end,
+    io:format("- ~B Tests ~B Failures ~B Ignored ~s\n", [Total, Failures, 0, Outcome]),
+    case Failures of
+        0 -> ok;
+        _ -> {error, {failures, Failures}}
+    end.
+
+test([], _Identification, _Options, State) ->
+    State;
+test([Test | Tail], Identification, Options, AccState) ->
+    NewState = test(Test, Identification, Options, AccState),
+    test(Tail, Identification, Options, NewState);
+test(Module, Identification, Options, State) when is_atom(Module) ->
+    test({module, Module}, Identification, Options, State);
+test({module, Module}, _Identification, Options, State) ->
+    Exports = Module:module_info(exports),
+    TestsModule = module_tests(Module, Exports, []),
+    ModuleTests = list_to_atom(atom_to_list(Module) ++ "_tests"),
+    TestsModuleTests =
+        try
+            case proplists:get_value(exact_execution, Options, false) of
+                true ->
+                    [];
+                false ->
+                    ExportsModuleTests = ModuleTests:module_info(exports),
+                    module_tests(ModuleTests, ExportsModuleTests, [])
+            end
+        catch
+            error:undef ->
+                []
+        end,
+    test(TestsModule ++ TestsModuleTests, [{module, Module}], Options, State);
+test({generator, Module, Function}, Identification, Options, State) ->
+    TestsList = Module:Function(),
+    test(TestsList, [{module, Module}, {test_case, Function} | Identification], Options, State);
+test({generator, Function}, Identification, Options, State) when is_function(Function) ->
+    TestsList = Function(),
+    test(TestsList, Identification, Options, State);
+test({Title, Tests}, Identification, Options, State) when
+    is_list(Title) andalso is_integer(hd(Title))
+->
+    test(Tests, [{title, Title} | Identification], Options, State);
+test(Tuple, Identification, Options, State) when
+    is_tuple(Tuple) andalso size(Tuple) > 2 andalso is_list(element(1, Tuple)) andalso
+        is_integer(hd(element(1, Tuple)))
+->
+    [Title | TupleT] = tuple_to_list(Tuple),
+    test(list_to_tuple(TupleT), [{title, Title} | Identification], Options, State);
+test({Line, Test}, Identification, Options, State) when is_integer(Line) ->
+    test(Test, [{line, Line} | Identification], Options, State);
+test({test, Module, Function}, Identification, Options, State) when
+    is_atom(Module) andalso is_atom(Function)
+->
+    test(
+        fun Module:Function/0,
+        [{module, Module}, {test_case, Function} | Identification],
+        Options,
+        State
+    );
+test(Function, Identification, Options, #state{runner = undefined} = State0) when
+    is_function(Function, 0)
+->
+    test({spawn, Function}, Identification, Options, State0);
+test(Function, Identification, _Options, State) when
+    is_function(Function, 0)
+->
+    run_test(Identification, Function, State);
+test(Instantiator, Identification, Options, State) when
+    is_function(Instantiator, 1)
+->
+    test(Instantiator(State#state.instantiator_arg), Identification, Options, State);
+test(
+    {spawn, Tests},
+    Identification,
+    Options,
+    #state{runner = PreviousRunner, timeout = Timeout} = State0
+) ->
+    Self = self(),
+    {Pid, MonitorRef} = spawn_opt(
+        fun() ->
+            State1 = test(Tests, Identification, Options, State0#state{runner = self()}),
+            Self ! {self(), State1#state{runner = PreviousRunner}}
+        end,
+        [monitor]
+    ),
+    receive
+        {Pid, Result} ->
+            demonitor(MonitorRef, [flush]),
+            Result;
+        {'DOWN', MonitorRef, process, Pid, Reason} ->
+            report({exit, Reason}, Identification),
+            State0#state{total = State0#state.total + 1, failures = State0#state.failures + 1}
+    after Timeout ->
+        report(timeout, Identification),
+        State0#state{total = State0#state.total + 1, failures = State0#state.failures + 1}
+    end;
+test({inorder, Tests}, Identification, Options, State) ->
+    test(Tests, Identification, Options, State);
+test({setup, Setup, Tests}, Identification, Options, State) ->
+    test({setup, Setup, fun(_) -> ok end, Tests}, Identification, Options, State);
+test({setup, Setup, TearDown, Tests}, Identification, Options, State) ->
+    test({setup, spawn, Setup, TearDown, Tests}, Identification, Options, State);
+test(
+    {setup, Where, Setup, TearDown, Tests},
+    Identification,
+    Options,
+    #state{runner = undefined} = State0
+) ->
+    test({spawn, {setup, Where, Setup, TearDown, Tests}}, Identification, Options, State0);
+test(
+    {setup, Where, Setup, TearDown, Tests},
+    Identification,
+    Options,
+    #state{instantiator_arg = InstantiatorArg0, runner = PreviousRunner} = State0
+) ->
+    SetupResult = Setup(),
+    SubRunner =
+        case Where of
+            spawn -> undefined;
+            local -> PreviousRunner
+        end,
+    State1 = test(Tests, Identification, Options, State0#state{
+        instantiator_arg = SetupResult, runner = SubRunner
+    }),
+    TearDown(SetupResult),
+    State1#state{instantiator_arg = InstantiatorArg0, runner = PreviousRunner};
+test({timeout, Timeout, Tests}, Identification, Options, State) ->
+    test(Tests, Identification, Options, State#state{timeout = Timeout * 1000}).
+
+module_tests(_Module, [], Acc) ->
+    lists:reverse(Acc);
+module_tests(Module, [{Func, 0} | Tail], Acc) ->
+    case lists:reverse(atom_to_list(Func)) of
+        "_tset_" ++ _ ->
+            module_tests(Module, Tail, [{generator, Module, Func} | Acc]);
+        "tset_" ++ _ ->
+            module_tests(Module, Tail, [{test, Module, Func} | Acc]);
+        _ ->
+            module_tests(Module, Tail, Acc)
+    end;
+module_tests(Module, [_ | Tail], Acc) ->
+    module_tests(Module, Tail, Acc).
+
+report(Progress, Identification) ->
+    {module, Module} = lists:keyfind(module, 1, Identification),
+    {test_case, TestCase} = lists:keyfind(test_case, 1, Identification),
+    LineString =
+        case lists:keyfind(line, 1, Identification) of
+            false -> "";
+            {line, Line} -> io_lib:format("~B:", [Line])
+        end,
+    TitleString =
+        case lists:keyfind(title, 1, Identification) of
+            false -> "";
+            {title, Title} -> io_lib:format(" (~s)", [Title])
+        end,
+    ProgressString =
+        case Progress of
+            start -> "...";
+            {pass, Result} -> io_lib:format(":PASS:~p", [Result]);
+            {fail, Error, StackTrace} -> io_lib:format(":FAIL:~p\n~p", [Error, StackTrace]);
+            {exit, Reason} -> io_lib:format(":FAIL:exited with ~p", [Reason]);
+            timeout -> ":FAIL:timeout"
+        end,
+    io:format("~s:~s ~s~s~s\n", [Module, LineString, TestCase, TitleString, ProgressString]).
+
+run_test(Identification, TestFun, #state{total = Total} = State0) ->
+    report(start, Identification),
+    try
+        Result = TestFun(),
+        report({pass, Result}, Identification),
+        State0#state{total = Total + 1}
+    catch
+        error:Error:StackTrace ->
+            report({fail, Error, StackTrace}, Identification),
+            State0#state{total = Total + 1, failures = State0#state.failures + 1}
+    end.
+
+start() ->
+    TestModules = lists:foldl(
+        fun({ModuleName, _, _}, Acc) ->
+            Module = binary_to_atom(iolist_to_binary(ModuleName), utf8),
+            ExportsModule = Module:module_info(exports),
+            case lists:member({test, 0}, ExportsModule) of
+                true -> [Module | Acc];
+                false -> Acc
+            end
+        end,
+        [],
+        code:all_available()
+    ),
+    test(TestModules, [exact_execution]),
+    ok.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,7 @@ target_link_libraries(test-structs PRIVATE libAtomVM libAtomVM${PLATFORM_LIB_SUF
 if (NOT "${CMAKE_GENERATOR}" MATCHES "Xcode")
     add_dependencies(test-erlang erlang_test_modules)
     add_subdirectory(erlang_tests)
+    add_subdirectory(libs/etest)
     add_subdirectory(libs/estdlib)
     add_subdirectory(libs/eavmlib)
     add_subdirectory(libs/alisp)

--- a/tests/libs/etest/CMakeLists.txt
+++ b/tests/libs/etest/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # This file is part of AtomVM.
 #
-# Copyright 2018-2020 Fred Dushin <fred@dushin.net>
+# Copyright 2024 Paul Guyot <pguyot@kallisys.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,13 +18,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-project(estest)
+project(test_etest)
 
 include(BuildErlang)
 
 set(ERLANG_MODULES
-    etest
-    eunit
+    test_eunit
 )
 
-pack_archive(etest ${ERLANG_MODULES})
+pack_archive(test_etest_lib ERLC_FLAGS -DTEST MODULES ${ERLANG_MODULES})
+pack_eunit(test_etest estdlib eavmlib etest)

--- a/tests/libs/etest/test_eunit.erl
+++ b/tests/libs/etest/test_eunit.erl
@@ -1,0 +1,65 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_eunit).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+assert_true_test() ->
+    ?assert(true).
+
+generator_test_() ->
+    ?_assert(true).
+
+generator_list_test_() ->
+    [
+        ?_assert(true),
+        ?_assert(true)
+    ].
+
+simple_spawn_test_() ->
+    {
+        spawn,
+        ?_assert(true)
+    }.
+
+spawn_common_process_test_() ->
+    {
+        spawn,
+        {inorder, [
+            ?_test(begin
+                put(val, 42)
+            end),
+            ?_assertEqual(42, get(val))
+        ]}
+    }.
+
+setup_test_() ->
+    {
+        setup,
+        fun() ->
+            register(setup_process, self())
+        end,
+        ?_test(begin
+            ?assertNotEqual(undefined, whereis(setup_process))
+        end)
+    }.


### PR DESCRIPTION
Add a simplified implementation of eunit interface, with an output compatible
with unity test as parsed by Python dut module for qemu-based eunit testing.

Eunit can be used on rebar3 projects on generic_unix on both BEAM and AtomVM
with:

```shell
rebar3 eunit
rebar3 as test atomvm packbeam
atomvm ${ATOMVMDIR}/build/libs/etest/src/beams/eunit.beam \
    ${ATOMVMDIR}/build/libs/atomvmlib.avm \
    _build/test/lib/*.avm
```

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
