### PR TITLE
Add functions to load and dump hex string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - ESP32: add support for `esp_adc` ADC driver, with Erlang and Elixir examples
 - Add handler for ESP32 network driver STA mode `beacon_timeout` (event: 21), see issue
 [#1100](https://github.com/atomvm/AtomVM/issues/1100)
+- Support for `binary_to_integer/2`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Add handler for ESP32 network driver STA mode `beacon_timeout` (event: 21), see issue
 [#1100](https://github.com/atomvm/AtomVM/issues/1100)
 - Support for `binary_to_integer/2`
+- Support for `binary:decode_hex/1` and `binary:encode_hex/1,2`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 [#1100](https://github.com/atomvm/AtomVM/issues/1100)
 - Support for `binary_to_integer/2`
 - Support for `binary:decode_hex/1` and `binary:encode_hex/1,2`
+- Support for Elixir `Base.decode16/2` and `Base.encode16/2`
 
 ### Changed
 

--- a/libs/estdlib/src/binary.erl
+++ b/libs/estdlib/src/binary.erl
@@ -2,6 +2,7 @@
 % This file is part of AtomVM.
 %
 % Copyright 2023 Paul Guyot <pguyot@kallisys.net>
+% Copyright 2024 Yuto Oguchi <oguchiyuto@realglobe.jp>, Realglobe Inc.
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -24,7 +25,7 @@
 %%-----------------------------------------------------------------------------
 -module(binary).
 
--export([at/2, part/3, split/2, split/3]).
+-export([at/2, decode_hex/1, encode_hex/1, encode_hex/2, part/3, split/2, split/3]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Binary binary to get a byte from
@@ -36,6 +37,42 @@
 -spec at(Binary :: binary(), Index :: non_neg_integer()) -> byte().
 at(_Binary, _Index) ->
     erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Data hex encoded binary to decode
+%% @returns decoded binary
+%% @doc     Decodes a hex encoded binary into a binary.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec decode_hex(Data :: <<_:_*16>>) -> binary().
+decode_hex(Data) ->
+    case byte_size(Data) rem 2 of
+        0 -> <<<<(binary_to_integer(B, 16))>> || <<B:2/binary>> <= Data>>;
+        _ -> erlang:error(badarg)
+    end.
+
+%%-----------------------------------------------------------------------------
+%% @param   Data binary data to convert into hex encoded binary
+%% @returns hex encoded binary
+%% @doc     Encodes a binary into a hex encoded binary using the specified case for the hexadecimal digits "a" to "f".
+%% @end
+%%-----------------------------------------------------------------------------
+-spec encode_hex(Data :: binary()) -> binary().
+encode_hex(Data) ->
+    encode_hex(Data, uppercase).
+
+%%-----------------------------------------------------------------------------
+%% @param   Data binary data to convert into hex encoded binary
+%% @param   Case which case to encode into
+%% @returns hex encoded binary
+%% @doc     Encodes a binary into a hex encoded binary using the specified case for the hexadecimal digits "a" to "f".
+%% @end
+%%-----------------------------------------------------------------------------
+-spec encode_hex(Data :: binary(), Case :: lowercase | uppercase) -> binary().
+encode_hex(Data, uppercase) ->
+    <<(integer_to_binary(B, 16)) || <<B:4>> <= Data>>;
+encode_hex(Data, lowercase) ->
+    <<<<(hd(string:to_lower(integer_to_list(B, 16)))):8>> || <<B:4>> <= Data>>.
 
 %%-----------------------------------------------------------------------------
 %% @param   Binary binary to extract a subbinary from

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -57,6 +57,7 @@
     binary_to_atom/1,
     binary_to_atom/2,
     binary_to_integer/1,
+    binary_to_integer/2,
     binary_to_list/1,
     atom_to_binary/1,
     atom_to_binary/2,
@@ -649,6 +650,16 @@ binary_to_atom(_Binary, _Encoding) ->
 %%-----------------------------------------------------------------------------
 -spec binary_to_integer(Binary :: binary()) -> integer().
 binary_to_integer(_Binary) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Binary  Binary to parse for integer
+%% @returns the integer represented by the binary
+%% @doc     Parse the text in a given binary as an integer.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec binary_to_integer(Binary :: binary(), Base :: 2..36) -> integer().
+binary_to_integer(_Binary, Base) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/libs/exavmlib/lib/Base.ex
+++ b/libs/exavmlib/lib/Base.ex
@@ -1,0 +1,227 @@
+#
+# This file is part of elixir-lang.
+#
+# Copyright 2014-2023 Elixir Contributors
+# https://github.com/elixir-lang/elixir/commits/v1.17.3/lib/elixir/lib/base.ex
+#
+# Copyright 2024 Yuto Oguchi <oguchiyuto@realglobe.jp>, Realglobe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Base do
+  @moduledoc """
+  This module provides data encoding and decoding functions
+  according to [RFC 4648](https://tools.ietf.org/html/rfc4648).
+
+  This document defines the commonly used base 16, base 32, and base
+  64 encoding schemes.
+
+  ## Base 16 alphabet
+
+  | Value | Encoding | Value | Encoding | Value | Encoding | Value | Encoding |
+  |------:|:---------|------:|:---------|------:|:---------|------:|:---------|
+  |     0 | 0        |     4 | 4        |     8 | 8        |    12 | C        |
+  |     1 | 1        |     5 | 5        |     9 | 9        |    13 | D        |
+  |     2 | 2        |     6 | 6        |    10 | A        |    14 | E        |
+  |     3 | 3        |     7 | 7        |    11 | B        |    15 | F        |
+
+  ## Base 32 alphabet
+
+  | Value | Encoding | Value | Encoding | Value | Encoding | Value | Encoding |
+  |------:|:---------|------:|:---------|------:|:---------|------:|:---------|
+  |     0 | A        |     9 | J        |    18 | S        |    27 | 3        |
+  |     1 | B        |    10 | K        |    19 | T        |    28 | 4        |
+  |     2 | C        |    11 | L        |    20 | U        |    29 | 5        |
+  |     3 | D        |    12 | M        |    21 | V        |    30 | 6        |
+  |     4 | E        |    13 | N        |    22 | W        |    31 | 7        |
+  |     5 | F        |    14 | O        |    23 | X        |       |          |
+  |     6 | G        |    15 | P        |    24 | Y        | (pad) | =        |
+  |     7 | H        |    16 | Q        |    25 | Z        |       |          |
+  |     8 | I        |    17 | R        |    26 | 2        |       |          |
+
+
+  ## Base 32 (extended hex) alphabet
+
+  | Value | Encoding | Value | Encoding | Value | Encoding | Value | Encoding |
+  |------:|:---------|------:|:---------|------:|:---------|------:|:---------|
+  |     0 | 0        |     9 | 9        |    18 | I        |    27 | R        |
+  |     1 | 1        |    10 | A        |    19 | J        |    28 | S        |
+  |     2 | 2        |    11 | B        |    20 | K        |    29 | T        |
+  |     3 | 3        |    12 | C        |    21 | L        |    30 | U        |
+  |     4 | 4        |    13 | D        |    22 | M        |    31 | V        |
+  |     5 | 5        |    14 | E        |    23 | N        |       |          |
+  |     6 | 6        |    15 | F        |    24 | O        | (pad) | =        |
+  |     7 | 7        |    16 | G        |    25 | P        |       |          |
+  |     8 | 8        |    17 | H        |    26 | Q        |       |          |
+
+  ## Base 64 alphabet
+
+  | Value |  Encoding | Value | Encoding | Value | Encoding | Value | Encoding |
+  |------:|:----------|------:|:---------|------:|:---------|------:|:---------|
+  |     0 | A         |    17 | R        |    34 | i        |    51 | z        |
+  |     1 | B         |    18 | S        |    35 | j        |    52 | 0        |
+  |     2 | C         |    19 | T        |    36 | k        |    53 | 1        |
+  |     3 | D         |    20 | U        |    37 | l        |    54 | 2        |
+  |     4 | E         |    21 | V        |    38 | m        |    55 | 3        |
+  |     5 | F         |    22 | W        |    39 | n        |    56 | 4        |
+  |     6 | G         |    23 | X        |    40 | o        |    57 | 5        |
+  |     7 | H         |    24 | Y        |    41 | p        |    58 | 6        |
+  |     8 | I         |    25 | Z        |    42 | q        |    59 | 7        |
+  |     9 | J         |    26 | a        |    43 | r        |    60 | 8        |
+  |    10 | K         |    27 | b        |    44 | s        |    61 | 9        |
+  |    11 | L         |    28 | c        |    45 | t        |    62 | +        |
+  |    12 | M         |    29 | d        |    46 | u        |    63 | /        |
+  |    13 | N         |    30 | e        |    47 | v        |       |          |
+  |    14 | O         |    31 | f        |    48 | w        | (pad) | =        |
+  |    15 | P         |    32 | g        |    49 | x        |       |          |
+  |    16 | Q         |    33 | h        |    50 | y        |       |          |
+
+  ## Base 64 (URL and filename safe) alphabet
+
+  | Value | Encoding | Value | Encoding | Value | Encoding | Value | Encoding |
+  |------:|:---------|------:|:---------|------:|:---------|------:|:---------|
+  |     0 | A        |    17 | R        |    34 | i        |    51 | z        |
+  |     1 | B        |    18 | S        |    35 | j        |    52 | 0        |
+  |     2 | C        |    19 | T        |    36 | k        |    53 | 1        |
+  |     3 | D        |    20 | U        |    37 | l        |    54 | 2        |
+  |     4 | E        |    21 | V        |    38 | m        |    55 | 3        |
+  |     5 | F        |    22 | W        |    39 | n        |    56 | 4        |
+  |     6 | G        |    23 | X        |    40 | o        |    57 | 5        |
+  |     7 | H        |    24 | Y        |    41 | p        |    58 | 6        |
+  |     8 | I        |    25 | Z        |    42 | q        |    59 | 7        |
+  |     9 | J        |    26 | a        |    43 | r        |    60 | 8        |
+  |    10 | K        |    27 | b        |    44 | s        |    61 | 9        |
+  |    11 | L        |    28 | c        |    45 | t        |    62 | -        |
+  |    12 | M        |    29 | d        |    46 | u        |    63 | _        |
+  |    13 | N        |    30 | e        |    47 | v        |       |          |
+  |    14 | O        |    31 | f        |    48 | w        | (pad) | =        |
+  |    15 | P        |    32 | g        |    49 | x        |       |          |
+  |    16 | Q        |    33 | h        |    50 | y        |       |          |
+
+  """
+
+  @type encode_case :: :upper | :lower
+  @type decode_case :: :upper | :lower | :mixed
+
+  @doc """
+  Decodes a base 16 encoded string into a binary string.
+
+  ## Options
+
+  The accepted options are:
+
+    * `:case` - specifies the character case to accept when decoding
+
+  The values for `:case` can be:
+
+    * `:upper` - only allows upper case characters (default)
+    * `:lower` - only allows lower case characters
+    * `:mixed` - allows mixed case characters
+
+  ## Examples
+
+      iex> Base.decode16("666F6F626172")
+      {:ok, "foobar"}
+
+      iex> Base.decode16("666f6f626172", case: :lower)
+      {:ok, "foobar"}
+
+      iex> Base.decode16("666f6F626172", case: :mixed)
+      {:ok, "foobar"}
+
+  """
+  @spec decode16(binary, case: decode_case) :: {:ok, binary} | :error
+  def decode16(string, ops \\ []) do
+    {:ok, decode16!(string, ops)}
+  rescue
+    ArgumentError -> :error
+  end
+
+  @doc """
+  Decodes a base 16 encoded string into a binary string.
+
+  ## Options
+
+  The accepted options are:
+
+    * `:case` - specifies the character case to accept when decoding
+
+  The values for `:case` can be:
+
+    * `:upper` - only allows upper case characters (default)
+    * `:lower` - only allows lower case characters
+    * `:mixed` - allows mixed case characters
+
+  An `ArgumentError` exception is raised if the padding is incorrect or
+  a non-alphabet character is present in the string.
+
+  ## Examples
+
+      iex> Base.decode16!("666F6F626172")
+      "foobar"
+
+      iex> Base.decode16!("666f6f626172", case: :lower)
+      "foobar"
+
+      iex> Base.decode16!("666f6F626172", case: :mixed)
+      "foobar"
+
+  """
+  @spec decode16!(binary, case: decode_case) :: binary
+  def decode16!(string, opts \\ [])
+
+  def decode16!(string, _ops) when is_binary(string) and rem(byte_size(string), 2) == 0 do
+    # TODO: support :case option
+    :binary.decode_hex(string)
+  end
+
+  def decode16!(string, _opts) when is_binary(string) do
+    raise ArgumentError,
+          "string given to decode has wrong length. An even number of bytes was expected, got: #{byte_size(string)}. " <>
+            "Double check your string for unwanted characters or pad it accordingly"
+  end
+
+  @doc """
+  Encodes a binary string into a base 16 encoded string.
+
+  ## Options
+
+  The accepted options are:
+
+    * `:case` - specifies the character case to use when encoding
+
+  The values for `:case` can be:
+
+    * `:upper` - uses upper case characters (default)
+    * `:lower` - uses lower case characters
+
+  ## Examples
+
+      iex> Base.encode16("foobar")
+      "666F6F626172"
+
+      iex> Base.encode16("foobar", case: :lower)
+      "666f6f626172"
+
+  """
+  @spec encode16(binary, case: encode_case) :: binary
+  def encode16(data, opts \\ []) do
+    case Keyword.get(opts, :case, :upper) do
+      :upper -> :binary.encode_hex(data, :uppercase)
+      :lower -> :binary.encode_hex(data, :lowercase)
+    end
+  end
+end

--- a/libs/exavmlib/lib/CMakeLists.txt
+++ b/libs/exavmlib/lib/CMakeLists.txt
@@ -24,6 +24,7 @@ include(BuildElixir)
 
 set(ELIXIR_MODULES
     AVMPort
+    Base
     Bitwise
     Code
     Console

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -47,6 +47,7 @@ erlang:binary_to_atom/1, &binary_to_atom_nif
 erlang:binary_to_atom/2, &binary_to_atom_nif
 erlang:binary_to_float/1, &binary_to_float_nif
 erlang:binary_to_integer/1, &binary_to_integer_nif
+erlang:binary_to_integer/2, &binary_to_integer_nif
 erlang:binary_to_list/1, &binary_to_list_nif
 erlang:binary_to_existing_atom/1, &binary_to_existing_atom_nif
 erlang:binary_to_existing_atom/2, &binary_to_existing_atom_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -431,6 +431,7 @@ compile_erlang(fail_apply_last)
 compile_erlang(pid_to_list_test)
 compile_erlang(ref_to_list_test)
 compile_erlang(test_binary_to_integer)
+compile_erlang(test_binary_to_integer_2)
 
 compile_erlang(count_char_bs)
 compile_erlang(count_char2_bs)
@@ -902,6 +903,7 @@ add_custom_target(erlang_test_modules DEPENDS
     pid_to_list_test.beam
     ref_to_list_test.beam
     test_binary_to_integer.beam
+    test_binary_to_integer_2.beam
 
     count_char_bs.beam
     count_char2_bs.beam

--- a/tests/erlang_tests/test_binary_to_integer_2.erl
+++ b/tests/erlang_tests/test_binary_to_integer_2.erl
@@ -1,0 +1,43 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Yuto Oguchi <oguchiyuto@realglobe.jp>, Realglobe Inc.
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_binary_to_integer_2).
+
+-export([start/0]).
+
+start() ->
+    ok = assert_badarg(fun() -> binary_to_integer(<<"10">>, -1) end),
+    ok = assert_badarg(fun() -> binary_to_integer(<<"10">>, 0) end),
+    ok = assert_badarg(fun() -> binary_to_integer(<<"10">>, 1) end),
+    2 = binary_to_integer(<<"10">>, 2),
+    36 = binary_to_integer(<<"10">>, 36),
+    ok = assert_badarg(fun() -> binary_to_integer(<<"10">>, 37) end),
+    ok = assert_badarg(fun() -> binary_to_integer(<<"">>, 10) end),
+    10 = binary_to_integer(<<"0A">>, 16),
+    10 = binary_to_integer(<<"0a">>, 16),
+    0.
+
+assert_badarg(F) ->
+    try
+        R = F(),
+        {fail_no_ex, R}
+    catch
+        error:badarg -> ok
+    end.

--- a/tests/libs/estdlib/test_binary.erl
+++ b/tests/libs/estdlib/test_binary.erl
@@ -26,6 +26,7 @@
 
 test() ->
     ok = test_split(),
+    ok = test_hex(),
     ok.
 
 test_split() ->
@@ -33,4 +34,13 @@ test_split() ->
     ?ASSERT_MATCH(binary:split(<<"foobar">>, <<"ooz">>), [<<"foobar">>]),
     ?ASSERT_MATCH(binary:split(<<"foobar">>, <<"o">>), [<<"f">>, <<"obar">>]),
     ?ASSERT_MATCH(binary:split(<<"foobar">>, <<"o">>, [global]), [<<"f">>, <<>>, <<"bar">>]),
+    ok.
+
+test_hex() ->
+    RawBinary = <<"Hello, AtomVM!">>,
+    ?ASSERT_MATCH(binary:encode_hex(RawBinary), <<"48656C6C6F2C2041746F6D564D21">>),
+    ?ASSERT_MATCH(binary:encode_hex(RawBinary, lowercase), <<"48656c6c6f2c2041746f6d564d21">>),
+    ?ASSERT_MATCH(RawBinary, binary:decode_hex(<<"48656C6C6F2C2041746F6D564D21">>)),
+    ?ASSERT_EXCEPTION(binary:decode_hex(<<"48656C6C6F2C2041746F6D564D2">>), error, badarg),
+    ?ASSERT_EXCEPTION(binary:decode_hex(<<"ABCDEFGH">>), error, badarg),
     ok.

--- a/tests/test.c
+++ b/tests/test.c
@@ -482,6 +482,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(pid_to_list_test, 63),
     TEST_CASE_EXPECTED(ref_to_list_test, 386),
     TEST_CASE_EXPECTED(test_binary_to_integer, 99),
+    TEST_CASE(test_binary_to_integer_2),
 
     TEST_CASE_EXPECTED(count_char_bs, 2),
     TEST_CASE_EXPECTED(count_char2_bs, 1002),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later

Closes #1287.