### PR TITLE
Add support for list_to_integer/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Support for `binary_to_integer/2`
 - Support for `binary:decode_hex/1` and `binary:encode_hex/1,2`
 - Support for Elixir `Base.decode16/2` and `Base.encode16/2`
+- Support for `erlang:list_to_integer/2`
 
 ### Changed
 

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -52,6 +52,7 @@
     list_to_existing_atom/1,
     list_to_binary/1,
     list_to_integer/1,
+    list_to_integer/2,
     list_to_tuple/1,
     iolist_to_binary/1,
     binary_to_atom/1,
@@ -599,6 +600,19 @@ list_to_binary(_IOList) ->
 %%-----------------------------------------------------------------------------
 -spec list_to_integer(String :: string()) -> integer().
 list_to_integer(_String) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   String  string to convert to integer
+%% @param   Base  string to convert to integer
+%% @returns an integer value from its string representation
+%% @doc     Convert a string (list of characters) to integer in specified base.
+%% Errors with `badarg' if the string is not a representation of an integer or
+%% the base is out of bounds.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec list_to_integer(String :: string(), Base :: 2..36) -> integer().
+list_to_integer(_String, _Base) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -73,6 +73,7 @@ erlang:integer_to_list/2, &integer_to_list_nif
 erlang:link/1, &link_nif
 erlang:list_to_binary/1, &list_to_binary_nif
 erlang:list_to_integer/1, &list_to_integer_nif
+erlang:list_to_integer/2, &list_to_integer_nif
 erlang:list_to_float/1, &list_to_float_nif
 erlang:list_to_tuple/1, &list_to_tuple_nif
 erlang:iolist_size/1, &iolist_size_nif

--- a/tests/erlang_tests/test_list_to_integer.erl
+++ b/tests/erlang_tests/test_list_to_integer.erl
@@ -23,10 +23,16 @@
 -export([start/0, sum_integers/2, append_0/1]).
 
 start() ->
-    sum_integers(append_0("10"), "-1") + safe_list_to_integer("--") - safe_list_to_integer(nan) +
-        safe_list_to_integer("+10") - 10 + safe_list_to_integer("-") - 5 + safe_list_to_integer("+") -
-        5 +
-        safe_list_to_integer("") - 5.
+    sum_integers(append_0("10"), "-1") +
+        safe_list_to_integer("--") - 5 +
+        safe_list_to_integer(nan) - 5 +
+        safe_list_to_integer("+10") - 10 +
+        safe_list_to_integer("-") - 5 +
+        safe_list_to_integer("+") - 5 +
+        safe_list_to_integer("") - 5 +
+        safe_list_to_integer("0a", 16) - 10 +
+        safe_list_to_integer("-0a", 16) + 10 +
+        safe_list_to_integer("1010", 2) - 10.
 
 append_0(L) ->
     L ++ "0".
@@ -35,7 +41,9 @@ sum_integers(A, B) ->
     list_to_integer(A) + list_to_integer(B).
 
 safe_list_to_integer(A) ->
-    try list_to_integer(A) of
+    safe_list_to_integer(A, 10).
+safe_list_to_integer(A, Base) ->
+    try list_to_integer(A, Base) of
         AnyValue -> AnyValue
     catch
         error:badarg ->


### PR DESCRIPTION
Tested on unix port of AtomVM, some interactive testing and `./test-erlang test_list_to_integer`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
