### PR TITLE
Add support for `gen_server:start_monitor/3,4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Add support to Elixir for `Process.send/2` `Process.send_after/3/4` and `Process.cancel_timer/1`
 - Add support for `handle_continue` callback in `gen_server`
 - Support for Elixir `List.Chars` protocol
+- Support for `gen_server:start_monitor/3,4`
 
 ### Changed
 


### PR DESCRIPTION
Similar to start_link but with `monitor` option.
Code for all "start with name" functions has been refactored to avoid duplication.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
