### PR TITLE
Update build matrices and set OTP27 as the default

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -33,12 +33,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  otp_version: 24
-  elixir_version: 1.14
+  otp_version: 27
+  elixir_version: 1.17
 
 jobs:
   compile_tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
 
   build-and-test-other:
     needs: compile_tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -40,141 +40,201 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: ["ubuntu-20.04", "ubuntu-22.04"]
-        cc: ["gcc-7", "gcc-8", "gcc-9", "gcc-10", "gcc-11", "gcc-12", "clang-10", "clang-11"]
-        # cc: ["gcc-7", "gcc-8", "gcc-9", "gcc-10", "gcc-11", "gcc-12", "clang-10", "clang-11", "clang-12", "clang-13", "clang-14"]
-        cflags: ["-O3"]
-        otp: ["21", "22", "23", "24", "25", "master"]
-
-        exclude:
-        # Ubuntu 22.04 with setup-beam only has OTP >= 24.2
-        - os: "ubuntu-22.04"
-          otp: "21"
-        - os: "ubuntu-22.04"
-          otp: "22"
-        - os: "ubuntu-22.04"
-          otp: "23"
-
         # Ubuntu 20.04 has gcc from 7 to 10 ("gcc" is gcc-9)
         # Ubuntu 22.04 has gcc from 9 to 12 ("gcc" is gcc-11)
+        # Ubuntu 24.04 has gcc from 9 to 14 ("gcc" is gcc-13)
         # Ubuntu 20.04 has clang 10 and 12 to  ("clang" is 10)
-        # Ubuntu 22.04 has clang from 12 to 14 ("clang" is 14)
+        # Ubuntu 22.04 has clang from 12 to 15 ("clang" is 14)
+        # Ubuntu 24.04 has clang from 14 to 18 ("clang" is 18)
         # We want to test every compiler but don't need to test every OS
-        # and we favor later Ubuntu 22.04 + defaults
-        - os: "ubuntu-22.04"
-          cc: "gcc-7"
-        - os: "ubuntu-22.04"
-          cc: "gcc-8"
-        - os: "ubuntu-20.04"
-          cc: "gcc-10"
-        - os: "ubuntu-20.04"
-          cc: "gcc-11"
-        - os: "ubuntu-20.04"
-          cc: "gcc-12"
-        - os: "ubuntu-22.04"
-          cc: "clang-10"
-        - os: "ubuntu-22.04"
-          cc: "clang-11"
-#       - os: "ubuntu-20.04"
-#         cc: "clang-12"
-#       - os: "ubuntu-20.04"
-#         cc: "clang-13"
-#       - os: "ubuntu-20.04"
-#         cc: "clang-14"
+        # We only test several OTP versions with default compilers (gcc-9, 11, 13, clang-10, 14, 18)
+        cc: ["gcc-9", "gcc-11", "gcc-13", "clang-10", "clang-14", "clang-18"]
+        cflags: ["-O3"]
+        otp: ["25", "26", "27"]
 
         include:
         - cc: "gcc-7"
           cxx: "g++-7"
           compiler_pkgs: "gcc-7 g++-7"
+          os: "ubuntu-20.04"
+          otp: "27"
         - cc: "gcc-8"
           cxx: "g++-8"
           compiler_pkgs: "gcc-8 g++-8"
+          os: "ubuntu-20.04"
+          otp: "27"
         - cc: "gcc-9"
           cxx: "g++-9"
           compiler_pkgs: "gcc-9 g++-9"
+          os: "ubuntu-20.04"
+          # otp: all
         - cc: "gcc-10"
           cxx: "g++-10"
           compiler_pkgs: "gcc-10 g++-10"
           # Use Werror for recent GCC versions that have better diagnostics
           cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-22.04"
+          otp: "27"
         - cc: "gcc-11"
           cxx: "g++-11"
           compiler_pkgs: "gcc-11 g++-11"
           # Use Werror for recent GCC versions that have better diagnostics
           cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-22.04"
+          # otp: all
         - cc: "gcc-12"
           cxx: "g++-12"
           compiler_pkgs: "gcc-12 g++-12"
           # Use Werror for recent GCC versions that have better diagnostics
           cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-24.04"
+          otp: "27"
+        - cc: "gcc-13"
+          cxx: "g++-13"
+          compiler_pkgs: "gcc-13 g++-13"
+          # Use Werror for recent GCC versions that have better diagnostics
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-24.04"
+          # otp: all
+        - cc: "gcc-14"
+          cxx: "g++-14"
+          compiler_pkgs: "gcc-14 g++-14"
+          # Use Werror for recent GCC versions that have better diagnostics
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-24.04"
+          otp: "27"
+
         - cc: "clang-10"
           cxx: "clang++-10"
           compiler_pkgs: "clang-10"
           cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-20.04"
