### PR TITLE
Emergengy documentation build fix

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -52,8 +52,8 @@ jobs:
         os: [ ubuntu-24.04 ]
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
-    # Documentation currently fails to build with OTP-27
-    container: erlang:26
+    # Documentation currently fails to build with OTP-27 and recent OTP-26.
+    container: erlang:25
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -61,7 +61,7 @@ jobs:
       - name: Install Deps
         run: |
           apt update -y
-          DEBIAN_FRONTEND=noninteractive apt install -y git cmake doxygen graphviz python3-pip python3-virtualenv python3.11-venv python3-setuptools python3-stemmer wget
+          DEBIAN_FRONTEND=noninteractive apt install -y git cmake doxygen graphviz python3-pip python3-virtualenv python3-setuptools python3-stemmer wget
 
       - uses: actions/cache@v4
         id: sphinx-cache
@@ -72,7 +72,7 @@ jobs:
       - name: Install Sphinx
         if: ${{ steps.sphinx-cache.outputs.cache-hit != 'true' }}
         run: |
-          python3 -m venv /home/runner/python-env/sphinx
+         virtualenv /home/runner/python-env/sphinx
           . /home/runner/python-env/sphinx/bin/activate
           python3 -m pip install sphinx
           python3 -m pip install myst-parser

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Sphinx
         if: ${{ steps.sphinx-cache.outputs.cache-hit != 'true' }}
         run: |
-          python3 -m venv /home/runner/python-env/sphinx
+          virtualenv /home/runner/python-env/sphinx
           . /home/runner/python-env/sphinx/bin/activate
           python3 -m pip install sphinx
           python3 -m pip install myst-parser
@@ -76,7 +76,7 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26"
+          otp-version: "25"
           elixir-version: "1.17"
           hexpm-mirrors: |
             https://builds.hex.pm


### PR DESCRIPTION
Recent CI updates bumped to the latest OTP-26 which has led to documentation build faulures. These changes temporarily revert to OTP-25 for building docs.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
