### PR TITLE
CI: fix publish-docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -131,6 +131,7 @@ jobs:
         if: github.repository == 'atomvm/AtomVM'
         working-directory: /home/runner/work/AtomVM/AtomVM/www
         run: |
+          export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"
           eval `ssh-agent -t 60 -s`
           echo "${{ secrets.PUBLISH_ACTION_KEY }}" | ssh-add -
           mkdir -p ~/.ssh/
@@ -139,4 +140,4 @@ jobs:
           echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=" >> ~/.ssh/known_hosts
           git remote add push_dest "git@github.com:atomvm/atomvm_www.git"
           git fetch push_dest
-          git diff --exit-code origin/Production || git push --set-upstream push_dest Production
+          git diff --exit-code push_dest/Production || git push --set-upstream push_dest Production


### PR DESCRIPTION
For some reason, even if we add ssh keys to known_hosts, it keeps failing.
The failure is related to confirm prompt, that tries to open tty (that is not available on CI).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
