### PR TITLE
Add Keyword.ex split/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for Elixir `List.Chars` protocol
 - Support for `gen_server:start_monitor/3,4`
 - Support for `code:ensure_loaded/1`
+- Add support to Elixir for `Keyword.split/2`
 
 ### Changed
 

--- a/libs/exavmlib/lib/Keyword.ex
+++ b/libs/exavmlib/lib/Keyword.ex
@@ -4,7 +4,7 @@
 # Copyright 2012-2024 Elixir Contributors
 # https://github.com/elixir-lang/elixir/commits/v1.10.1/lib/elixir/lib/keyword.ex
 #
-# merge/2 take/2 pop/2/3 pop!/2 keyword?/1 has_key?/2 from:
+# merge/2 take/2 pop/2/3 pop!/2 keyword?/1 has_key?/2 split/2 from:
 # https://github.com/elixir-lang/elixir/blob/v1.16/lib/elixir/lib/keyword.ex
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,6 +99,19 @@ defmodule Keyword do
       true -> delete_key(keywords, key)
       _ -> keywords
     end
+  end
+
+  def split(keywords, keys) when is_list(keywords) and is_list(keys) do
+    fun = fn {k, v}, {take, drop} ->
+      case k in keys do
+        true -> {[{k, v} | take], drop}
+        false -> {take, [{k, v} | drop]}
+      end
+    end
+
+    acc = {[], []}
+    {take, drop} = :lists.foldl(fun, acc, keywords)
+    {:lists.reverse(take), :lists.reverse(drop)}
   end
 
   def take(keywords, keys) when is_list(keywords) and is_list(keys) do


### PR DESCRIPTION
Used by Supervisor.ex

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
