### PR TITLE
Make SPI device_config optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 instead
 - `Enum.find_index` and `Enum.find_value` support Enumerable and not just lists
 - Install AtomVM libraries source code and binaries for better dialyzer integration
+- Made the `device_config` properties list in `spi:open/1` optional (defaults to `[]`), so you can use the function with only a `bus_config`
 
 ### Fixed
 

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -1452,10 +1452,10 @@ The [`spi` module](./apidocs/erlang/eavmlib/spi.md) encapsulates functionality a
 Information about the ESP32 SPI leader mode interface can be found in the IDF SDK [SPI Documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/spi_master.html).
 ```
 
-The AtomVM SPI implementation uses the AtomVM Port mechanism and must be initialized using the [`spi:open/1`](./apidocs/erlang/eavmlib/spi.md#open1) function.  The single parameter to this function is a properties list containing two elements:
+The AtomVM SPI implementation uses the AtomVM Port mechanism and must be initialized using the [`spi:open/1`](./apidocs/erlang/eavmlib/spi.md#open1) function.  The single parameter to this function is a properties list containing:
 
 * [`bus_config`](./apidocs/erlang/eavmlib/spi.md#bus_config) -- a properties list containing entries for the SPI bus
-* [`device_config`](./apidocs/erlang/eavmlib/spi.md#device_config) -- a properties list containing entries for each device attached to the SPI Bus
+* [`device_config`](./apidocs/erlang/eavmlib/spi.md#device_config) -- an optional properties list containing entries for each device attached to the SPI Bus
 
 The `bus_config` properties list contains the following entries:
 

--- a/libs/eavmlib/src/spi.erl
+++ b/libs/eavmlib/src/spi.erl
@@ -59,10 +59,14 @@
     | {command_len_bits, 0..16}
 ].
 -type device_name() :: atom().
--type params() :: [
-    {bus_config, bus_config()}
-    | {device_config, [{device_name(), device_config()}]}
-].
+-type params() ::
+    [
+        {bus_config, bus_config()}
+    ]
+    | [
+        {bus_config, bus_config()}
+        | {device_config, [{device_name(), device_config()}]}
+    ].
 
 -type spi() :: pid().
 -type address() :: non_neg_integer().
@@ -294,7 +298,7 @@ write_read(SPI, DeviceName, Transaction) when
 validate_params(Params) when is_map(Params) orelse is_list(Params) ->
     #{
         bus_config => validate_bus_config(get_value(bus_config, Params, undefined)),
-        device_config => validate_device_config(get_value(device_config, Params, undefined))
+        device_config => validate_device_config(get_value(device_config, Params, []))
     };
 validate_params(Params) ->
     throw({error, {not_a_map_or_list, Params}}).


### PR DESCRIPTION
currently it's a required param, even in a scenario where it's meant to be empty (nif c code handles device_config: [] already)

eg device_config: [] is currently required:

```
    spi_settings = [
      bus_config: [
        miso: 19,
        mosi: 23,
        sclk: 18,
        peripheral: "spi3"
      ],
      device_config: []
    ]

    spi = :spi.open(spi_settings)
    :ok = :esp.mount("sdspi", "/test", :fat, spi_host: spi, cs: 5)
```

PR allows leaving out 'device_config: []' - for simpler/better DX. 
(I wasted a ton of time figuring out the empty device_config array requirement)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
