### PR TITLE
Fix a bug where x0 and x1 were corrupted by failing guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for setting channel used by network driver wifi access point.
 - Support for `maps:iterator/2` and `~kp` with `io_lib:format/2` that were introduced with OTP26.
 - Support for `erlang:apply/2`
+- Support for `lists:keystore/4`
 
 ### Changed
 
@@ -31,6 +32,7 @@ in ESP-IDF Kconfig options.
 - Fix creation of multiple links for the same process and not removing link at trapped exits.
 See issue [#1193](https://github.com/atomvm/AtomVM/issues/1193).
 - Fix error that is raised when a function is undefined
+- Fix bug where failing guards would corrupt x0 and x1
 
 ## [0.6.2] - 25-05-2024
 

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -42,9 +42,16 @@
     ctx->x[1] = (error_type_atom);   \
     return term_invalid_term();
 
-#define VALIDATE_VALUE(value, verify_function) \
-    if (UNLIKELY(!verify_function((value)))) { \
-        RAISE_ERROR(BADARG_ATOM);              \
+#define RAISE_ERROR_BIF(fail_label, error_type_atom) \
+    if (fail_label == 0) {                           \
+        ctx->x[0] = ERROR_ATOM;                      \
+        ctx->x[1] = (error_type_atom);               \
+    }                                                \
+    return term_invalid_term();
+
+#define VALIDATE_VALUE_BIF(fail_label, value, verify_function) \
+    if (UNLIKELY(!verify_function((value)))) {                 \
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);              \
     }
 
 const struct ExportedFunction *bif_registry_get_handler(AtomString module, AtomString function, int arity)
@@ -65,7 +72,7 @@ term bif_erlang_self_0(Context *ctx)
     return term_from_local_process_id(ctx->process_id);
 }
 
-term bif_erlang_byte_size_1(Context *ctx, int live, term arg1)
+term bif_erlang_byte_size_1(Context *ctx, uint32_t fail_label, int live, term arg1)
 {
     UNUSED(live);
 
@@ -76,14 +83,14 @@ term bif_erlang_byte_size_1(Context *ctx, int live, term arg1)
         term src_bin = term_get_match_state_binary(arg1);
         len = term_binary_size(src_bin) - offset / 8;
     } else {
-        VALIDATE_VALUE(arg1, term_is_binary);
+        VALIDATE_VALUE_BIF(fail_label, arg1, term_is_binary);
         len = term_binary_size(arg1);
     }
 
     return term_from_int32(len);
 }
 
-term bif_erlang_bit_size_1(Context *ctx, int live, term arg1)
+term bif_erlang_bit_size_1(Context *ctx, uint32_t fail_label, int live, term arg1)
 {
     UNUSED(live);
 
@@ -94,103 +101,118 @@ term bif_erlang_bit_size_1(Context *ctx, int live, term arg1)
         term src_bin = term_get_match_state_binary(arg1);
         len = term_binary_size(src_bin) * 8 - offset;
     } else {
-        VALIDATE_VALUE(arg1, term_is_binary);
+        VALIDATE_VALUE_BIF(fail_label, arg1, term_is_binary);
         len = term_binary_size(arg1) * 8;
     }
 
     return term_from_int32(len);
 }
 
