### PR TITLE
Fix nif declarations in esp_adc module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.6] - Unreleased
 
+### Fixed
+
+- Fixed specifications of nifs from `esp_adc` module
+
 ## [0.6.5] - 2024-10-15
 
 ### Added

--- a/libs/eavmlib/src/esp_adc.erl
+++ b/libs/eavmlib/src/esp_adc.erl
@@ -117,7 +117,7 @@
 %%-----------------------------------------------------------------------------
 -spec init() -> {ok, ADCUnit :: adc_rsrc()} | {error, Reason :: term()}.
 init() ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   UnitResource returned from init/0
@@ -134,7 +134,7 @@ init() ->
 %%-----------------------------------------------------------------------------
 -spec deinit(UnitResource :: adc_rsrc()) -> ok | {error, Reason :: term()}.
 deinit(_UnitResource) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Pin         Pin to configure as ADC
@@ -185,7 +185,7 @@ acquire(Pin, UnitHandle) ->
     Attenuation :: attenuation()
 ) -> {ok, Channel :: adc_rsrc()} | {error, Reason :: term()}.
 acquire(_Pin, _UnitHandle, _BitWidth, _Attenuation) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   ChannelResource of the pin returned from acquire/4
@@ -204,7 +204,7 @@ acquire(_Pin, _UnitHandle, _BitWidth, _Attenuation) ->
 %%-----------------------------------------------------------------------------
 -spec release_channel(ChannelResource :: adc_rsrc()) -> ok | {error, Reason :: term()}.
 release_channel(_ChannelResource) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   ChannelResource of the pin returned from acquire/4
@@ -256,7 +256,7 @@ sample(ChannelResource, UnitResource) ->
     ChannelResource :: adc_rsrc(), UnitResource :: adc_rsrc(), ReadOptions :: read_options()
 ) -> {ok, Result :: reading()} | {error, Reason :: term()}.
 sample(_ChannelResource, _UnitResource, _ReadOptions) ->
-    throw(nif_error).
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @returns {ok, Pid}


### PR DESCRIPTION
Use proper `erlang:nif_error(undefined)` so that dialyzer doesn't consider the functions never return.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
