### PR TITLE
Update code example to use .uf2 files for Pi Pico

### DIFF
--- a/doc/src/getting-started-guide.md
+++ b/doc/src/getting-started-guide.md
@@ -353,7 +353,7 @@ total 16
 -rwxrwxrwx  1 joe  staff  241 Sep  5  2008 INDEX.HTM*
 -rwxrwxrwx  1 joe  staff   62 Sep  5  2008 INFO_UF2.TXT*
 
-$ cp ~/Downloads/atomvmlib-v0.6.0.avm /Volumes/RPI-RP2/.
+$ cp ~/Downloads/atomvmlib-v0.6.0.uf2 /Volumes/RPI-RP2/.
 ```
 
 ... and again, at this point, the device will auto-unmount.


### PR DESCRIPTION
It seems like the code snippets reference the wrong file format for the Pi Pico


These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