+          # otp: all
         - cc: "clang-11"
           cxx: "clang++-11"
           compiler_pkgs: "clang-11"
           cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
-#       - cc: "clang-12"
-#         cxx: "clang++-12"
-#         compiler_pkgs: "clang-12"
-#       - cc: "clang-13"
-#         cxx: "clang++-13"
-#         compiler_pkgs: "clang-13"
-#       - cc: "clang-14"
-#         cxx: "clang++-14"
-#         compiler_pkgs: "clang-14"
-
-
-        - otp: "21"
-          elixir_version: "1.7"
-
-        - otp: "22"
-          elixir_version: "1.8"
-
-        - otp: "23"
-          elixir_version: "1.11"
-
-        - otp: "24"
-          elixir_version: "1.14"
+          os: "ubuntu-20.04"
+          otp: "27"
+        - cc: "clang-12"
+          cxx: "clang++-12"
+          compiler_pkgs: "clang-12"
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-22.04"
+          otp: "27"
+        - cc: "clang-13"
+          cxx: "clang++-13"
+          compiler_pkgs: "clang-13"
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-22.04"
+          otp: "27"
+        - cc: "clang-14"
+          cxx: "clang++-14"
+          compiler_pkgs: "clang-14"
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-22.04"
+          # otp: all
+        - cc: "clang-15"
+          cxx: "clang++-15"
+          compiler_pkgs: "clang-15"
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-24.04"
+          otp: "27"
+        - cc: "clang-16"
+          cxx: "clang++-16"
+          compiler_pkgs: "clang-16"
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-24.04"
+          otp: "27"
+        - cc: "clang-17"
+          cxx: "clang++-17"
+          compiler_pkgs: "clang-17"
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-24.04"
+          otp: "27"
+        - cc: "clang-18"
+          cxx: "clang++-18"
+          compiler_pkgs: "clang-18"
+          cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
+          os: "ubuntu-24.04"
+          # otp: all
 
         - otp: "25"
           elixir_version: "1.14"
 
-        - otp: "master"
+        - otp: "26"
+          elixir_version: "1.17"
+
+        - otp: "27"
+          elixir_version: "1.17"
+
+        # Old versions of OTP/Elixir
+        - os: "ubuntu-20.04"
+          cc: "cc"
+          cxx: "c++"
+          otp: "21"
+          cflags: ""
+          elixir_version: "1.7"
+
+        - os: "ubuntu-20.04"
+          cc: "cc"
+          cxx: "c++"
+          otp: "22"
+          cflags: ""
+          elixir_version: "1.8"
+
+        - os: "ubuntu-20.04"
+          cc: "cc"
+          cxx: "c++"
+          otp: "23"
+          cflags: ""
+          elixir_version: "1.11"
+
+        - os: "ubuntu-22.04"
+          cc: "cc"
+          cxx: "c++"
+          otp: "24"
+          cflags: ""
+          elixir_version: "1.14"
+
+        # master version of OTP/Elixir
+        - os: "ubuntu-24.04"
+          cc: "cc"
+          cxx: "c++"
+          otp: "master"
           elixir_version: "master"
 
         # Additional default compiler builds
         - os: "ubuntu-20.04"
           cc: "cc"
           cxx: "c++"
-          otp: "25"
+          otp: "27"
           cflags: ""
-          elixir_version: "1.14"
+          elixir_version: "1.17"
 
         - os: "ubuntu-22.04"
           cc: "cc"
           cxx: "c++"
-          otp: "25"
+          otp: "27"
           cflags: ""
-          elixir_version: "1.14"
+          elixir_version: "1.17"
 
         # Additional latest & -Os compiler builds
-        - os: "ubuntu-22.04"
-          cc: "gcc-12"
-          cxx: "g++-12"
-          otp: "24"
+        - os: "ubuntu-24.04"
+          cc: "gcc-14"
+          cxx: "g++-14"
+          otp: "27"
           cflags: "-Os"
-          elixir_version: "1.14"
-          compiler_pkgs: "gcc-12 g++-12"
+          elixir_version: "1.17"
+          compiler_pkgs: "gcc-14 g++-14"
 
-#       - os: "ubuntu-22.04"
-#         cc: "clang-14"
-#         cxx: "clang++-14"
-#         otp: "24"
-#         cflags: "-Os"
-#         elixir_version: "1.14"
-#         compiler_pkgs: "clang-14"
+        - os: "ubuntu-24.04"
+          cc: "clang-18"
+          cxx: "clang++-18"
+          otp: "27"
+          cflags: "-Os"
+          elixir_version: "1.17"
+          compiler_pkgs: "clang-18"
 
         # Additional 32 bits build
         - os: "ubuntu-20.04"

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -52,18 +52,23 @@ jobs:
           test_erlang_opts: "-s prime_smp"
           otp: "23"
 
-        - os: "ubuntu-22.04"
+        - os: "ubuntu-24.04"
           test_erlang_opts: "-s prime_smp"
           otp: "24"
 
