### PR TITLE
POSIX directory functions (opendir, closedir and readdir)

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -93,7 +93,9 @@ jobs:
         - arch: "arm32v7"
           platform: "arm/v7"
           tag: "bullseye"
-          cflags: "-mcpu=cortex-a7 -mfloat-abi=hard -O2 -mthumb -mthumb-interwork"
+          # -D_FILE_OFFSET_BITS=64 is required for making atomvm:posix_readdir/1 test work
+          # otherwise readdir will fail due to 64 bits inode numbers with 32 bit ino_t
+          cflags: "-mcpu=cortex-a7 -mfloat-abi=hard -O2 -mthumb -mthumb-interwork -D_FILE_OFFSET_BITS=64"
           cmake_opts: "-DAVM_WARNINGS_ARE_ERRORS=ON"
 
         - arch: "arm64v8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for Elixir `IO.chardata_to_string/1`
 - Support for Elixir `List.duplicate/2`
 - Support for `binary:copy/1,2`
+- Support for directory listing using POSIX APIs: (`atomvm:posix_opendir/1`,
+`atomvm:posix_readdir/1`, `atomvm:posix_closedir/1`).
 
 ### Changed
 

--- a/libs/eavmlib/src/atomvm.erl
+++ b/libs/eavmlib/src/atomvm.erl
@@ -40,12 +40,16 @@
     posix_close/1,
     posix_read/2,
     posix_write/2,
