### PR TITLE
Bump timeout of whereis_dead_process test

### DIFF
--- a/tests/erlang_tests/whereis_dead_process.erl
+++ b/tests/erlang_tests/whereis_dead_process.erl
@@ -38,7 +38,7 @@ test_names(Names) ->
     ok =
         receive
             {'DOWN', Monitor, process, Pid, _} -> ok
-        after 500 -> timeout
+        after 1000 -> timeout
         end,
     ok = test_unregistered(Names).
 


### PR DESCRIPTION
CI crash shows the message in the mailbox, so bumping timeout might help

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
