### PR TITLE
Fix slow SNTP sync from cold boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `code:all_loaded/0` and `code:all_available/0`
 - Added menuconfig option for enabling USE_USB_SERIAL, eg. serial over USB for certain ESP32-S2 boards etc.
 
+### Fixed
+- ESP32: improved sntp sync speed from a cold boot.
+
 ## [0.6.6] - Unreleased
 
 ### Added

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -335,6 +335,9 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
             case IP_EVENT_STA_GOT_IP: {
                 ip_event_got_ip_t *event = (ip_event_got_ip_t *) event_data;
                 ESP_LOGI(TAG, "IP_EVENT_STA_GOT_IP: %s", inet_ntoa(event->ip_info.ip));
+                // we restart sntp here for faster time sync (especially evident on coldboots)
+                // the sntp_restart is no-op if sntp isn't configured
+                esp_sntp_restart();
                 send_got_ip(data, (esp_netif_ip_info_t *) &event->ip_info.ip);
                 break;
             }


### PR DESCRIPTION
using ap_sta_network example https://github.com/atomvm/AtomVM/blob/release-0.6/examples/erlang/esp32/ap_sta_network.erl

testing on real devices (and hundreds of wokwi ci runs) - a cold boot often produces a significant wait for sntp sync: 20-30 seconds.

calling esp_sntp_restart() on the got_ip event fixes this. the function is noop if sntp is not init'ed/config'ed. https://github.com/espressif/esp-idf/blob/707d097b01756687cca18be855a2675d150247ae/components/lwip/apps/sntp/sntp.c#L123

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
