### PR TITLE
Bump test_heap_growth timeout

### DIFF
--- a/tests/erlang_tests/test_heap_growth.erl
+++ b/tests/erlang_tests/test_heap_growth.erl
@@ -47,7 +47,7 @@ test_grow_beyond_min_heap_size() ->
     ok =
         receive
             {'DOWN', Ref1, process, Pid1, normal} -> ok
-        after 500 -> timeout
+        after 1000 -> timeout
         end,
     ok.
 


### PR DESCRIPTION
This will reduce (slightly) the flappiness of our tests

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
