### PR TITLE
Work around recent setup-beam action failures

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -32,38 +32,24 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/main' && github.ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  otp_version: 27
-  elixir_version: 1.17
-
 jobs:
   compile_tests:
     runs-on: ubuntu-24.04
+    container: erlang:27
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
 
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: ${{ env.otp_version }}
-        elixir-version: ${{ env.elixir_version }}
-
-    - name: apt update
-      run: sudo apt update
-
     - name: Install required packages
-      run: sudo apt install -y gperf
+      run: apt update && apt install -y gperf zlib1g-dev cmake ninja-build
 
     - name: Compile test modules
       run: |
         set -e
         mkdir build_tests
         cd build_tests
-        cmake ..
-        make erlang_test_modules
-        make test_estdlib
-        make test_eavmlib
-        make test_alisp
+        cmake .. -G Ninja -DAVM_WARNINGS_ARE_ERRORS=ON
+        ninja erlang_test_modules test_estdlib test_eavmlib test_alisp
 
     - name: Upload test modules
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -197,12 +197,12 @@ jobs:
           cflags: ""
           elixir_version: "1.14"
 
-        # master version of OTP/Elixir
+        # master/main version of OTP/Elixir
         - os: "ubuntu-24.04"
           cc: "cc"
           cxx: "c++"
           otp: "master"
-          elixir_version: "master"
+          elixir_version: "main"
 
         # Additional default compiler builds
         - os: "ubuntu-20.04"
@@ -266,6 +266,10 @@ jobs:
       with:
         otp-version: ${{ matrix.otp }}
         elixir-version: ${{ matrix.elixir_version }}
+        hexpm-mirrors: |
+          https://builds.hex.pm
+          https://repo.hex.pm
+          https://cdn.jsdelivr.net/hex
 
     - name: "Add i386 architecture"
       if: matrix.arch == 'i386'

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -46,6 +46,7 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    container: erlang:27
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -53,8 +54,8 @@ jobs:
 
       - name: Install Deps
         run: |
-          sudo apt update -y
-          DEBIAN_FRONTEND=noninteractive sudo apt install -y git cmake doxygen graphviz python3-pip python3-virtualenv python3-setuptools python3-stemmer wget
+          apt update -y
+          DEBIAN_FRONTEND=noninteractive apt install -y git cmake doxygen graphviz python3-pip python3-virtualenv python3.11-venv python3-setuptools python3-stemmer wget
 
       - uses: actions/cache@v4
         id: sphinx-cache
@@ -76,18 +77,6 @@ jobs:
           python3 -m pip install breathe
           python3 -m pip install pygments
 
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: "25"
-          elixir-version: "1.15"
-
-      - name: Install rebar3
-        working-directory: /tmp
-        run: |
-          wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
-          ./rebar3 local install
-          echo "/home/runner/.cache/rebar3/bin" >> ${GITHUB_PATH}
-
       - uses: actions/checkout@v4
         with:
           repository: ${{ vars.GITHUB_REPOSITORY }}
@@ -97,6 +86,7 @@ jobs:
         shell: bash
         run: |
           . /home/runner/python-env/sphinx/bin/activate
+          git config --global --add safe.directory ${PWD}
           mkdir build
           cd build
           cmake ..

--- a/.github/workflows/build-libraries.yaml
+++ b/.github/workflows/build-libraries.yaml
@@ -16,7 +16,8 @@ permissions:
 
 jobs:
   build-libraries:
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
+    container: erlang:27
     strategy:
       fail-fast: false
 
@@ -25,11 +26,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: "24"
-        elixir-version: "1.11"
 
     - name: "APT update"
       run: sudo apt update -y

--- a/.github/workflows/build-linux-artifacts.yaml
+++ b/.github/workflows/build-linux-artifacts.yaml
@@ -14,38 +14,27 @@ on:
 permissions:
   contents: write
 
-env:
-  otp_version: 24
-  elixir_version: 1.14
-
 jobs:
   compile_tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    container: erlang:27
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
-
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: ${{ env.otp_version }}
-        elixir-version: ${{ env.elixir_version }}
 
     - name: apt update
       run: sudo apt update
 
     - name: Install required packages