-    posix_clock_settime/2
+    posix_clock_settime/2,
+    posix_opendir/1,
+    posix_closedir/1,
+    posix_readdir/1
 ]).
 
 -export_type([
     posix_fd/0,
-    posix_open_flag/0
+    posix_open_flag/0,
+    posix_dir/0
 ]).
 
 -deprecated([
@@ -83,6 +87,8 @@
 -type posix_error() ::
     atom()
     | integer().
+
+-opaque posix_dir() :: binary().
 
 %%-----------------------------------------------------------------------------
 %% @returns The platform name.
@@ -294,4 +300,38 @@ posix_write(_File, _Data) ->
 ) ->
     ok | {error, Reason :: posix_error()}.
 posix_clock_settime(_ClockId, _Time) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Path    Path to the directory to open
+%% @returns A tuple with a directory descriptor or an error tuple.
+%% @doc     Open a file (on platforms that have `opendir(3)').
+%% @end
+%%-----------------------------------------------------------------------------
+-spec posix_opendir(Path :: iodata()) ->
+    {ok, posix_dir()} | {error, posix_error()}.
+posix_opendir(_Path) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Dir    Descriptor to a directory to close
+%% @returns `ok' or an error tuple
+%% @doc     Close a directory that was opened with `posix_opendir/1'
+%% @end
+%%-----------------------------------------------------------------------------
+-spec posix_closedir(Dir :: posix_dir()) -> ok | {error, posix_error()}.
+posix_closedir(_Dir) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Dir    Descriptor to an open directory
+%% @returns a `{dirent, InodeNo, Name}' tuple, `eof' or an error tuple
+%% @doc     Read a directory entry
+%% `eof' is returned if no more data can be read because the directory cursor
+%% reached the end.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec posix_readdir(Dir :: posix_dir()) ->
+    {ok, {dirent, Inode :: integer(), Name :: binary()}} | eof | {error, posix_error()}.
+posix_readdir(_Dir) ->
     erlang:nif_error(undefined).

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -187,10 +187,13 @@ if (NOT ATOMIC_POINTER_LOCK_FREE_IS_TWO AND NOT (HAVE_PLATFORM_ATOMIC_H OR (AVM_
 endif()
 
 include(DefineIfExists)
-# HAVE_OPEN & HAVE_CLOSE are used in globalcontext.h
+# HAVE_OPEN, HAVE_OPENDIR, HAVE_CLOSE HAVE_CLOSEDIR, HAVE_READDIR are used in globalcontext.h
 define_if_function_exists(libAtomVM open "fcntl.h" PUBLIC HAVE_OPEN)
+define_if_function_exists(libAtomVM opendir "dirent.h" PUBLIC HAVE_OPENDIR)
 define_if_function_exists(libAtomVM close "unistd.h" PUBLIC HAVE_CLOSE)
+define_if_function_exists(libAtomVM closedir "dirent.h" PUBLIC HAVE_CLOSEDIR)
 define_if_function_exists(libAtomVM mkfifo "sys/stat.h" PRIVATE HAVE_MKFIFO)
+define_if_function_exists(libAtomVM readdir "dirent.h" PUBLIC HAVE_READDIR)
 define_if_function_exists(libAtomVM unlink "unistd.h" PRIVATE HAVE_UNLINK)
 define_if_symbol_exists(libAtomVM O_CLOEXEC "fcntl.h" PRIVATE HAVE_O_CLOEXEC)
 define_if_symbol_exists(libAtomVM O_DIRECTORY "fcntl.h" PRIVATE HAVE_O_DIRECTORY)

--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -135,6 +135,21 @@ GlobalContext *globalcontext_new()
     }
 #endif
 
+#if HAVE_OPENDIR && HAVE_READDIR && HAVE_CLOSEDIR
+    ErlNifEnv dir_env;
+    erl_nif_env_partial_init_from_globalcontext(&dir_env, glb);
+    glb->posix_dir_resource_type = enif_init_resource_type(&env, "posix_dir", &posix_dir_resource_type_init, ERL_NIF_RT_CREATE, NULL);
+    if (IS_NULL_PTR(glb->posix_dir_resource_type)) {
+#ifndef AVM_NO_SMP
+        smp_rwlock_destroy(glb->modules_lock);
+#endif
+        free(glb->modules_table);
+        atom_table_destroy(glb->atom_table);
+        free(glb);
+        return NULL;
+    }
+#endif
+
     sys_init_platform(glb);
 
 #ifndef AVM_NO_SMP

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -152,6 +152,10 @@ struct GlobalContext
     ErlNifResourceType *posix_fd_resource_type;
 #endif
 
+#if HAVE_OPENDIR && HAVE_READDIR && HAVE_CLOSEDIR
+    ErlNifResourceType *posix_dir_resource_type;
+#endif
+
     void *platform_data;
 };
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -794,6 +794,11 @@ DEFINE_MATH_NIF(tanh)
 #else
 #define IF_HAVE_CLOCK_SETTIME_OR_SETTIMEOFDAY(expr) NULL
 #endif
+#if HAVE_OPENDIR && HAVE_READDIR && HAVE_CLOSEDIR
+#define IF_HAVE_OPENDIR_READDIR_CLOSEDIR(expr) (expr)
+#else
+#define IF_HAVE_OPENDIR_READDIR_CLOSEDIR(expr) NULL
+#endif
 
 //Ignore warning caused by gperf generated code
 #pragma GCC diagnostic push

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -141,6 +141,9 @@ atomvm:posix_select_stop/1, IF_HAVE_OPEN_CLOSE(&atomvm_posix_select_stop_nif)
 atomvm:posix_mkfifo/2, IF_HAVE_MKFIFO(&atomvm_posix_mkfifo_nif)
 atomvm:posix_unlink/1, IF_HAVE_UNLINK(&atomvm_posix_unlink_nif)
 atomvm:posix_clock_settime/2, IF_HAVE_CLOCK_SETTIME_OR_SETTIMEOFDAY(&atomvm_posix_clock_settime_nif)
+atomvm:posix_opendir/1, IF_HAVE_OPENDIR_READDIR_CLOSEDIR(&atomvm_posix_opendir_nif)
+atomvm:posix_closedir/1, IF_HAVE_OPENDIR_READDIR_CLOSEDIR(&atomvm_posix_closedir_nif)
+atomvm:posix_readdir/1, IF_HAVE_OPENDIR_READDIR_CLOSEDIR(&atomvm_posix_readdir_nif)
 code:load_abs/1, &code_load_abs_nif
 code:load_binary/3, &code_load_binary_nif
 code:ensure_loaded/1, &code_ensure_loaded_nif

--- a/src/libAtomVM/posix_nifs.h
+++ b/src/libAtomVM/posix_nifs.h
@@ -53,6 +53,12 @@ extern const struct Nif atomvm_posix_unlink_nif;
 #if defined(HAVE_CLOCK_SETTIME) || defined(HAVE_SETTIMEOFDAY)
 extern const struct Nif atomvm_posix_clock_settime_nif;
 #endif
+#if HAVE_OPENDIR && HAVE_READDIR && HAVE_CLOSEDIR
+extern const ErlNifResourceTypeInit posix_dir_resource_type_init;
+extern const struct Nif atomvm_posix_opendir_nif;
+extern const struct Nif atomvm_posix_readdir_nif;
+extern const struct Nif atomvm_posix_closedir_nif;
+#endif
 
 /**
  * @brief Convenient function to return posix errors as atom.

--- a/src/platforms/esp32/CMakeLists.txt
+++ b/src/platforms/esp32/CMakeLists.txt
@@ -31,6 +31,12 @@ set(HAVE_MKFIFO "" CACHE INTERNAL "Have symbol mkfifo" FORCE)
 # in CMAKE_REQUIRED_INCLUDES as lwip includes freetos and many esp system components
 set(HAVE_SOCKET 1 CACHE INTERNAL "Have symbol socket" FORCE)
 
+# opendir, closedir and readdir functions are not detected
+# but they are available
+set(HAVE_OPENDIR 1 CACHE INTERNAL "Have symbol opendir" FORCE)
+set(HAVE_CLOSEDIR 1 CACHE INTERNAL "Have symbol closedir" FORCE)
+set(HAVE_READDIR 1 CACHE INTERNAL "Have symbol readdir" FORCE)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../CMakeModules")
 
 # Disable SMP with esp32 socs that have only one core

--- a/tests/libs/eavmlib/CMakeLists.txt
+++ b/tests/libs/eavmlib/CMakeLists.txt
@@ -23,6 +23,7 @@ project(test_eavmlib)
 include(BuildErlang)
 
 set(ERLANG_MODULES
+    test_dir
     test_file
     test_ahttp_client
     test_port

--- a/tests/libs/eavmlib/test_dir.erl
+++ b/tests/libs/eavmlib/test_dir.erl
@@ -1,7 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2019 Fred Dushin <fred@dushin.net>
+% Copyright 2024 Davide Bettio <davide@uninstall.it>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -18,15 +18,21 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
--module(tests).
+-module(test_dir).
 
--export([start/0]).
+-export([test/0]).
 
-start() ->
-    etest:test([
-        test_dir,
-        test_file,
-        test_port,
-        test_timer_manager,
-        test_ahttp_client
-    ]).
+-include("etest.hrl").
+
+test() ->
+    {ok, Dir} = atomvm:posix_opendir("."),
+    [eof | _Entries] = all_dir_entries(Dir, []),
+    ok = atomvm:posix_closedir(Dir).
+
+all_dir_entries(Dir, Acc) ->
+    case atomvm:posix_readdir(Dir) of
+        eof ->
+            [eof | Acc];
+        {ok, {dirent, Inode, Name} = Dirent} when is_integer(Inode) and is_binary(Name) ->
+            all_dir_entries(Dir, [Dirent | Acc])
+    end.


### PR DESCRIPTION
Directory listing using POSIX functions. Beware of 32 bit ARM and other 32 bit architectures, where `ino_t ` is 32 bit while inodes are frequently 64 bit.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
