### PR TITLE
Process.ex send/2 send_after/3 and /4 cancel_timer/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Add support to Elixir `Enumerable` protocol also for `Enum.all?`, `Enum.any?`, `Enum.each` and
 `Enum.filter`
 - Add support for `is_bitstring/1` construct which is used in Elixir protocols runtime.
+- Add support to Elixir for `Process.send/2` `Process.send_after/3/4` and `Process.cancel_timer/1`
 
 ### Changed
 

--- a/libs/exavmlib/lib/Process.ex
+++ b/libs/exavmlib/lib/Process.ex
@@ -146,6 +146,20 @@ defmodule Process do
     receive after: (timeout -> :ok)
   end
 
+  @spec send(dest, msg) :: :ok | :noconnect | :nosuspend
+        when dest: dest(),
+             msg: any
+  defdelegate send(dest, msg), to: :erlang
+
+  @spec send_after(pid | atom, term, non_neg_integer, [option]) :: reference
+        when option: {:abs, boolean}
+  def send_after(dest, msg, time, _opts \\ []) do
+    :erlang.send_after(time, dest, msg)
+  end
+
+  @spec cancel_timer(reference) :: non_neg_integer | false | :ok
+  defdelegate cancel_timer(timer_ref), to: :erlang
+
   @type spawn_opt ::
           :link
           | :monitor


### PR DESCRIPTION
send_after is stubbed for /4 and abs option is ignored. Believe those are related to time warping. See https://hexdocs.pm/elixir/1.17.3/Process.html#send_after/4

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