-      run: sudo apt install -y gperf
+      run: sudo apt install -y cmake gperf zlib1g-dev ninja-build
 
     - name: Compile test modules
       run: |
         set -e
         mkdir build_tests
         cd build_tests
-        cmake ..
-        make erlang_test_modules
-        make test_estdlib
-        make test_eavmlib
-        make test_alisp
+        cmake .. -G Ninja -DAVM_WARNINGS_ARE_ERRORS=ON
+        ninja erlang_test_modules test_estdlib test_eavmlib test_alisp
 
     - name: Upload test modules
       uses: actions/upload-artifact@v4

--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -27,19 +27,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  clang-format-check:
-    runs-on: ubuntu-20.04
+  clang-format-prettier-check:
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: 24.3
-        elixir-version: 1.12
-
     - name: "Install run-clang-format"
       run: |
-        wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main" | sudo tee -a /etc/apt/sources.list
         echo "deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main" | sudo tee -a /etc/apt/sources.list
         sudo apt-get update
@@ -51,8 +46,19 @@ jobs:
       run: |
         ./run-clang-format --style=file --clang-format-executable=clang-format-16 -r src/ tests/
 
-    - name: "Check formatting with Erlang fmt"
+    - name: "Check formatting with prettier"
       if: success() || failure()
+      run: |
+        npm install prettier
+        find ../src/platforms/emscripten/ ../examples/emscripten/ -name "*.js" -o -name "*.html" | xargs npx prettier -c
+
+  erlfmt-check:
+    runs-on: ubuntu-24.04
+    container: erlang:27
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: "Check formatting with Erlang fmt"
       run: |
         cd ..
         git clone --depth 1 -b v1.1.0 https://github.com/WhatsApp/erlfmt.git
@@ -61,14 +67,13 @@ jobs:
         cd ../AtomVM
         find . -name *.erl | xargs ../erlfmt/_build/release/bin/erlfmt -c
 
+  mix-format-check:
+    runs-on: ubuntu-24.04
+    container: elixir:1.17.1
+    steps:
+    - uses: actions/checkout@v4
+
     - name: "Check formatting with Elixir mix format"
-      if: success() || failure()
       run: |
         cd libs/exavmlib/
         mix format --check-formatted
-
-    - name: "Check formatting with prettier"
-      if: success() || failure()
-      run: |
-        npm install prettier
-        find ../src/platforms/emscripten/ ../examples/emscripten/ -name "*.js" -o -name "*.html" | xargs npx prettier -c

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -39,8 +39,8 @@ jobs:
         cc: ["clang-10"]
         cxx: ["clang++-10"]
         cflags: ["-O3"]
-        otp: ["24"]
-        elixir_version: ["1.11"]
+        otp: ["27"]
+        elixir_version: ["1.17"]
         compiler_pkgs: ["clang-10"]
         soc: ["esp32", "esp32c2", "esp32c3", "esp32s2", "esp32s3", "esp32c6", "esp32h2"]
 
@@ -59,6 +59,10 @@ jobs:
       with:
         otp-version: ${{ matrix.otp }}
         elixir-version: ${{ matrix.elixir_version }}
+        hexpm-mirrors: |
+          https://builds.hex.pm
+          https://repo.hex.pm
+          https://cdn.jsdelivr.net/hex
 
     - name: "APT update"
       run: apt update -y

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -69,8 +69,12 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "25"
-          elixir-version: "1.15"
+          otp-version: "27"
+          elixir-version: "1.17"
+          hexpm-mirrors: |
+            https://builds.hex.pm
+            https://repo.hex.pm
+            https://cdn.jsdelivr.net/hex
 
       - name: Install rebar3
         working-directory: /tmp

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -40,25 +40,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: "ubuntu-20.04"
+        - os: "ubuntu-24.04"
           test_erlang_opts: "-s prime_smp"
-          otp: "21"
-
-        - os: "ubuntu-20.04"
-          test_erlang_opts: "-s prime_smp"
-          otp: "22"
-
-        - os: "ubuntu-20.04"
-          test_erlang_opts: "-s prime_smp"
-          otp: "23"
+          container: erlang:21
 
         - os: "ubuntu-24.04"
           test_erlang_opts: "-s prime_smp"
