### PR TITLE
Fix broken docs workflows

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -45,8 +45,8 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    container: erlang:27
+    runs-on: ubuntu-24.04
+    container: erlang:26
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -36,7 +36,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       AVM_DOCS_NAME: ${{ github.ref_name }}
@@ -72,7 +72,7 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "27"
+          otp-version: "26"
           elixir-version: "1.17"
           hexpm-mirrors: |
             https://builds.hex.pm


### PR DESCRIPTION
`edown` is only tested up to OTP-25. It seems to work fine with OTP-26, but fails to parse many of our modules using OTP-27. This change reverts to OTP-26 until an update or alternative makes it possible to build with OTP-27.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
