### PR TITLE
fix: ESP32 gpiodriver_set_int - pin number handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ instead
 ### Fixed
 
 - ESP32: content of `boot.avm` partition is not truncated anymore
+- ESP32: Fixed gpio:set_int` to accept any pin, not only pin 2
 
 ## [0.6.4] - 2024-08-18
 

--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -422,10 +422,10 @@ static term gpiodriver_set_int(Context *ctx, int32_t target_pid, term cmd)
 
     struct GPIOData *gpio_data = ctx->platform_data;
 
-    term gpio_num_term = term_to_int32(term_get_tuple_element(cmd, 1));
+    term gpio_num_term = term_get_tuple_element(cmd, 1);
     gpio_num_t gpio_num;
     if (LIKELY(term_is_integer(gpio_num_term))) {
-        avm_int_t pin_int = term_to_int32(gpio_num_term);
+        int32_t pin_int = term_to_int32(gpio_num_term);
         if (UNLIKELY((pin_int < 0) || (pin_int >= GPIO_NUM_MAX))) {
             return ERROR_ATOM;
         }
@@ -525,10 +525,10 @@ static term gpiodriver_remove_int(Context *ctx, term cmd)
 {
     struct GPIOData *gpio_data = ctx->platform_data;
 
-    term gpio_num_term = term_to_int32(term_get_tuple_element(cmd, 1));
+    term gpio_num_term = term_get_tuple_element(cmd, 1);
     gpio_num_t gpio_num;
     if (LIKELY(term_is_integer(gpio_num_term))) {
-        avm_int_t pin_int = term_to_int32(gpio_num_term);
+        int32_t pin_int = term_to_int32(gpio_num_term);
         if (UNLIKELY((pin_int < 0) || (pin_int >= GPIO_NUM_MAX))) {
             return ERROR_ATOM;
         }


### PR DESCRIPTION
Cast Pin number to integer after checking if it is integer.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