-term bif_erlang_is_atom_1(Context *ctx, term arg1)
+term bif_erlang_is_atom_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     return term_is_atom(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_binary_1(Context *ctx, term arg1)
+term bif_erlang_is_binary_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     return term_is_binary(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_boolean_1(Context *ctx, term arg1)
+term bif_erlang_is_boolean_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     return (arg1 == TRUE_ATOM || arg1 == FALSE_ATOM) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_float_1(Context *ctx, term arg1)
+term bif_erlang_is_float_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     return term_is_float(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_function_1(Context *ctx, term arg1)
+term bif_erlang_is_function_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     return term_is_function(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_integer_1(Context *ctx, term arg1)
+term bif_erlang_is_integer_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     return term_is_any_integer(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_list_1(Context *ctx, term arg1)
+term bif_erlang_is_list_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     return term_is_list(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_number_1(Context *ctx, term arg1)
+term bif_erlang_is_number_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     //TODO: change to term_is_number
     return term_is_any_integer(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_pid_1(Context *ctx, term arg1)
+term bif_erlang_is_pid_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     return term_is_pid(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_reference_1(Context *ctx, term arg1)
+term bif_erlang_is_reference_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     return term_is_reference(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_tuple_1(Context *ctx, term arg1)
+term bif_erlang_is_tuple_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     return term_is_tuple(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_map_1(Context *ctx, term arg1)
+term bif_erlang_is_map_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);
+    UNUSED(fail_label);
 
     return term_is_map(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
-term bif_erlang_is_map_key_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_is_map_key_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     if (UNLIKELY(!term_is_map(arg2))) {
+        if (fail_label) {
+            return term_invalid_term();
+        }
         if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &arg2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, &ctx->heap);
         term_put_tuple_element(err, 0, BADMAP_ATOM);
@@ -203,71 +225,73 @@ term bif_erlang_is_map_key_2(Context *ctx, term arg1, term arg2)
         case TERM_MAP_NOT_FOUND:
             return FALSE_ATOM;
         case TERM_MAP_MEMORY_ALLOC_FAIL:
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
         default:
             return TRUE_ATOM;
     }
 }
 
-term bif_erlang_length_1(Context *ctx, int live, term arg1)
+term bif_erlang_length_1(Context *ctx, uint32_t fail_label, int live, term arg1)
 {
     UNUSED(live);
 
-    VALIDATE_VALUE(arg1, term_is_list);
+    VALIDATE_VALUE_BIF(fail_label, arg1, term_is_list);
 
     int proper;
     avm_int_t len = term_list_length(arg1, &proper);
     if (UNLIKELY(!proper)) {
-        RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
     }
 
     return term_from_int(len);
 }
 
-term bif_erlang_hd_1(Context *ctx, term arg1)
+term bif_erlang_hd_1(Context *ctx, uint32_t fail_label, term arg1)
 {
-    VALIDATE_VALUE(arg1, term_is_nonempty_list);
+    VALIDATE_VALUE_BIF(fail_label, arg1, term_is_nonempty_list);
 
     return term_get_list_head(arg1);
 }
 
-term bif_erlang_tl_1(Context *ctx, term arg1)
+term bif_erlang_tl_1(Context *ctx, uint32_t fail_label, term arg1)
 {
-    VALIDATE_VALUE(arg1, term_is_nonempty_list);
+    VALIDATE_VALUE_BIF(fail_label, arg1, term_is_nonempty_list);
 
     return term_get_list_tail(arg1);
 }
 
-term bif_erlang_element_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_element_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
-    VALIDATE_VALUE(arg1, term_is_integer);
-    VALIDATE_VALUE(arg2, term_is_tuple);
+    VALIDATE_VALUE_BIF(fail_label, arg1, term_is_integer);
+    VALIDATE_VALUE_BIF(fail_label, arg2, term_is_tuple);
 
     // indexes are 1 based
     int elem_index = term_to_int32(arg1) - 1;
     if (LIKELY((elem_index >= 0) && (elem_index < term_get_tuple_arity(arg2)))) {
         return term_get_tuple_element(arg2, elem_index);
-
     } else {
-        RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
     }
 }
 
-term bif_erlang_tuple_size_1(Context *ctx, term arg1)
+term bif_erlang_tuple_size_1(Context *ctx, uint32_t fail_label, term arg1)
 {
-    VALIDATE_VALUE(arg1, term_is_tuple);
+    VALIDATE_VALUE_BIF(fail_label, arg1, term_is_tuple);
 
     return term_from_int32(term_get_tuple_arity(arg1));
 }
 
-term bif_erlang_map_size_1(Context *ctx, int live, term arg1)
+term bif_erlang_map_size_1(Context *ctx, uint32_t fail_label, int live, term arg1)
 {
     UNUSED(live);
 
     if (!UNLIKELY(term_is_map(arg1))) {
+        if (fail_label) {
+            return term_invalid_term();
+        }
         // We don't need to preserve registers as we're raising
         if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &arg1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, &ctx->heap);
         term_put_tuple_element(err, 0, BADMAP_ATOM);
@@ -279,12 +303,15 @@ term bif_erlang_map_size_1(Context *ctx, int live, term arg1)
     return term_from_int32(term_get_map_size(arg1));
 }
 
-term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_map_get_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     if (!UNLIKELY(term_is_map(arg2))) {
+        if (fail_label) {
+            return term_invalid_term();
+        }
         // We don't need to preserve registers as we're raising
         if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &arg2, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, &ctx->heap);
         term_put_tuple_element(err, 0, BADMAP_ATOM);
@@ -295,9 +322,12 @@ term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
 
     int pos = term_find_map_pos(arg2, arg1, ctx->global);
     if (pos == TERM_MAP_NOT_FOUND) {
+        if (fail_label) {
+            return term_invalid_term();
+        }
         // We don't need to preserve registers as we're raising
         if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &arg1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
         }
         term err = term_alloc_tuple(2, &ctx->heap);
         term_put_tuple_element(err, 0, BADKEY_ATOM);
@@ -305,35 +335,35 @@ term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2)
 
         RAISE_ERROR(err);
     } else if (UNLIKELY(pos == TERM_MAP_MEMORY_ALLOC_FAIL)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
     return term_get_map_value(arg2, pos);
 }
 
-static inline term make_boxed_int(Context *ctx, uint32_t live, avm_int_t value)
+static inline term make_boxed_int(Context *ctx, uint32_t fail_label, uint32_t live, avm_int_t value)
 {
     if (UNLIKELY(memory_ensure_free_with_roots(ctx, BOXED_INT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
 
     return term_make_boxed_int(value, &ctx->heap);
 }
 
 #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-static inline term make_boxed_int64(Context *ctx, uint32_t live, avm_int64_t value)
+static inline term make_boxed_int64(Context *ctx, uint32_t fail_label, uint32_t live, avm_int64_t value)
 {
     if (UNLIKELY(memory_ensure_free_with_roots(ctx, BOXED_INT64_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
 
     return term_make_boxed_int64(value, &ctx->heap);
 }
 #endif
 
-static inline term make_maybe_boxed_int(Context *ctx, uint32_t live, avm_int_t value)
+static inline term make_maybe_boxed_int(Context *ctx, uint32_t fail_label, uint32_t live, avm_int_t value)
 {
     if ((value < MIN_NOT_BOXED_INT) || (value > MAX_NOT_BOXED_INT)) {
-        return make_boxed_int(ctx, live, value);
+        return make_boxed_int(ctx, fail_label, live, value);
 
     } else {
         return term_from_int(value);
@@ -341,13 +371,13 @@ static inline term make_maybe_boxed_int(Context *ctx, uint32_t live, avm_int_t v
 }
 
 #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-static inline term make_maybe_boxed_int64(Context *ctx, uint32_t live, avm_int64_t value)
+static inline term make_maybe_boxed_int64(Context *ctx, uint32_t fail_label, uint32_t live, avm_int64_t value)
 {
     if ((value < AVM_INT_MIN) || (value > AVM_INT_MAX)) {
-        return make_boxed_int64(ctx, live, value);
+        return make_boxed_int64(ctx, fail_label, live, value);
 
     } else if ((value < MIN_NOT_BOXED_INT) || (value > MAX_NOT_BOXED_INT)) {
-        return make_boxed_int(ctx, live, value);
+        return make_boxed_int(ctx, fail_label, live, value);
 
     } else {
         return term_from_int(value);
@@ -355,15 +385,15 @@ static inline term make_maybe_boxed_int64(Context *ctx, uint32_t live, avm_int64
 }
 #endif
 
-static term add_overflow_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term add_overflow_helper(Context *ctx, uint32_t fail_label, uint32_t live, term arg1, term arg2)
 {
     avm_int_t val1 = term_to_int(arg1);
     avm_int_t val2 = term_to_int(arg2);
 
-    return make_boxed_int(ctx, live, val1 + val2);
+    return make_boxed_int(ctx, fail_label, live, val1 + val2);
 }
 
-static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term add_boxed_helper(Context *ctx, uint32_t fail_label, uint32_t live, term arg1, term arg2)
 {
     int use_float = 0;
     int size = 0;
@@ -373,7 +403,7 @@ static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
         use_float = 1;
     } else if (!term_is_integer(arg1)) {
         TRACE("error: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 
     if (term_is_boxed_integer(arg2)) {
@@ -382,7 +412,7 @@ static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
         use_float = 1;
     } else if (!term_is_integer(arg2)) {
         TRACE("error: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 
     if (use_float) {
@@ -390,11 +420,11 @@ static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
         avm_float_t farg2 = term_conv_to_float(arg2);
         avm_float_t fresult = farg1 + farg2;
         if (UNLIKELY(!isfinite(fresult))) {
-            RAISE_ERROR(BADARITH_ATOM);
+            RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
         }
 
         if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, &ctx->heap);
     }
@@ -413,17 +443,17 @@ static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
             if (BUILTIN_ADD_OVERFLOW_INT(val1, val2, &res)) {
                 #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
                     avm_int64_t res64 = (avm_int64_t) val1 + (avm_int64_t) val2;
-                    return make_boxed_int64(ctx, live, res64);
+                    return make_boxed_int64(ctx, fail_label, live, res64);
 
                 #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                     TRACE("overflow: arg1: " AVM_INT64_FMT ", arg2: " AVM_INT64_FMT "\n", arg1, arg2);
-                    RAISE_ERROR(OVERFLOW_ATOM);
+                    RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
                 #else
                     #error "Unsupported configuration."
                 #endif
             }
 
-            return make_maybe_boxed_int(ctx, live, res);
+            return make_maybe_boxed_int(ctx, fail_label, live, res);
         }
 
     #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
@@ -435,19 +465,19 @@ static term add_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
 
             if (BUILTIN_ADD_OVERFLOW_INT64(val1, val2, &res)) {
                 TRACE("overflow: val1: " AVM_INT64_FMT ", val2: " AVM_INT64_FMT "\n", arg1, arg2);
-                RAISE_ERROR(OVERFLOW_ATOM);
+                RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
             }
 
-            return make_maybe_boxed_int64(ctx, live, res);
+            return make_maybe_boxed_int64(ctx, fail_label, live, res);
         }
     #endif
 
         default:
-            RAISE_ERROR(OVERFLOW_ATOM);
+            RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
     }
 }
 
-term bif_erlang_add_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_add_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
     UNUSED(live);
 
@@ -457,22 +487,22 @@ term bif_erlang_add_2(Context *ctx, int live, term arg1, term arg2)
         if (!BUILTIN_ADD_OVERFLOW((avm_int_t) (arg1 & ~TERM_INTEGER_TAG), (avm_int_t) (arg2 & ~TERM_INTEGER_TAG), &res)) {
             return res | TERM_INTEGER_TAG;
         } else {
-            return add_overflow_helper(ctx, live, arg1, arg2);
+            return add_overflow_helper(ctx, fail_label, live, arg1, arg2);
         }
     } else {
-        return add_boxed_helper(ctx, live, arg1, arg2);
+        return add_boxed_helper(ctx, fail_label, live, arg1, arg2);
     }
 }
 
-static term sub_overflow_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term sub_overflow_helper(Context *ctx, uint32_t fail_label, uint32_t live, term arg1, term arg2)
 {
     avm_int_t val1 = term_to_int(arg1);
     avm_int_t val2 = term_to_int(arg2);
 
-    return make_boxed_int(ctx, live, val1 - val2);
+    return make_boxed_int(ctx, fail_label, live, val1 - val2);
 }
 
-static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term sub_boxed_helper(Context *ctx, uint32_t fail_label, uint32_t live, term arg1, term arg2)
 {
     int use_float = 0;
     int size = 0;
@@ -482,7 +512,7 @@ static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
         use_float = 1;
     } else if (!term_is_integer(arg1)) {
         TRACE("error: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 
     if (term_is_boxed_integer(arg2)) {
@@ -491,7 +521,7 @@ static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
         use_float = 1;
     } else if (!term_is_integer(arg2)) {
         TRACE("error: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 
     if (use_float) {
@@ -499,10 +529,10 @@ static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
         avm_float_t farg2 = term_conv_to_float(arg2);
         avm_float_t fresult = farg1 - farg2;
         if (UNLIKELY(!isfinite(fresult))) {
-            RAISE_ERROR(BADARITH_ATOM);
+            RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
         }
         if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, &ctx->heap);
     }
@@ -521,17 +551,17 @@ static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
             if (BUILTIN_SUB_OVERFLOW_INT(val1, val2, &res)) {
                 #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
                     avm_int64_t res64 = (avm_int64_t) val1 - (avm_int64_t) val2;
-                    return make_boxed_int64(ctx, live, res64);
+                    return make_boxed_int64(ctx, fail_label, live, res64);
 
                 #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                     TRACE("overflow: arg1: " AVM_INT64_FMT ", arg2: " AVM_INT64_FMT "\n", arg1, arg2);
-                    RAISE_ERROR(OVERFLOW_ATOM);
+                    RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
                 #else
                     #error "Unsupported configuration."
                 #endif
             }
 
-            return make_maybe_boxed_int(ctx, live, res);
+            return make_maybe_boxed_int(ctx, fail_label, live, res);
         }
 
     #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
@@ -543,19 +573,19 @@ static term sub_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
 
             if (BUILTIN_SUB_OVERFLOW_INT64(val1, val2, &res)) {
                 TRACE("overflow: val1: " AVM_INT64_FMT ", val2: " AVM_INT64_FMT "\n", arg1, arg2);
-                RAISE_ERROR(OVERFLOW_ATOM);
+                RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
             }
 
-            return make_maybe_boxed_int64(ctx, live, res);
+            return make_maybe_boxed_int64(ctx, fail_label, live, res);
         }
     #endif
 
         default:
-            RAISE_ERROR(OVERFLOW_ATOM);
+            RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
     }
 }
 
-term bif_erlang_sub_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_sub_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
     UNUSED(live);
 
@@ -565,14 +595,14 @@ term bif_erlang_sub_2(Context *ctx, int live, term arg1, term arg2)
         if (!BUILTIN_SUB_OVERFLOW((avm_int_t) (arg1 & ~TERM_INTEGER_TAG), (avm_int_t) (arg2 & ~TERM_INTEGER_TAG), &res)) {
             return res | TERM_INTEGER_TAG;
         } else {
-            return sub_overflow_helper(ctx, live, arg1, arg2);
+            return sub_overflow_helper(ctx, fail_label, live, arg1, arg2);
         }
     } else {
-        return sub_boxed_helper(ctx, live, arg1, arg2);
+        return sub_boxed_helper(ctx, fail_label, live, arg1, arg2);
     }
 }
 
-static term mul_overflow_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term mul_overflow_helper(Context *ctx, uint32_t fail_label, uint32_t live, term arg1, term arg2)
 {
     avm_int_t val1 = term_to_int(arg1);
     avm_int_t val2 = term_to_int(arg2);
@@ -583,19 +613,19 @@ static term mul_overflow_helper(Context *ctx, uint32_t live, term arg1, term arg
 #endif
 
     if (!BUILTIN_MUL_OVERFLOW_INT(val1, val2, &res)) {
-        return make_boxed_int(ctx, live, res);
+        return make_boxed_int(ctx, fail_label, live, res);
 
 #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
     } else if (!BUILTIN_MUL_OVERFLOW_INT64((avm_int64_t) val1, (avm_int64_t) val2, &res64)) {
-        return make_boxed_int64(ctx, live, res64);
+        return make_boxed_int64(ctx, fail_label, live, res64);
 #endif
 
     } else {
-        RAISE_ERROR(OVERFLOW_ATOM);
+        RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
     }
 }
 
-static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term mul_boxed_helper(Context *ctx, uint32_t fail_label, uint32_t live, term arg1, term arg2)
 {
     int use_float = 0;
     int size = 0;
@@ -605,7 +635,7 @@ static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
         use_float = 1;
     } else if (!term_is_integer(arg1)) {
         TRACE("error: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 
     if (term_is_boxed_integer(arg2)) {
@@ -614,7 +644,7 @@ static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
         use_float = 1;
     } else if (!term_is_integer(arg2)) {
         TRACE("error: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 
     if (use_float) {
@@ -622,10 +652,10 @@ static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
         avm_float_t farg2 = term_conv_to_float(arg2);
         avm_float_t fresult = farg1 * farg2;
         if (UNLIKELY(!isfinite(fresult))) {
-            RAISE_ERROR(BADARITH_ATOM);
+            RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
         }
         if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, &ctx->heap);
     }
@@ -644,17 +674,17 @@ static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
             if (BUILTIN_MUL_OVERFLOW_INT(val1, val2, &res)) {
                 #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
                     avm_int64_t res64 = (avm_int64_t) val1 * (avm_int64_t) val2;
-                    return make_boxed_int64(ctx, live, res64);
+                    return make_boxed_int64(ctx, fail_label, live, res64);
 
                 #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                     TRACE("overflow: arg1: " AVM_INT64_FMT ", arg2: " AVM_INT64_FMT "\n", arg1, arg2);
-                    RAISE_ERROR(OVERFLOW_ATOM);
+                    RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
                 #else
                     #error "Unsupported configuration."
                 #endif
             }
 
-            return make_maybe_boxed_int(ctx, live, res);
+            return make_maybe_boxed_int(ctx, fail_label, live, res);
         }
 
     #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
@@ -666,19 +696,19 @@ static term mul_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
 
             if (BUILTIN_MUL_OVERFLOW_INT64(val1, val2, &res)) {
                 TRACE("overflow: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-                RAISE_ERROR(OVERFLOW_ATOM);
+                RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
             }
 
-            return make_maybe_boxed_int64(ctx, live, res);
+            return make_maybe_boxed_int64(ctx, fail_label, live, res);
         }
     #endif
 
         default:
-            RAISE_ERROR(OVERFLOW_ATOM);
+            RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
     }
 }
 
-term bif_erlang_mul_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_mul_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
     UNUSED(live);
 
@@ -689,27 +719,27 @@ term bif_erlang_mul_2(Context *ctx, int live, term arg1, term arg2)
         if (!BUILTIN_MUL_OVERFLOW(a, b, &res)) {
             return res | TERM_INTEGER_TAG;
         } else {
-            return mul_overflow_helper(ctx, live, arg1, arg2);
+            return mul_overflow_helper(ctx, fail_label, live, arg1, arg2);
         }
     } else {
-        return mul_boxed_helper(ctx, live, arg1, arg2);
+        return mul_boxed_helper(ctx, fail_label, live, arg1, arg2);
     }
 }
 
-static term div_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term div_boxed_helper(Context *ctx, uint32_t fail_label, uint32_t live, term arg1, term arg2)
 {
     int size = 0;
     if (term_is_boxed_integer(arg1)) {
         size = term_boxed_size(arg1);
     } else if (UNLIKELY(!term_is_integer(arg1))) {
         TRACE("error: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
     if (term_is_boxed_integer(arg2)) {
         size |= term_boxed_size(arg2);
     } else if (UNLIKELY(!term_is_integer(arg2))) {
         TRACE("error: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 
     switch (size) {
@@ -722,19 +752,19 @@ static term div_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
             avm_int_t val1 = term_maybe_unbox_int(arg1);
             avm_int_t val2 = term_maybe_unbox_int(arg2);
             if (UNLIKELY(val2 == 0)) {
-                RAISE_ERROR(BADARITH_ATOM);
+                RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
 
             } else if (UNLIKELY((val2 == -1) && (val1 == AVM_INT_MIN))) {
                 #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
-                    return make_boxed_int64(ctx, live, -((avm_int64_t) AVM_INT_MIN));
+                    return make_boxed_int64(ctx, fail_label, live, -((avm_int64_t) AVM_INT_MIN));
 
                 #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                     TRACE("overflow: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-                    RAISE_ERROR(OVERFLOW_ATOM);
+                    RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
                 #endif
 
             } else {
-                return make_maybe_boxed_int(ctx, live, val1 / val2);
+                return make_maybe_boxed_int(ctx, fail_label, live, val1 / val2);
             }
         }
 
@@ -744,24 +774,24 @@ static term div_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
             avm_int64_t val1 = term_maybe_unbox_int64(arg1);
             avm_int64_t val2 = term_maybe_unbox_int64(arg2);
             if (UNLIKELY(val2 == 0)) {
-                RAISE_ERROR(BADARITH_ATOM);
+                RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
 
             } else if (UNLIKELY((val2 == -1) && (val1 == INT64_MIN))) {
                 TRACE("overflow: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-                RAISE_ERROR(OVERFLOW_ATOM);
+                RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
 
             } else {
-                return make_maybe_boxed_int64(ctx, live, val1 / val2);
+                return make_maybe_boxed_int64(ctx, fail_label, live, val1 / val2);
             }
         }
         #endif
 
         default:
-            RAISE_ERROR(OVERFLOW_ATOM);
+            RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
     }
 }
 
-term bif_erlang_div_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_div_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
     UNUSED(live);
 
@@ -770,30 +800,30 @@ term bif_erlang_div_2(Context *ctx, int live, term arg1, term arg2)
         if (operand_b != 0) {
             avm_int_t res = term_to_int(arg1) / operand_b;
             if (UNLIKELY(res == -MIN_NOT_BOXED_INT)) {
-                return make_boxed_int(ctx, live, -MIN_NOT_BOXED_INT);
+                return make_boxed_int(ctx, fail_label, live, -MIN_NOT_BOXED_INT);
 
             } else {
                 return term_from_int(res);
             }
         } else {
-            RAISE_ERROR(BADARITH_ATOM);
+            RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
         }
 
     } else {
-        return div_boxed_helper(ctx, live, arg1, arg2);
+        return div_boxed_helper(ctx, fail_label, live, arg1, arg2);
     }
 }
 
-static term neg_boxed_helper(Context *ctx, uint32_t live, term arg1)
+static term neg_boxed_helper(Context *ctx, uint32_t fail_label, uint32_t live, term arg1)
 {
     if (term_is_float(arg1)) {
         avm_float_t farg1 = term_conv_to_float(arg1);
         avm_float_t fresult = -farg1;
         if (UNLIKELY(!isfinite(fresult))) {
-            RAISE_ERROR(BADARITH_ATOM);
+            RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
         }
         if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, &ctx->heap);
     }
@@ -812,18 +842,18 @@ static term neg_boxed_helper(Context *ctx, uint32_t live, term arg1)
 
                     case AVM_INT_MIN:
                         #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
-                            return make_boxed_int64(ctx, live, -((avm_int64_t) val));
+                            return make_boxed_int64(ctx, fail_label, live, -((avm_int64_t) val));
 
                         #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                             TRACE("overflow: val: " AVM_INT_FMT "\n", val);
-                            RAISE_ERROR(OVERFLOW_ATOM);
+                            RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
 
                         #else
                             #error "Unsupported configuration."
                         #endif
 
                     default:
-                        return make_boxed_int(ctx, live, -val);
+                        return make_boxed_int(ctx, fail_label, live, -val);
                 }
             }
 
@@ -833,39 +863,39 @@ static term neg_boxed_helper(Context *ctx, uint32_t live, term arg1)
 
                 if (val == INT64_MIN) {
                     TRACE("overflow: arg1: " AVM_INT64_FMT "\n", arg1);
-                    RAISE_ERROR(OVERFLOW_ATOM);
+                    RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
 
                 } else {
-                    return make_boxed_int64(ctx, live, -val);
+                    return make_boxed_int64(ctx, fail_label, live, -val);
                 }
             }
             #endif
             default:
-                RAISE_ERROR(OVERFLOW_ATOM);
+                RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
         }
     } else {
         TRACE("error: arg1: 0x%lx\n", arg1);
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 }
 
-term bif_erlang_neg_1(Context *ctx, int live, term arg1)
+term bif_erlang_neg_1(Context *ctx, uint32_t fail_label, int live, term arg1)
 {
     UNUSED(live);
 
     if (LIKELY(term_is_integer(arg1))) {
         avm_int_t int_val = term_to_int(arg1);
         if (UNLIKELY(int_val == MIN_NOT_BOXED_INT)) {
-            return make_boxed_int(ctx, live, -MIN_NOT_BOXED_INT);
+            return make_boxed_int(ctx, fail_label, live, -MIN_NOT_BOXED_INT);
         } else {
             return term_from_int(-int_val);
         }
     } else {
-        return neg_boxed_helper(ctx, live, arg1);
+        return neg_boxed_helper(ctx, fail_label, live, arg1);
     }
 }
 
-static term abs_boxed_helper(Context *ctx, uint32_t live, term arg1)
+static term abs_boxed_helper(Context *ctx, uint32_t fail_label, uint32_t live, term arg1)
 {
     if (term_is_float(arg1)) {
         avm_float_t farg1 = term_conv_to_float(arg1);
@@ -877,10 +907,10 @@ static term abs_boxed_helper(Context *ctx, uint32_t live, term arg1)
         #endif
 
         if (UNLIKELY(!isfinite(fresult))) {
-            RAISE_ERROR(BADARITH_ATOM);
+            RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
         }
         if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
         }
         return term_from_float(fresult, &ctx->heap);
     }
@@ -899,18 +929,18 @@ static term abs_boxed_helper(Context *ctx, uint32_t live, term arg1)
 
                 if (val == AVM_INT_MIN) {
                     #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
-                        return make_boxed_int64(ctx, live, -((avm_int64_t) val));
+                        return make_boxed_int64(ctx, fail_label, live, -((avm_int64_t) val));
 
                     #elif BOXED_TERMS_REQUIRED_FOR_INT64 == 1
                         TRACE("overflow: val: " AVM_INT_FMT "\n", val);
-                        RAISE_ERROR(OVERFLOW_ATOM);
+                        RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
 
                     #else
                         #error "Unsupported configuration."
                     #endif
 
                 } else {
-                    return make_boxed_int(ctx, live, -val);
+                    return make_boxed_int(ctx, fail_label, live, -val);
                 }
             }
 
@@ -923,23 +953,23 @@ static term abs_boxed_helper(Context *ctx, uint32_t live, term arg1)
 
                 if (val == INT64_MIN) {
                     TRACE("overflow: val:" AVM_INT64_FMT "\n", val);
-                    RAISE_ERROR(OVERFLOW_ATOM);
+                    RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
 
                 } else {
-                    return make_boxed_int64(ctx, live, -val);
+                    return make_boxed_int64(ctx, fail_label, live, -val);
                 }
             }
             #endif
             default:
-                RAISE_ERROR(OVERFLOW_ATOM);
+                RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
         }
     } else {
         TRACE("error: arg1: 0x%lx\n", arg1);
-        RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
     }
 }
 
