### PR TITLE
Add support for Elixir `IO.chardata_to_string/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Add support to Elixir for `Keyword.split/2`
 - Support for `binary:split/3` and `string:find/2,3`
 - Support for large tuples (more than 255 elements) in external terms.
+- Support for Elixir `IO.chardata_to_string/1`
 
 ### Changed
 

--- a/libs/exavmlib/lib/IO.ex
+++ b/libs/exavmlib/lib/IO.ex
@@ -25,6 +25,42 @@ defmodule IO do
   @compile {:autoload, false}
 
   # Taken from Elixir io.ex
+  @type chardata :: String.t() | maybe_improper_list(char | chardata, String.t() | [])
+
+  # Taken from Elixir io.ex
+  @doc """
+  Converts chardata into a string.
+
+  For more information about chardata, see the ["Chardata"](#module-chardata)
+  section in the module documentation.
+
+  In case the conversion fails, it raises an `UnicodeConversionError`.
+  If a string is given, it returns the string itself.
+
+  ## Examples
+
+      iex> IO.chardata_to_string([0x00E6, 0x00DF])
+      "æß"
+
+      iex> IO.chardata_to_string([0x0061, "bc"])
+      "abc"
+
+      iex> IO.chardata_to_string("string")
+      "string"
+
+  """
+  @spec chardata_to_string(chardata) :: String.t()
+  def chardata_to_string(chardata)
+
+  def chardata_to_string(string) when is_binary(string) do
+    string
+  end
+
+  def chardata_to_string(list) when is_list(list) do
+    List.to_string(list)
+  end
+
+  # Taken from Elixir io.ex
   @doc """
   Converts iodata (a list of integers representing bytes, lists
   and binaries) into a binary.


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
