### PR TITLE
ESP32: fix `gpio:init/1` on GPIO >= 32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed specifications of nifs from `esp_adc` module
+- ESP32: fix `gpio:init/1` on GPIO >= 32
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -660,7 +660,7 @@ static term nif_gpio_init(Context *ctx, int argc, term argv[])
     }
 
     gpio_config_t config = {};
-    config.pin_bit_mask = 1 << gpio_num;
+    config.pin_bit_mask = 1ULL << gpio_num;
     config.mode = GPIO_MODE_DISABLE;
     config.pull_up_en = GPIO_PULLUP_DISABLE;
     config.pull_down_en = GPIO_PULLDOWN_DISABLE;


### PR DESCRIPTION
Use 1ULL as integer constant (so uint64_t is used), in order to make room for GPIO index >= 32 when shifting.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