-term bif_erlang_abs_1(Context *ctx, int live, term arg1)
+term bif_erlang_abs_1(Context *ctx, uint32_t fail_label, int live, term arg1)
 {
     UNUSED(live);
 
@@ -948,7 +978,7 @@ term bif_erlang_abs_1(Context *ctx, int live, term arg1)
 
         if (int_val < 0) {
             if (UNLIKELY(int_val == MIN_NOT_BOXED_INT)) {
-                return make_boxed_int(ctx, live, -MIN_NOT_BOXED_INT);
+                return make_boxed_int(ctx, fail_label, live, -MIN_NOT_BOXED_INT);
             } else {
                 return term_from_int(-int_val);
             }
@@ -957,24 +987,24 @@ term bif_erlang_abs_1(Context *ctx, int live, term arg1)
         }
 
     } else {
-        return abs_boxed_helper(ctx, live, arg1);
+        return abs_boxed_helper(ctx, fail_label, live, arg1);
     }
 }
 
-static term rem_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
+static term rem_boxed_helper(Context *ctx, uint32_t fail_label, uint32_t live, term arg1, term arg2)
 {
     int size = 0;
     if (term_is_boxed_integer(arg1)) {
         size = term_boxed_size(arg1);
     } else if (UNLIKELY(!term_is_integer(arg1))) {
         TRACE("error: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
     if (term_is_boxed_integer(arg2)) {
         size |= term_boxed_size(arg2);
     } else if (UNLIKELY(!term_is_integer(arg2))) {
         TRACE("error: arg1: 0x%lx, arg2: 0x%lx\n", arg1, arg2);
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 
     switch (size) {
@@ -987,10 +1017,10 @@ static term rem_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
             avm_int_t val1 = term_maybe_unbox_int(arg1);
             avm_int_t val2 = term_maybe_unbox_int(arg2);
             if (UNLIKELY(val2 == 0)) {
-                RAISE_ERROR(BADARITH_ATOM);
+                RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
             }
 
-            return make_maybe_boxed_int(ctx, live, val1 % val2);
+            return make_maybe_boxed_int(ctx, fail_label, live, val1 % val2);
         }
 
         #if BOXED_TERMS_REQUIRED_FOR_INT64 == 2
@@ -999,19 +1029,19 @@ static term rem_boxed_helper(Context *ctx, uint32_t live, term arg1, term arg2)
             avm_int64_t val1 = term_maybe_unbox_int64(arg1);
             avm_int64_t val2 = term_maybe_unbox_int64(arg2);
             if (UNLIKELY(val2 == 0)) {
-                RAISE_ERROR(BADARITH_ATOM);
+                RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
             }
 
-            return make_maybe_boxed_int64(ctx, live, val1 % val2);
+            return make_maybe_boxed_int64(ctx, fail_label, live, val1 % val2);
         }
         #endif
 
         default:
-            RAISE_ERROR(OVERFLOW_ATOM);
+            RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
     }
 }
 
-term bif_erlang_rem_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_rem_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
     UNUSED(live);
 
@@ -1021,22 +1051,22 @@ term bif_erlang_rem_2(Context *ctx, int live, term arg1, term arg2)
             return term_from_int(term_to_int(arg1) % operand_b);
 
         } else {
-            RAISE_ERROR(BADARITH_ATOM);
+            RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
         }
 
     } else {
-        return rem_boxed_helper(ctx, live, arg1, arg2);
+        return rem_boxed_helper(ctx, fail_label, live, arg1, arg2);
     }
 }
 
