### PR TITLE
ESP32: move Elixir support to new Elixir images

### DIFF
--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -43,6 +43,7 @@ jobs:
         elixir_version: ["1.17"]
         compiler_pkgs: ["clang-10"]
         soc: ["esp32", "esp32c2", "esp32c3", "esp32s2", "esp32s3", "esp32c6", "esp32h2"]
+        flavor: ["", "-elixir"]
 
     env:
       CC: ${{ matrix.cc }}
@@ -117,27 +118,35 @@ jobs:
       run: |
         cp sdkconfig.release-defaults sdkconfig.defaults
 
-    - name: "Build ${{ matrix.soc }} with idf.py"
+    - name: "Build ${{ matrix.soc }}${{ matrix.flavor }} with idf.py"
       shell: bash
       working-directory: ./src/platforms/esp32/
       run: |
         rm -rf build
         . $IDF_PATH/export.sh
+        if [ ! -z "${{ matrix.flavor }}" ]
+        then
+          mv partitions${{ matrix.flavor }}.csv partitions.csv
+        fi
         idf.py set-target ${{ matrix.soc }}
         idf.py reconfigure
         idf.py build
 
-    - name: "Create a ${{ matrix.soc }} image"
+    - name: "Create a ${{ matrix.soc }}${{ matrix.flavor }} image"
       working-directory: ./src/platforms/esp32/build
       run: |
         ./mkimage.sh
+        if [ ! -z "${{ matrix.flavor }}" ]
+        then
+          mv atomvm-${{ matrix.soc }}.img atomvm-${{ matrix.soc }}${{ matrix.flavor }}.img
+        fi
         ls -l *.img
 
     - name: "Upload ${{ matrix.soc }} artifacts"
       uses: actions/upload-artifact@v4
       with:
-        name: atomvm-${{ matrix.soc }}-image
-        path: ./src/platforms/esp32/build/atomvm-${{ matrix.soc }}.img
+        name: atomvm-${{ matrix.soc }}${{ matrix.flavor }}-image
+        path: ./src/platforms/esp32/build/atomvm-${{ matrix.soc }}${{ matrix.flavor }}.img
         if-no-files-found: error
 
     - name: "Rename and write sha256sum"
@@ -145,8 +154,8 @@ jobs:
       shell: bash
       working-directory: src/platforms/esp32/build
       run: |
-        ATOMVM_IMG="AtomVM-${{ matrix.soc }}-${{ github.ref_name }}.img"
-        mv atomvm-${{ matrix.soc }}.img "${ATOMVM_IMG}"
+        ATOMVM_IMG="AtomVM-${{ matrix.soc }}${{ matrix.flavor }}-${{ github.ref_name }}.img"
+        mv atomvm-${{ matrix.soc }}${{ matrix.flavor }}.img "${ATOMVM_IMG}"
         sha256sum "${ATOMVM_IMG}" > "${ATOMVM_IMG}.sha256"
 
     - name: Release
@@ -156,5 +165,5 @@ jobs:
         draft: true
         fail_on_unmatched_files: true
         files: |
-          src/platforms/esp32/build/AtomVM-${{ matrix.soc }}-${{ github.ref_name }}.img
-          src/platforms/esp32/build/AtomVM-${{ matrix.soc }}-${{ github.ref_name }}.img.sha256
+          src/platforms/esp32/build/AtomVM-${{ matrix.soc }}${{ matrix.flavor }}-${{ github.ref_name }}.img
+          src/platforms/esp32/build/AtomVM-${{ matrix.soc }}${{ matrix.flavor }}-${{ github.ref_name }}.img.sha256

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -135,9 +135,13 @@ jobs:
     - name: "Create a ${{ matrix.soc }}${{ matrix.flavor }} image"
       working-directory: ./src/platforms/esp32/build
       run: |
-        ./mkimage.sh
-        if [ ! -z "${{ matrix.flavor }}" ]
+        if [ -z "${{ matrix.flavor }}" ]
         then
+          ./mkimage.sh
+        else
+          FLAVOR_SUFFIX=$(echo "${{ matrix.flavor }}" | sed 's/-//g')
+          BOOT_FILE="build/libs/esp32boot/${FLAVOR_SUFFIX}_esp32boot.avm"
+          ./mkimage.sh --boot="$BOOT_FILE"
           mv atomvm-${{ matrix.soc }}.img atomvm-${{ matrix.soc }}${{ matrix.flavor }}.img
         fi
         ls -l *.img

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32: add a new Elixir release "flavor" with a bigger boot.avm partition that has room for
 Elixir standard library modules
 
+### Changed
+
+- ESP32: Elixir library is not shipped anymore with `esp32boot.avm`. Use `elixir_esp32boot.avm`
+instead
+
+### Fixed
+
+- ESP32: content of `boot.avm` partition is not truncated anymore
+
 ## [0.6.4] - 2024-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ESP32: add a new Elixir release "flavor" with a bigger boot.avm partition that has room for
 Elixir standard library modules
+- ESP32: `--boot` option to mkimage.sh tool
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.5] - Unreleased
 
+### Added
+
+- ESP32: add a new Elixir release "flavor" with a bigger boot.avm partition that has room for
+Elixir standard library modules
+
 ## [0.6.4] - 2024-08-18
 
 ### Added

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -6,6 +6,12 @@
 
 # AtomVM Update Instructions
 
+## v0.6.4 -> v0.6.5
+
+- ESP32: partitioning schema for Elixir flavor is different, so app offset has been changed for
+Elixir images. Make sure to use `0x250000` as offset in your mix.exs or when performing manual
+flashing.
+
 ## v0.6.0-beta.1 -> v0.6.0-rc.0
 
 - Drivers that send messages from Esp32 callbacks should use new functions

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -8,6 +8,8 @@
 
 ## v0.6.4 -> v0.6.5
 
