### PR TITLE
Fix unicode bogus oom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ instead
 - ESP32: `Fixed gpio:set_int` to accept any pin, not only pin 2
 - Fix memory corruption in `unicode:characters_to_binary`
 - Fix handling of large literal indexes
+- `unicode:characters_to_list`: fixed bogus out_of_memory error on some platforms such as ESP32
 
 ## [0.6.4] - 2024-08-18
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -4552,7 +4552,10 @@ static term nif_unicode_characters_to_list(Context *ctx, int argc, term argv[])
     }
     size_t len = size / sizeof(uint32_t);
     uint32_t *chars = malloc(size);
-    if (IS_NULL_PTR(chars)) {
+    // fun fact: malloc(size) when size is 0, on some platforms may return NULL, causing a failure here
+    // so in order to avoid out_of_memory (while having plenty of memory) let's treat size==0 as a
+    // special case
+    if (UNLIKELY((chars == NULL) && (size != 0))) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     size_t needed_terms = CONS_SIZE * len;

--- a/tests/test.c
+++ b/tests/test.c
@@ -75,6 +75,34 @@ struct Test
 #define SKIP_STACKTRACES false
 #endif
 
+// Enabling this will override malloc and calloc weak symbols,
+// so we can force an alternative version of malloc that returns
+// NULL when size is 0.
+// This is useful to find debugging or finding some kind of issues.
+#ifdef FORCE_MALLOC_ZERO_RETURNS_NULL
+void *malloc(size_t size)
+{
+    if (size == 0) {
+        return NULL;
+    } else {
+        void *memptr = NULL;
+        if (posix_memalign(&memptr, sizeof(void *), size) != 0) {
+            return NULL;
+        }
+        return memptr;
+    }
+}
+
+void *calloc(size_t nmemb, size_t size)
+{
+    void *ptr = malloc(nmemb * size);
+    if (ptr != NULL) {
+        memset(ptr, 0, nmemb * size);
+    }
+    return ptr;
+}
+#endif
+
 struct Test tests[] = {
     TEST_CASE_EXPECTED(add, 17),
     TEST_CASE_EXPECTED(fact, 120),


### PR DESCRIPTION
`unicode:characters_to_list(<<>>)` was failing with (a bogus) out_of_memory error.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
