### PR TITLE
Export missing types in gen_server module

### DIFF
--- a/libs/estdlib/src/gen_server.erl
+++ b/libs/estdlib/src/gen_server.erl
@@ -51,6 +51,11 @@
 
 -export([init_it/4, init_it/5]).
 
+-export_type([
+    server_ref/0,
+    from/0
+]).
+
 -record(state, {
     name = undefined :: atom(),
     mod :: module(),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
