### PR TITLE
Add support for `maps:merge_with/3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Add support to Elixir `Enumerable` protocol also for `Enum.all?`, `Enum.any?`, `Enum.each` and
 `Enum.filter`
 - Add support for `is_bitstring/1` construct which is used in Elixir protocols runtime.
+- Support for `maps:merge_with/3`
 
 ### Changed
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