+- ESP32: `esp32boot.avm` doesn't contain anymore Elixir standard library, use instead
+`elixir_esp32boot.avm`, or the Elixir release flavor when using an image.
 - ESP32: partitioning schema for Elixir flavor is different, so app offset has been changed for
 Elixir images. Make sure to use `0x250000` as offset in your mix.exs or when performing manual
 flashing.

--- a/libs/esp32boot/CMakeLists.txt
+++ b/libs/esp32boot/CMakeLists.txt
@@ -23,7 +23,7 @@ project(esp32boot)
 include(BuildErlang)
 
 if (Elixir_FOUND)
-    pack_runnable(esp32boot esp32init esp32devmode eavmlib estdlib alisp exavmlib)
-else()
-    pack_runnable(esp32boot esp32init esp32devmode eavmlib estdlib alisp)
+    pack_runnable(elixir_esp32boot esp32init esp32devmode eavmlib estdlib alisp exavmlib)
 endif()
+
+pack_runnable(esp32boot esp32init esp32devmode eavmlib estdlib alisp)

--- a/src/platforms/esp32/partitions-elixir.csv
+++ b/src/platforms/esp32/partitions-elixir.csv
@@ -1,0 +1,12 @@
+# Copyright 2018-2021 Davide Bettio <davide@uninstall.it>
+# Copyright 2018-2021 Fred Dushin <fred@dushin.net>
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+
+# Name,   Type, SubType, Offset,  Size, Flags
+# Note: if you change the phy_init or app partition offset, make sure to change the offset in Kconfig.projbuild
+nvs,      data, nvs,       0x9000,     0x6000,
+phy_init, data, phy,       0xf000,     0x1000,
+factory,  app,  factory,  0x10000,   0x1C0000,
+boot.avm,  data, phy,     0x1D0000,    0x80000,
+main.avm, data, phy,     0x250000,   0x100000

--- a/src/platforms/esp32/tools/mkimage.config.in
+++ b/src/platforms/esp32/tools/mkimage.config.in
@@ -38,7 +38,7 @@
         #{
             name => "AtomVM Boot and Core BEAM Library",
             offset =>  "0x1D0000",
-            path => ["${BUILD_DIR}/../../../../build/libs/esp32boot/esp32boot.avm"]
+            path => ["$[BOOT_FILE]"]
         }
     ]
 }.

--- a/src/platforms/esp32/tools/mkimage.erl
+++ b/src/platforms/esp32/tools/mkimage.erl
@@ -42,9 +42,12 @@ do_main(Argv) ->
                 RootDir ->
                     try
                         Config = load_config(maps:get(config, Opts, "mkimage.config")),
+                        BuildDir = get_build_dir(Opts, RootDir),
+                        BootFile = BuildDir ++ "/libs/esp32boot/esp32boot.avm",
                         mkimage(
                             RootDir,
-                            get_build_dir(Opts, RootDir),
+                            BuildDir,
+                            maps:get(boot, Opts, BootFile),
                             maps:get(out, Opts, "atomvm.img"),
                             maps:get(segments, Config)
                         ),
@@ -65,6 +68,8 @@ parse_args(Argv) ->
 %% @private
 parse_args([], {Opts, Args}) ->
     {Opts, lists:reverse(Args)};
+parse_args(["--boot", Path | T], {Opts, Args}) ->
+    parse_args(T, {Opts#{boot => Path}, Args});
 parse_args(["--out", Path | T], {Opts, Args}) ->
     parse_args(T, {Opts#{out => Path}, Args});
 parse_args(["--root_dir", Path | T], {Opts, Args}) ->
@@ -92,6 +97,7 @@ print_help() ->
         "The following options are supported:"
         "~n"
         "    * --root_dir <path>    Path to the root directory of the AtomVM git checkout~n"
+        "    * --boot <path>        Path to a esp32boot.avm file~n"
         "    * --build_dir <path>   Path to the AtomVM build directory (defaults to root_dir/build, if unspecifeid)~n"
         "    * --out <path>         Output path for AtomVM image file~n"
         "    * --config <path>      Path to mkimage configuration file~n"
@@ -124,7 +130,7 @@ get_build_dir(Opts, RootDir) ->
     end.
 
 %% @private
-mkimage(RootDir, BuildDir, OutputFile, Segments) ->
+mkimage(RootDir, BuildDir, BootFile, OutputFile, Segments) ->
     io:format("Writing output to ~s~n", [OutputFile]),
     io:format("=============================================~n"),
     case file:open(OutputFile, [write, binary]) of
@@ -156,7 +162,7 @@ mkimage(RootDir, BuildDir, OutputFile, Segments) ->
                             end
                     end,
                     SegmentPaths = [
-                        replace("BUILD_DIR", BuildDir, replace("ROOT_DIR", RootDir, SegmentPath))
+                        replace("BUILD_DIR", BuildDir, replace("BOOT_FILE", BootFile, replace("ROOT_DIR", RootDir, SegmentPath)))
                      || SegmentPath <- maps:get(path, Segment)
                     ],
                     case try_read(SegmentPaths) of
@@ -200,4 +206,5 @@ from_hex([$0, $x | Bits]) ->
 
 %% @private
 replace(VariableName, Value, String) ->
-    string:replace(String, io_lib:format("${~s}", [VariableName]), Value).
+    string:replace(String, io_lib:format("${~s}", [VariableName]), Value),
+    string:replace(String, io_lib:format("$[~s]", [VariableName]), Value).


### PR DESCRIPTION
**BREAKING CHANGE**:
Starting with this PR, Elixir support is only available in Elixir images with bigger boot.avm partition.

Fixes #1262 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
