### PR TITLE
ESP32-S2: fix compilation with USE_USB_SERIAL

### DIFF
--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -41,6 +41,7 @@
 // idf.py add-dependency esp_tinyusb
 // and enable CDC in menu config
 #ifdef USE_USB_SERIAL
+void init_usb_serial(void);
 #include "tinyusb.h"
 #include "tusb_cdc_acm.h"
 #include "tusb_console.h"


### PR DESCRIPTION
Compiling with USE_USB_SERIAL for usb console on s2, would fail as init_usb_serial() is defined after it's called.

Safe for 0.6.5 inclusion.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
