### PR TITLE
Introduce ESP32 ADC driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for Elixir `List.Chars` protocol
 - Support for `gen_server:start_monitor/3,4`
 - Support for `code:ensure_loaded/1`
+- ESP32: add support for `esp_adc` ADC driver, with Erlang and Elixir examples
 
 ### Changed
 

--- a/examples/elixir/esp32/Adc_nifs.ex
+++ b/examples/elixir/esp32/Adc_nifs.ex
@@ -1,0 +1,45 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2024 Winford <winford@object.stream>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+
+defmodule ADCnifs do
+  # suppress warnings when compiling the VM
+  @compile {:no_warn_undefined, [Esp.ADC]}
+  @pin 33
+
+  def start() do
+    IO.puts("Testing ADC on pin #{@pin}")
+    {:ok, unit} = Esp.ADC.init()
+    {:ok, chan} = Esp.ADC.acquire(@pin, unit, :bit_max, :db_12)
+    loop(@pin, unit, chan)
+  end
+
+  defp loop(pin, unit, chan) do
+    case Esp.ADC.sample(chan, unit, [:raw, :voltage, {:samples, 64}]) do
+      {:ok, {raw, mv}} ->
+        IO.puts("Pin #{pin} value = #{raw}, millivolts = #{mv}")
+      error ->
+        IO.puts("Error taking ADC sample from pin #{pin}: #{error}")
+    end
+    Process.sleep(500)
+    loop(pin, unit, chan)
+  end
+
+end

--- a/examples/erlang/esp32/adc_example.erl
+++ b/examples/erlang/esp32/adc_example.erl
@@ -1,0 +1,40 @@
+%% Copyright (c) 2020 dushin.net
+%% Copyright (c) 2024 Winford <winford@object.stream>
+%% All rights reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(adc_example).
+
+-export([start/0]).
+
+-define(Pin, 34).
+
+start() ->
+    io:format("Testing ADC on pin ~p~n", [?Pin]),
+    ok = esp_adc:start(?Pin),
+    loop(?Pin).
+
+loop(Pin) ->
+    case esp_adc:read(Pin) of
+        {ok, {Raw, MilliVolts}} ->
+            io:format("Raw: ~p Voltage: ~pmV~n", [Raw, MilliVolts]);
+        Error ->
+            io:format("Error taking reading: ~p~n", [Error])
+    end,
+    timer:sleep(1000),
+    loop(Pin).

--- a/examples/erlang/esp32/adc_nif_example.erl
+++ b/examples/erlang/esp32/adc_nif_example.erl
@@ -1,0 +1,40 @@
+%%
+%% Copyright (c) 2024 Winford <winford@object.stream>
+%% All rights reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(adc_nif_example).
+
+-export([start/0]).
+-define(Pin, 34).
+
+start() ->
+    io:format("Testing ADC resource NIFs on pin ~p~n", [?Pin]),
+    {ok, Unit} = esp_adc:init(),
+    {ok, Chan} = esp_adc:acquire(?Pin, Unit),
+    loop(Chan, Unit).
+
+loop(Chan, Unit) ->
+    case esp_adc:sample(Chan, Unit) of
+        {ok, {Raw, MilliVolts}} ->
+            io:format("Raw: ~p Voltage: ~pmV~n", [Raw, MilliVolts]);
+        Error ->
+            io:format("Error taking reading: ~p~n", [Error])
+    end,
+    timer:sleep(1000),
+    loop(Chan, Unit).

