### PR TITLE
CI: build-and-test: disable OTP master

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -197,12 +197,14 @@ jobs:
           cflags: ""
           elixir_version: "1.14"
 
-        # master/main version of OTP/Elixir
-        - os: "ubuntu-24.04"
-          cc: "cc"
-          cxx: "c++"
-          otp: "master"
-          elixir_version: "main"
+# TODO: enable master again
+# master will not work until we don't adapt to atom table changes
+#        # master/main version of OTP/Elixir
+#        - os: "ubuntu-24.04"
+#          cc: "cc"
+#          cxx: "c++"
+#          otp: "master"
+#          elixir_version: "main"
 
         # Additional default compiler builds
         - os: "ubuntu-20.04"


### PR DESCRIPTION
A recent change made impossible to use beam files compiled with OTP master, so let's disable it.

See also #1321 and https://github.com/erlang/otp/pull/8913

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
