### PR TITLE
Add support for `binary:copy/1,2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Add support to Elixir for `Keyword.split/2`
 - Support for `binary:split/3` and `string:find/2,3`
 - Support for large tuples (more than 255 elements) in external terms.
+- Support for `binary:copy/1,2`
 
 ### Changed
 

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -32,6 +32,8 @@ struct NifNameAndNifPtr
 };
 %%
 binary:at/2, &binary_at_nif
+binary:copy/1, &binary_copy_nif
+binary:copy/2, &binary_copy_nif
 binary:first/1, &binary_first_nif
 binary:last/1, &binary_last_nif
 binary:part/3, &binary_part_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -267,6 +267,7 @@ compile_erlang(spawn_fun3)
 compile_erlang(binary_at_test)
 compile_erlang(binary_first_test)
 compile_erlang(binary_last_test)
+compile_erlang(test_binary_copy)
 
 compile_erlang(test_integer_to_binary)
 compile_erlang(test_list_to_binary)
@@ -736,6 +737,7 @@ add_custom_target(erlang_test_modules DEPENDS
     binary_at_test.beam
     binary_first_test.beam
     binary_last_test.beam
+    test_binary_copy.beam
 
     test_integer_to_binary.beam
     test_list_to_binary.beam

--- a/tests/erlang_tests/test_binary_copy.erl
+++ b/tests/erlang_tests/test_binary_copy.erl
@@ -1,0 +1,40 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_binary_copy).
+
+-export([start/0]).
+
+start() ->
+    ok = test_copy1(),
+    ok = test_copy2(),
+    0.
+
+test_copy1() ->
+    <<>> = binary:copy(<<>>),
+    <<"foo">> = binary:copy(<<"foo">>),
+    ok.
+
+test_copy2() ->
+    <<>> = binary:copy(<<>>, 1),
+    <<"foo">> = binary:copy(<<"foo">>, 1),
+    <<>> = binary:copy(<<"foo">>, 0),
+    <<"foofoo">> = binary:copy(<<"foo">>, 2),
+    ok.

--- a/tests/test.c
+++ b/tests/test.c
@@ -309,6 +309,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(binary_at_test, 121),
     TEST_CASE_EXPECTED(binary_first_test, 82),
     TEST_CASE_EXPECTED(binary_last_test, 110),
+    TEST_CASE(test_binary_copy),
 
     TEST_CASE(test_integer_to_binary),
     TEST_CASE(test_list_to_binary),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
