### PR TITLE
Add .git_ignore esp32/test/__pycache__/**

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ xcode/**
 src/platforms/esp32/build/**
 src/platforms/esp32/build/**/*.d
 src/platforms/esp32/test/build/**
+src/platforms/esp32/test/__pycache__/**
 src/platforms/esp32/components/**
 src/platforms/esp32/managed_components/**
 src/platforms/esp32/sdkconfig


### PR DESCRIPTION
When running pytest in esp32/test it will create files eg: `src/platforms/esp32/test/__pycache__/test_atomvm.cpython-312-pytest-8.2.2.pyc` this git_ignores that folder.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
