### PR TITLE
Documentation typo corrections

### DIFF
--- a/doc/src/atomvm-internals.md
+++ b/doc/src/atomvm-internals.md
@@ -124,9 +124,9 @@ This section is under construction
 ## Function Calls and Return Values
 
 ## Exception Handling
+-->
 
 ## The Scheduler
--->
 
 In SMP builds, AtomVM runs one scheduler thread per core.  Scheduler threads are actually started on demand.  The number of scheduler threads can be queried with [`erlang:system_info/1`](./apidocs/erlang/estdlib/erlang.md#system_info1) and be modified with [`erlang:system_flag/2`](./apidocs/erlang/estdlib/erlang.md#system_flag2).  All scheduler threads are considered equal and there is no notion of main thread except when shutting down (main thread is shut down last).
 
@@ -255,7 +255,9 @@ This list is populated at code load time.  When a line reference is encountered 
 
 The memory cost of this list is `num_line_refs * sizeof(struct LineRefOffset)`, for each loaded module, or 0, if there is no `Line` chunk in the associated BEAM file.
 
+<!-- TODO: this sub-section can be expanded at a later date.
 ### Raw Stacktraces
+-->
 
 ## AtomVM WebAssembly port
 

--- a/doc/src/getting-started-guide.md
+++ b/doc/src/getting-started-guide.md
@@ -123,10 +123,8 @@ $ esptool.py --chip auto --port /dev/ttyUSB0 --baud 921600 erase_flash
 ```
 
 ```{note}
-Specify the device port and baud settings and AtomVM image name to suit your particular environment.
+Specify the device port and baud settings and AtomVM image name to suit your particular environment.  A baud rate of 921600 works well for most ESP32 devices, some can work reliably at higher rates of 1500000, or even 2000000, but some devices (especially those with a 26Mhz crystal frequency, rather than the more common 40 Mhz crystal) may need to use a slower baud rate such as 115200.
 ```
-
-> Note. A baud rate of 921600 works well for most ESP32 devices, some can work reliably at higher rates of 1500000, or even 2000000, but some devices (especially those with a 26Mhz crystal frequency, rather than the more common 40 Mhz crystal) may need to use a slower baud rate such as 115200.
 
 Download the latest [release image](https://github.com/atomvm/AtomVM/releases) for ESP32.
 


### PR DESCRIPTION
Fix several mistakes with misplaced markdown and comment notation that lead to mistakes in the rendered documentation.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
