### PR TITLE
Add menuconfig option for USE_USB_SERIAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a limited implementation of the OTP `ets` interface
 - Added `code:all_loaded/0` and `code:all_available/0`
+- Added menuconfig option for enabling USE_USB_SERIAL, eg. serial over USB for certain ESP32-S2 boards etc.
 
 ## [0.6.6] - Unreleased
 

--- a/src/platforms/esp32/main/Kconfig.projbuild
+++ b/src/platforms/esp32/main/Kconfig.projbuild
@@ -26,4 +26,18 @@ menu "AtomVM configuration"
         help
             Reboot the ESP32 device if the start/0 entrypoint does not return the `ok` atom.
 
+     config USE_USB_SERIAL
+         bool "Enable USB CDC Serial"
+         default n
+         select TINYUSB_CDC_ENABLED
+         help
+             Enable USB CDC Serial functionality.
+
+     config TINYUSB_CDC_ENABLED
+         bool "Enable TinyUSB CDC (requires 'idf.py add-dependency esp_tinyusb')"
+         default y
+         depends on USE_USB_SERIAL
+         help
+             Enable TinyUSB CDC functionality if USE_USB_SERIAL is enabled.
+             
 endmenu

--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -39,8 +39,8 @@
 
 // before enabling this:
 // idf.py add-dependency esp_tinyusb
-// and enable CDC in menu config
-#ifdef USE_USB_SERIAL
+// and enable USE_USB_SERIAL in menu config
+#ifdef CONFIG_USE_USB_SERIAL
 void init_usb_serial(void);
 #include "tinyusb.h"
 #include "tusb_cdc_acm.h"
@@ -70,7 +70,7 @@ void app_main()
 {
     esp32_sys_queue_init();
 
-#ifdef USE_USB_SERIAL
+#ifdef CONFIG_USE_USB_SERIAL
     init_usb_serial();
 #endif
 
@@ -151,7 +151,7 @@ void app_main()
     }
 }
 
-#ifdef USE_USB_SERIAL
+#ifdef CONFIG_USE_USB_SERIAL
 void init_usb_serial()
 {
     /* Setting TinyUSB up */


### PR DESCRIPTION
Improve DX a lot for enabling serial over usb for boards like the S2 Mini.

<img width="572" alt="Screenshot 2024-10-15 at 11 36 22" src="https://github.com/user-attachments/assets/ea851cbd-52b8-4874-ae04-0ebf79609f3d">

Will fail in a good way if enabled without esp_tinyusb being installed:

```
/AtomVM/src/platforms/esp32/main/main.c:45:10: fatal error: tinyusb.h: No such file or directory
   45 | #include "tinyusb.h"
      |          ^~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
HINT: tinyusb.h was removed. Please use esp_tinyusb component from IDF component manager instead.
You can install `esp_tinyusb` using 'idf.py add-dependency espressif/esp_tinyusb' command.
Refer to the migration guide for more details.
```

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
