### PR TITLE
Add support for `is_bistring/1` construct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for Elixir `Enum.at/3`
 - Add support to Elixir `Enumerable` protocol also for `Enum.all?`, `Enum.any?`, `Enum.each` and
 `Enum.filter`
+- Add support for `is_bitstring/1` construct which is used in Elixir protocols runtime.
 
 ### Changed
 

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -41,6 +41,7 @@ erlang:byte_size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = b
 erlang:bit_size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_bit_size_1}
 erlang:get/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_get_1}
 erlang:is_atom/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_atom_1}
+erlang:is_bitstring/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_binary_1}
 erlang:is_binary/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_binary_1}
 erlang:is_boolean/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_boolean_1}
 erlang:is_float/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_float_1}

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -5363,7 +5363,9 @@ wait_timeout_trap_handler:
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("is_bitstr/2, label=%i, arg1=%lx\n", label, arg1);
 
-                    pc = mod->labels[label];
+                    if (!term_is_binary(arg1)) {
+                        pc = mod->labels[label];
+                    }
                 #endif
 
                 #ifdef IMPL_CODE_LOADER

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -143,6 +143,7 @@ compile_erlang(test_list_to_integer)
 compile_erlang(test_abs)
 compile_erlang(test_is_process_alive)
 compile_erlang(test_is_not_type)
+compile_erlang(test_is_bitstring_is_binary)
 compile_erlang(test_badarith)
 compile_erlang(test_badarith2)
 compile_erlang(test_badarith3)
@@ -607,6 +608,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_abs.beam
     test_is_process_alive.beam
     test_is_not_type.beam
+    test_is_bitstring_is_binary.beam
     test_badarith.beam
     test_badarith2.beam
     test_badarith3.beam

--- a/tests/erlang_tests/test_is_bitstring_is_binary.erl
+++ b/tests/erlang_tests/test_is_bitstring_is_binary.erl
@@ -1,0 +1,50 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_is_bitstring_is_binary).
+
+-export([start/0, id/1]).
+
+start() ->
+    test_is_bitstring(),
+    test_is_binary(),
+    0.
+
+id(X) -> X.
+
+test_is_bitstring() ->
+    true = is_bitstring(id(<<"hello">>)),
+    % bitstrings are currently unsupported
+    %   true = is_bitstring(id(<<1:1>>)),
+    true = is_bitstring(id(<<>>)),
+    false = is_bitstring(id(binary)),
+    false = is_bitstring(id("hello")),
+    false = is_bitstring(id(42)),
+    ok.
+
+test_is_binary() ->
+    true = is_binary(id(<<"hello">>)),
+    % bitstrings are currently unsupported
+    %   false = is_binary(id(<<1:1>>)),
+    true = is_binary(id(<<>>)),
+    false = is_binary(id(binary)),
+    false = is_binary(id("hello")),
+    false = is_binary(id(42)),
+    ok.

--- a/tests/test.c
+++ b/tests/test.c
@@ -166,6 +166,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(test_abs, 5),
     TEST_CASE_EXPECTED(test_is_process_alive, 121),
     TEST_CASE_EXPECTED(test_is_not_type, 255),
+    TEST_CASE(test_is_bitstring_is_binary),
     TEST_CASE_EXPECTED(test_badarith, -87381),
     TEST_CASE_EXPECTED(test_badarith2, -87381),
     TEST_CASE_EXPECTED(test_badarith3, -1365),


### PR DESCRIPTION
This construct is used in Elixir protocols runtime (*.BitString).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
