### PR TITLE
Allow continuing to support 512k flash STM32 boards

### DIFF
--- a/src/platforms/stm32/cmake/compile-flags.cmake
+++ b/src/platforms/stm32/cmake/compile-flags.cmake
@@ -36,6 +36,7 @@ set(CXX_WARN_FLAGS "${COMMON_WARN_FLAGS}")
 # Use C and C++ compiler optimizatons for size and speed.
 if (${CMAKE_FLASH_SIZE} STREQUAL "ROM_512K")
 set(OPTIMIZE_FLAG "-Os")
+set(LINKER_FLAGS "${LINKER_FLAGS} -specs=nano.specs")
 else()
 set(OPTIMIZE_FLAG "-O2")
 endif()


### PR DESCRIPTION
For STM32 devices with 512k flash newlib-nano needs to be used otherwise the compiled binary is too large to leave space for user applications.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
