### PR TITLE
Add support for `maps:iterator/2` and ~kp with `io_lib:format/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for ESP32-H2
 - lists:keytake/3 implemented.
 - Support for setting channel used by network driver wifi access point.
+- Support for `maps:iterator/2` and `~kp` with `io_lib:format/2` that were introduced with OTP26.
 
 ### Changed
 

--- a/tests/libs/estdlib/test_io_lib.erl
+++ b/tests/libs/estdlib/test_io_lib.erl
@@ -112,8 +112,8 @@ test() ->
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [{bar, "tapas"}])), "foo: {bar,\"tapas\"}\n"),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [#{}])), "foo: #{}\n"),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p~n", [#{a => 1}])), "foo: #{a => 1}\n"),
-    % OTP-27 can return either map representations
-    % https://github.com/erlang/otp/issues/8606
+    % OTP-26+ can return either map representations
+    % https://www.erlang.org/patches/otp-26.0#OTP-18414
     ?ASSERT_TRUE(
         lists:member(?FLT(io_lib:format("foo: ~p", [#{a => 1, b => 2}])), [
             "foo: #{a => 1,b => 2}", "foo: #{b => 2,a => 1}"
@@ -124,6 +124,21 @@ test() ->
             "foo: #{a => 1,b => 2}", "foo: #{b => 2,a => 1}"
         ])
     ),
+    HasKModifier =
+        case erlang:system_info(machine) of
+            "BEAM" ->
+                erlang:system_info(version) >= "14.";
+            "ATOM" ->
+                true
+        end,
+    case HasKModifier of
+        true ->
+            ?ASSERT_MATCH(
+                ?FLT(io_lib:format("foo: ~kp~n", [#{a => 1, b => 2}])), "foo: #{a => 1,b => 2}\n"
+            );
+        false ->
+            ok
+    end,
     ?ASSERT_MATCH(?FLT(io_lib:format("foo: ~p", [#{{x, y} => z}])), "foo: #{{x,y} => z}"),
     ?ASSERT_MATCH(
         ?FLT(io_lib:format("foo: ~p", [#{"foo" => "bar"}])), "foo: #{\"foo\" => \"bar\"}"

--- a/tests/libs/estdlib/test_maps.erl
+++ b/tests/libs/estdlib/test_maps.erl
@@ -29,6 +29,22 @@ test() ->
     ok = test_is_key(),
     ok = test_put(),
     ok = test_iterator(),
+    HasIterator2 =
+        case erlang:system_info(machine) of
+            "BEAM" ->
+                erlang:system_info(version) >= "14.";
+            "ATOM" ->
+                true
+        end,
+    case HasIterator2 of
+        true ->
+            ok = test_iterator_2_undefined(),
+            ok = test_iterator_2_ordered(),
+            ok = test_iterator_2_reversed(),
+            ok = test_iterator_2_f();
+        false ->
+            ok
+    end,
     ok = test_keys(),
     ok = test_values(),
     ok = test_to_list(),
@@ -76,6 +92,71 @@ test_iterator() ->
     {YK, YV, Iterator2} = maps:next(Iterator1),
     {ZK, ZV, Iterator3} = maps:next(Iterator2),
     [{a, 1}, {b, 2}, {c, 3}] = lists:sort([{XK, XV}, {YK, YV}, {ZK, ZV}]),
+    none = maps:next(Iterator3),
+    none = maps:next(none),
+
+    EmptyMap = maps:new(),
+    EmptyIterator = maps:iterator(EmptyMap),
+    none = maps:next(EmptyIterator),
+
+    ok.
+
+test_iterator_2_undefined() ->
+    Map = #{c => 3, a => 1, b => 2},
+    Iterator0 = maps:iterator(Map, undefined),
+    {XK, XV, Iterator1} = maps:next(Iterator0),
+    {YK, YV, Iterator2} = maps:next(Iterator1),
+    {ZK, ZV, Iterator3} = maps:next(Iterator2),
+    [{a, 1}, {b, 2}, {c, 3}] = lists:sort([{XK, XV}, {YK, YV}, {ZK, ZV}]),
+    none = maps:next(Iterator3),
+    none = maps:next(none),
+
+    EmptyMap = maps:new(),
+    EmptyIterator = maps:iterator(EmptyMap),
+    none = maps:next(EmptyIterator),
+
+    ok.
+
+test_iterator_2_ordered() ->
+    Map = #{c => 3, a => 1, b => 2},
+    Iterator0 = maps:iterator(Map, ordered),
+    {a, 1, Iterator1} = maps:next(Iterator0),
+    {b, 2, Iterator2} = maps:next(Iterator1),
+    {c, 3, Iterator3} = maps:next(Iterator2),
+    none = maps:next(Iterator3),
+    none = maps:next(none),
+
+    EmptyMap = maps:new(),
+    EmptyIterator = maps:iterator(EmptyMap),
+    none = maps:next(EmptyIterator),
+
+    ok.
+
+test_iterator_2_reversed() ->
+    Map = #{c => 3, a => 1, b => 2},
+    Iterator0 = maps:iterator(Map, reversed),
+    {c, 3, Iterator1} = maps:next(Iterator0),
+    {b, 2, Iterator2} = maps:next(Iterator1),
+    {a, 1, Iterator3} = maps:next(Iterator2),
+    none = maps:next(Iterator3),
+    none = maps:next(none),
+
+    EmptyMap = maps:new(),
+    EmptyIterator = maps:iterator(EmptyMap),
+    none = maps:next(EmptyIterator),
+
+    ok.
+
+test_iterator_2_f_order(c, _) -> true;
+test_iterator_2_f_order(a, b) -> true;
+test_iterator_2_f_order(_, _) -> false.
+
+test_iterator_2_f() ->
+    Map = #{c => 3, a => 1, b => 2},
+    Iterator0 = maps:iterator(Map, fun test_iterator_2_f_order/2),
+    {c, 3, Iterator1} = maps:next(Iterator0),
+    {a, 1, Iterator2} = maps:next(Iterator1),
+    {b, 2, Iterator3} = maps:next(Iterator2),
     none = maps:next(Iterator3),
     none = maps:next(none),
 


### PR DESCRIPTION
These were introduced with OTP26 that made iteration order non-deterministic across VM executions

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
