### PR TITLE
Add support for `erlang:size/1` bif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `maps:iterator/2` and `~kp` with `io_lib:format/2` that were introduced with OTP26.
 - Support for `erlang:apply/2`
 - Support for `lists:keystore/4`
+- Support for `erlang:size/1` bif
 
 ### Changed
 

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -1500,3 +1500,15 @@ term bif_erlang_max_2(Context *ctx, uint32_t fail_label, term arg1, term arg2)
     }
     return r == TermGreaterThan ? arg1 : arg2;
 }
+
+term bif_erlang_size_1(Context *ctx, uint32_t fail_label, int live, term arg1)
+{
+    if (term_is_binary(arg1)) {
+        // For bitstrings, number of bytes is rounded down
+        return bif_erlang_byte_size_1(ctx, fail_label, live, arg1);
+    } else if (term_is_tuple(arg1)) {
+        return bif_erlang_tuple_size_1(ctx, fail_label, arg1);
+    }
+
+    RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
+}

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -110,6 +110,8 @@ term bif_erlang_get_1(Context *ctx, uint32_t fail_label, term arg1);
 term bif_erlang_min_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 term bif_erlang_max_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 
+term bif_erlang_size_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -90,3 +90,4 @@ erlang:map_size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bi
 erlang:map_get/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_map_get_2}
 erlang:min/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_min_2}
 erlang:max/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_max_2}
+erlang:size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_size_1}

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -120,6 +120,7 @@ compile_erlang(test_bitwise2)
 compile_erlang(test_boolean)
 compile_erlang(test_gt_and_le)
 compile_erlang(test_tuple_size)
+compile_erlang(test_size)
 compile_erlang(test_element)
 compile_erlang(test_setelement)
 compile_erlang(test_insert_element)
@@ -580,6 +581,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_boolean.beam
     test_gt_and_le.beam
     test_tuple_size.beam
+    test_size.beam
     test_element.beam
     test_setelement.beam
     test_insert_element.beam

--- a/tests/erlang_tests/test_size.erl
+++ b/tests/erlang_tests/test_size.erl
@@ -1,0 +1,89 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_size).
+
+-export([start/0, test_size/2, test_size_guard/2]).
+
+start() ->
+    gt = ?MODULE:test_size_guard({1, 2, 3}, 4),
+    lt = ?MODULE:test_size_guard({1, 2, 3}, 2),
+    eq = ?MODULE:test_size_guard({1, 2, 3}, 3),
+    gt = ?MODULE:test_size_guard(<<1, 2, 3>>, 4),
+    lt = ?MODULE:test_size_guard(<<1, 2, 3>>, 2),
+    eq = ?MODULE:test_size_guard(<<1, 2, 3>>, 3),
+    gt = ?MODULE:test_size_guard(<<3, 14, 1, 2, 3>>, 4),
+    lt = ?MODULE:test_size_guard(<<3, 14, 1, 2, 3>>, 2),
+    eq = ?MODULE:test_size_guard(<<3, 14, 1, 2, 3>>, 3),
+    false = ?MODULE:test_size_guard(#{a => 1, b => 2, c => 3}, 4),
+    false = ?MODULE:test_size_guard([1, 2, 3], 2),
+
+    gt = ?MODULE:test_size({1, 2, 3}, 4),
+    lt = ?MODULE:test_size({1, 2, 3}, 2),
+    eq = ?MODULE:test_size({1, 2, 3}, 3),
+    gt = ?MODULE:test_size(<<1, 2, 3>>, 4),
+    lt = ?MODULE:test_size(<<1, 2, 3>>, 2),
+    eq = ?MODULE:test_size(<<1, 2, 3>>, 3),
+    gt = ?MODULE:test_size(<<3, 14, 1, 2, 3>>, 4),
+    lt = ?MODULE:test_size(<<3, 14, 1, 2, 3>>, 2),
+    eq = ?MODULE:test_size(<<3, 14, 1, 2, 3>>, 3),
+    ok =
+        try
+            ?MODULE:test_size([1, 2, 3], 2),
+            fail
+        catch
+            error:badarg ->
+                ok
+        end,
+    ok =
+        try
+            ?MODULE:test_size(#{a => 1, b => 2, c => 3}, 4),
+            fail
+        catch
+            error:badarg ->
+                ok
+        end,
+    0.
+
+% OTP-27 encodes this as a call to byte_size/1, passing it the matching state
+% OTP-21 encodes this as a call to size/1, but encodes bs_context_to_binary
+% first.
+test_size_guard(<<3, 14, Elem/binary>>, S) when size(Elem) < S -> gt;
+test_size_guard(<<3, 14, Elem/binary>>, S) when size(Elem) > S -> lt;
+test_size_guard(<<3, 14, Elem/binary>>, S) when size(Elem) =:= S -> eq;
+test_size_guard(Elem, S) when size(Elem) < S -> gt;
+test_size_guard(Elem, S) when size(Elem) > S -> lt;
+test_size_guard(Elem, S) when size(Elem) =:= S -> eq;
+test_size_guard(_Elem, _S) -> false.
+
+test_size(<<3, 14, Elem/binary>>, S) ->
+    Size = size(Elem),
+    if
+        Size < S -> gt;
+        Size > S -> lt;
+        true -> eq
+    end;
+test_size(Elem, S) ->
+    Size = size(Elem),
+    if
+        Size < S -> gt;
+        Size > S -> lt;
+        true -> eq
+    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -143,6 +143,7 @@ struct Test tests[] = {
     TEST_CASE(test_boolean),
     TEST_CASE_EXPECTED(test_gt_and_le, 255),
     TEST_CASE_EXPECTED(test_tuple_size, 6),
+    TEST_CASE(test_size),
     TEST_CASE_EXPECTED(test_element, 7),
     TEST_CASE_EXPECTED(test_setelement, 121),
     TEST_CASE_EXPECTED(test_insert_element, 121),


### PR DESCRIPTION
The BIF was missing and it would yield a crash.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
