### PR TITLE
Adjust test timeouts

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -322,7 +322,7 @@ jobs:
 
     # Test
     - name: "Test: test-erlang"
-      timeout-minutes: 10
+      timeout-minutes: 15
       working-directory: build
       run: |
         ./tests/test-erlang -s prime_smp
@@ -348,7 +348,7 @@ jobs:
         valgrind ./tests/test-structs
 
     - name: "Test: test_estdlib.avm"
-      timeout-minutes: 10
+      timeout-minutes: 5
       working-directory: build
       run: |
         ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm


### PR DESCRIPTION
* Bump timeout of test-erlang which can take more than 10 minutes on slow GitHub runners
* Reduce timeout of test-estdlib.avm which is definitely broken when it takes more than 5 minutes

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