-term bif_erlang_ceil_1(Context *ctx, int live, term arg1)
+term bif_erlang_ceil_1(Context *ctx, uint32_t fail_label, int live, term arg1)
 {
     UNUSED(live);
 
     if (term_is_float(arg1)) {
         avm_float_t fvalue = term_to_float(arg1);
         if ((fvalue <= INT64_MIN_AS_AVM_FLOAT) || (fvalue >= INT64_MAX_AS_AVM_FLOAT)) {
-            RAISE_ERROR(OVERFLOW_ATOM);
+            RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
         }
 
         avm_int64_t result;
@@ -1047,9 +1077,9 @@ term bif_erlang_ceil_1(Context *ctx, int live, term arg1)
         #endif
 
         #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-            return make_maybe_boxed_int64(ctx, live, result);
+            return make_maybe_boxed_int64(ctx, fail_label, live, result);
         #else
-            return make_maybe_boxed_int(ctx, live, result);
+            return make_maybe_boxed_int(ctx, fail_label, live, result);
         #endif
     }
 
@@ -1057,18 +1087,18 @@ term bif_erlang_ceil_1(Context *ctx, int live, term arg1)
         return arg1;
 
     } else {
-        RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
     }
 }
 
-term bif_erlang_floor_1(Context *ctx, int live, term arg1)
+term bif_erlang_floor_1(Context *ctx, uint32_t fail_label, int live, term arg1)
 {
     UNUSED(live);
 
     if (term_is_float(arg1)) {
         avm_float_t fvalue = term_to_float(arg1);
         if ((fvalue <= INT64_MIN_AS_AVM_FLOAT) || (fvalue >= INT64_MAX_AS_AVM_FLOAT)) {
-            RAISE_ERROR(OVERFLOW_ATOM);
+            RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
         }
 
         avm_int64_t result;
@@ -1079,9 +1109,9 @@ term bif_erlang_floor_1(Context *ctx, int live, term arg1)
         #endif
 
         #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-            return make_maybe_boxed_int64(ctx, live, result);
+            return make_maybe_boxed_int64(ctx, fail_label, live, result);
         #else
-            return make_maybe_boxed_int(ctx, live, result);
+            return make_maybe_boxed_int(ctx, fail_label, live, result);
         #endif
     }
 
@@ -1089,18 +1119,18 @@ term bif_erlang_floor_1(Context *ctx, int live, term arg1)
         return arg1;
 
     } else {
-        RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
     }
 }
 
