### PR TITLE
Add support for `io_lib:latin1_char_list/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for Elixir `List.Chars` protocol
 - Support for `gen_server:start_monitor/3,4`
 - Support for `code:ensure_loaded/1`
+- Support for `io_lib:latin1_char_list/1`
 
 ### Changed
 

--- a/libs/estdlib/src/io_lib.erl
+++ b/libs/estdlib/src/io_lib.erl
@@ -27,7 +27,7 @@
 %%-----------------------------------------------------------------------------
 -module(io_lib).
 
--export([format/2]).
+-export([format/2, latin1_char_list/1]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Format format string
@@ -49,6 +49,20 @@ format(Format, Args) ->
         false ->
             error(badarg)
     end.
+
+%%-----------------------------------------------------------------------------
+%% @param   Term term to test
+%% @returns true if Term is a list of latin1 characters, false otherwise.
+%% @doc     Determine if passed term is a list of ISO-8859-1 characters (0-255).
+%% @end
+%%-----------------------------------------------------------------------------
+-spec latin1_char_list(Term :: any()) -> boolean().
+latin1_char_list([H | T]) when is_integer(H) andalso H >= 0 andalso H =< 255 ->
+    latin1_char_list(T);
+latin1_char_list([]) ->
+    true;
+latin1_char_list(_) ->
+    false.
 
 %%
 %% internal operations

--- a/tests/libs/estdlib/test_io_lib.erl
+++ b/tests/libs/estdlib/test_io_lib.erl
@@ -27,6 +27,11 @@
 -define(FLT(L), lists:flatten(L)).
 
 test() ->
+    test_format(),
+    test_latin1_char_list(),
+    ok.
+
+test_format() ->
     ?ASSERT_MATCH(?FLT(io_lib:format("", [])), ""),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo", [])), "foo"),
     ?ASSERT_MATCH(?FLT(io_lib:format("foo~n", [])), "foo\n"),
@@ -238,6 +243,17 @@ test() ->
     ?ASSERT_MATCH(?FLT(io_lib:format("~.16+", [-31])), "-16#1f"),
     ?ASSERT_MATCH(?FLT(io_lib:format("~i~n", [foo])), "\n"),
 
+    ok.
+
+test_latin1_char_list() ->
+    true = io_lib:latin1_char_list([]),
+    false = io_lib:latin1_char_list(foo),
+    false = io_lib:latin1_char_list(<<>>),
+    false = io_lib:latin1_char_list(<<"hello">>),
+    true = io_lib:latin1_char_list("hello"),
+    true = io_lib:latin1_char_list("été"),
+    false = io_lib:latin1_char_list(["hello"]),
+    false = io_lib:latin1_char_list([$h, $e, $l, $l | $o]),
     ok.
 
 id(X) ->


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
