### PR TITLE
Fix `unicode:characters_to_binary`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ instead
 
 - ESP32: content of `boot.avm` partition is not truncated anymore
 - ESP32: Fixed gpio:set_int` to accept any pin, not only pin 2
+- Fix memory corruption in `unicode:characters_to_binary`
 
 ## [0.6.4] - 2024-08-18
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -4616,7 +4616,7 @@ static term nif_unicode_characters_to_binary(Context *ctx, int argc, term argv[]
     if (UNLIKELY(conv_result == UnicodeBadArg)) {
         RAISE_ERROR(BADARG_ATOM);
     }
-    size_t needed_terms = term_binary_data_size_in_terms(len);
+    size_t needed_terms = term_binary_heap_size(len);
     if (UNLIKELY(conv_result == UnicodeError || conv_result == UnicodeIncompleteTransform)) {
         needed_terms += TUPLE_SIZE(3) + rest_size;
     }


### PR DESCRIPTION
This PR fixes a memory corruption.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