-        - os: "ubuntu-22.04"
+        - os: "ubuntu-24.04"
           test_erlang_opts: "-s prime_smp"
           otp: "25"
 
-        - os: "ubuntu-22.04"
+        - os: "ubuntu-24.04"
           test_erlang_opts: "-s prime_smp,test_gc"
           otp: "26"
           container: erlang:26
+
+        - os: "ubuntu-24.04"
+          test_erlang_opts: "-s prime_smp,test_gc"
+          otp: "27"
+          container: erlang:27
 
         # This is ARM64
         - os: "macos-14"

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -580,7 +580,13 @@ void sys_init_platform(GlobalContext *global)
 #else
     platform->listeners_poll_count = -1;
     platform->select_events_poll_count = -1;
+#if __GNUC__ >= 14
+#pragma GCC diagnostic ignored "-Walloc-size"
+#endif
     platform->fds = malloc(0);
+#if __GNUC__ >= 14
+#pragma GCC diagnostic pop
+#endif
 #ifndef AVM_NO_SMP
 #ifdef HAVE_EVENTFD
     int signal_fd = eventfd(0, EFD_NONBLOCK);

--- a/tests/libs/estdlib/test_io_lib.erl
+++ b/tests/libs/estdlib/test_io_lib.erl
@@ -112,8 +112,18 @@ test() ->
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [{bar, "tapas"}])), "foo: {bar,\"tapas\"}\n"),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [#{}])), "foo: #{}\n"),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [#{a => 1}])), "foo: #{a => 1}\n"),
-    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p", [#{a => 1, b => 2}])), "foo: #{a => 1,b => 2}"),
-    ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p", [#{b => 2, a => 1}])), "foo: #{a => 1,b => 2}"),
+    % OTP-27 can return either map representations
+    % https://github.com/erlang/otp/issues/8606
+    ?ASSERT_TRUE(
+        lists:member(?FLT(io_lib:format("foo: ~p", [#{a => 1, b => 2}])), [
+            "foo: #{a => 1,b => 2}", "foo: #{b => 2,a => 1}"
+        ])
+    ),
+    ?ASSERT_TRUE(
+        lists:member(?FLT(io_lib:format("foo: ~p", [#{b => 2, a => 1}])), [
+            "foo: #{a => 1,b => 2}", "foo: #{b => 2,a => 1}"
+        ])
+    ),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p", [#{{x, y} => z}])), "foo: #{{x,y} => z}"),
     ?ASSERT_MATCH(
         ?FLT(io_lib:format("foo: ~p", [#{"foo" => "bar"}])), "foo: #{\"foo\" => \"bar\"}"
@@ -122,11 +132,21 @@ test() ->
     ?ASSERT_MATCH(?FLT(io_lib:format("~p", [foo])), "foo"),
     ?ASSERT_MATCH(?FLT(io_lib:format("~p", ['-foo'])), "'-foo'"),
     ?ASSERT_MATCH(?FLT(io_lib:format("~p", ['try'])), "'try'"),
-    ?ASSERT_MATCH(?FLT(io_lib:format("~p", ['maybe'])), "maybe"),
+    MaybeAtomStr =
+        case erlang:system_info(machine) of
+            "BEAM" ->
+                case erlang:system_info(version) >= "15." of
+                    true -> "'maybe'";
+                    false -> "maybe"
+                end;
+            "ATOM" ->
+                "maybe"
+        end,
+    ?ASSERT_MATCH(?FLT(io_lib:format("~p", ['maybe'])), MaybeAtomStr),
     ?ASSERT_MATCH(?FLT(io_lib:format("~w", [foo])), "foo"),
     ?ASSERT_MATCH(?FLT(io_lib:format("~w", ['-foo'])), "'-foo'"),
     ?ASSERT_MATCH(?FLT(io_lib:format("~w", ['try'])), "'try'"),
-    ?ASSERT_MATCH(?FLT(io_lib:format("~w", ['maybe'])), "maybe"),
+    ?ASSERT_MATCH(?FLT(io_lib:format("~w", ['maybe'])), MaybeAtomStr),
     ?ASSERT_MATCH(?FLT(io_lib:format("~s", [foo])), "foo"),
     ?ASSERT_MATCH(?FLT(io_lib:format("~s", ['-foo'])), "-foo"),
     ?ASSERT_MATCH(?FLT(io_lib:format("~s", ['try'])), "try"),


### PR DESCRIPTION
* Update Linux Build matrix to favor more compilers, three latest OTP versions, while maintaining builds from 21 to master, reducing combinations from 46 to 39
* Update Run tests on BEAM workflow to include OTP27
* Update build and test on other Linuxes to use OTP27
* Fix test_io_lib for OTP27 (including workaround for https://github.com/erlang/otp/issues/8606)
* Fix compilation with gcc-14

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