-term bif_erlang_round_1(Context *ctx, int live, term arg1)
+term bif_erlang_round_1(Context *ctx, uint32_t fail_label, int live, term arg1)
 {
     UNUSED(live);
 
     if (term_is_float(arg1)) {
         avm_float_t fvalue = term_to_float(arg1);
         if ((fvalue <= INT64_MIN_AS_AVM_FLOAT) || (fvalue >= INT64_MAX_AS_AVM_FLOAT)) {
-            RAISE_ERROR(OVERFLOW_ATOM);
+            RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
         }
 
         avm_int64_t result;
@@ -1111,9 +1141,9 @@ term bif_erlang_round_1(Context *ctx, int live, term arg1)
         #endif
 
         #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-            return make_maybe_boxed_int64(ctx, live, result);
+            return make_maybe_boxed_int64(ctx, fail_label, live, result);
         #else
-            return make_maybe_boxed_int(ctx, live, result);
+            return make_maybe_boxed_int(ctx, fail_label, live, result);
         #endif
     }
 
@@ -1121,18 +1151,18 @@ term bif_erlang_round_1(Context *ctx, int live, term arg1)
         return arg1;
 
     } else {
-        RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
     }
 }
 
-term bif_erlang_trunc_1(Context *ctx, int live, term arg1)
+term bif_erlang_trunc_1(Context *ctx, uint32_t fail_label, int live, term arg1)
 {
     UNUSED(live);
 
     if (term_is_float(arg1)) {
         avm_float_t fvalue = term_to_float(arg1);
         if ((fvalue <= INT64_MIN_AS_AVM_FLOAT) || (fvalue >= INT64_MAX_AS_AVM_FLOAT)) {
-            RAISE_ERROR(OVERFLOW_ATOM);
+            RAISE_ERROR_BIF(fail_label, OVERFLOW_ATOM);
         }
 
         avm_int64_t result;
@@ -1143,9 +1173,9 @@ term bif_erlang_trunc_1(Context *ctx, int live, term arg1)
         #endif
 
         #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-            return make_maybe_boxed_int64(ctx, live, result);
+            return make_maybe_boxed_int64(ctx, fail_label, live, result);
         #else
-            return make_maybe_boxed_int(ctx, live, result);
+            return make_maybe_boxed_int(ctx, fail_label, live, result);
         #endif
     }
 
@@ -1153,18 +1183,18 @@ term bif_erlang_trunc_1(Context *ctx, int live, term arg1)
         return arg1;
 
     } else {
-        RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
     }
 }
 
 typedef int64_t (*bitwise_op)(int64_t a, int64_t b);
 
