### PR TITLE
Support handle_continue in gen_server.erl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for Elixir `Enum.at/3`
 - Add support to Elixir `Enumerable` protocol also for `Enum.all?`, `Enum.any?`, `Enum.each` and
 `Enum.filter`
+- Add support for `handle_continue` callback in `gen_server`
 
 ### Changed
 

--- a/tests/libs/estdlib/test_gen_server.erl
+++ b/tests/libs/estdlib/test_gen_server.erl
@@ -21,7 +21,7 @@
 -module(test_gen_server).
 
 -export([test/0]).
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+-export([init/1, handle_continue/2, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -record(state, {
     num_casts = 0,
@@ -36,6 +36,7 @@ test() ->
     ok = test_cast(),
     ok = test_info(),
     ok = test_start_link(),
+    ok = test_continue(),
     ok = test_init_exception(),
     ok = test_late_reply(),
     ok = test_concurrent_clients(),
@@ -76,6 +77,50 @@ test_start_link() ->
         end,
     true = erlang:process_flag(trap_exit, false),
     ok.
+
+test_continue() ->
+    {ok, Pid} = gen_server:start_link(?MODULE, {continue, self()}, []),
+    [{Pid, continue}, {Pid, after_continue}] = read_replies(Pid),
+
+    gen_server:call(Pid, {continue_reply, self()}),
+    [{Pid, continue}, {Pid, after_continue}] = read_replies(Pid),
+
+    gen_server:call(Pid, {continue_noreply, self()}),
+    [{Pid, continue}, {Pid, after_continue}] = read_replies(Pid),
+
+    gen_server:cast(Pid, {continue_noreply, self()}),
+    [{Pid, continue}, {Pid, after_continue}] = read_replies(Pid),
+
+    Pid ! {continue_noreply, self()},
+    [{Pid, continue}, {Pid, after_continue}] = read_replies(Pid),
+
+    Pid ! {continue_continue, self()},
+    [{Pid, before_continue}, {Pid, continue}, {Pid, after_continue}] = read_replies(Pid),
+
+    Ref = monitor(process, Pid),
+    Pid ! continue_stop,
+    verify_down_reason(Ref, Pid, normal).
+
+read_replies(Pid) ->
+    receive
+        {Pid, ack} -> read_replies()
+    after 1000 ->
+        error
+    end.
+
+read_replies() ->
+    receive
+        Msg -> [Msg | read_replies()]
+    after 0 -> []
+    end.
+
+verify_down_reason(MRef, Server, Reason) ->
+    receive
+        {'DOWN', MRef, process, Server, Reason} ->
+            ok
+    after 5000 ->
+        error
+    end.
 
 test_cast() ->
     {ok, Pid} = gen_server:start(?MODULE, [], []),
@@ -353,11 +398,35 @@ test_stop_noproc() ->
 
 init(throwme) ->
     throw(throwme);
+init({continue, Pid}) ->
+    io:format("init(continue) -> ~p~n", [Pid]),
+    self() ! {after_continue, Pid},
+    {ok, [], {continue, {message, Pid}}};
 init(_) ->
     {ok, #state{}}.
 
+handle_continue({continue, Pid}, State) ->
+    Pid ! {self(), before_continue},
+    self() ! {after_continue, Pid},
+    {noreply, State, {continue, {message, Pid}}};
+handle_continue(stop, State) ->
+    {stop, normal, State};
+handle_continue({message, Pid}, State) ->
+    Pid ! {self(), continue},
+    {noreply, State};
+handle_continue({message, Pid, From}, State) ->
+    Pid ! {self(), continue},
+    gen_server:reply(From, ok),
+    {noreply, State}.
+
 handle_call(ping, _From, State) ->
     {reply, pong, State};
+handle_call({continue_reply, Pid}, _From, State) ->
+    self() ! {after_continue, Pid},
+    {reply, ok, State, {continue, {message, Pid}}};
+handle_call({continue_noreply, Pid}, From, State) ->
+    self() ! {after_continue, Pid},
+    {noreply, State, {continue, {message, Pid, From}}};
 handle_call(reply_ping, From, State) ->
     gen_server:reply(From, pong),
     {noreply, State};
@@ -392,6 +461,9 @@ handle_call(crash_me, _From, State) ->
 handle_call(crash_in_terminate, _From, State) ->
     {reply, ok, State#state{crash_in_terminate = true}}.
 
+handle_cast({continue_noreply, Pid}, State) ->
+    self() ! {after_continue, Pid},
+    {noreply, State, {continue, {message, Pid}}};
 handle_cast(crash, _State) ->
     throw(test_crash);
 handle_cast(ping, #state{num_casts = NumCasts} = State) ->
@@ -403,6 +475,17 @@ handle_cast({set_info_timeout, Timeout}, State) ->
 handle_cast(_Request, State) ->
     {noreply, State}.
 
+handle_info({after_continue, Pid}, State) ->
+    Pid ! {self(), after_continue},
+    Pid ! {self(), ack},
+    {noreply, State};
+handle_info(continue_stop, State) ->
+    {noreply, State, {continue, stop}};
+handle_info({continue_noreply, Pid}, State) ->
+    self() ! {after_continue, Pid},
+    {noreply, State, {continue, {message, Pid}}};
+handle_info({continue_continue, Pid}, State) ->
+    {noreply, State, {continue, {continue, Pid}}};
 handle_info(ping, #state{num_infos = NumInfos, info_timeout = InfoTimeout} = State) ->
     NewState = State#state{num_infos = NumInfos + 1},
     case InfoTimeout of


### PR DESCRIPTION
Adds gen_server support for handle_continue (https://www.erlang.org/doc/apps/stdlib/gen_server.html#c:handle_continue/2), tests are carbon copy from upstream test suite https://github.com/erlang/otp/blob/141120ab9de7e6069ee45280dc7f6a251f89e081/lib/stdlib/test/gen_server_SUITE.erl#L1012

Added to otp back in 2017: https://github.com/erlang/otp/pull/1490 - often used in elixir land.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
