### PR TITLE
externalterm: add externalterm_to_term_copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ also non string parameters (e.g. `Enum.join([1, 2], ",")`
 - Make external term serialize functions available without using `externalterm_to_binary` so terms
 can be written directly to a buffer.
 - Support for `erlang:list_to_integer/2`
+- Add `externalterm_to_term_copy` that can be safely used from NIFs taking temporary buffers
 
 ### Changed
 

--- a/src/libAtomVM/externalterm.c
+++ b/src/libAtomVM/externalterm.c
@@ -133,6 +133,12 @@ term externalterm_to_term(const void *external_term, size_t size, Context *ctx, 
     return externalterm_to_term_internal(external_term, size, ctx, opts, &bytes_read, false);
 }
 
+term externalterm_to_term_copy(const void *external_term, size_t size, Context *ctx, ExternalTermOpts opts)
+{
+    size_t bytes_read = 0;
+    return externalterm_to_term_internal(external_term, size, ctx, opts, &bytes_read, true);
+}
+
 enum ExternalTermResult externalterm_from_binary(Context *ctx, term *dst, term binary, size_t *bytes_read)
 {
     if (!term_is_binary(binary)) {

--- a/src/libAtomVM/externalterm.h
+++ b/src/libAtomVM/externalterm.h
@@ -67,6 +67,22 @@ term externalterm_to_term(
     const void *external_term, size_t size, Context *ctx, ExternalTermOpts opts);
 
 /**
+ * @brief Gets a term from external term data, and makes a copy of all data.
+ *
+ * @details Deserialize an external term from external format and returns a term.
+ * @param external_term the external term that will be deserialized.
+ * @param size to allocate for term.
+ * @param ctx the context that owns the memory that will be allocated.
+ * @param opts if non-zero, use a heap fragment to store the generated
+ * terms.  Otherwise, use the heap in the provided context.  Note that when using the
+ * context heap, this function may call the GC, if there is insufficient space to
+ * store the generated terms.
+ * @returns a term.
+ */
+term externalterm_to_term_copy(
+    const void *external_term, size_t size, Context *ctx, ExternalTermOpts opts);
+
+/**
  * @brief Create a term from a binary.
  *
  * @details Deserialize a binary term that stores term data in Erlang external term format,


### PR DESCRIPTION
This goes in pair with the recent addition for storing a term into a buffer.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
