### PR TITLE
Fix AVMPort compiler warnings

### DIFF
--- a/libs/exavmlib/lib/AVMPort.ex
+++ b/libs/exavmlib/lib/AVMPort.ex
@@ -22,6 +22,8 @@
 defmodule AVMPort do
   # This avoids crashing the compiler at build time
   @compile {:autoload, false}
+  # This avoids compiler warnings
+  @compile {:no_warn_undefined, [:port]}
   @moduledoc """
   This module provides an interface to communicate with AtomVM port processes.
   The functionality of AVMPort.call is identical to the eavmlib :port.call/2 and


### PR DESCRIPTION
Recent changes introduced a spew of compiler warnings eg. see bottom here: https://github.com/atomvm/AtomVM/pull/1351/files

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
