### PR TITLE
Better message after wifi config (esp32devmode)

### DIFF
--- a/libs/esp32devmode/src/esp32devmode.erl
+++ b/libs/esp32devmode/src/esp32devmode.erl
@@ -302,7 +302,7 @@ handle_req("POST", [], Conn) ->
             "<html>\n"
             "   <body>\n"
             "       <h1>Configuration</h1>\n"
-            "       <p>Configured.</p>\n"
+            "       <p>Configured, restart device to apply wifi configuration.</p>\n"
             "   </body>\n"
             "</html>"
         >>,


### PR DESCRIPTION
I got confused as nothing was happening.

I assumed device was restarting and configuration going into use.

This makes it clear for a beginner and improves DX.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
