### PR TITLE
Implement `gpio:init/1` on esp32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.4] - Unreleased
 
+### Added
+
+- Implement `gpio:init/1` on esp32 to initialize pins for GPIO usage, which some pins
+require depending on default function and bootloader code
+
 ## [0.6.3] - 20-07-2024
 
 ### Added

--- a/libs/eavmlib/src/gpio.erl
+++ b/libs/eavmlib/src/gpio.erl
@@ -296,7 +296,7 @@ remove_int(GPIO, Pin) ->
 %% @param   Pin number to initialize
 %% @returns ok
 %% @doc     Initialize a pin to be used as GPIO.
-%%          Currently only implemented (and required) for RP2040 (Pico).
+%%          This is required on RP2040 and for some pins on ESP32.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec init(Pin :: pin()) -> ok.


### PR DESCRIPTION
Some GPIO pins require initialization as gpio pins to work, for example GPIO 4 on ESP32C3. This is achieved by calling esp-idf `gpio_config`. Implement this within `gpio:init/1` which is used on rp2040.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
