### PR TITLE
Add support for `io:put_chars/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Add support to Elixir for `Keyword.split/2`
 - Support for `binary:split/3` and `string:find/2,3`
 - Support for large tuples (more than 255 elements) in external terms.
+- Support for `io:put_chars/2`
 
 ### Changed
 

--- a/libs/estdlib/src/io.erl
+++ b/libs/estdlib/src/io.erl
@@ -27,7 +27,7 @@
 %%-----------------------------------------------------------------------------
 -module(io).
 
--export([format/1, format/2, get_line/1, put_chars/1]).
+-export([format/1, format/2, get_line/1, put_chars/1, put_chars/2]).
 
 %%-----------------------------------------------------------------------------
 %% @doc     Equivalent to format(Format, []).
@@ -96,3 +96,15 @@ put_chars(Chars) ->
                 {io_reply, Ref, Line} -> Line
             end
     end.
+
+%%-----------------------------------------------------------------------------
+%% @param   Chars character(s) to write to console
+%% @returns ok
+%% @doc     Writes the given character(s) to the console.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec put_chars(Device :: any(), Chars :: list() | binary()) -> ok.
+put_chars(standard_error, Chars) ->
+    put_chars(Chars);
+put_chars(standard_output, Chars) ->
+    put_chars(Chars).


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
