### PR TITLE
Fix Elixir warning

### DIFF
--- a/tests/libs/exavmlib/Tests.ex
+++ b/tests/libs/exavmlib/Tests.ex
@@ -19,6 +19,9 @@
 #
 
 defmodule Tests do
+
+  @compile {:no_warn_undefined, :undef}
+
   def start() do
     :ok = IO.puts("Running Elixir tests")
     :ok = test_enum()


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
