### PR TITLE
Add erlang:apply/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - lists:keytake/3 implemented.
 - Support for setting channel used by network driver wifi access point.
 - Support for `maps:iterator/2` and `~kp` with `io_lib:format/2` that were introduced with OTP26.
+- Support for `erlang:apply/2`
 
 ### Changed
 

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -26,6 +26,7 @@
 -module(erlang).
 
 -export([
+    apply/2,
     apply/3,
     start_timer/3, start_timer/4,
     cancel_timer/1,
@@ -341,6 +342,41 @@ apply(Module, Function, Args) ->
             Module:Function(Arg1, Arg2, Arg3, Arg4, Arg5);
         [Arg1, Arg2, Arg3, Arg4, Arg5, Arg6] ->
             Module:Function(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6);
+        _ ->
+            error(badarg)
+    end.
+
+%%-----------------------------------------------------------------------------
+%% @param   Function Function to call
+%% @param   Args Parameters to pass to function (max 6)
+%% @returns Returns the result of Function(Args).
+%% @doc     Returns the result of applying Function to Args. The arity of the
+%%          function is the length of Args. Example:
+%%          ```> apply(fun(R) -> lists:reverse(R) end, [[a, b, c]]).
+%%          [c,b,a]
+%%          > apply(fun erlang:atom_to_list/1, ['AtomVM']).
+%%          "AtomVM"'''
+%%          If the number of arguments are known at compile time, the call is better
+%%          written as Function(Arg1, Arg2, ..., ArgN).
+%% @end
+%%-----------------------------------------------------------------------------
+-spec apply(Function :: fun(), Args :: [term()]) -> term().
+apply(Function, Args) ->
+    case Args of
+        [] ->
+            Function();
+        [Arg1] ->
+            Function(Arg1);
+        [Arg1, Arg2] ->
+            Function(Arg1, Arg2);
+        [Arg1, Arg2, Arg3] ->
+            Function(Arg1, Arg2, Arg3);
+        [Arg1, Arg2, Arg3, Arg4] ->
+            Function(Arg1, Arg2, Arg3, Arg4);
+        [Arg1, Arg2, Arg3, Arg4, Arg5] ->
+            Function(Arg1, Arg2, Arg3, Arg4, Arg5);
+        [Arg1, Arg2, Arg3, Arg4, Arg5, Arg6] ->
+            Function(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6);
         _ ->
             error(badarg)
     end.

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -23,6 +23,7 @@ project(test_estdlib)
 include(BuildErlang)
 
 set(ERLANG_MODULES
+    test_apply
     test_calendar
     test_gen_event
     test_gen_server

--- a/tests/libs/estdlib/test_apply.erl
+++ b/tests/libs/estdlib/test_apply.erl
@@ -1,0 +1,59 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_apply).
+
+-export([test/0, f/0, f/1, f/2, f/3, f/4, f/5, f/6]).
+
+test() ->
+    ok = test_apply_3(),
+    ok = test_apply_2(),
+    ok.
+
+%% apply/2 and apply/3 are not nifs but implemented
+%% in erlang module.
+
+test_apply_3() ->
+    0 = apply(?MODULE, f, []),
+    1 = apply(?MODULE, f, [1]),
+    3 = apply(?MODULE, f, [1, 2]),
+    6 = apply(?MODULE, f, [1, 2, 3]),
+    11 = apply(?MODULE, f, [1, 2, 3, 5]),
+    19 = apply(?MODULE, f, [1, 2, 3, 5, 8]),
+    32 = apply(?MODULE, f, [1, 2, 3, 5, 8, 13]),
+    ok.
+
+test_apply_2() ->
+    0 = apply(fun ?MODULE:f/0, []),
+    1 = apply(fun ?MODULE:f/1, [1]),
+    3 = apply(fun ?MODULE:f/2, [1, 2]),
+    6 = apply(fun ?MODULE:f/3, [1, 2, 3]),
+    11 = apply(fun ?MODULE:f/4, [1, 2, 3, 5]),
+    19 = apply(fun ?MODULE:f/5, [1, 2, 3, 5, 8]),
+    32 = apply(fun ?MODULE:f/6, [1, 2, 3, 5, 8, 13]),
+    ok.
+
+f() -> 0.
+f(A) -> A.
+f(A, B) -> A + B.
+f(A, B, C) -> A + B + C.
+f(A, B, C, D) -> A + B + C + D.
+f(A, B, C, D, E) -> A + B + C + D + E.
+f(A, B, C, D, E, F) -> A + B + C + D + E + F.

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -39,6 +39,7 @@ get_tests(OTPVersion) when
     [test_tcp_socket, test_udp_socket, test_net, test_ssl | get_tests(undefined)];
 get_tests(_OTPVersion) ->
     [
+        test_apply,
         test_lists,
         test_calendar,
         test_gen_event,


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
