### PR TITLE
Fix several Doxygen documentation entries in source files

### DIFF
--- a/src/libAtomVM/memory.h
+++ b/src/libAtomVM/memory.h
@@ -339,6 +339,7 @@ static inline void memory_heap_append_heap(Heap *target, Heap *source)
  * the copy of a term to or from a process mailbox.
  * @param mso_list the list of mark-sweep object in a heap "space"
  * @param global the global context
+ * @param from_task boolean, true if called from a task, false otherwise
  */
 void memory_sweep_mso_list(term mso_list, GlobalContext *global, bool from_task);
 

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -149,10 +149,11 @@ enum ModuleLoadResult
 
 #ifdef ENABLE_ADVANCED_TRACE
 /**
- * @briefs Gets imported function module and name
+ * @brief Gets imported function module and name
  *
  * @details Gets imported function module and name given its import table index.
  * @param this_module the module on which the function will be searched.
+ * @param index the modules import table offset to begin searching.
  * @param module_atom module name atom string.
  * @param function_atom function name atom string.
  */
@@ -207,7 +208,7 @@ static inline size_t module_get_exported_functions_list_size(Module *this_module
 term module_get_exported_functions(Module *this_module, Heap *heap, GlobalContext *global);
 
 /***
- * @brief Destoys an existing Module
+ * @brief Destroys an existing Module
  *
  * @details Destroys a module and free Module resources.
  * @param module the module that will be freed.

--- a/src/libAtomVM/otp_net.c
+++ b/src/libAtomVM/otp_net.c
@@ -110,7 +110,6 @@ static term eai_errno_to_term(int err, GlobalContext *glb)
  * @param heap the heap to create terms in, should have sufficient free space
  * @details This function is called in a loop to create optimized maps that
  * share keys.
- * @end
  */
 static term make_getaddrinfo_result(term *keys, int ai_protocol, int ai_socktype, term inner_addr, GlobalContext *global, Heap *heap)
 {

--- a/src/libAtomVM/otp_socket.c
+++ b/src/libAtomVM/otp_socket.c
@@ -442,7 +442,6 @@ static inline int get_protocol(GlobalContext *global, term protocol_term, bool *
  * @details This function is meant to be called from a nif that should return
  * its result directly, to allow for further processing of a possible out of
  * memory exception.
- * @end
  */
 static inline term make_error_tuple(term reason, Context *ctx)
 {

--- a/src/libAtomVM/otp_socket.h
+++ b/src/libAtomVM/otp_socket.h
@@ -151,7 +151,6 @@ struct LWIPEvent
  * so platforms using a queue need a global variable.
  * If lwIP callbacks are not called from ISR, calling handler with the event is
  * sufficient.
- * @end
  */
 void otp_socket_lwip_enqueue(struct LWIPEvent *event);
 


### PR DESCRIPTION
Fixes several warning by removing occourences of the unrecocognisied `@end` directive, and typos in direcive names. Adds missing parameters.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