-static inline term bitwise_helper(Context *ctx, int live, term arg1, term arg2, bitwise_op op)
+static inline term bitwise_helper(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2, bitwise_op op)
 {
     UNUSED(live);
 
     if (UNLIKELY(!term_is_any_integer(arg1) || !term_is_any_integer(arg2))) {
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 
     int64_t a = term_maybe_unbox_int64(arg1);
@@ -1172,9 +1202,9 @@ static inline term bitwise_helper(Context *ctx, int live, term arg1, term arg2, 
     int64_t result = op(a, b);
 
     #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-        return make_maybe_boxed_int64(ctx, live, result);
+        return make_maybe_boxed_int64(ctx, fail_label, live, result);
     #else
-        return make_maybe_boxed_int(ctx, live, result);
+        return make_maybe_boxed_int(ctx, fail_label, live, result);
     #endif
 }
 
@@ -1183,12 +1213,12 @@ static inline int64_t bor(int64_t a, int64_t b)
     return a | b;
 }
 
-term bif_erlang_bor_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_bor_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
     if (LIKELY(term_is_integer(arg1) && term_is_integer(arg2))) {
         return arg1 | arg2;
     } else {
-        return bitwise_helper(ctx, live, arg1, arg2, bor);
+        return bitwise_helper(ctx, fail_label, live, arg1, arg2, bor);
     }
 }
 
@@ -1197,12 +1227,12 @@ static inline int64_t band(int64_t a, int64_t b)
     return a & b;
 }
 
-term bif_erlang_band_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_band_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
     if (LIKELY(term_is_integer(arg1) && term_is_integer(arg2))) {
         return arg1 & arg2;
     } else {
-        return bitwise_helper(ctx, live, arg1, arg2, band);
+        return bitwise_helper(ctx, fail_label, live, arg1, arg2, band);
     }
 }
 
@@ -1211,23 +1241,23 @@ static inline int64_t bxor(int64_t a, int64_t b)
     return a ^ b;
 }
 
-term bif_erlang_bxor_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_bxor_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
     if (LIKELY(term_is_integer(arg1) && term_is_integer(arg2))) {
         return (arg1 ^ arg2) | TERM_INTEGER_TAG;
     } else {
-        return bitwise_helper(ctx, live, arg1, arg2, bxor);
+        return bitwise_helper(ctx, fail_label, live, arg1, arg2, bxor);
     }
 }
 
 typedef int64_t (*bitshift_op)(int64_t a, avm_int_t b);
 
-static inline term bitshift_helper(Context *ctx, int live, term arg1, term arg2, bitshift_op op)
+static inline term bitshift_helper(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2, bitshift_op op)
 {
     UNUSED(live);
 
     if (UNLIKELY(!term_is_any_integer(arg1) || !term_is_integer(arg2))) {
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 
     int64_t a = term_maybe_unbox_int64(arg1);
@@ -1235,9 +1265,9 @@ static inline term bitshift_helper(Context *ctx, int live, term arg1, term arg2,
     int64_t result = op(a, b);
 
     #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
-        return make_maybe_boxed_int64(ctx, live, result);
+        return make_maybe_boxed_int64(ctx, fail_label, live, result);
     #else
-        return make_maybe_boxed_int(ctx, live, result);
+        return make_maybe_boxed_int(ctx, fail_label, live, result);
     #endif
 }
 
@@ -1247,9 +1277,9 @@ static inline int64_t bsl(int64_t a, avm_int_t b)
     return a << b;
 }
 
-term bif_erlang_bsl_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_bsl_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
-    return bitshift_helper(ctx, live, arg1, arg2, bsl);
+    return bitshift_helper(ctx, fail_label, live, arg1, arg2, bsl);
 }
 
 static inline int64_t bsr(int64_t a, avm_int_t b)
@@ -1258,12 +1288,12 @@ static inline int64_t bsr(int64_t a, avm_int_t b)
     return a >> b;
 }
 
-term bif_erlang_bsr_2(Context *ctx, int live, term arg1, term arg2)
+term bif_erlang_bsr_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
-    return bitshift_helper(ctx, live, arg1, arg2, bsr);
+    return bitshift_helper(ctx, fail_label, live, arg1, arg2, bsr);
 }
 
-term bif_erlang_bnot_1(Context *ctx, int live, term arg1)
+term bif_erlang_bnot_1(Context *ctx, uint32_t fail_label, int live, term arg1)
 {
     UNUSED(live);
 
@@ -1271,11 +1301,11 @@ term bif_erlang_bnot_1(Context *ctx, int live, term arg1)
         return ~arg1 | TERM_INTEGER_TAG;
 
     } else {
-        RAISE_ERROR(BADARITH_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
     }
 }
 
-term bif_erlang_not_1(Context *ctx, term arg1)
+term bif_erlang_not_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     if (arg1 == TRUE_ATOM) {
         return FALSE_ATOM;
@@ -1284,11 +1314,11 @@ term bif_erlang_not_1(Context *ctx, term arg1)
         return TRUE_ATOM;
 
     } else {
-        RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
     }
 }
 
-term bif_erlang_and_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_and_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     if ((arg1 == FALSE_ATOM) && (arg2 == FALSE_ATOM)) {
         return FALSE_ATOM;
@@ -1303,11 +1333,11 @@ term bif_erlang_and_2(Context *ctx, term arg1, term arg2)
         return TRUE_ATOM;
 
     } else {
-        RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
     }
 }
 
-term bif_erlang_or_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_or_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     if ((arg1 == FALSE_ATOM) && (arg2 == FALSE_ATOM)) {
         return FALSE_ATOM;
@@ -1322,11 +1352,11 @@ term bif_erlang_or_2(Context *ctx, term arg1, term arg2)
         return TRUE_ATOM;
 
     } else {
-        RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
     }
 }
 
-term bif_erlang_xor_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_xor_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     if ((arg1 == FALSE_ATOM) && (arg2 == FALSE_ATOM)) {
         return FALSE_ATOM;
@@ -1341,11 +1371,11 @@ term bif_erlang_xor_2(Context *ctx, term arg1, term arg2)
         return FALSE_ATOM;
 
     } else {
-        RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
     }
 }
 
-term bif_erlang_equal_to_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_equal_to_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result == TermEquals) {
@@ -1353,11 +1383,11 @@ term bif_erlang_equal_to_2(Context *ctx, term arg1, term arg2)
     } else if (result & (TermLessThan | TermGreaterThan)) {
         return FALSE_ATOM;
     } else {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
 }
 
-term bif_erlang_not_equal_to_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_not_equal_to_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result & (TermLessThan | TermGreaterThan)) {
@@ -1365,11 +1395,11 @@ term bif_erlang_not_equal_to_2(Context *ctx, term arg1, term arg2)
     } else if (result == TermEquals) {
         return FALSE_ATOM;
     } else {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
 }
 
-term bif_erlang_exactly_equal_to_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_exactly_equal_to_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     //TODO: 5.0 != 5
     TermCompareResult result = term_compare(arg1, arg2, TermCompareExact, ctx->global);
@@ -1378,11 +1408,11 @@ term bif_erlang_exactly_equal_to_2(Context *ctx, term arg1, term arg2)
     } else if (result & (TermLessThan | TermGreaterThan)) {
         return FALSE_ATOM;
     } else {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
 }
 
-term bif_erlang_exactly_not_equal_to_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_exactly_not_equal_to_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareExact, ctx->global);
     if (result & (TermLessThan | TermGreaterThan)) {
@@ -1390,11 +1420,11 @@ term bif_erlang_exactly_not_equal_to_2(Context *ctx, term arg1, term arg2)
     } else if (result == TermEquals) {
         return FALSE_ATOM;
     } else {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
 }
 
