### PR TITLE
Fix Elixir `inspect()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ instead
 - Fix handling of large literal indexes
 - `unicode:characters_to_list`: fixed bogus out_of_memory error on some platforms such as ESP32
 - Fix crash in Elixir library when doing `inspect(:atom)`
+- General inspect() compliance with Elixir behavior (but there are still some minor differences)
 
 ## [0.6.4] - 2024-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ instead
 - Fix memory corruption in `unicode:characters_to_binary`
 - Fix handling of large literal indexes
 - `unicode:characters_to_list`: fixed bogus out_of_memory error on some platforms such as ESP32
+- Fix crash in Elixir library when doing `inspect(:atom)`
 
 ## [0.6.4] - 2024-08-18
 

--- a/libs/exavmlib/lib/Kernel.ex
+++ b/libs/exavmlib/lib/Kernel.ex
@@ -42,7 +42,7 @@ defmodule Kernel do
   def inspect(term, opts \\ []) when is_list(opts) do
     case term do
       t when is_atom(t) ->
-        [?:, atom_to_string(t)]
+        atom_to_string(t, ":")
 
       t when is_integer(t) ->
         :erlang.integer_to_binary(t)
@@ -118,10 +118,26 @@ defmodule Kernel do
     )
   end
 
-  defp atom_to_string(atom) do
-    # TODO: use unicode rather than plain latin1
-    # handle spaces and special characters
-    :erlang.atom_to_binary(atom, :latin1)
+  defp atom_to_string(atom, prefix \\ "") do
+    case atom do
+      true ->
+        "true"
+
+      false ->
+        "false"
+
+      nil ->
+        "nil"
+
+      any_atom ->
+        case :erlang.atom_to_binary(any_atom) do
+          <<"Elixir.", displayable::binary>> ->
+            displayable
+
+          other ->
+            <<prefix::binary, other::binary>>
+        end
+    end
   end
 
   @doc """

--- a/tests/libs/exavmlib/Tests.ex
+++ b/tests/libs/exavmlib/Tests.ex
@@ -19,6 +19,11 @@
 #
 
 defmodule Tests do
+  #  defstruct [
+  #    :field1,
+  #    field2: 42
+  #  ]
+
   @compile {:no_warn_undefined, :undef}
 
   def start() do
@@ -244,10 +249,53 @@ defmodule Tests do
     ":アトム" = inspect(:アトム)
     "Test" = inspect(Test)
 
+    "5" = inspect(5)
+    "5.0" = inspect(5.0)
+
+    ~s[""] = inspect("")
+    ~s["hello"] = inspect("hello")
+    ~s["アトム"] = inspect("アトム")
+
+    "<<10>>" = inspect("\n")
+    "<<0, 1, 2, 3>>" = inspect(<<0, 1, 2, 3>>)
+    "<<195, 168, 0>>" = inspect(<<195, 168, 0>>)
+
+    "[]" = inspect([])
+    "[0]" = inspect([0])
+    "[9, 10]" = inspect([9, 10])
+    ~s'["test"]' = inspect(["test"])
+    "'hello'" = inspect('hello')
+    "[127]" = inspect([127])
+    "[104, 101, 108, 108, 248]" = inspect('hellø')
+
+    ~s([5 | "hello"]) = inspect([5 | "hello"])
+
+    "{}" = inspect({})
+    "{1, 2}" = inspect({1, 2})
+    "{:test, 1}" = inspect({:test, 1})
+
+    "%{}" = inspect(%{})
+    either("%{a: 1, b: 2}", "%{b: 2, a: 1}", inspect(%{a: 1, b: 2}))
+    either(~s[%{"a" => 1, "b" => 2}], ~s[%{"b" => 2, "a" => 1}], inspect(%{"a" => 1, "b" => 2}))
+
+    # TODO: structs are not yet supported
+    # either(
+    #   ~s[%#{__MODULE__}{field1: nil, field2: 42}],
+    #   ~s[%#{__MODULE__}{field2: 42, field1: nil}],
+    #   inspect(%__MODULE__{})
+    # )
+
     :ok
   end
 
   defp fact(n) when n < 0, do: :test
   defp fact(0), do: 1
   defp fact(n), do: fact(n - 1) * n
+
+  def either(a, b, value) do
+    case value do
+      ^a -> a
+      ^b -> b
+    end
+  end
 end

--- a/tests/libs/exavmlib/Tests.ex
+++ b/tests/libs/exavmlib/Tests.ex
@@ -26,6 +26,7 @@ defmodule Tests do
     :ok = test_enum()
     :ok = test_exception()
     :ok = test_chars_protocol()
+    :ok = test_inspect()
     :ok = IO.puts("Finished Elixir tests")
   end
 
@@ -231,6 +232,18 @@ defmodule Tests do
     "1.0" = String.Chars.to_string(1.0)
     "abc" = String.Chars.to_string(~c"abc")
     "test" = String.Chars.to_string("test")
+    :ok
+  end
+
+  def test_inspect() do
+    "true" = inspect(true)
+    "false" = inspect(false)
+    "nil" = inspect(nil)
+
+    ":test" = inspect(:test)
+    ":アトム" = inspect(:アトム)
+    "Test" = inspect(Test)
+
     :ok
   end
 


### PR DESCRIPTION
Closer to Elixir one (and more reliable), but not yet perfect.
e.g. structs are still printed as maps.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
