### PR TITLE
Add missing paths to documentation workflow triggers

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -23,6 +23,10 @@ on:
       - 'doc/**'
       - 'libs/**'
       - 'src/libAtomVM/**'
+      - 'UPDATING.md'
+      - 'CONTRIBUTING.md'
+      - 'CHANGELOG.md'
+      - 'CODE_OF_CONDUCT.md'
   push:
     repositories:
       - '!atomvm/AtomVM'
@@ -32,6 +36,10 @@ on:
       - 'doc/**'
       - 'libs/**'
       - 'src/libAtomVM/**'
+      - 'UPDATING.md'
+      - 'CONTRIBUTING.md'
+      - 'CHANGELOG.md'
+      - 'CODE_OF_CONDUCT.md'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -23,6 +23,10 @@ on:
       - 'doc/**'
       - 'libs/**'
       - 'src/libAtomVM/**'
+      - 'UPDATING.md'
+      - 'CONTRIBUTING.md'
+      - 'CHANGELOG.md'
+      - 'CODE_OF_CONDUCT.md'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Adds missing file triggers for files included in the documentation.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
