### PR TITLE
Add support for Elixir `List.duplicate/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Add support to Elixir for `Keyword.split/2`
 - Support for `binary:split/3` and `string:find/2,3`
 - Support for large tuples (more than 255 elements) in external terms.
+- Support for Elixir `List.duplicate/2`
 
 ### Changed
 

--- a/libs/exavmlib/lib/List.ex
+++ b/libs/exavmlib/lib/List.ex
@@ -148,6 +148,34 @@ defmodule List do
   @compile :inline_list_funcs
 
   @doc """
+  Duplicates the given element `n` times in a list.
+
+  `n` is an integer greater than or equal to `0`.
+
+  If `n` is `0`, an empty list is returned.
+
+  ## Examples
+
+      iex> List.duplicate("hello", 0)
+      []
+
+      iex> List.duplicate("hi", 1)
+      ["hi"]
+
+      iex> List.duplicate("bye", 2)
+      ["bye", "bye"]
+
+      iex> List.duplicate([1, 2], 3)
+      [[1, 2], [1, 2], [1, 2]]
+
+  """
+  @spec duplicate(any, 0) :: []
+  @spec duplicate(elem, pos_integer) :: [elem, ...] when elem: var
+  def duplicate(elem, n) do
+    :lists.duplicate(n, elem)
+  end
+
+  @doc """
   Deletes the given `element` from the `list`. Returns a new list without
   the element.
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
