### PR TITLE
Fix `AVMPort`

### DIFF
--- a/examples/elixir/HelloWorld.ex
+++ b/examples/elixir/HelloWorld.ex
@@ -25,7 +25,7 @@ defmodule HelloWorld do
   def start() do
     Console.print("Hello World\n")
     Console.puts("Console.puts() and Console.print() work with binary ")
-    Console.puts('or charlist strings.\n')
+    Console.puts(~c"or charlist strings.\n")
     Console.flush()
   end
 end

--- a/libs/exavmlib/lib/AVMPort.ex
+++ b/libs/exavmlib/lib/AVMPort.ex
@@ -31,39 +31,12 @@ defmodule AVMPort do
 
   @spec call(pid(), term()) :: term()
   def call(pid, message) do
-    case :erlang.is_process_alive(pid) do
-      false ->
-        {:error, :noproc}
-
-      true ->
-        ref = :erlang.make_ref()
-        send(pid, {self(), ref, message})
-
-        receive do
-          :out_of_memory -> :out_of_memory
-          {^ref, reply} -> reply
-        end
-    end
+    :port.call(pid, message)
   end
 
   @spec call(pid(), term(), non_neg_integer()) :: term()
   def call(pid, message, timeoutMs) do
-    case :erlang.is_process_alive(pid) do
-      false ->
-        {:error, :noproc}
-
-      true ->
-        ref = :erlang.make_ref()
-        send(pid, {self(), ref, message})
-
-        receive do
-          :out_of_memory -> :out_of_memory
-          {^ref, reply} -> reply
-        after
-          timeoutMs ->
-            {:error, :timeout}
-        end
-    end
+    :port.call(pid, message, timeoutMs)
   end
 
   @spec open(term(), list()) :: pid()


### PR DESCRIPTION
Fix AVMPort, and remove warning from HelloWorld.ex.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
