### PR TITLE
Fix test_gc test with BEAM

### DIFF
--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -61,12 +61,12 @@ jobs:
           otp: "25"
 
         - os: "ubuntu-24.04"
-          test_erlang_opts: "-s prime_smp,test_gc"
+          test_erlang_opts: "-s prime_smp"
           otp: "26"
           container: erlang:26
 
         - os: "ubuntu-24.04"
-          test_erlang_opts: "-s prime_smp,test_gc"
+          test_erlang_opts: "-s prime_smp"
           otp: "27"
           container: erlang:27
 


### PR DESCRIPTION
`test_gc` was disabled because it failed more or less randomly with OTP26. It seems to be related to a change in how the eval string from the command line is processed by OTP, allocating more memory and therefore making the effect of garbage collector less obvious. Fix it by spawning a fresh process for the test.

Special thanks to @karlsson for investigating this.

Fixes #1219

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
