### PR TITLE
Stub `erlang:error/3` for Elixir support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ require depending on default function and bootloader code
 - Support for Elixir `MapSet` module
 - Support for Elixir `Range` module
 - Support for Elixir `Kernel.min` and `Kernel.max`
+- Support (as stub) for `erlang:error/3` (that is required from Elixir code)
 
 ## [0.6.3] - 20-07-2024
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3250,6 +3250,8 @@ static term nif_erlang_garbage_collect(Context *ctx, int argc, term argv[])
     return TRUE_ATOM;
 }
 
+// TODO: WORKAROUND: this function also implements erlang:error/3, but it ignores Args and Options
+// since we don't have required machinery to make use of them
 static term nif_erlang_error(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -50,6 +50,7 @@ erlang:delete_element/2, &delete_element_nif
 erlang:erase/1, &erase_nif
 erlang:error/1, &error_nif
 erlang:error/2, &error_nif
+erlang:error/3, &error_nif
 erlang:exit/1, &exit_nif
 erlang:exit/2, &exit_nif
 erlang:display/1, &display_nif


### PR DESCRIPTION
Stub function used from certain Elixir versions.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
