### PR TITLE
Correction to publish_docs workflow for branches

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -91,6 +91,14 @@ jobs:
           repository: ${{ vars.GITHUB_REPOSITORY }}
           fetch-depth: 0
 
+      - name: Track all branches
+        shell: bash
+        run: |
+          git config --global --add safe.directory /__w/AtomVM/AtomVM
+          for branch in `git branch -a | grep "remotes/origin" | grep -v HEAD | grep -v  "${{ github.ref_name }}"`; do
+            git branch --track ${branch#remotes/origin/} $branch
+          done
+
       - name: Build Site
         shell: bash
         run: |

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -98,6 +98,14 @@ jobs:
           ref: Production
           path: /home/runner/work/AtomVM/AtomVM/www
 
+      - name: Track all branches
+        shell: bash
+        run: |
+          git config --global --add safe.directory /__w/AtomVM/AtomVM
+          for branch in `git branch -a | grep "remotes/origin" | grep -v HEAD | grep -v "${{ github.ref_name }}" `; do
+            git branch --track ${branch#remotes/origin/} $branch
+          done
+
       - name: Build Site
         shell: bash
         run: |

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -171,7 +171,7 @@ for tag in tag_list:
     versions.append(tag.name)
     release_list.append(tag.name)
 
-omit_branch_list = ('release-0.5')
+omit_branch_list = [ 'release-0.5' ]
 branch_list = sorted(repo.branches, key=lambda t: t.commit.committed_datetime)
 for branch in branch_list:
     if branch.name not in omit_branch_list:


### PR DESCRIPTION
The github `actions/checkout@v4` only tracks the current branch, even when
`fetch-depth: 0` is used, this causes branch names other than the current one
to be missed when creating the html navigation menus. This is solved by adding
a step to track all of the remote branches that were fetched during checkout.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
