### PR TITLE
Fix bug in STM32 GPIO driver

### DIFF
--- a/src/platforms/stm32/src/lib/gpio_driver.c
+++ b/src/platforms/stm32/src/lib/gpio_driver.c
@@ -812,7 +812,7 @@ static term gpiodriver_set_int(Context *ctx, int32_t target_pid, term cmd)
         term pid = term_get_tuple_element(cmd, 3);
         if (UNLIKELY(!term_is_pid(pid) && !term_is_atom(pid))) {
             AVM_LOGE(TAG, "Invalid listener parameter, must be a pid() or registered process!");
-            return create_pair(ctx, ERROR_ATOM, invalid_listener_atom);
+            return create_pair(ctx, ERROR_ATOM, globalcontext_make_atom(ctx->global, invalid_listener_atom));
         }
         if (term_is_pid(pid)) {
             target_local_pid = term_to_local_process_id(pid);


### PR DESCRIPTION
There was an incorrect case of passing the pointer to the atom string, instead of the atom index itself in the gpiodriver_set_int function.

On more recent versions of arm-none-eabi compiler this is a compiler error, on some previous versions it was a warning, that must have been overlooked.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
