### PR TITLE
Update ESP32 workflows and supported versions in release notes

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -38,17 +38,14 @@ jobs:
       matrix:
         esp-idf-target: ["esp32", "esp32c3"]
         idf-version:
-         - 'v4.4.7'
-         - 'v5.0.6'
+         - 'v5.0.7'
          - 'v5.1.4'
          - 'v5.2.2'
-         - 'v5.3-rc1'
+         - 'v5.3.1'
 
         exclude:
         - esp-idf-target: "esp32c3"
-          idf-version: 'v4.4.7'
-        - esp-idf-target: "esp32c3"
-          idf-version: 'v5.0.6'
+          idf-version: 'v5.0.7'
         - esp-idf-target: "esp32c3"
           idf-version: 'v5.1.4'
     steps:

--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -13,12 +13,14 @@ on:
       - 'CMakeLists.txt'
       - 'libs/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/esp32/**/**'
       - 'src/libAtomVM/**'
       - 'tools/packbeam/**'
   pull_request:
     paths:
       - '.github/workflows/esp32-build.yaml'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/esp32/**/**'
       - 'src/libAtomVM/**'
 
 concurrency:

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -13,12 +13,14 @@ on:
       - 'CMakeLists.txt'
       - 'libs/**'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/esp32/**/**'
       - 'src/libAtomVM/**'
       - 'tools/packbeam/**'
   pull_request:
     paths:
       - '.github/workflows/esp32-mkimage.yaml'
       - 'src/platforms/esp32/**'
+      - 'src/platforms/esp32/**/**'
       - 'src/libAtomVM/**'
 
 permissions:

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -32,18 +32,18 @@ concurrency:
 
 jobs:
   esp32-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: espressif/idf:v${{ matrix.idf-version }}
 
     strategy:
       matrix:
-        idf-version: ["5.1.4"]
-        cc: ["clang-10"]
-        cxx: ["clang++-10"]
+        idf-version: ["5.3.1"]
+        cc: ["clang-14"]
+        cxx: ["clang++-14"]
         cflags: ["-O3"]
         otp: ["27"]
         elixir_version: ["1.17"]
-        compiler_pkgs: ["clang-10"]
+        compiler_pkgs: ["clang-14"]
         soc: ["esp32", "esp32c2", "esp32c3", "esp32s2", "esp32s3", "esp32c6", "esp32h2"]
 
     env:
@@ -51,7 +51,7 @@ jobs:
       CXX: ${{ matrix.cxx }}
       CFLAGS: ${{ matrix.cflags }}
       CXXFLAGS: ${{ matrix.cflags }}
-      ImageOS: "ubuntu20"
+      ImageOS: "ubuntu22"
 
     steps:
     - name: Checkout repo

--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -67,10 +67,10 @@ AtomVM currently supports the following versions of ESP-IDF:
 
 | IDF SDK supported versions | AtomVM support |
 |------------------------------|----------------|
-| ESP-IDF [v4.4](https://docs.espressif.com/projects/esp-idf/en/v4.4.7/esp32/get-started/index.html) | ✅ |
-| ESP-IDF [v5.0](https://docs.espressif.com/projects/esp-idf/en/v5.0.6/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.0](https://docs.espressif.com/projects/esp-idf/en/v5.0.7/esp32/get-started/index.html) | ✅ |
 | ESP-IDF [v5.1](https://docs.espressif.com/projects/esp-idf/en/v5.1.4/esp32/get-started/index.html) | ✅ |
 | ESP-IDF [v5.2](https://docs.espressif.com/projects/esp-idf/en/v5.2.2/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.3](https://docs.espressif.com/projects/esp-idf/en/v5.3/esp32/get-started/index.html) | ✅ |
 
 Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.  We recommend you to use the latest subminor (patch) versions for source builds. You can check the current version used for testing in the [esp32-build.yaml](https://github.com/atomvm/AtomVM/actions/workflows/esp32-build.yaml) workflow.
 


### PR DESCRIPTION
Updates the esp32 workflows to versions currently supported by Espressif, and updates the supported versions table in the release notes to match the CI.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