-          otp: "24"
+          container: erlang:22
 
         - os: "ubuntu-24.04"
           test_erlang_opts: "-s prime_smp"
-          otp: "25"
+          container: erlang:23
+
+        - os: "ubuntu-24.04"
+          test_erlang_opts: "-s prime_smp"
+          container: erlang:24
+
+        - os: "ubuntu-24.04"
+          test_erlang_opts: "-s prime_smp"
+          container: erlang:25
 
         - os: "ubuntu-24.04"
           test_erlang_opts: "-s prime_smp,test_gc"
@@ -89,19 +89,8 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - uses: erlef/setup-beam@v1
-      if: runner.os == 'Linux' && matrix.container == ''
-      with:
-        otp-version: ${{ matrix.otp }}
-
-    - name: "Install deps (Linux)"
-      if: runner.os == 'Linux' && matrix.container == ''
-      run: |
-        sudo apt update -y
-        sudo apt install -y cmake gperf zlib1g-dev ninja-build
-
     - name: "Install deps (container)"
-      if: runner.os == 'Linux' && matrix.container != ''
+      if: runner.os == 'Linux'
       run: |
         apt update -y
         apt install -y cmake gperf zlib1g-dev ninja-build

--- a/.github/workflows/stm32-build.yaml
+++ b/.github/workflows/stm32-build.yaml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   stm32:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/cache@v4
       id: builddeps-cache
@@ -38,7 +38,11 @@ jobs:
 
     - uses: erlef/setup-beam@v1
       with:
-        otp-version: "26"
+        otp-version: "27"
+        hexpm-mirrors: |
+          https://builds.hex.pm
+          https://repo.hex.pm
+          https://cdn.jsdelivr.net/hex
 
     - name: Install arm-embedded toolchain
       if: ${{ steps.builddeps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -29,27 +29,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/main' && github.ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  otp_version: 24
-  elixir_version: 1.14
-
 jobs:
   compile_tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    container: erlang:27
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
 
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: ${{ env.otp_version }}
-        elixir-version: ${{ env.elixir_version }}
-
-    - name: apt update
-      run: sudo apt update
-
     - name: Install required packages
-      run: sudo apt install -y gperf zlib1g-dev ninja-build
+      run: apt update && apt install -y gperf zlib1g-dev cmake ninja-build
 
     - name: Compile AtomVM and test modules
       run: |

--- a/libs/exavmlib/lib/Bitwise.ex
+++ b/libs/exavmlib/lib/Bitwise.ex
@@ -70,7 +70,7 @@ defmodule Bitwise do
           [bnot: 1, band: 2, bor: 2, bxor: 2, bsl: 2, bsr: 2]
 
         Keyword.get(options, :skip_operators) ->
-          [~~~: 1, &&&: 2, |||: 2, ^^^: 2, <<<: 2, >>>: 2]
+          ["~~~": 1, &&&: 2, |||: 2, "^^^": 2, <<<: 2, >>>: 2]
 
         true ->
           []
@@ -213,7 +213,7 @@ defmodule Bitwise do
   end
 
   @doc false
-  def unquote(:^^^)(left, right) do
+  def unquote(:"^^^")(left, right) do
     :erlang.bxor(left, right)
   end
 

--- a/libs/exavmlib/lib/Process.ex
+++ b/libs/exavmlib/lib/Process.ex
@@ -176,7 +176,7 @@ defmodule Process do
       #=> #PID<0.95.0>
 
   """
-  @spec spawn((() -> any), spawn_opts) :: pid | {pid, reference}
+  @spec spawn((-> any), spawn_opts) :: pid | {pid, reference}
   defdelegate spawn(fun, opts), to: :erlang, as: :spawn_opt
 
   @doc """


### PR DESCRIPTION
* Use Erlang Docker container where possible
* Add hexpm mirrors to remaining setup-beam invocations
* Bump OTP version to 17 and Elixir to 1.17
* Split check formatting build in three jobs with different containers
* Use elixir 1.17.1 container for mix format and reformat files accordingly

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
