### PR TITLE
CI: fix `esp32-mkimage` GH workflow

### DIFF
--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -142,8 +142,8 @@ jobs:
           ./mkimage.sh
         else
           FLAVOR_SUFFIX=$(echo "${{ matrix.flavor }}" | sed 's/-//g')
-          BOOT_FILE="build/libs/esp32boot/${FLAVOR_SUFFIX}_esp32boot.avm"
-          ./mkimage.sh --boot="$BOOT_FILE"
+          BOOT_FILE="../../../../build/libs/esp32boot/${FLAVOR_SUFFIX}_esp32boot.avm"
+          ./mkimage.sh --boot "$BOOT_FILE"
           mv atomvm-${{ matrix.soc }}.img atomvm-${{ matrix.soc }}${{ matrix.flavor }}.img
         fi
         ls -l *.img

--- a/src/platforms/esp32/tools/mkimage.erl
+++ b/src/platforms/esp32/tools/mkimage.erl
@@ -132,6 +132,7 @@ get_build_dir(Opts, RootDir) ->
 %% @private
 mkimage(RootDir, BuildDir, BootFile, OutputFile, Segments) ->
     io:format("Writing output to ~s~n", [OutputFile]),
+    io:format("boot file is ~s~n", [BootFile]),
     io:format("=============================================~n"),
     case file:open(OutputFile, [write, binary]) of
         {ok, Fout} ->


### PR DESCRIPTION
It was making Elixir images without Elixir.

Also add an additional debug message to mkimage.erl.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
