### PR TITLE
Increase Elixir support (part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Elixir standard library modules
 - ESP32: `--boot` option to mkimage.sh tool
 - Add `erlang:atom_to_binary/1` that is equivalent to `erlang:atom_to_binary(Atom, utf8)`
-- Support for Elixir `String.Chars` protocol
+- Support for Elixir `String.Chars` protocol, now functions such as `Enum.join` are able to take
+also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for Elixir `Enum.at/3`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Elixir standard library modules
 - ESP32: `--boot` option to mkimage.sh tool
 - Add `erlang:atom_to_binary/1` that is equivalent to `erlang:atom_to_binary(Atom, utf8)`
 - Support for Elixir `String.Chars` protocol
+- Support for Elixir `Enum.at/3`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Elixir standard library modules
 - ESP32: `--boot` option to mkimage.sh tool
 - Add `erlang:atom_to_binary/1` that is equivalent to `erlang:atom_to_binary(Atom, utf8)`
+- Support for Elixir `String.Chars` protocol
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Elixir standard library modules
 - Support for Elixir `String.Chars` protocol, now functions such as `Enum.join` are able to take
 also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for Elixir `Enum.at/3`
-- Add support to Elixir `Enumerable` protocol also for `Enum.all?`, `Enum.any?` and `Enum.filter`
+- Add support to Elixir `Enumerable` protocol also for `Enum.all?`, `Enum.any?`, `Enum.each` and
+`Enum.filter`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32: add a new Elixir release "flavor" with a bigger boot.avm partition that has room for
 Elixir standard library modules
 - ESP32: `--boot` option to mkimage.sh tool
+- Add `erlang:atom_to_binary/1` that is equivalent to `erlang:atom_to_binary(Atom, utf8)`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Elixir standard library modules
 - Support for Elixir `String.Chars` protocol, now functions such as `Enum.join` are able to take
 also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for Elixir `Enum.at/3`
-- Add support to Elixir `Enumerable` protocol also for `Enum.all?` and `Enum.any?`
+- Add support to Elixir `Enumerable` protocol also for `Enum.all?`, `Enum.any?` and `Enum.filter`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Elixir standard library modules
 - Support for Elixir `String.Chars` protocol, now functions such as `Enum.join` are able to take
 also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for Elixir `Enum.at/3`
+- Add support to Elixir `Enumerable` protocol also for `Enum.all?` and `Enum.any?`
 
 ### Changed
 

--- a/libs/exavmlib/lib/CMakeLists.txt
+++ b/libs/exavmlib/lib/CMakeLists.txt
@@ -74,6 +74,13 @@ set(ELIXIR_MODULES
     Collectable.List
     Collectable.Map
     Collectable.MapSet
+
+    String.Chars
+    String.Chars.Atom
+    String.Chars.BitString
+    String.Chars.Float
+    String.Chars.Integer
+    String.Chars.List
 )
 
 pack_archive(exavmlib ${ELIXIR_MODULES})

--- a/libs/exavmlib/lib/Enum.ex
+++ b/libs/exavmlib/lib/Enum.ex
@@ -448,12 +448,12 @@ defmodule Enum do
   end
 
   @doc """
-  Joins the given enumerable into a binary using `joiner` as a
+  Joins the given `enumerable` into a binary using `joiner` as a
   separator.
 
   If `joiner` is not passed at all, it defaults to the empty binary.
 
-  All items in the enumerable must be convertible to a binary,
+  All elements in the `enumerable` must be convertible to a binary,
   otherwise an error is raised.
 
   ## Examples
@@ -467,6 +467,12 @@ defmodule Enum do
   """
   @spec join(t, String.t()) :: String.t()
   def join(enumerable, joiner \\ "")
+
+  def join(enumerable, "") do
+    enumerable
+    |> map(&entry_to_string(&1))
+    |> IO.iodata_to_binary()
+  end
 
   def join(enumerable, joiner) when is_binary(joiner) do
     reduced =
@@ -669,6 +675,7 @@ defmodule Enum do
   @compile {:inline, entry_to_string: 1, reduce: 3}
 
   defp entry_to_string(entry) when is_binary(entry), do: entry
+  defp entry_to_string(entry), do: String.Chars.to_string(entry)
 
   ## drop
 

--- a/libs/exavmlib/lib/Enum.ex
+++ b/libs/exavmlib/lib/Enum.ex
@@ -128,8 +128,33 @@ defmodule Enum do
     filter_list(enumerable, fun)
   end
 
+  @doc """
+  Returns the first element for which `fun` returns a truthy value.
+  If no such element is found, returns `default`.
+
+  ## Examples
+
+      iex> Enum.find([2, 3, 4], fn x -> rem(x, 2) == 1 end)
+      3
+
+      iex> Enum.find([2, 4, 6], fn x -> rem(x, 2) == 1 end)
+      nil
+      iex> Enum.find([2, 4, 6], 0, fn x -> rem(x, 2) == 1 end)
+      0
+
+  """
+  @spec find(t, default, (element -> any)) :: element | default
+  def find(enumerable, default \\ nil, fun)
+
   def find(enumerable, default, fun) when is_list(enumerable) do
     find_list(enumerable, default, fun)
+  end
+
+  def find(enumerable, default, fun) do
+    Enumerable.reduce(enumerable, {:cont, default}, fn entry, default ->
+      if fun.(entry), do: {:halt, entry}, else: {:cont, default}
+    end)
+    |> elem(1)
   end
 
   def find_index(enumerable, fun) when is_list(enumerable) do

--- a/libs/exavmlib/lib/Enum.ex
+++ b/libs/exavmlib/lib/Enum.ex
@@ -209,8 +209,31 @@ defmodule Enum do
     end
   end
 
+  @doc """
+  Invokes the given `fun` for each element in the `enumerable`.
+
+  Returns `:ok`.
+
+  ## Examples
+
+      Enum.each(["some", "example"], fn x -> IO.puts(x) end)
+      "some"
+      "example"
+      #=> :ok
+
+  """
+  @spec each(t, (element -> any)) :: :ok
   def each(enumerable, fun) when is_list(enumerable) do
     :lists.foreach(fun, enumerable)
+    :ok
+  end
+
+  def each(enumerable, fun) do
+    reduce(enumerable, nil, fn entry, _ ->
+      fun.(entry)
+      nil
+    end)
+
     :ok
   end
 

--- a/libs/exavmlib/lib/Enum.ex
+++ b/libs/exavmlib/lib/Enum.ex
@@ -55,12 +55,98 @@ defmodule Enum do
     Enumerable.reduce(enumerable, {:cont, acc}, fn x, acc -> {:cont, fun.(x, acc)} end) |> elem(1)
   end
 
+  @doc """
+  Returns `true` if `fun.(element)` is truthy for all elements in `enumerable`.
+
+  Iterates over the `enumerable` and invokes `fun` on each element. When an invocation
+  of `fun` returns a falsy value (`false` or `nil`) iteration stops immediately and
+  `false` is returned. In all other cases `true` is returned.
+
+  ## Examples
+
+      iex> Enum.all?([2, 4, 6], fn x -> rem(x, 2) == 0 end)
+      true
+
+      iex> Enum.all?([2, 3, 4], fn x -> rem(x, 2) == 0 end)
+      false
+
+      iex> Enum.all?([], fn x -> x > 0 end)
+      true
+
+  If no function is given, the truthiness of each element is checked during iteration.
+  When an element has a falsy value (`false` or `nil`) iteration stops immediately and
+  `false` is returned. In all other cases `true` is returned.
+
+      iex> Enum.all?([1, 2, 3])
+      true
+
+      iex> Enum.all?([1, nil, 3])
+      false
+
+      iex> Enum.all?([])
+      true
+
+  """
+  @spec all?(t, (element -> as_boolean(term))) :: boolean
+
+  def all?(enumerable, fun \\ fn x -> x end)
+
   def all?(enumerable, fun) when is_list(enumerable) do
     all_list(enumerable, fun)
   end
 
+  def all?(enumerable, fun) do
+    Enumerable.reduce(enumerable, {:cont, true}, fn entry, _ ->
+      if fun.(entry), do: {:cont, true}, else: {:halt, false}
+    end)
+    |> elem(1)
+  end
+
+  @doc """
+  Returns `true` if `fun.(element)` is truthy for at least one element in `enumerable`.
+
+  Iterates over the `enumerable` and invokes `fun` on each element. When an invocation
+  of `fun` returns a truthy value (neither `false` nor `nil`) iteration stops
+  immediately and `true` is returned. In all other cases `false` is returned.
+
+  ## Examples
+
+      iex> Enum.any?([2, 4, 6], fn x -> rem(x, 2) == 1 end)
+      false
+
+      iex> Enum.any?([2, 3, 4], fn x -> rem(x, 2) == 1 end)
+      true
+
+      iex> Enum.any?([], fn x -> x > 0 end)
+      false
+
+  If no function is given, the truthiness of each element is checked during iteration.
+  When an element has a truthy value (neither `false` nor `nil`) iteration stops
+  immediately and `true` is returned. In all other cases `false` is returned.
+
+      iex> Enum.any?([false, false, false])
+      false
+
+      iex> Enum.any?([false, true, false])
+      true
+
+      iex> Enum.any?([])
+      false
+
+  """
+  @spec any?(t, (element -> as_boolean(term))) :: boolean
+
+  def any?(enumerable, fun \\ fn x -> x end)
+
   def any?(enumerable, fun) when is_list(enumerable) do
     any_list(enumerable, fun)
+  end
+
+  def any?(enumerable, fun) do
+    Enumerable.reduce(enumerable, {:cont, false}, fn entry, _ ->
+      if fun.(entry), do: {:halt, true}, else: {:cont, false}
+    end)
+    |> elem(1)
   end
 
   @doc """

--- a/libs/exavmlib/lib/Enum.ex
+++ b/libs/exavmlib/lib/Enum.ex
@@ -31,6 +31,10 @@ defmodule Enum do
 
   require Stream.Reducers, as: R
 
+  defmacrop skip(acc) do
+    acc
+  end
+
   defmacrop next(_, entry, acc) do
     quote(do: [unquote(entry) | unquote(acc)])
   end
@@ -210,8 +214,43 @@ defmodule Enum do
     :ok
   end
 
+  @doc """
+  Filters the `enumerable`, i.e. returns only those elements
+  for which `fun` returns a truthy value.
+
+  See also `reject/2` which discards all elements where the
+  function returns a truthy value.
+
+  ## Examples
+
+      iex> Enum.filter([1, 2, 3], fn x -> rem(x, 2) == 0 end)
+      [2]
+
+  Keep in mind that `filter` is not capable of filtering and
+  transforming an element at the same time. If you would like
+  to do so, consider using `flat_map/2`. For example, if you
+  want to convert all strings that represent an integer and
+  discard the invalid one in one pass:
+
+      strings = ["1234", "abc", "12ab"]
+
+      Enum.flat_map(strings, fn string ->
+        case Integer.parse(string) do
+          # transform to integer
+          {int, _rest} -> [int]
+          # skip the value
+          :error -> []
+        end
+      end)
+
+  """
+  @spec filter(t, (element -> as_boolean(term))) :: list
   def filter(enumerable, fun) when is_list(enumerable) do
     filter_list(enumerable, fun)
+  end
+
+  def filter(enumerable, fun) do
+    reduce(enumerable, [], R.filter(fun)) |> :lists.reverse()
   end
 
   @doc """

--- a/libs/exavmlib/lib/Enum.ex
+++ b/libs/exavmlib/lib/Enum.ex
@@ -27,6 +27,8 @@ defmodule Enum do
   @type index :: integer
   @type element :: any
 
+  @type default :: any
+
   require Stream.Reducers, as: R
 
   defmacrop next(_, entry, acc) do
@@ -59,6 +61,38 @@ defmodule Enum do
 
   def any?(enumerable, fun) when is_list(enumerable) do
     any_list(enumerable, fun)
+  end
+
+  @doc """
+  Finds the element at the given `index` (zero-based).
+
+  Returns `default` if `index` is out of bounds.
+
+  A negative `index` can be passed, which means the `enumerable` is
+  enumerated once and the `index` is counted from the end (for example,
+  `-1` finds the last element).
+
+  ## Examples
+
+      iex> Enum.at([2, 4, 6], 0)
+      2
+
+      iex> Enum.at([2, 4, 6], 2)
+      6
+
+      iex> Enum.at([2, 4, 6], 4)
+      nil
+
+      iex> Enum.at([2, 4, 6], 4, :none)
+      :none
+
+  """
+  @spec at(t, index, default) :: element | default
+  def at(enumerable, index, default \\ nil) when is_integer(index) do
+    case slice_any(enumerable, index, 1) do
+      [value] -> value
+      [] -> default
+    end
   end
 
   @doc """

--- a/libs/exavmlib/lib/Enumerable.MapSet.ex
+++ b/libs/exavmlib/lib/Enumerable.MapSet.ex
@@ -34,6 +34,6 @@ defimpl Enumerable, for: MapSet do
 
   def slice(map_set) do
     size = MapSet.size(map_set)
-    {:ok, size, &MapSet.to_list/1}
+    {:ok, size, &Enumerable.List.slice(MapSet.to_list(map_set), &1, &2, size)}
   end
 end

--- a/libs/exavmlib/lib/String.Chars.Atom.ex
+++ b/libs/exavmlib/lib/String.Chars.Atom.ex
@@ -1,0 +1,32 @@
+#
+# This file is part of elixir-lang.
+#
+# Copyright 2013-2023 Elixir Contributors
+# https://github.com/elixir-lang/elixir/commits/v1.17.2/lib/elixir/lib/string/chars.ex
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import Kernel, except: [to_string: 1]
+
+defimpl String.Chars, for: Atom do
+  def to_string(nil) do
+    ""
+  end
+
+  def to_string(atom) do
+    Atom.to_string(atom)
+  end
+end

--- a/libs/exavmlib/lib/String.Chars.BitString.ex
+++ b/libs/exavmlib/lib/String.Chars.BitString.ex
@@ -1,0 +1,35 @@
+#
+# This file is part of elixir-lang.
+#
+# Copyright 2013-2023 Elixir Contributors
+# https://github.com/elixir-lang/elixir/commits/v1.17.2/lib/elixir/lib/string/chars.ex
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import Kernel, except: [to_string: 1]
+
+defimpl String.Chars, for: BitString do
+  def to_string(term) when is_binary(term) do
+    term
+  end
+
+  def to_string(term) do
+    raise Protocol.UndefinedError,
+      protocol: @protocol,
+      value: term,
+      description: "cannot convert a bitstring to a string"
+  end
+end

--- a/libs/exavmlib/lib/String.Chars.Float.ex
+++ b/libs/exavmlib/lib/String.Chars.Float.ex
@@ -1,0 +1,29 @@
+#
+# This file is part of elixir-lang.
+#
+# Copyright 2013-2023 Elixir Contributors
+# https://github.com/elixir-lang/elixir/commits/v1.17.2/lib/elixir/lib/string/chars.ex
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import Kernel, except: [to_string: 1]
+
+defimpl String.Chars, for: Float do
+  def to_string(term) do
+    # TODO: :short option not yet supported right now, so :decimals+:compact should be replaced
+    :erlang.float_to_binary(term, [{:decimals, 17}, :compact])
+  end
+end

--- a/libs/exavmlib/lib/String.Chars.Integer.ex
+++ b/libs/exavmlib/lib/String.Chars.Integer.ex
@@ -1,0 +1,28 @@
+#
+# This file is part of elixir-lang.
+#
+# Copyright 2013-2023 Elixir Contributors
+# https://github.com/elixir-lang/elixir/commits/v1.17.2/lib/elixir/lib/string/chars.ex
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import Kernel, except: [to_string: 1]
+
+defimpl String.Chars, for: Integer do
+  def to_string(term) do
+    Integer.to_string(term)
+  end
+end

--- a/libs/exavmlib/lib/String.Chars.List.ex
+++ b/libs/exavmlib/lib/String.Chars.List.ex
@@ -1,0 +1,26 @@
+#
+# This file is part of elixir-lang.
+#
+# Copyright 2013-2023 Elixir Contributors
+# https://github.com/elixir-lang/elixir/commits/v1.17.2/lib/elixir/lib/string/chars.ex
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import Kernel, except: [to_string: 1]
+
+defimpl String.Chars, for: List do
+  def to_string(charlist), do: List.to_string(charlist)
+end

--- a/libs/exavmlib/lib/String.Chars.ex
+++ b/libs/exavmlib/lib/String.Chars.ex
@@ -1,0 +1,44 @@
+#
+# This file is part of elixir-lang.
+#
+# Copyright 2013-2023 Elixir Contributors
+# https://github.com/elixir-lang/elixir/commits/v1.17.2/lib/elixir/lib/string/chars.ex
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import Kernel, except: [to_string: 1]
+
+defprotocol String.Chars do
+  @moduledoc ~S"""
+  The `String.Chars` protocol is responsible for
+  converting a structure to a binary (only if applicable).
+
+  The only function required to be implemented is
+  `to_string/1`, which does the conversion.
+
+  The `to_string/1` function automatically imported
+  by `Kernel` invokes this protocol. String
+  interpolation also invokes `to_string/1` in its
+  arguments. For example, `"foo#{bar}"` is the same
+  as `"foo" <> to_string(bar)`.
+  """
+
+  @doc """
+  Converts `term` to a string.
+  """
+  @spec to_string(t) :: String.t()
+  def to_string(term)
+end

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -94,7 +94,7 @@ static term nif_binary_part_3(Context *ctx, int argc, term argv[]);
 static term nif_binary_split_2(Context *ctx, int argc, term argv[]);
 static term nif_calendar_system_time_to_universal_time_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_delete_element_2(Context *ctx, int argc, term argv[]);
-static term nif_erlang_atom_to_binary_2(Context *ctx, int argc, term argv[]);
+static term nif_erlang_atom_to_binary(Context *ctx, int argc, term argv[]);
 static term nif_erlang_atom_to_list_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_binary_to_atom_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_binary_to_float_1(Context *ctx, int argc, term argv[]);
@@ -243,7 +243,7 @@ static const struct Nif make_ref_nif =
 static const struct Nif atom_to_binary_nif =
 {
     .base.type = NIFFunctionType,
-    .nif_ptr = nif_erlang_atom_to_binary_2
+    .nif_ptr = nif_erlang_atom_to_binary
 };
 
 static const struct Nif atom_to_list_nif =
@@ -2072,14 +2072,12 @@ term list_to_atom(Context *ctx, int argc, term argv[], int create_new)
     return term_from_atom_index(global_atom_index);
 }
 
-static term nif_erlang_atom_to_binary_2(Context *ctx, int argc, term argv[])
+static term nif_erlang_atom_to_binary(Context *ctx, int argc, term argv[])
 {
-    UNUSED(argc);
-
     term atom_term = argv[0];
     VALIDATE_VALUE(atom_term, term_is_atom);
 
-    term encoding = argv[1];
+    term encoding = (argc == 1) ? UTF8_ATOM : argv[1];
 
     GlobalContext *glb = ctx->global;
 

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -37,6 +37,7 @@ binary:last/1, &binary_last_nif
 binary:part/3, &binary_part_nif
 binary:split/2, &binary_split_nif
 calendar:system_time_to_universal_time/2, &system_time_to_universal_time_nif
+erlang:atom_to_binary/1, &atom_to_binary_nif
 erlang:atom_to_binary/2, &atom_to_binary_nif
 erlang:atom_to_list/1, &atom_to_list_nif
 erlang:binary_to_atom/1, &binary_to_atom_nif

--- a/tests/libs/exavmlib/Tests.ex
+++ b/tests/libs/exavmlib/Tests.ex
@@ -41,6 +41,7 @@ defmodule Tests do
     :atom = Enum.find([1, 2, :atom, 3, 4], -1, fn item -> not is_integer(item) end)
     true = Enum.all?([1, 2, 3], fn n -> n >= 0 end)
     true = Enum.any?([1, -2, 3], fn n -> n < 0 end)
+    [2] = Enum.filter([1, 2, 3], fn n -> rem(n, 2) == 0 end)
 
     # map
     2 = Enum.count(%{a: 1, b: 2})
@@ -63,6 +64,7 @@ defmodule Tests do
     {:d, 3} = Enum.find(%{a: 1, b: 2, c: :atom, d: 3}, fn {k, _v} -> k == :d end)
     true = Enum.all?(%{a: 1, b: 2}, fn {_k, v} -> v >= 0 end)
     true = Enum.any?(%{a: 1, b: -2}, fn {_k, v} -> v < 0 end)
+    [b: 2] = Enum.filter(%{a: 1, b: 2, c: 3}, fn {_k, v} -> rem(v, 2) == 0 end)
 
     # map set
     3 = Enum.count(MapSet.new([0, 1, 2]))
@@ -78,6 +80,7 @@ defmodule Tests do
     :atom = Enum.find(MapSet.new([1, 2, :atom, 3, 4]), fn item -> not is_integer(item) end)
     true = Enum.all?(MapSet.new([1, 2, 3]), fn n -> n >= 0 end)
     true = Enum.any?(MapSet.new([1, -2, 3]), fn n -> n < 0 end)
+    [2] = Enum.filter(MapSet.new([1, 2, 3]), fn n -> rem(n, 2) == 0 end)
 
     # range
     4 = Enum.count(1..4)
@@ -90,6 +93,7 @@ defmodule Tests do
     8 = Enum.find(-10..10, fn item -> item >= 8 end)
     true = Enum.all?(0..10, fn n -> n >= 0 end)
     true = Enum.any?(-1..10, fn n -> n < 0 end)
+    [0, 1, 2] = Enum.filter(-10..2, fn n -> n >= 0 end)
 
     # into
     %{a: 1, b: 2} = Enum.into([a: 1, b: 2], %{})

--- a/tests/libs/exavmlib/Tests.ex
+++ b/tests/libs/exavmlib/Tests.ex
@@ -38,6 +38,7 @@ defmodule Tests do
     6 = Enum.reduce([1, 2, 3], 0, fn x, acc -> acc + x end)
     [2, 3] = Enum.slice([1, 2, 3], 1, 2)
     :test = Enum.at([0, 1, :test, 3], 2)
+    :atom = Enum.find([1, 2, :atom, 3, 4], -1, fn item -> not is_integer(item) end)
 
     # map
     2 = Enum.count(%{a: 1, b: 2})
@@ -56,6 +57,8 @@ defmodule Tests do
     true = at_0 == {:a, 1} or at_0 == {:b, 2}
     true = at_1 == {:a, 1} or at_1 == {:b, 2}
     true = at_0 != at_1
+    {:c, :atom} = Enum.find(%{a: 1, b: 2, c: :atom, d: 3}, fn {_k, v} -> not is_integer(v) end)
+    {:d, 3} = Enum.find(%{a: 1, b: 2, c: :atom, d: 3}, fn {k, _v} -> k == :d end)
 
     # map set
     3 = Enum.count(MapSet.new([0, 1, 2]))
@@ -68,6 +71,7 @@ defmodule Tests do
     ms_at_1 = Enum.at(MapSet.new([1, 2]), 1)
     true = ms_at_0 == 1 or ms_at_0 == 2
     true = ms_at_1 == 1 or ms_at_1 == 2
+    :atom = Enum.find(MapSet.new([1, 2, :atom, 3, 4]), fn item -> not is_integer(item) end)
 
     # range
     4 = Enum.count(1..4)
@@ -77,6 +81,7 @@ defmodule Tests do
     55 = Enum.reduce(1..10, 0, fn x, acc -> x + acc end)
     [6, 7, 8, 9, 10] = Enum.slice(1..10, 5, 100)
     7 = Enum.at(1..10, 6)
+    8 = Enum.find(-10..10, fn item -> item >= 8 end)
 
     # into
     %{a: 1, b: 2} = Enum.into([a: 1, b: 2], %{})

--- a/tests/libs/exavmlib/Tests.ex
+++ b/tests/libs/exavmlib/Tests.ex
@@ -39,6 +39,8 @@ defmodule Tests do
     [2, 3] = Enum.slice([1, 2, 3], 1, 2)
     :test = Enum.at([0, 1, :test, 3], 2)
     :atom = Enum.find([1, 2, :atom, 3, 4], -1, fn item -> not is_integer(item) end)
+    true = Enum.all?([1, 2, 3], fn n -> n >= 0 end)
+    true = Enum.any?([1, -2, 3], fn n -> n < 0 end)
 
     # map
     2 = Enum.count(%{a: 1, b: 2})
@@ -59,6 +61,8 @@ defmodule Tests do
     true = at_0 != at_1
     {:c, :atom} = Enum.find(%{a: 1, b: 2, c: :atom, d: 3}, fn {_k, v} -> not is_integer(v) end)
     {:d, 3} = Enum.find(%{a: 1, b: 2, c: :atom, d: 3}, fn {k, _v} -> k == :d end)
+    true = Enum.all?(%{a: 1, b: 2}, fn {_k, v} -> v >= 0 end)
+    true = Enum.any?(%{a: 1, b: -2}, fn {_k, v} -> v < 0 end)
 
     # map set
     3 = Enum.count(MapSet.new([0, 1, 2]))
@@ -72,6 +76,8 @@ defmodule Tests do
     true = ms_at_0 == 1 or ms_at_0 == 2
     true = ms_at_1 == 1 or ms_at_1 == 2
     :atom = Enum.find(MapSet.new([1, 2, :atom, 3, 4]), fn item -> not is_integer(item) end)
+    true = Enum.all?(MapSet.new([1, 2, 3]), fn n -> n >= 0 end)
+    true = Enum.any?(MapSet.new([1, -2, 3]), fn n -> n < 0 end)
 
     # range
     4 = Enum.count(1..4)
@@ -82,6 +88,8 @@ defmodule Tests do
     [6, 7, 8, 9, 10] = Enum.slice(1..10, 5, 100)
     7 = Enum.at(1..10, 6)
     8 = Enum.find(-10..10, fn item -> item >= 8 end)
+    true = Enum.all?(0..10, fn n -> n >= 0 end)
+    true = Enum.any?(-1..10, fn n -> n < 0 end)
 
     # into
     %{a: 1, b: 2} = Enum.into([a: 1, b: 2], %{})

--- a/tests/libs/exavmlib/Tests.ex
+++ b/tests/libs/exavmlib/Tests.ex
@@ -19,13 +19,13 @@
 #
 
 defmodule Tests do
-
   @compile {:no_warn_undefined, :undef}
 
   def start() do
     :ok = IO.puts("Running Elixir tests")
     :ok = test_enum()
     :ok = test_exception()
+    :ok = test_chars_protocol()
     :ok = IO.puts("Finished Elixir tests")
   end
 
@@ -147,6 +147,17 @@ defmodule Tests do
 
     %MatchError{} = ex5
 
+    :ok
+  end
+
+  def test_chars_protocol() do
+    "" = String.Chars.to_string(nil)
+    "hello" = String.Chars.to_string(:hello)
+    "hellø" = String.Chars.to_string(:hellø)
+    "123" = String.Chars.to_string(123)
+    "1.0" = String.Chars.to_string(1.0)
+    "abc" = String.Chars.to_string(~c"abc")
+    "test" = String.Chars.to_string("test")
     :ok
   end
 

--- a/tests/libs/exavmlib/Tests.ex
+++ b/tests/libs/exavmlib/Tests.ex
@@ -37,6 +37,7 @@ defmodule Tests do
     [0, 2, 4] = Enum.map([0, 1, 2], fn x -> x * 2 end)
     6 = Enum.reduce([1, 2, 3], 0, fn x, acc -> acc + x end)
     [2, 3] = Enum.slice([1, 2, 3], 1, 2)
+    :test = Enum.at([0, 1, :test, 3], 2)
 
     # map
     2 = Enum.count(%{a: 1, b: 2})
@@ -49,7 +50,12 @@ defmodule Tests do
     :a = kw2[:A]
     :b = kw2[:B]
     kw3 = Enum.slice(%{a: 1, b: 2}, 0, 1)
-    true = (length(kw3) == 1) and ((kw3[:a] == 1) or (kw3[:b] == 2))
+    true = length(kw3) == 1 and (kw3[:a] == 1 or kw3[:b] == 2)
+    at_0 = Enum.at(%{a: 1, b: 2}, 0)
+    at_1 = Enum.at(%{a: 1, b: 2}, 1)
+    true = at_0 == {:a, 1} or at_0 == {:b, 2}
+    true = at_1 == {:a, 1} or at_1 == {:b, 2}
+    true = at_0 != at_1
 
     # map set
     3 = Enum.count(MapSet.new([0, 1, 2]))
@@ -58,6 +64,10 @@ defmodule Tests do
     [0, 2, 4] = Enum.map(MapSet.new([0, 1, 2]), fn x -> x * 2 end)
     6 = Enum.reduce(MapSet.new([1, 2, 3]), 0, fn x, acc -> acc + x end)
     [] = Enum.slice(MapSet.new([1, 2]), 1, 0)
+    ms_at_0 = Enum.at(MapSet.new([1, 2]), 0)
+    ms_at_1 = Enum.at(MapSet.new([1, 2]), 1)
+    true = ms_at_0 == 1 or ms_at_0 == 2
+    true = ms_at_1 == 1 or ms_at_1 == 2
 
     # range
     4 = Enum.count(1..4)
@@ -66,6 +76,7 @@ defmodule Tests do
     [1, 2, 3, 4] = Enum.map(1..4, fn x -> x end)
     55 = Enum.reduce(1..10, 0, fn x, acc -> x + acc end)
     [6, 7, 8, 9, 10] = Enum.slice(1..10, 5, 100)
+    7 = Enum.at(1..10, 6)
 
     # into
     %{a: 1, b: 2} = Enum.into([a: 1, b: 2], %{})

--- a/tests/libs/exavmlib/Tests.ex
+++ b/tests/libs/exavmlib/Tests.ex
@@ -91,6 +91,8 @@ defmodule Tests do
 
     # Enum.join
     "1, 2, 3" = Enum.join(["1", "2", "3"], ", ")
+    "1, 2, 3" = Enum.join([1, 2, 3], ", ")
+    "123" = Enum.join([1, 2, 3], "")
 
     # Enum.reverse
     [4, 3, 2] = Enum.reverse([2, 3, 4])

--- a/tests/libs/exavmlib/Tests.ex
+++ b/tests/libs/exavmlib/Tests.ex
@@ -42,6 +42,7 @@ defmodule Tests do
     true = Enum.all?([1, 2, 3], fn n -> n >= 0 end)
     true = Enum.any?([1, -2, 3], fn n -> n < 0 end)
     [2] = Enum.filter([1, 2, 3], fn n -> rem(n, 2) == 0 end)
+    :ok = Enum.each([1, 2, 3], fn n -> true = is_integer(n) end)
 
     # map
     2 = Enum.count(%{a: 1, b: 2})
@@ -65,6 +66,7 @@ defmodule Tests do
     true = Enum.all?(%{a: 1, b: 2}, fn {_k, v} -> v >= 0 end)
     true = Enum.any?(%{a: 1, b: -2}, fn {_k, v} -> v < 0 end)
     [b: 2] = Enum.filter(%{a: 1, b: 2, c: 3}, fn {_k, v} -> rem(v, 2) == 0 end)
+    :ok = Enum.each(%{a: 1, b: 2}, fn {_k, v} -> true = is_integer(v) end)
 
     # map set
     3 = Enum.count(MapSet.new([0, 1, 2]))
@@ -81,6 +83,7 @@ defmodule Tests do
     true = Enum.all?(MapSet.new([1, 2, 3]), fn n -> n >= 0 end)
     true = Enum.any?(MapSet.new([1, -2, 3]), fn n -> n < 0 end)
     [2] = Enum.filter(MapSet.new([1, 2, 3]), fn n -> rem(n, 2) == 0 end)
+    :ok = Enum.each(MapSet.new([1, 2, 3]), fn n -> true = is_integer(n) end)
 
     # range
     4 = Enum.count(1..4)
@@ -94,6 +97,7 @@ defmodule Tests do
     true = Enum.all?(0..10, fn n -> n >= 0 end)
     true = Enum.any?(-1..10, fn n -> n < 0 end)
     [0, 1, 2] = Enum.filter(-10..2, fn n -> n >= 0 end)
+    :ok = Enum.each(-5..5, fn n -> true = is_integer(n) end)
 
     # into
     %{a: 1, b: 2} = Enum.into([a: 1, b: 2], %{})


### PR DESCRIPTION
This PR introduces a number of important Elixir features, such as `String.Chars` protocol
and wider support to `Enumerable` in `Enum` module.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
