### PR TITLE
Install AtomVM applications with beams, source code and avm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - ESP32: Elixir library is not shipped anymore with `esp32boot.avm`. Use `elixir_esp32boot.avm`
 instead
 - `Enum.find_index` and `Enum.find_value` support Enumerable and not just lists
+- Install AtomVM libraries source code and binaries for better dialyzer integration
 
 ### Fixed
 

--- a/libs/alisp/src/CMakeLists.txt
+++ b/libs/alisp/src/CMakeLists.txt
@@ -32,3 +32,24 @@ set(ERLANG_MODULES
 )
 
 pack_archive(alisp ${ERLANG_MODULES})
+
+include(../../../version.cmake)
+
+set(ALISP_VERSION ${ATOMVM_BASE_VERSION})
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/beams/
+    DESTINATION lib/atomvm/lib/alisp-${ALISP_VERSION}/ebin
+    FILES_MATCHING PATTERN "*.beam"
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/alisp.avm
+    DESTINATION lib/atomvm/lib/alisp-${ALISP_VERSION}/ebin/
+)
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+    DESTINATION lib/atomvm/lib/alisp-${ALISP_VERSION}/src
+    FILES_MATCHING PATTERN "*.erl"
+)

--- a/libs/eavmlib/src/CMakeLists.txt
+++ b/libs/eavmlib/src/CMakeLists.txt
@@ -46,3 +46,24 @@ set(ERLANG_MODULES
 )
 
 pack_archive(eavmlib ${ERLANG_MODULES})
+
+include(../../../version.cmake)
+
+set(EAVMLIB_VERSION ${ATOMVM_BASE_VERSION})
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/beams/
+    DESTINATION lib/atomvm/lib/eavmlib-${EAVMLIB_VERSION}/ebin
+    FILES_MATCHING PATTERN "*.beam"
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/eavmlib.avm
+    DESTINATION lib/atomvm/lib/eavmlib-${EAVMLIB_VERSION}/ebin/
+)
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+    DESTINATION lib/atomvm/lib/eavmlib-${EAVMLIB_VERSION}/src
+    FILES_MATCHING PATTERN "*.erl"
+)

--- a/libs/esp32devmode/src/CMakeLists.txt
+++ b/libs/esp32devmode/src/CMakeLists.txt
@@ -23,3 +23,24 @@ project(esp32devmode)
 include(BuildErlang)
 
 pack_archive(esp32devmode esp32devmode)
+
+include(../../../version.cmake)
+
+set(ESP32DEVMODE_VERSION ${ATOMVM_BASE_VERSION})
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/beams/
+    DESTINATION lib/atomvm/lib/esp32devmode-${ESP32DEVMODE_VERSION}/ebin
+    FILES_MATCHING PATTERN "*.beam"
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/esp32devmode.avm
+    DESTINATION lib/atomvm/lib/esp32devmode-${ESP32DEVMODE_VERSION}/ebin/
+)
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+    DESTINATION lib/atomvm/lib/esp32devmode-${ESP32DEVMODE_VERSION}/src
+    FILES_MATCHING PATTERN "*.erl"
+)

--- a/libs/estdlib/src/CMakeLists.txt
+++ b/libs/estdlib/src/CMakeLists.txt
@@ -60,3 +60,24 @@ set(ERLANG_MODULES
 )
 
 pack_archive(estdlib ${ERLANG_MODULES})
+
+include(../../../version.cmake)
+
+set(ESTDLIB_VERSION ${ATOMVM_BASE_VERSION})
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/beams/
+    DESTINATION lib/atomvm/lib/estdlib-${ESTDLIB_VERSION}/ebin
+    FILES_MATCHING PATTERN "*.beam"
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/estdlib.avm
+    DESTINATION lib/atomvm/lib/estdlib-${ESTDLIB_VERSION}/ebin/
+)
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+    DESTINATION lib/atomvm/lib/estdlib-${ESTDLIB_VERSION}/src
+    FILES_MATCHING PATTERN "*.erl"
+)

--- a/libs/etest/src/CMakeLists.txt
+++ b/libs/etest/src/CMakeLists.txt
@@ -27,3 +27,24 @@ set(ERLANG_MODULES
 )
 
 pack_archive(etest ${ERLANG_MODULES})
+
+include(../../../version.cmake)
+
+set(ETEST_VERSION ${ATOMVM_BASE_VERSION})
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/beams/
+    DESTINATION lib/atomvm/lib/etest-${ETEST_VERSION}/ebin
+    FILES_MATCHING PATTERN "*.beam"
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/etest.avm
+    DESTINATION lib/atomvm/lib/etest-${ETEST_VERSION}/ebin/
+)
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+    DESTINATION lib/atomvm/lib/etest-${ETEST_VERSION}/src
+    FILES_MATCHING PATTERN "*.erl"
+)

--- a/libs/exavmlib/lib/CMakeLists.txt
+++ b/libs/exavmlib/lib/CMakeLists.txt
@@ -92,3 +92,24 @@ set(ELIXIR_MODULES
 )
 
 pack_archive(exavmlib ${ELIXIR_MODULES})
+
+include(../../../version.cmake)
+
+set(EXAVMLIB_VERSION ${ATOMVM_BASE_VERSION})
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/beams/
+    DESTINATION lib/atomvm/lib/exavmlib-${EXAVMLIB_VERSION}/ebin
+    FILES_MATCHING PATTERN "*.beam"
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/exavmlib.avm
+    DESTINATION lib/atomvm/lib/exavmlib-${EXAVMLIB_VERSION}/ebin/
+)
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+    DESTINATION lib/atomvm/lib/exavmlib-${EXAVMLIB_VERSION}/lib
+    FILES_MATCHING PATTERN "*.ex"
+)


### PR DESCRIPTION
This allows users to create dialyzer plt for their version of dialyzer

Until we manage versions of application, these are installed under PREFIX/lib/atomvm/lib/APP-ATOMVM_VERSION

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
