### PR TITLE
Bump test_exit2 timeout

### DIFF
--- a/tests/erlang_tests/test_exit2.erl
+++ b/tests/erlang_tests/test_exit2.erl
@@ -248,7 +248,7 @@ test_reason_normal_self() ->
         receive
             {Pid2, {'EXIT', Pid2, normal}} -> ok;
             Other -> Other
-        after 500 -> timeout
+        after 1000 -> timeout
         end,
     ok =
         receive


### PR DESCRIPTION
Test sometimes fails on GitHub with a 500ms timeout. This could be reproduced locally by running test 200 times in parallel within multipass. Bumping timeout to 1 second makes the problem disappear locally and hopefully will also fix it on GitHub CI.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
