### PR TITLE
ESP32: USB serial output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `erlang:apply/2`
 - Support for `lists:keystore/4`
 - Support for `erlang:size/1` bif
+- Support for USB serial output on ESP32 (needs to be manually enabled)
 
 ### Changed
 


### PR DESCRIPTION
This PR just add USB serial output on ESP32, that should be manually enabled.
There will be one more PR in main branch that will enable pre-built images, menu entries, etc...

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later