-term bif_erlang_greater_than_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_greater_than_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result == TermGreaterThan) {
@@ -1402,11 +1432,11 @@ term bif_erlang_greater_than_2(Context *ctx, term arg1, term arg2)
     } else if (result & (TermEquals | TermLessThan)) {
         return FALSE_ATOM;
     } else {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
 }
 
-term bif_erlang_less_than_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_less_than_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result == TermLessThan) {
@@ -1414,11 +1444,11 @@ term bif_erlang_less_than_2(Context *ctx, term arg1, term arg2)
     } else if (result & (TermEquals | TermGreaterThan)) {
         return FALSE_ATOM;
     } else {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
 }
 
-term bif_erlang_less_than_or_equal_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_less_than_or_equal_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result & (TermLessThan | TermEquals)) {
@@ -1426,11 +1456,11 @@ term bif_erlang_less_than_or_equal_2(Context *ctx, term arg1, term arg2)
     } else if (result == TermGreaterThan) {
         return FALSE_ATOM;
     } else {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
 }
 
-term bif_erlang_greater_than_or_equal_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_greater_than_or_equal_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     TermCompareResult result = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (result & (TermGreaterThan | TermEquals)) {
@@ -1438,35 +1468,35 @@ term bif_erlang_greater_than_or_equal_2(Context *ctx, term arg1, term arg2)
     } else if (result & TermLessThan) {
         return FALSE_ATOM;
     } else {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
 }
 
-term bif_erlang_get_1(Context *ctx, term arg1)
+term bif_erlang_get_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     term value;
     DictionaryFunctionResult result = dictionary_get(&ctx->dictionary, arg1, &value, ctx->global);
     if (UNLIKELY(result != DictionaryOk)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
 
     return value;
 }
 
-term bif_erlang_min_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_min_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     TermCompareResult r = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (UNLIKELY(r == TermCompareMemoryAllocFail)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);       
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
     return r == TermLessThan ? arg1 : arg2;
 }
 
-term bif_erlang_max_2(Context *ctx, term arg1, term arg2)
+term bif_erlang_max_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
 {
     TermCompareResult r = term_compare(arg1, arg2, TermCompareNoOpts, ctx->global);
     if (UNLIKELY(r == TermCompareMemoryAllocFail)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);       
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
     return r == TermGreaterThan ? arg1 : arg2;
 }

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -42,73 +42,73 @@ extern "C" {
 const struct ExportedFunction *bif_registry_get_handler(AtomString module, AtomString function, int arity);
 
 term bif_erlang_self_0(Context *ctx);
-term bif_erlang_byte_size_1(Context *ctx, int live, term arg1);
-term bif_erlang_bit_size_1(Context *ctx, int live, term arg1);
-term bif_erlang_length_1(Context *ctx, int live, term arg1);
+term bif_erlang_byte_size_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+term bif_erlang_bit_size_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+term bif_erlang_length_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 
-term bif_erlang_is_atom_1(Context *ctx, term arg1);
-term bif_erlang_is_binary_1(Context *ctx, term arg1);
-term bif_erlang_is_boolean_1(Context *ctx, term arg1);
-term bif_erlang_is_float_1(Context *ctx, term arg1);
-term bif_erlang_is_function_1(Context *ctx, term arg1);
-term bif_erlang_is_integer_1(Context *ctx, term arg1);
-term bif_erlang_is_list_1(Context *ctx, term arg1);
-term bif_erlang_is_number_1(Context *ctx, term arg1);
-term bif_erlang_is_pid_1(Context *ctx, term arg1);
-term bif_erlang_is_reference_1(Context *ctx, term arg1);
-term bif_erlang_is_tuple_1(Context *ctx, term arg1);
-term bif_erlang_is_map_1(Context *ctx, term arg1);
-term bif_erlang_is_map_key_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_is_atom_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_binary_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_boolean_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_float_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_function_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_integer_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_list_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_number_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_pid_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_reference_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_tuple_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_map_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_map_key_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 
-term bif_erlang_hd_1(Context *ctx, term arg1);
-term bif_erlang_tl_1(Context *ctx, term arg1);
+term bif_erlang_hd_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_tl_1(Context *ctx, uint32_t fail_label, term arg1);
 
-term bif_erlang_element_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_tuple_size_1(Context *ctx, term arg1);
+term bif_erlang_element_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
+term bif_erlang_tuple_size_1(Context *ctx, uint32_t fail_label, term arg1);
 
-term bif_erlang_map_size_1(Context *ctx, int live, term arg1);
-term bif_erlang_map_get_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_map_size_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+term bif_erlang_map_get_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 
-term bif_erlang_add_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_sub_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_mul_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_div_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_rem_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_neg_1(Context *ctx, int live, term arg1);
-term bif_erlang_abs_1(Context *ctx, int live, term arg1);
+term bif_erlang_add_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+term bif_erlang_sub_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+term bif_erlang_mul_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+term bif_erlang_div_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+term bif_erlang_rem_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+term bif_erlang_neg_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+term bif_erlang_abs_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 
-term bif_erlang_ceil_1(Context *ctx, int live, term arg1);
-term bif_erlang_floor_1(Context *ctx, int live, term arg1);
-term bif_erlang_round_1(Context *ctx, int live, term arg1);
-term bif_erlang_trunc_1(Context *ctx, int live, term arg1);
+term bif_erlang_ceil_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+term bif_erlang_floor_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+term bif_erlang_round_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+term bif_erlang_trunc_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 
-term bif_erlang_bor_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_band_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_bxor_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_bsl_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_bsr_2(Context *ctx, int live, term arg1, term arg2);
-term bif_erlang_bnot_1(Context *ctx, int live, term arg1);
+term bif_erlang_bor_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+term bif_erlang_band_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+term bif_erlang_bxor_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+term bif_erlang_bsl_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+term bif_erlang_bsr_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+term bif_erlang_bnot_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 
-term bif_erlang_not_1(Context *ctx, term arg1);
-term bif_erlang_and_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_or_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_xor_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_not_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_and_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
+term bif_erlang_or_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
+term bif_erlang_xor_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 
-term bif_erlang_equal_to_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_not_equal_to_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_equal_to_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
+term bif_erlang_not_equal_to_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 
-term bif_erlang_exactly_equal_to_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_exactly_not_equal_to_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_exactly_equal_to_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
+term bif_erlang_exactly_not_equal_to_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 
-term bif_erlang_greater_than_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_less_than_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_less_than_or_equal_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_greater_than_or_equal_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_greater_than_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
+term bif_erlang_less_than_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
+term bif_erlang_less_than_or_equal_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
+term bif_erlang_greater_than_or_equal_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 
-term bif_erlang_get_1(Context *ctx, term arg1);
+term bif_erlang_get_1(Context *ctx, uint32_t fail_label, term arg1);
 
-term bif_erlang_min_2(Context *ctx, term arg1, term arg2);
-term bif_erlang_max_2(Context *ctx, term arg1, term arg2);
+term bif_erlang_min_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
+term bif_erlang_max_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 
 #ifdef __cplusplus
 }

--- a/src/libAtomVM/exportedfunction.h
+++ b/src/libAtomVM/exportedfunction.h
@@ -38,12 +38,12 @@ typedef struct Module Module;
 #endif
 
 typedef term (*BifImpl0)(Context *ctx);