--- a/libs/eavmlib/src/CMakeLists.txt
+++ b/libs/eavmlib/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(ERLANG_MODULES
     console
     emscripten
     esp
+    esp_adc
     gpio
     i2c
     http_server

--- a/libs/eavmlib/src/esp_adc.erl
+++ b/libs/eavmlib/src/esp_adc.erl
@@ -1,0 +1,541 @@
+%%
+%% Copyright (c) 2020-2023 dushin.net
+%% Copyright (c) 2022-2024 Winford <winford@object.stream>
+%% All rights reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%%-----------------------------------------------------------------------------
+%% @doc Analog to digital peripheral support.
+%%
+%% Use this module to take ADC (analog voltage) readings. Currently this driver
+%% only supports the esp32 family of chips, but support for other platforms is
+%% planned in the future. On an ESP32 device ADC unit 1 allows taking reading from
+%% pins 32-39. ADC unit2 is disabled by default for the ESP32 classic, but when
+%% enabled in the build configuration allows pins 0, 2, 4, 12-15, and 25-27 to be
+%% used as long as WiFi is not required by the application. Unit 2 is disabled for
+%% ESP32C3 due to its inaccurate results. ADC unit 2 is enabled for all other ESP32
+%% series with more than one ADC unit; there is an arbitrator peripheral that allows
+%% ADC unit 2 to be used while WiFI is active.  The pins available for ADC use vary
+%% by device, check your datasheet for specific hardware support.
+%%
+%% There are two sets of APIs for interacting with the ADC hardware, only one set
+%% of API may be used by an application.
+%%
+%% The core functionality is provided by the low level resource based nif functions.
+%% To use the resource based nifs `esp_adc:init/0' and `esp_adc:deinit/1' will acquire and
+%% release the adc `unit' resource needed for all other functions. A `channel' resource
+%% used to take measurements from a pin can be obtained using `esp_adc:acquire/4', and
+%% released using `esp_adc:release_channel/1'. ADC measurements are taken using `sample/3'.
+%%
+%% For convenience a gen_server managed set of APIs using pin numbers are also available.
+%% A pin may be configured using `esp_adc:start/1,2', measurements are taken using
+%% `esp_adc:read/1,2', pins can be released individually with `esp_adc:stop/1`, or the driver
+%% can be stopped completely using `esp_adc:stop/0'.
+%% @end
+%%-----------------------------------------------------------------------------
+-module(esp_adc).
+
+-behaviour(gen_server).
+
+%% Low level resource based nif functions
+-export([acquire/4, init/0, release_channel/1, deinit/1, sample/3]).
+%% Nif convenience functions
+-export([acquire/2, sample/2]).
+
+%% gen_server convenience functions
+-export([start/0, start/1, start/2, read/1, read/2, stop/1, stop/0]).
+%% gen_server internals
+-export([init/1, handle_call/3, handle_cast/2]).
+-export([handle_info/2, terminate/2]).
+
+-type adc_rsrc() :: {'$adc', Resource :: binary(), Ref :: reference()}.
+-type adc_pin() :: non_neg_integer().
+%% ADC capable pins vary by chipset. Consult your datasheet.
+-type bit_width() :: bit_9 | bit_10 | bit_11 | bit_12 | bit_13 | bit_max.
+%% The default `bit_max' will select the highest value supported by the chipset. Some models only support a single
+%% fixed bit width.
+-type attenuation() :: db_0 | db_2_5 | db_6 | db_11 | db_12.
+%% The decibel gain determines the maximum safe voltage to be measured. Default is `db_11'. The specific range of
+%% voltages supported by each setting varies by device. Typical voltage ranges are depicted in the table below:
+%% <table>
+%%   <tr> <th> Attenuation </th><th> Min Millivolts </th><th> Max Millivolts </th></tr>
+%%   <tr> <td>`db_0'</td> <td>0-100</td> <td>750-950</td></tr>
+%%   <tr> <td>`db_2_5'</td> <td>0-100</td> <td>1050-1250</td></tr>
+%%   <tr> <td>`db_6'</td> <td>0-150</td> <td>1300-1750</td></tr>
+%%   <tr> <td>`bd_11' | `db_12' </td> <td>0-150</td> <td>2450-2500</td></tr>
+%% </table>
+%% Consult the datasheet for your device to determine the exact voltage ranges supported by each gain setting.
+%% The option `db_11' has been superseded by `db_12'. The option`db_11' and will be deprecated in a future release,
+%% applications should be updated to use `db_12' (except for builds with ESP-IDF versions prior to v5.2). To Continue
+%% to support older IDF version builds, the default will remain `db_11', which is the maximum tolerated voltage on
+%% all builds, as `db_12' supported builds will automatically use `db_12' in place of `db_11', when `db_11' is
+%% deprecated in all builds the default will be changed to `db_12'.
+
+-type pin_options() :: [pin_option()].
+-type pin_option() :: {bitwidth, Width :: bit_width()} | {atten, Decibels :: attenuation()}.
+-type read_options() :: [read_option()].
+-type read_option() :: raw | voltage | {samples, 1..100000}.
+%% The value of the `samples' key is the number of samples to be taken and averaged when returning a measurement,
+%% default is 64. For optimal stable readings use a 100nF ceramic capacitor input filter, for more info consult
+%% Espressif's "ADC Calibration Driver" documentation.
+%% The keys `raw' and `voltage' determine if these values are included in the results or returned as `undefined'.
+-type raw_value() :: 0..511 | 0..1023 | 0..2047 | 0..4095 | 0..8191 | undefined.
+%% The maximum analog value is determined by `bit_width()'.
+-type voltage_reading() :: 0..3300 | undefined.
+%% The maximum safe millivolt value that can be measured is determined by `attenuation()', this value should never
+%% exceed the chips maximum input tolerance.
+-type reading() :: {raw_value() | undefined, voltage_reading() | undefined}.
+
+-define(ADC_RSRC, {'$adc', _Resource, _Ref}).
+-define(DEFAULT_SAMPLES, 64).
+-define(DEFAULT_READ_OPTIONS, [raw, voltage, {samples, ?DEFAULT_SAMPLES}]).
+-define(DEFAULT_PIN_OPTIONS, [{bitwidth, bit_max}, {atten, db_11}]).
+
+%%-----------------------------------------------------------------------------
+%% @returns {ok, ADCUnit :: adc_rsrc()} | {error, Reason}
+%% @doc     Nif to initialize the ADC unit hardware.
+%%
+%% The returned ADC unit handle resource must be supplied for all future ADC operations.
+%%
+%% This is a low level nif that cannot be used in an application that uses the
+%% convenience functions.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec init() -> {ok, ADCUnit :: adc_rsrc()} | {error, Reason :: term()}.
+init() ->
+    throw(nif_error).
+
+%%-----------------------------------------------------------------------------
+%% @param   UnitResource returned from init/0
+%% @returns ok | {error, Reason}
+%% @doc     Nif to release the ADC unit resource returned from init/0.
+%%
+%% Stop the ADC driver and free the unit resource. All active ADC channels should
+%% be released using `release_channel/1' to free each configured channel before
+%% freeing the unit resource.
+%%
+%% This is a low level nif that cannot be used in an application that uses the
+%% convenience functions.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec deinit(UnitResource :: adc_rsrc()) -> ok | {error, Reason :: term()}.
+deinit(_UnitResource) ->
+    throw(nif_error).
+
+%%-----------------------------------------------------------------------------
+%% @param   Pin         Pin to configure as ADC
+%% @param   UnitHandle  The unit handle returned from `init/0'
+%% @equiv   acquire(Pin, UnitHandle, bit_max, db_11)
+%% @returns {ok, Channel::adc_rsrc()} | {error, Reason}
+%% @doc     Nif to initialize an ADC pin.
+%%
+%% Initializes an ADC pin and returns a channel handle resources.
+%%
+%% This is a low level nif that cannot be used in an application that uses the
+%% convenience functions.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec acquire(Pin :: adc_pin(), UnitHandle :: adc_rsrc()) ->
+    {ok, Channel :: adc_rsrc()} | {error, Reason :: term()}.
+acquire(Pin, UnitHandle) ->
+    ?MODULE:acquire(Pin, UnitHandle, bit_max, db_11).
+
+%%-----------------------------------------------------------------------------
+%% @param   Pin         Pin to configure as ADC
+%% @param   UnitHandle  The unit handle returned from `init/0'
+%% @param   BitWidth    Resolution in bit to measure
+%% @param   Attenuation Decibel gain for voltage range
+%% @returns {ok, Channel::adc_rsrc()} | {error, Reason}
+%% @doc     Nif to initialize an ADC pin.
+%%
+%% The BitWidth value `bit_max' may be used to automatically select the highest
+%% sample rate supported by your ESP chip-set, or choose from a bit width supported
+%% by the device.
+%%
+%% The Attenuation value can be used to adust the gain, and therefore safe
+%% measurement range on voltage the exact range of voltages supported by each
+%% db gain varies by chip, consult the data sheet for exact range of your model.
+%% For more information see the `attenuation()' type specification.
+%%
+%% Use the returned `Channel' reference in subsequent ADC operations on
+%% the same pin.
+%%
+%% This is a low level nif that cannot be used in an application that uses the
+%% convenience functions.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec acquire(
+    Pin :: adc_pin(),
+    UnitHandle :: adc_rsrc(),
+    BitWidth :: bit_width(),
+    Attenuation :: attenuation()
+) -> {ok, Channel :: adc_rsrc()} | {error, Reason :: term()}.
+acquire(_Pin, _UnitHandle, _BitWidth, _Attenuation) ->
+    throw(nif_error).
+
+%%-----------------------------------------------------------------------------
+%% @param   ChannelResource of the pin returned from acquire/4
+%% @returns ok | {error, Reason}
+%% @doc     Nif to deinitialize the specified ADC channel.
+%%
+%% In the case that an error is returned it is safe to "drop" the `ChannelResource'
+%% handle from use. After there are no remaining processes with references to
+%% the channel resource handle, the calibration profile and any remaining resources
+%% associated with the channel will be released as part of the next garbage
+%% collection event.
+%%
+%% This is a low level nif that cannot be used in an application that uses the
+%% convenience functions.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec release_channel(ChannelResource :: adc_rsrc()) -> ok | {error, Reason :: term()}.
+release_channel(_ChannelResource) ->
+    throw(nif_error).
+
+%%-----------------------------------------------------------------------------
+%% @param   ChannelResource of the pin returned from acquire/4
+%% @param   UnitResource of the pin returned from init/0
+%% @returns {ok, {RawValue, MilliVolts}} | {error, Reason}
+%% @equiv   sample(ChannelResource, UnitResource, [raw, voltage, {samples, 64}])
+%% @doc     Nif to take a reading using default values from an ADC channel.
+%%
+%% This is a low level nif that cannot be used in an application that uses the
+%% convenience functions.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec sample(ChannelResource :: adc_rsrc(), UnitResource :: adc_rsrc()) ->
+    {ok, reading()} | {error, Reason :: term()}.
+sample(ChannelResource, UnitResource) ->
+    ?MODULE:sample(ChannelResource, UnitResource, ?DEFAULT_READ_OPTIONS).
+
+%%-----------------------------------------------------------------------------
+%% @param   ChannelResource of the pin returned from acquire/4
+%% @param   UnitResource of the pin returned from init/0
+%% @param   ReadOptions extra list of options to override defaults.
+%% @returns {ok, {RawValue, MilliVolts}} | {error, Reason}
+%% @doc     Nif to take a reading from an ADC channel.
+%%
+%% The Options parameter may be used to specify the behavior of the read
+%% operation.
+%%
+%% If the ReadOptions contains the atom `raw', then the raw value will be returned
+%% in the first element of the returned tuple.  Otherwise, this element will be
+%% the atom `undefined'.
+%%
+%% If the ReadOptions contains the atom `voltage', then the voltage value will be
+%% returned in millivolts in the second element of the returned tuple.  Otherwise,
+%% this element will be the atom `undefined'.
+%%
+%% You may specify the number of samples to be taken and averaged over using the
+%% tuple `{samples, Samples::pos_integer()}'.
+%%
+%% If the error `Reason' is timeout and the adc channel is on unit 2 then WiFi is
+%% likely enabled and adc2 readings may be blocked until there is less network
+%% traffic. On and ESP32 classic the results for unit 2 will always be
+%% `{error, timeout}' if wifi is enabled.
+%%
+%% This is a low level nif that cannot be used in an application that uses the
+%% convenience functions.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec sample(
+    ChannelResource :: adc_rsrc(), UnitResource :: adc_rsrc(), ReadOptions :: read_options()
+) -> {ok, Result :: reading()} | {error, Reason :: term()}.
+sample(_ChannelResource, _UnitResource, _ReadOptions) ->
+    throw(nif_error).
+
+%%-----------------------------------------------------------------------------
+%% @returns {ok, Pid}
+%% @doc     Optionally initialize a gen_server managed ADC driver without a pin.
+%%
+%% Use of this function is optional, but may be desired if the drivers pid is needed,
+%% or it is desireable to start the driver without configuring an initial ADC channel.
+%%
+%% Note: since only one instance of the driver is allowed it is registered with the
+%% name `adc_driver', which also may be used to directly call the gen_server.
+%%
+%% This convenience function cannot be used in an application that uses the low level
+%% nif APIs.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec start() -> {ok, Pid :: pid()}.
+start() ->
+    Pid = get_adc_pid(),
+    {ok, Pid}.
+
+%%-----------------------------------------------------------------------------
+%% @param   Pin         Pin to configure as ADC
+%% @equiv   start(Pin, [{bitwidth, bit_max}, {atten, db_11}])
+%% @returns ok | {error, Reason}
+%% @doc     Initialize a gen_server managed ADC pin with default options.
+%%
+%% This convenience function configures an ADC pin with the default options for
+%% use with the optional `gen_server' APIs.  Default options are:
+%% `[{bitwidth, bit_max}, {atten, db_11}]'
+%%
+%% This function cannot be used in an application that uses the low level
+%% nif APIs.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec start(Pin :: adc_pin()) -> ok | {error, Reason :: term()}.
+start(Pin) ->
+    start(Pin, ?DEFAULT_PIN_OPTIONS).
+
+%%-----------------------------------------------------------------------------
+%% @param   Pin         Pin to configure as ADC
+%% @param   Options     List of options to override default settings
+%% @returns ok | {error, Reason}
+%% @doc     Initialize a gen_server managed ADC pin with the supplied options.
+%%
+%% This convenience function configures an ADC pin with the provided options to
+%% override the default configuration: `[{bitwidth, bit_max}, {atten, db_11}]'.
+%%
+%% For more details about these options see the `attenuation()' and `bit_width()'
+%% type specifications.
+%%
+%% This function cannot be used in an application that uses the low level nif APIs.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec start(Pin :: adc_pin(), Options :: pin_options()) -> ok | {error, Reason :: term()}.
+start(Pin, Options) ->
+    {Bits, Atten} = validate_pin_options(Options),
+    gen_server:call(get_adc_pid(), {acquire, Pin, Bits, Atten}).
+
+%%-----------------------------------------------------------------------------
+%% @param   Pin the pin to be released
+%% @returns ok | {error, Reason}
+%% @doc     De-initialize the specified ADC pin.
+%%
+%% This convenience function is used to release a pin from the gen_server managed
+%% ADC driver. If an error is returned the ADC channel will still be stopped and
+%% release internal resources during the next VM garbage collection event, the pin
+%% will immediately no longer be useable in any case.
+%%
+%% This function cannot be used in an application that uses the low level nif APIs.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec stop(Pin :: adc_pin()) -> ok | {error, Reason :: term()}.
+stop(Pin) ->
+    gen_server:call(adc_driver, {stop, Pin}).
+
+%%-----------------------------------------------------------------------------
+%% @returns ok | {error, Reason}
+%% @doc     Stop the ADC driver and release all resources.
+%%
+%% This convenience function is used to completely stop the gen_server managed
+%% ADC driver and release all resources.
+%%
+%% Note: if an error is returned, a full shutdown of the ADC peripheral should
+%% still occur, and any remaining resources freed with next VM garbage collection
+%% event. Regardless the gen_server will exit normally and the adc peripheral
+%% will no longer be usable.
+%%
+%% This function cannot be used in an application that uses the low level nif APIs.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec stop() -> ok | {error, Reason :: term()}.
+stop() ->
+    gen_server:call(adc_driver, stop).
+
+%%-----------------------------------------------------------------------------
+%% @param   Pin     The pin from which to take ADC measurement
+%% @returns {ok, {RawValue, MilliVolts}} | {error, Reason}
+%% @equiv   read(Pin, [raw, voltage, {samples, 64}])
+%% @doc     Take a reading using default values from an ADC pin.
+%%
+%% This convenience function is used to take a measurement from a previously
+%% started adc pin.
+%%
+%% This function cannot be used in an application that uses the low level
+%% nif APIs.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec read(Pin :: adc_pin()) -> {ok, reading()} | {error, Reason :: term()}.
+read(Pin) ->
+    gen_server:call(adc_driver, {read, Pin, ?DEFAULT_READ_OPTIONS}).
+
+%%-----------------------------------------------------------------------------
+%% @param   Pin         The pin from which to take ADC measurement
+%% @param   ReadOptions Extra options
+%% @returns {ok, {RawValue, MilliVolts}} | {error, Reason}
+%% @doc     Take a reading from an ADC pin using the supplied options.
+%%
+%% This convenience function is used to take a measurement from a previously
+%% started adc pin, using the supplied read options parameter.
+%%
+%% The Options parameter may be used to specify the behavior of the read
+%% operation.
+%%
+%% If the ReadOptions contains the atom `raw', then the raw value will be returned
+%% in the first element of the returned tuple.  Otherwise, this element will be the
+%% atom `undefined'.
+%%
+%% If the ReadOptions contains the atom `voltage', then the voltage value will be returned
+%% in millivolts in the second element of the returned tuple.  Otherwise, this element will
+%% be the atom `undefined'.
+%%
+%% You may specify the number of samples to be taken and averaged over using the tuple
+%% `{samples, Samples::pos_integer()}', the default is `64'.
+%%
+%% If the error `Reason' is timeout and the adc channel is on unit 2 then WiFi is
+%% likely enabled and adc2 readings may be blocked until there is less network
+%% traffic. On and ESP32 classic the results for unit 2 will always be
+%% `{error, timeout}' if wifi is enabled.
+%%
+%% This function cannot be used in an application that uses the low level nif APIs.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec read(Pin :: adc_pin(), ReadOptions :: read_options()) ->
+    {ok, Result :: reading()} | {error, Reason :: term()}.
+read(Pin, ReadOptions) ->
+    gen_server:call(adc_driver, {read, Pin, ReadOptions}).
+
+%%
+%% gen_server
+%%
+
+-record(state, {
+    handle,
+    pins = #{}
+}).
+
+%% @hidden
+init([]) ->
+    try ?MODULE:init() of
+        {ok, UnitHandle} ->
+            {ok, #state{handle = UnitHandle}};
+        Error ->
+            Error
+    catch
+        _E:Reason ->
+            {error, Reason}
+    end.
+
+%% @hidden
+handle_call(stop, _From, State) ->
+    case do_stop_driver(State) of
+        {ok, NewState} ->
+            {stop, normal, ok, NewState};
+        {Error, NewState} ->
+            {stop, normal, {error, Error}, NewState}
+    end;
+handle_call({stop, Pin}, _From, State) ->
+    {Result, NewState} = do_deinit_pin(Pin, State),
+    {reply, Result, NewState};
+handle_call({acquire, Pin, Bits, Atten}, _From, State) ->
+    {Result, NewState} = do_config_pin({Pin, Bits, Atten}, State),
+    {reply, Result, NewState};
+handle_call({read, Pin, Options}, _From, State) ->
+    {reply, do_take_reading(maps:get(Pin, State#state.pins), State#state.handle, Options), State};
+handle_call(Request, _From, State) ->
+    {reply, {error, {unknown_request, Request}}, State}.
+
+%% @hidden
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% @hidden
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @hidden
+terminate(_Reason, _State) ->
+    ok.
+
+%%
+%% private fun
+%%
+
+%% private
+get_adc_pid() ->
+    case erlang:whereis(adc_driver) of
+        undefined ->
+            case gen_server:start_link({local, adc_driver}, ?MODULE, [], []) of
+                {ok, Pid} -> Pid;
+                Err -> erlang:throw(Err)
+            end;
+        Pid when is_pid(Pid) ->
+            Pid
+    end.
+
+% private
+validate_pin_options(Options) ->
+    Bits = proplists:get_value(bitwidth, Options, bit_max),
+    Atten = proplists:get_value(atten, Options, db_11),
+    {Bits, Atten}.
+
+%private
+do_config_pin({Pin, Bits, Atten}, State) ->
+    try ?MODULE:acquire(Pin, State#state.handle, Bits, Atten) of
+        {ok, ChanRsrc} ->
+            {ok, State#state{pins = maps:put(Pin, ChanRsrc, State#state.pins)}};
+        Error ->
+            io:format("[~p] adc_driver: failed to acquire pin, error: ~p~n", [
+                erlang:monotonic_time(millisecond), Error
+            ]),
+            {Error, State}
+    catch
+        _E:Reason ->
+            {{error, Reason}, State}
+    end.
+
+% private
+do_take_reading(ChannelHandle, UnitHandle, Options) ->
+    try ?MODULE:sample(ChannelHandle, UnitHandle, Options) of
+        Result -> Result
+    catch
+        _E:Reason ->
+            {error, Reason}
+    end.
+
+% private
+do_deinit_pin(Pin, State) ->
+    try ?MODULE:release_channel(maps:get(Pin, State#state.pins)) of
+        ok ->
+            {ok, State#state{pins = maps:remove(Pin, State#state.pins)}};
+        Error ->
+            {Error, State#state{pins = maps:remove(Pin, State#state.pins)}}
+    catch
+        _E:Reason ->
+            {{error, Reason}, State#state{pins = maps:remove(Pin, State#state.pins)}}
+    end.
+
+% private
+do_stop_driver(State) ->
+    Pins = maps:keys(State#state.pins),
+    case Pins of
+        [] ->
+            NewState = State;
+        _ ->
+            NewState = stop_pins_from_list(Pins, State)
+    end,
+    try ?MODULE:deinit(NewState#state.handle) of
+        ok ->
+            {ok, NewState#state{handle = undefined}};
+        Error ->
+            {Error, NewState#state{handle = undefined}}
+    catch
+        _E:Reason ->
+            {{error, Reason}, NewState#state{handle = undefined}}
+    end.
+
+% private
+stop_pins_from_list([], State) ->
+    {ok, State};
+stop_pins_from_list([Pin | List], State) ->
+    {ok, NewState} = do_deinit_pin(Pin, State),
+    stop_pins_from_list(List, NewState).

--- a/src/platforms/esp32/components/avm_builtins/CMakeLists.txt
+++ b/src/platforms/esp32/components/avm_builtins/CMakeLists.txt
@@ -35,7 +35,8 @@ set(AVM_BUILTIN_COMPONENT_SRCS
 )
 
 if (IDF_VERSION_MAJOR GREATER_EQUAL 5)
-    set(ADDITIONAL_PRIV_REQUIRES "esp_hw_support" "efuse")
+    set(ADDITIONAL_PRIV_REQUIRES "esp_hw_support" "efuse" "esp_adc")
+    set(AVM_BUILTIN_COMPONENT_SRCS "adc_driver.c" ${AVM_BUILTIN_COMPONENT_SRCS})
 else()
     set(ADDITIONAL_PRIV_REQUIRES "")
 endif()

--- a/src/platforms/esp32/components/avm_builtins/Kconfig
+++ b/src/platforms/esp32/components/avm_builtins/Kconfig
@@ -20,6 +20,33 @@
 
 menu "AtomVM Built-In Components"
 
+config AVM_ENABLE_ADC_NIFS
+    bool "Enable ADC NIFs"
+    default y
+
+    config AVM_ADC2_ENABLE
+        depends on AVM_ENABLE_ADC_NIFS
+        depends on SOC_ADC_PERIPH_NUM >= 2
+        bool "Enable ADC Unit 2"
+        default "y" if ADC_ONESHOT_FORCE_USE_ADC2_ON_C3 && IDF_TARGET_ESP32C3
+        default "n" if IDF_TARGET_ESP32C3
+        default "n" if IDF_TARGET_ESP32
+        default "y"
+        help
+            This will allow using both ADC units.
+
+            ADC2 is used by the Wi-Fi driver. The ESP32 classic can only use ADC2 when the
+            wifi driver is not in use, all other models have an arbitrator peripheral that
+            allows the simultaneous use of ADC unit 2 with WiFi. With the possibility of occasional
+            timeout errors when taking a measurements during times of heavy network traffic.
+
+            The results from ADC2 on the ESP32C3 are not at all accurate and should not be used.
+            See: https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32c3/index.html
+
+            For the ESP32C3 if you choose to ignore these warnings and enable unit 2 anyway,
+            "ADC_ONESHOT_FORCE_USE_ADC2_ON_C3" must also be enabled in the "ADC and ADC Calibration"
+            submenu.
+
 config AVM_ENABLE_GPIO_NIFS
     bool "Enable GPIO NIFs"
     default y

--- a/src/platforms/esp32/components/avm_builtins/adc_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/adc_driver.c
@@ -1,0 +1,781 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2020-2023 dushin.net
+ * Copyright 2024 Ricardo Lanziano <arpunk@fatelectron.net>
+ * Copyright 2022-2024 Winford <winford@object.stream>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+// References
+// https://docs.espressif.com/projects/esp-idf/en/v5.0.7/esp32/api-reference/peripherals/adc_oneshot.html
+// https://docs.espressif.com/projects/esp-idf/en/v5.0.7/esp32/api-reference/peripherals/adc_calibration.html
+// https://docs.espressif.com/projects/esp-idf/en/v5.3/esp32/api-reference/peripherals/adc_oneshot.html
+// https://docs.espressif.com/projects/esp-idf/en/v5.3/esp32/api-reference/peripherals/adc_calibration.html
+
+#include <sdkconfig.h>
+#ifdef CONFIG_AVM_ENABLE_ADC_NIFS
+
+#include <context.h>
+#include <defaultatoms.h>
+#include <erl_nif_priv.h>
+#include <esp32_sys.h>
+#include <globalcontext.h>
+#include <interop.h>
+#include <nifs.h>
+#include <term.h>
+
+// #define ENABLE_TRACE
+#include <trace.h>
+
+#include <esp_adc/adc_cali.h>
+#include <esp_adc/adc_cali_scheme.h>
+#include <esp_adc/adc_oneshot.h>
+#include <esp_log.h>
+#include <hal/adc_types.h>
+#include <sdkconfig.h>
+#include <soc/soc_caps.h>
+
+#include <math.h>
+#include <stdlib.h>
+
+#define TAG "atomvm_adc"
+#define DEFAULT_SAMPLES 64
+#define DEFAULT_VREF 1100U
+#define ADC_INVALID_PARAM -1
+// 110000 will trigger the watchdog on esp32, other platforms can go higher, but this seems more than enough.
+#define MAX_SAMPLES 100000
+
+void atomvm_adc_init(GlobalContext *global);
+const struct Nif *atomvm_adc_get_nif(const char *nifname);
+
+typedef enum avm_calibration_method
+{
+    UNCALIBRATED,
+    ESTIMATED,
+    CURVE,
+    LINE,
+} cali_method_t;
+
+struct ChannelResource
+{
+    adc_atten_t attenuation;
+    adc_bitwidth_t width;
+    adc_unit_t adc_unit;
+    adc_channel_t channel;
+    adc_cali_handle_t cali_handle;
+    cali_method_t calibration;
+};
+
+struct UnitResource
+{
+    adc_oneshot_unit_handle_t unit_handle;
+#ifdef CONFIG_AVM_ADC2_ENABLE
+    adc_oneshot_unit_handle_t unit2_handle;
+#endif
+};
+
+static const AtomStringIntPair bit_width_table[] = {
+    { ATOM_STR("\x7", "bit_max"), ADC_BITWIDTH_DEFAULT },
+#if SOC_ADC_MAX_BITWIDTH == 13
+    { ATOM_STR("\x6", "bit_13"), ADC_BITWIDTH_13 },
+#elif SOC_ADC_MAX_BITWIDTH == 12
+    { ATOM_STR("\x6", "bit_12"), ADC_BITWIDTH_12 },
+#elif CONFIG_IDF_TARGET_ESP32
+    { ATOM_STR("\x6", "bit_11"), ADC_BITWIDTH_11 },
+    { ATOM_STR("\x6", "bit_10"), ADC_BITWIDTH_10 },
+    { ATOM_STR("\x5", "bit_9"), ADC_BITWIDTH_9 },
+#endif
+    SELECT_INT_DEFAULT(ADC_INVALID_PARAM)
+};
+
+static const AtomStringIntPair attenuation_table[] = {
+    { ATOM_STR("\x4", "db_0"), ADC_ATTEN_DB_0 },
+    { ATOM_STR("\x6", "db_2_5"), ADC_ATTEN_DB_2_5 },
+    { ATOM_STR("\x4", "db_6"), ADC_ATTEN_DB_6 },
+#if (ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 1, 0))
+    { ATOM_STR("\x5", "db_11"), ADC_ATTEN_DB_11 },
+#else
+    { ATOM_STR("\x5", "db_12"), ADC_ATTEN_DB_12 },
+#endif
+    SELECT_INT_DEFAULT(ADC_INVALID_PARAM)
+};
+
+static ErlNifResourceType *adc_unit_resource;
+static ErlNifResourceType *adc_channel_resource;
+
+//
+// internal functions
+//
+
+static bool is_adc_resource(GlobalContext *global, term t)
+{
+    bool ret = term_is_tuple(t)
+        && term_get_tuple_arity(t) == 3
+        && globalcontext_is_term_equal_to_atom_string(global, term_get_tuple_element(t, 0), ATOM_STR("\x4", "$adc"))
+        && term_is_binary(term_get_tuple_element(t, 1))
+        && term_is_reference(term_get_tuple_element(t, 2));
+
+    return ret;
+}
+
+static bool to_channel_resource(term chan_resource, struct ChannelResource **rsrc_obj, Context *ctx)
+{
+    if (!is_adc_resource(ctx->global, chan_resource)) {
+        return false;
+    }
+    void *rsrc_obj_ptr;
+    if (UNLIKELY(!enif_get_resource(erl_nif_env_from_context(ctx), term_get_tuple_element(chan_resource, 1), adc_channel_resource, &rsrc_obj_ptr))) {
+        return false;
+    }
+    *rsrc_obj = (struct ChannelResource *) rsrc_obj_ptr;
+
+    return true;
+}
+
+static bool to_unit_resource(term unit_resource, struct UnitResource **rsrc_obj, Context *ctx)
+{
+    if (!is_adc_resource(ctx->global, unit_resource)) {
+        return false;
+    }
+    void *rsrc_obj_ptr;
+    if (UNLIKELY(!enif_get_resource(erl_nif_env_from_context(ctx), term_get_tuple_element(unit_resource, 1), adc_unit_resource, &rsrc_obj_ptr))) {
+        return false;
+    }
+    *rsrc_obj = (struct UnitResource *) rsrc_obj_ptr;
+
+    return true;
+}
+
+static int approximate_millivolts(int adc_reading, adc_atten_t attenuation, adc_bitwidth_t width)
+{
+    int digi_max = (int) pow(2, width); // casting double to int here is safe because values are always between 512-8192
+    int millivolt_max = 0;
+
+    switch (attenuation) {
+        case ADC_ATTEN_DB_0:
+            millivolt_max = 950;
+            break;
+        case ADC_ATTEN_DB_2_5:
+            millivolt_max = 1250;
+            break;
+        case ADC_ATTEN_DB_6:
+            millivolt_max = 1750;
+            break;
+#if (ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 1, 0))
+        case ADC_ATTEN_DB_11:
+            millivolt_max = 2450;
+            break;
+#else
+        case ADC_ATTEN_DB_12:
+            millivolt_max = 2450;
+            break;
+#endif
+    }
+
+    // Estimate V = RAW * ATTEN_MAX_MV / 2^BITWIDTH
+    // See: https://docs.espressif.com/projects/esp-idf/en/v5.2.2/esp32/api-reference/peripherals/adc_oneshot.html#read-conversion-result
+
+    return (adc_reading * millivolt_max) / digi_max;
+}
+
+static term adc_err_to_atom_term(GlobalContext *glb, esp_err_t error)
+{
+    term atom = term_invalid_term();
+    switch (error) {
+        case ESP_ERR_INVALID_ARG:
+            atom = BADARG_ATOM;
+            break;
+        case ESP_ERR_NO_MEM:
+            atom = OUT_OF_MEMORY_ATOM;
+            break;
+        case ESP_ERR_NOT_FOUND:
+            atom = BADARG_ATOM;
+            break;
+        case ESP_FAIL:
+            atom = globalcontext_make_atom(glb, ATOM_STR("\x8", "no_clock"));
+            break;
+        case ESP_ERR_TIMEOUT:
+            atom = globalcontext_make_atom(glb, ATOM_STR("\x7", "timeout"));
+            break;
+        default:
+            atom = BADARG_ATOM;
+    }
+    return atom;
+}
+
+static term create_pair(Context *ctx, term term1, term term2)
+{
+    term ret = term_alloc_tuple(2, &ctx->heap);
+    term_put_tuple_element(ret, 0, term1);
+    term_put_tuple_element(ret, 1, term2);
+
+    return ret;
+}
+
+static term error_return_tuple(Context *ctx, term term)
+{
+    if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    return create_pair(ctx, ERROR_ATOM, term);
+}
+
+static cali_method_t do_adc_calibration(adc_unit_t unit, adc_channel_t chan, adc_atten_t atten, adc_bitwidth_t width, adc_cali_handle_t *cali_handle)
+{
+    cali_method_t calibration = UNCALIBRATED;
+    esp_err_t err;
+
+#if defined ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+    adc_cali_curve_fitting_config_t cali_config = {
+        .unit_id = unit,
+        .chan = chan,
+        .atten = atten,
+        .bitwidth = width,
+    };
+    err = adc_cali_create_scheme_curve_fitting(&cali_config, cali_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "failed to calibrate using the supported curve fitting scheme: %s", esp_err_to_name(err));
+        ESP_LOGW(TAG, "any reading requesting 'voltage' will receive an estimated value");
+    } else {
+        calibration = CURVE;
+        ESP_LOGD(TAG, "Characterized using curve fitting scheme");
+    }
+#elif defined ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+#ifndef CONFIG_IDF_TARGET_ESP32 // other line fitting targets do not use default vref
+    adc_cali_line_fitting_config_t cali_config = {
+        .unit_id = unit,
+        .atten = atten,
+        .bitwidth = width,
+    };
+    err = adc_cali_create_scheme_line_fitting(&cali_config, cali_handle);
+#else // CONFIG_IDF_TARGET_ESP32 is defined
+    adc_cali_line_fitting_efuse_val_t cali_fuse;
+    err = adc_cali_scheme_line_fitting_check_efuse(&cali_fuse);
+    if ((err == ESP_OK) && (cali_fuse == ADC_CALI_LINE_FITTING_EFUSE_VAL_DEFAULT_VREF)) {
+        ESP_LOGI(TAG, "Unit calibrated with line_fitting scheme, channel uses default vref of %u mV.", DEFAULT_VREF);
+        ESP_LOGW(TAG, "A stable voltage of 1100 mV should be supplied to the pin during acquisition for accurate calibration.");
+        adc_cali_line_fitting_config_t cali_config = {
+            .unit_id = unit,
+            .atten = atten,
+            .bitwidth = width,
+            .default_vref = DEFAULT_VREF,
+        };
+        err = adc_cali_create_scheme_line_fitting(&cali_config, cali_handle);
+    } else {
+        adc_cali_line_fitting_config_t cali_config = {
+            .unit_id = unit,
+            .atten = atten,
+            .bitwidth = width,
+        };
+        err = adc_cali_create_scheme_line_fitting(&cali_config, cali_handle);
+    }
+#endif // end CONFIG_IDF_TARGET ifelse
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "failed to calibrate using the supported line fitting scheme: %s", esp_err_to_name(err));
+        ESP_LOGW(TAG, "any reading requesting 'voltage' will receive an estimated value");
+    } else {
+        calibration = LINE;
+        ESP_LOGD(TAG, "Characterized using line fitting scheme");
+    }
+#else // no calibration support defined
+    calibration = ESTIMATED;
+    ESP_LOGD(TAG, "No supported calibration method, readings requesting 'voltage' will receive an estimated value");
+#endif
+
+    return calibration;
+}
+
+//
+// Nif functions
+//
+
+static term nif_adc_init(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    UNUSED(argv);
+
+    struct UnitResource *unit_rsrc = enif_alloc_resource(adc_unit_resource, sizeof(struct UnitResource));
+    if (IS_NULL_PTR(unit_rsrc)) {
+        ESP_LOGE(TAG, "failed to allocate resource: %s:%i.", __FILE__, __LINE__);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    unit_rsrc->unit_handle = NULL;
+
+    adc_unit_t adc_unit = ADC_UNIT_1;
+
+    adc_oneshot_unit_init_cfg_t init_config = {
+        .unit_id = adc_unit,
+        .ulp_mode = ADC_ULP_MODE_DISABLE,
+    };
+
+    esp_err_t err = adc_oneshot_new_unit(&init_config, &unit_rsrc->unit_handle);
+    if (UNLIKELY(err != ESP_OK)) {
+        return error_return_tuple(ctx, adc_err_to_atom_term(ctx->global, err));
+    }
+
+#ifdef CONFIG_AVM_ADC2_ENABLE
+    unit_rsrc->unit2_handle = NULL;
+
+    adc_unit = ADC_UNIT_2;
+
+    adc_oneshot_unit_init_cfg_t init_config2 = {
+        .unit_id = adc_unit,
+        .ulp_mode = ADC_ULP_MODE_DISABLE,
+    };
+
+    err = adc_oneshot_new_unit(&init_config2, &unit_rsrc->unit2_handle);
+    if (UNLIKELY(err != ESP_OK)) {
+        return error_return_tuple(ctx, adc_err_to_atom_term(ctx->global, err));
+    }
+#endif
+
+    if (UNLIKELY(memory_ensure_free(ctx, TERM_BOXED_RESOURCE_SIZE) != MEMORY_GC_OK)) {
+        enif_release_resource(unit_rsrc);
+        ESP_LOGE(TAG, "failed to allocate memory for resource: %s:%i.", __FILE__, __LINE__);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    ERL_NIF_TERM unit_obj = enif_make_resource(erl_nif_env_from_context(ctx), unit_rsrc);
+    enif_release_resource(unit_rsrc);
+
+    // {ok, {'$adc', Unit :: resource(), ref()}}
+    size_t requested_size = TUPLE_SIZE(2) + TUPLE_SIZE(3) + REF_SIZE;
+    ESP_LOGD(TAG, "Requesting memory size %u for return message", requested_size);
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, requested_size, 1, &unit_obj, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        ESP_LOGE(TAG, "failed to allocate tuple memory size %u: %s:%i.", requested_size, __FILE__, __LINE__);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    term unit_resource = term_alloc_tuple(3, &ctx->heap);
+    term_put_tuple_element(unit_resource, 0, globalcontext_make_atom(ctx->global, ATOM_STR("\x4", "$adc")));
+    term_put_tuple_element(unit_resource, 1, unit_obj);
+    uint64_t ref_ticks = globalcontext_get_ref_ticks(ctx->global);
+    term ref = term_from_ref_ticks(ref_ticks, &ctx->heap);
+    term_put_tuple_element(unit_resource, 2, ref);
+
+    term ret = term_alloc_tuple(2, &ctx->heap);
+    term_put_tuple_element(ret, 0, OK_ATOM);
+    term_put_tuple_element(ret, 1, unit_resource);
+
+    return ret;
+}
+
+static term nif_adc_deinit(Context *ctx, int argc, term argv[])
+{
+    term unit_term = argv[0];
+    if (UNLIKELY(!is_adc_resource(ctx->global, unit_term))) {
+        ESP_LOGE(TAG, "handle supplied is not a valid adc resource");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    struct UnitResource *unit_rsrc = NULL;
+    if (UNLIKELY(!to_unit_resource(unit_term, &unit_rsrc, ctx))) {
+        ESP_LOGE(TAG, "resource supplied is not a valid adc unit resource");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    esp_err_t err = adc_oneshot_del_unit(unit_rsrc->unit_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "failed to release ADC Unit 1");
+        return error_return_tuple(ctx, adc_err_to_atom_term(ctx->global, err));
+    }
+    unit_rsrc->unit_handle = NULL;
+    ESP_LOGD(TAG, "ADC unit 1 released");
+#ifdef CONFIG_AVM_ADC2_ENABLE
+    err = adc_oneshot_del_unit(unit_rsrc->unit2_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "failed to release ADC Unit 2");
+        return error_return_tuple(ctx, adc_err_to_atom_term(ctx->global, err));
+    }
+    unit_rsrc->unit2_handle = NULL;
+    ESP_LOGD(TAG, "ADC unit 2 released");
+#endif
+
+    return OK_ATOM;
+}
+
+static term nif_adc_acquire(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    term pin = argv[0];
+    VALIDATE_VALUE(pin, term_is_integer);
+    int pin_num = term_to_int(pin);
+
+    adc_unit_t adc_unit;
+    adc_channel_t adc_channel;
+
+    esp_err_t err = adc_oneshot_io_to_channel(pin_num, &adc_unit, &adc_channel);
+    if (UNLIKELY(err != ESP_OK)) {
+        ESP_LOGE(TAG, "pin %i does not support ADC peripheral", pin_num);
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    term unit_term = argv[1];
+    struct UnitResource *unit_rsrc = NULL;
+    if (UNLIKELY(!is_adc_resource(ctx->global, unit_term))) {
+        ESP_LOGE(TAG, "handle supplied is not a valid adc resource");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    if (UNLIKELY(!to_unit_resource(unit_term, &unit_rsrc, ctx))) {
+        ESP_LOGE(TAG, "resource supplied is not a valid adc unit resource");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    adc_oneshot_unit_handle_t unit_handle = NULL;
+    if (adc_unit == ADC_UNIT_1) {
+        unit_handle = unit_rsrc->unit_handle;
+    }
+#ifdef CONFIG_AVM_ADC2_ENABLE
+    else if (adc_unit == ADC_UNIT_2) {
+        unit_handle = unit_rsrc->unit2_handle;
+    }
+#endif
+    else {
+        ESP_LOGE(TAG, "no enabled ADC unit matching pin");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    term width = argv[2];
+    VALIDATE_VALUE(width, term_is_atom);
+    int bits = interop_atom_term_select_int(bit_width_table, width, ctx->global);
+    if (UNLIKELY(bits == ADC_INVALID_PARAM)) {
+        ESP_LOGE(TAG, "invalid bitwidth");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    adc_bitwidth_t bit_width = (adc_bitwidth_t) bits;
+
+    term attenuation = argv[3];
+    VALIDATE_VALUE(attenuation, term_is_atom);
+    // TODO: remove macro and update log to ESP_LOGW after ESP-IDf v5.1 is EOL; then all current will deprecate db_11.
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0))
+    if (attenuation == globalcontext_make_atom(ctx->global, ATOM_STR("\x5", "db_11"))) {
+        ESP_LOGI(TAG, "attenuation 'db_11' replaced by 'db_12' and will be deprecated in a future\nrelease, applications should be updated to use 'db_12' instead.");
+        attenuation = globalcontext_make_atom(ctx->global, ATOM_STR("\x5", "db_12"));
+    }
+#endif
+    adc_atten_t atten = interop_atom_term_select_int(attenuation_table, attenuation, ctx->global);
+    if (UNLIKELY(atten == ADC_INVALID_PARAM)) {
+        ESP_LOGE(TAG, "invalid attenuation");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    adc_oneshot_chan_cfg_t config = {
+        .bitwidth = bit_width,
+        .atten = atten,
+    };
+
+    err = adc_oneshot_config_channel(unit_handle, adc_channel, &config);
+    if (UNLIKELY(err != ESP_OK)) {
+        return error_return_tuple(ctx, (adc_err_to_atom_term(ctx->global, err)));
+    }
+
+    struct ChannelResource *chan_rsrc = enif_alloc_resource(adc_channel_resource, sizeof(struct ChannelResource));
+    if (IS_NULL_PTR(chan_rsrc)) {
+        ESP_LOGE(TAG, "failed to allocate resource: %s:%i.", __FILE__, __LINE__);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    chan_rsrc->cali_handle = NULL;
+    cali_method_t calibration = do_adc_calibration(adc_unit, adc_channel, atten, bit_width, &chan_rsrc->cali_handle);
+
+    chan_rsrc->attenuation = atten;
+    chan_rsrc->width = bit_width;
+    chan_rsrc->adc_unit = adc_unit;
+    chan_rsrc->channel = adc_channel;
+    chan_rsrc->calibration = calibration;
+
+    if (UNLIKELY(memory_ensure_free(ctx, TERM_BOXED_RESOURCE_SIZE != MEMORY_GC_OK))) {
+        enif_release_resource(chan_rsrc);
+        ESP_LOGE(TAG, "failed to allocate memory for resource: %s:%i.", __FILE__, __LINE__);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    term chan_obj = enif_make_resource(erl_nif_env_from_context(ctx), chan_rsrc);
+    enif_release_resource(chan_rsrc);
+
+    // {ok, {'$adc', resource(), ref()}}
+    size_t requested_size = TUPLE_SIZE(2) + TUPLE_SIZE(3) + REF_SIZE;
+    ESP_LOGD(TAG, "Requesting memory size %u for return message", requested_size);
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, requested_size, 1, &chan_obj, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        ESP_LOGE(TAG, "failed to allocate tuple memory size %u: %s:%i.", requested_size, __FILE__, __LINE__);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    term chan_resource = term_alloc_tuple(3, &ctx->heap);
+    term_put_tuple_element(chan_resource, 0, globalcontext_make_atom(ctx->global, ATOM_STR("\x4", "$adc")));
+    term_put_tuple_element(chan_resource, 1, chan_obj);
+    uint64_t ref_ticks = globalcontext_get_ref_ticks(ctx->global);
+    term ref = term_from_ref_ticks(ref_ticks, &ctx->heap);
+    term_put_tuple_element(chan_resource, 2, ref);
+
+    term ret = term_alloc_tuple(2, &ctx->heap);
+    term_put_tuple_element(ret, 0, OK_ATOM);
+    term_put_tuple_element(ret, 1, chan_resource);
+
+    return ret;
+}
+
+static term nif_adc_release_channel(Context *ctx, int argc, term argv[])
+{
+    if (UNLIKELY(!is_adc_resource(ctx->global, argv[0]))) {
+        ESP_LOGE(TAG, "no valid adc channel resource");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    term channel_resource = argv[0];
+    struct ChannelResource *chan_rsrc;
+    if (UNLIKELY(!to_channel_resource(channel_resource, &chan_rsrc, ctx))) {
+        ESP_LOGE(TAG, "resource is not a valid adc channel resource");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    if (chan_rsrc->calibration > ESTIMATED) {
+#if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+        ESP_LOGD(TAG, "deregister curve fitting calibration scheme");
+        esp_err_t err = adc_cali_delete_scheme_curve_fitting(chan_rsrc->cali_handle);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "failed to release calibration profile");
+            return error_return_tuple(ctx, (adc_err_to_atom_term(ctx->global, err)));
+        }
+
+#elif ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+        ESP_LOGD(TAG, "deregister line fitting calibration scheme");
+        esp_err_t err = adc_cali_delete_scheme_line_fitting(chan_rsrc->cali_handle);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "failed to release calibration profile");
+            return error_return_tuple(ctx, (adc_err_to_atom_term(ctx->global, err)));
+        }
+#endif
+    }
+    chan_rsrc->cali_handle = NULL;
+    chan_rsrc->calibration = UNCALIBRATED;
+
+    return OK_ATOM;
+}
+
+static term nif_adc_sample(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+
+    term chan_term = argv[0];
+    if (UNLIKELY(!is_adc_resource(ctx->global, chan_term))) {
+        ESP_LOGE(TAG, "Invalid channel resource");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    struct ChannelResource *chan_rsrc;
+    if (UNLIKELY(!to_channel_resource(chan_term, &chan_rsrc, ctx))) {
+        ESP_LOGE(TAG, "failed to convert adc channel resource");
+        RAISE_ERROR(BADARG_ATOM);
+        return BADARG_ATOM;
+    }
+
+    term unit_term = argv[1];
+    if (UNLIKELY(!is_adc_resource(ctx->global, unit_term))) {
+        ESP_LOGE(TAG, "handle supplied is not a valid adc resource");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    struct UnitResource *unit_rsrc = NULL;
+    if (UNLIKELY(!to_unit_resource(unit_term, &unit_rsrc, ctx))) {
+        ESP_LOGE(TAG, "resource supplied is not a valid adc unit resource");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    adc_oneshot_unit_handle_t unit_handle = NULL;
+    if (chan_rsrc->adc_unit == ADC_UNIT_1) {
+        unit_handle = unit_rsrc->unit_handle;
+#ifdef CONFIG_AVM_ADC2_ENABLE
+    } else if (chan_rsrc->adc_unit == ADC_UNIT_2) {
+        unit_handle = unit_rsrc->unit2_handle;
+#endif
+    } else {
+        ESP_LOGE(TAG, "no valid unit handle found in resource");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    term read_options = argv[2];
+    VALIDATE_VALUE(read_options, term_is_list);
+    term samples = interop_kv_get_value_default(read_options, ATOM_STR("\x7", "samples"), term_from_int32(DEFAULT_SAMPLES), ctx->global);
+    if (UNLIKELY(!term_is_integer(samples))) {
+        ESP_LOGE(TAG, "samples value must be an integer from 1 to 1024.");
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    int samples_val = term_to_int32(samples);
+    if (UNLIKELY((samples_val < 1) || (samples_val > MAX_SAMPLES))) {
+        ESP_LOGE(TAG, "invalid samples value: %i, out of range (1..1024)", samples_val);
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    ESP_LOGD(TAG, "read samples: %i", samples_val);
+    term raw = interop_kv_get_value_default(read_options, ATOM_STR("\x3", "raw"), FALSE_ATOM, ctx->global);
+    term voltage = interop_kv_get_value_default(read_options, ATOM_STR("\x7", "voltage"), FALSE_ATOM, ctx->global);
+
+    int adc_reading = 0;
+    int adc_raw = 0;
+
+    esp_err_t err = ESP_FAIL;
+    for (int i = 0; i < samples_val; ++i) {
+        err = adc_oneshot_read(unit_handle, chan_rsrc->channel, &adc_reading);
+        if (UNLIKELY(err != ESP_OK)) {
+            ESP_LOGE(TAG, "adc_oneshot_read read failed for unit: %i channel: %i", (int) chan_rsrc->adc_unit, (int) chan_rsrc->channel);
+            return adc_err_to_atom_term(ctx->global, err);
+        }
+        adc_raw += adc_reading;
+    }
+
+    adc_raw /= samples_val;
+    ESP_LOGD(TAG, "read adc raw reading: %i", adc_raw);
+
+    raw = raw == TRUE_ATOM ? term_from_int32(adc_raw) : UNDEFINED_ATOM;
+    if (voltage == TRUE_ATOM) {
+        int millivolts = 0;
+        if (chan_rsrc->calibration > ESTIMATED) {
+            err = adc_cali_raw_to_voltage(chan_rsrc->cali_handle, adc_raw, &millivolts);
+            if (UNLIKELY(err != ESP_OK)) {
+                ESP_LOGW(TAG, "Failed to get calibrated voltage, returning estimated voltage");
+                voltage = term_from_int32(approximate_millivolts(adc_raw, chan_rsrc->attenuation, chan_rsrc->width));
+            } else {
+                voltage = term_from_int32(millivolts);
+            }
+        } else {
+            ESP_LOGD(TAG, "ADC channel not calibrated, using estimated voltage");
+            voltage = term_from_int32(approximate_millivolts(adc_raw, chan_rsrc->attenuation, chan_rsrc->width));
+        }
+    } else {
+        voltage = UNDEFINED_ATOM;
+    };
+
+    size_t request_size = TUPLE_SIZE(2) + TUPLE_SIZE(2);
+    if (UNLIKELY(memory_ensure_free_opt(ctx, request_size, MEMORY_NO_SHRINK) != MEMORY_GC_OK)) {
+        return OUT_OF_MEMORY_ATOM;
+    }
+    term values = create_pair(ctx, raw, voltage);
+    term ret = create_pair(ctx, OK_ATOM, values);
+
+    return ret;
+}
+
+//
+// Nif Entry/Exit
+//
+
+static void nif_adc_chan_resource_dtor(ErlNifEnv *caller_env, void *obj)
+{
+    UNUSED(caller_env);
+
+    struct ChannelResource *chan_rsrc = (struct ChannelResource *) obj;
+
+    if (LIKELY((chan_rsrc->cali_handle != NULL) && (chan_rsrc->calibration > ESTIMATED))) {
+#if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
+        ESP_LOGD(TAG, "deregister curve fitting calibration scheme");
+        esp_err_t err = adc_cali_delete_scheme_curve_fitting(chan_rsrc->cali_handle);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "failed to release curve fitting calibration profile");
+        }
+
+#elif ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+        ESP_LOGD(TAG, "deregister line fitting calibration scheme");
+        esp_err_t err = adc_cali_delete_scheme_line_fitting(chan_rsrc->cali_handle);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "failed to release line fitting calibration profile");
+        }
+#endif
+    }
+}
+
+static void nif_adc_unit_resource_dtor(ErlNifEnv *caller_env, void *obj)
+{
+    UNUSED(caller_env);
+
+    struct UnitResource *unit_rsrc = (struct UnitResource *) obj;
+
+    if (LIKELY(unit_rsrc->unit_handle != NULL)) {
+        esp_err_t err = adc_oneshot_del_unit(unit_rsrc->unit_handle);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "failed to release adc");
+        }
+    }
+#ifdef CONFIG_AVM_ADC2_ENABLE
+    if (LIKELY(unit_rsrc->unit2_handle != NULL)) {
+        esp_err_t err = adc_oneshot_del_unit(unit_rsrc->unit2_handle);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "failed to release adc");
+        }
+    }
+#endif
+}
+
+static const ErlNifResourceTypeInit ChannelResourceTypeInit = {
+    .members = 1,
+    .dtor = nif_adc_chan_resource_dtor,
+};
+
+static const ErlNifResourceTypeInit UnitResourceTypeInit = {
+    .members = 1,
+    .dtor = nif_adc_unit_resource_dtor,
+};
+
+static const struct Nif adc_init_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_adc_init
+};
+static const struct Nif adc_deinit_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_adc_deinit
+};
+static const struct Nif adc_acquire_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_adc_acquire
+};
+static const struct Nif adc_release_channel_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_adc_release_channel
+};
+static const struct Nif adc_sample_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_adc_sample
+};
+
+void atomvm_adc_init(GlobalContext *global)
+{
+    ErlNifEnv env;
+    erl_nif_env_partial_init_from_globalcontext(&env, global);
+    adc_channel_resource = enif_init_resource_type(&env, "adc_channel_resource", &ChannelResourceTypeInit, ERL_NIF_RT_CREATE, NULL);
+    adc_unit_resource = enif_init_resource_type(&env, "adc_unit_resource", &UnitResourceTypeInit, ERL_NIF_RT_CREATE, NULL);
+}
+
+const struct Nif *atomvm_adc_get_nif(const char *nifname)
+{
+    TRACE("Locating nif %s ...", nifname);
+    if (strcmp("esp_adc:sample/3", nifname) == 0 || strcmp("Elixir.Esp.ADC:sample/3", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...", nifname);
+        return &adc_sample_nif;
+    }
+    if (strcmp("esp_adc:acquire/4", nifname) == 0 || strcmp("Elixir.Esp.ADC:acquire/4", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...", nifname);
+        return &adc_acquire_nif;
+    }
+    if (strcmp("esp_adc:release_channel/1", nifname) == 0 || strcmp("Elixir.Esp.ADC:release_channel/1", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...", nifname);
+        return &adc_release_channel_nif;
+    }
+    if (strcmp("esp_adc:init/0", nifname) == 0 || strcmp("Elixir.Esp.ADC:init/0", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...", nifname);
+        return &adc_init_nif;
+    }
+    if (strcmp("esp_adc:deinit/1", nifname) == 0 || strcmp("Elixir.Esp.ADC:deinit/1", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...", nifname);
+        return &adc_deinit_nif;
+    }
+    return NULL;
+}
+
+REGISTER_NIF_COLLECTION(atomvm_adc, atomvm_adc_init, NULL, atomvm_adc_get_nif)
+#endif


### PR DESCRIPTION
This set of changes adds support for the ESP32 ADC peripheral, with documentation and examples.

Closes #250

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