-typedef term (*BifImpl1)(Context *ctx, term arg1);
-typedef term (*BifImpl2)(Context *ctx, term arg1, term arg2);
+typedef term (*BifImpl1)(Context *ctx, uint32_t fail_label, term arg1);
+typedef term (*BifImpl2)(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 
-typedef term (*GCBifImpl1)(Context *ctx, int live, term arg1);
-typedef term (*GCBifImpl2)(Context *ctx, int live, term arg1, term arg2);
-typedef term (*GCBifImpl3)(Context *ctx, int live, term arg1, term arg2, term arg3);
+typedef term (*GCBifImpl1)(Context *ctx, uint32_t fail_label, int live, term arg1);
+typedef term (*GCBifImpl2)(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+typedef term (*GCBifImpl3)(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2, term arg3);
 
 typedef term (*NifImpl)(Context *ctx, int argc, term argv[]);
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1505,15 +1505,15 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
             const struct GCBif *gcbif = EXPORTED_FUNCTION_TO_GCBIF(exported_bif);
             switch (arity) {
                 case 1: {
-                    *return_value = gcbif->gcbif1_ptr(ctx, 0, ctx->x[0]);
+                    *return_value = gcbif->gcbif1_ptr(ctx, 0, 0, ctx->x[0]);
                     return true;
                 }
                 case 2: {
-                    *return_value = gcbif->gcbif2_ptr(ctx, 0, ctx->x[0], ctx->x[1]);
+                    *return_value = gcbif->gcbif2_ptr(ctx, 0, 0, ctx->x[0], ctx->x[1]);
                     return true;
                 }
                 case 3: {
-                    *return_value = gcbif->gcbif3_ptr(ctx, 0, ctx->x[0], ctx->x[1], ctx->x[2]);
+                    *return_value = gcbif->gcbif3_ptr(ctx, 0, 0, ctx->x[0], ctx->x[1], ctx->x[2]);
                     return true;
                 }
             }
@@ -1525,11 +1525,11 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
                     return true;
                 }
                 case 1: {
-                    *return_value = bif->bif1_ptr(ctx, ctx->x[0]);
+                    *return_value = bif->bif1_ptr(ctx, 0, ctx->x[0]);
                     return true;
                 }
                 case 2: {
-                    *return_value = bif->bif2_ptr(ctx, ctx->x[0], ctx->x[1]);
+                    *return_value = bif->bif2_ptr(ctx, 0, ctx->x[0], ctx->x[1]);
                     return true;
                 }
             }
@@ -1936,10 +1936,10 @@ schedule_in:
                                     x_regs[0] = bif->bif0_ptr(ctx);
                                     break;
                                 case 1:
-                                    x_regs[0] = bif->bif1_ptr(ctx, x_regs[0]);
+                                    x_regs[0] = bif->bif1_ptr(ctx, 0, x_regs[0]);
                                     break;
                                 case 2:
-                                    x_regs[0] = bif->bif2_ptr(ctx, x_regs[0], x_regs[1]);
+                                    x_regs[0] = bif->bif2_ptr(ctx, 0, x_regs[0], x_regs[1]);
                                     break;
                                 default:
                                     fprintf(stderr, "Invalid arity %" PRIu32 " for bif\n", arity);
@@ -2036,10 +2036,10 @@ schedule_in:
                                     x_regs[0] = bif->bif0_ptr(ctx);
                                     break;
                                 case 1:
-                                    x_regs[0] = bif->bif1_ptr(ctx, x_regs[0]);
+                                    x_regs[0] = bif->bif1_ptr(ctx, 0, x_regs[0]);
                                     break;
                                 case 2:
-                                    x_regs[0] = bif->bif2_ptr(ctx, x_regs[0], x_regs[1]);
+                                    x_regs[0] = bif->bif2_ptr(ctx, 0, x_regs[0], x_regs[1]);
                                     break;
                                 default:
                                     fprintf(stderr, "Invalid arity %" PRIu32 " for bif\n", arity);
@@ -2099,7 +2099,7 @@ schedule_in:
                     const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
                     BifImpl1 func = EXPORTED_FUNCTION_TO_BIF(exported_bif)->bif1_ptr;
                     DEBUG_FAIL_NULL(func);
-                    term ret = func(ctx, arg1);
+                    term ret = func(ctx, fail_label, arg1);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
                         if (fail_label) {
                             pc = mod->labels[fail_label];
@@ -2138,7 +2138,7 @@ schedule_in:
                     const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
                     BifImpl2 func = EXPORTED_FUNCTION_TO_BIF(exported_bif)->bif2_ptr;
                     DEBUG_FAIL_NULL(func);
-                    term ret = func(ctx, arg1, arg2);
+                    term ret = func(ctx, fail_label, arg1, arg2);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
                         if (fail_label) {
                             pc = mod->labels[fail_label];
@@ -3485,10 +3485,10 @@ wait_timeout_trap_handler:
                                     x_regs[0] = bif->bif0_ptr(ctx);
                                     break;
                                 case 1:
-                                    x_regs[0] = bif->bif1_ptr(ctx, x_regs[0]);
+                                    x_regs[0] = bif->bif1_ptr(ctx, 0, x_regs[0]);
                                     break;
                                 case 2:
-                                    x_regs[0] = bif->bif2_ptr(ctx, x_regs[0], x_regs[1]);
+                                    x_regs[0] = bif->bif2_ptr(ctx, 0, x_regs[0], x_regs[1]);
                                     break;
                                 default:
                                     fprintf(stderr, "Invalid arity %" PRIu32 " for bif\n", arity);
@@ -5273,7 +5273,7 @@ wait_timeout_trap_handler:
 
                     const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
                     GCBifImpl1 func = EXPORTED_FUNCTION_TO_GCBIF(exported_bif)->gcbif1_ptr;
-                    term ret = func(ctx, live, arg1);
+                    term ret = func(ctx, fail_label, live, arg1);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
                         if (fail_label) {
                             pc = mod->labels[fail_label];
@@ -5320,7 +5320,7 @@ wait_timeout_trap_handler:
 
                     const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
                     GCBifImpl2 func = EXPORTED_FUNCTION_TO_GCBIF(exported_bif)->gcbif2_ptr;
-                    term ret = func(ctx, live, arg1, arg2);
+                    term ret = func(ctx, fail_label, live, arg1, arg2);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
                         if (fail_label) {
                             pc = mod->labels[fail_label];
@@ -5393,7 +5393,7 @@ wait_timeout_trap_handler:
 
                     const struct ExportedFunction *exported_bif = mod->imported_funcs[bif];
                     GCBifImpl3 func = EXPORTED_FUNCTION_TO_GCBIF(exported_bif)->gcbif3_ptr;
-                    term ret = func(ctx, live, arg1, arg2, arg3);
+                    term ret = func(ctx, fail_label, live, arg1, arg2, arg3);
                     if (UNLIKELY(term_is_invalid_term(ret))) {
                         if (fail_label) {
                             pc = mod->labels[fail_label];

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -31,6 +31,7 @@ test() ->
     ok = test_keyfind(),
     ok = test_keydelete(),
     ok = test_keyreplace(),
+    ok = test_keystore(),
     ok = test_keytake(),
     ok = test_foldl(),
     ok = test_foldr(),
@@ -103,6 +104,27 @@ test_keyreplace() ->
         {a, x},
         {a, x},
         []
+    ]),
+    ok.
+
+test_keystore() ->
+    ?ASSERT_MATCH(lists:keystore(a, 1, [], {foo, bar}), [{foo, bar}]),
+    ?ASSERT_MATCH(lists:keystore(a, 1, [{a, x}, b, []], {1, 2}), [{1, 2}, b, []]),
+    ?ASSERT_MATCH(lists:keystore(x, 2, [b, {a, x}, []], {1, 2}), [b, {1, 2}, []]),
+    ?ASSERT_MATCH(lists:keystore(a, 1, [b, {a, x}, {a, x}, {a, x}, []], {1, 2}), [
+        b,
+        {1, 2},
+        {a, x},
+        {a, x},
+        []
+    ]),
+    ?ASSERT_MATCH(lists:keystore(a, 3, [b, {a, x}, {a, x}, {a, x}, []], {1, 2}), [
+        b,
+        {a, x},
+        {a, x},
+        {a, x},
+        [],
+        {1, 2}
     ]),
     ok.
 


### PR DESCRIPTION
* Also simplify implementation of `lists:keyreplace/4` (which this bug affects)
* Also add `lists:keystore/4`

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
