### PR TITLE
Add support for encoded refs in external terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `erlang:split_binary/2`
 - Added `inet:getaddr/2`
 - Added support for external pids and encoded pids in external terms
+- Added support for external refs and encoded refs in external terms
 
 ## [0.6.6] - Unreleased
 

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -231,7 +231,7 @@ void context_process_flush_monitor_signal(Context *ctx, uint64_t ref_ticks, bool
         if (term_is_tuple(msg)
             && term_get_tuple_arity(msg) == 5
             && term_get_tuple_element(msg, 0) == DOWN_ATOM
-            && term_is_reference(term_get_tuple_element(msg, 1))
+            && term_is_local_reference(term_get_tuple_element(msg, 1))
             && term_to_ref_ticks(term_get_tuple_element(msg, 1)) == ref_ticks) {
             mailbox_remove_message(&ctx->mailbox, &ctx->heap);
             // If option info is combined with option flush, false is returned if a flush was needed, otherwise true.

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -624,6 +624,10 @@ static void memory_scan_and_copy(HeapFragment *old_fragment, term *mem_start, co
                     TRACE("- Found external pid.\n");
                     break;
 
+                case TERM_BOXED_EXTERNAL_REF:
+                    TRACE("- Found external ref.\n");
+                    break;
+
                 case TERM_BOXED_FUN: {
                     TRACE("- Found fun, size: %i.\n", (int) arity);
 
@@ -744,6 +748,10 @@ static void memory_scan_and_rewrite(size_t count, term *terms, const term *old_s
                     break;
 
                 case TERM_BOXED_EXTERNAL_PID:
+                    ptr += term_get_size_from_boxed_header(t);
+                    break;
+
+                case TERM_BOXED_EXTERNAL_REF:
                     ptr += term_get_size_from_boxed_header(t);
                     break;
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3343,7 +3343,7 @@ static term nif_ets_new(Context *ctx, int argc, term argv[])
 
 static inline bool is_ets_table_id(term t)
 {
-    return term_is_reference(t) || term_is_atom(t);
+    return term_is_local_reference(t) || term_is_atom(t);
 }
 
 static term nif_ets_insert(Context *ctx, int argc, term argv[])
@@ -3477,10 +3477,9 @@ static term nif_erlang_pid_to_list(Context *ctx, int argc, term argv[])
 
     term t = argv[0];
     VALIDATE_VALUE(t, term_is_pid);
-    size_t max_len = term_is_external(t) ? EXTERNAL_PID_AS_CSTRING_LEN : LOCAL_PID_AS_CSTRING_LEN;
 
-    char buf[max_len];
-    int str_len = term_snprint(buf, max_len, t, ctx->global);
+    char buf[PID_AS_CSTRING_LEN];
+    int str_len = term_snprint(buf, PID_AS_CSTRING_LEN, t, ctx->global);
     if (UNLIKELY(str_len < 0)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
@@ -3498,7 +3497,6 @@ static term nif_erlang_ref_to_list(Context *ctx, int argc, term argv[])
     char buf[REF_AS_CSTRING_LEN];
     int str_len = term_snprint(buf, REF_AS_CSTRING_LEN, t, ctx->global);
     if (UNLIKELY(str_len < 0)) {
-        // TODO: change to internal error or something like that
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
@@ -3798,7 +3796,7 @@ static term nif_erlang_demonitor(Context *ctx, int argc, term argv[])
         info = interop_proplist_get_value_default(options, INFO_ATOM, FALSE_ATOM) == TRUE_ATOM;
     }
 
-    VALIDATE_VALUE(ref, term_is_reference);
+    VALIDATE_VALUE(ref, term_is_local_reference);
     uint64_t ref_ticks = term_to_ref_ticks(ref);
 
     bool result = globalcontext_demonitor(ctx->global, ref_ticks);

--- a/src/libAtomVM/otp_socket.c
+++ b/src/libAtomVM/otp_socket.c
@@ -593,7 +593,7 @@ bool term_is_otp_socket(term socket_term)
     bool ret = term_is_tuple(socket_term)
         && term_get_tuple_arity(socket_term) == 2
         && term_is_binary(term_get_tuple_element(socket_term, 0))
-        && term_is_reference(term_get_tuple_element(socket_term, 1));
+        && term_is_local_reference(term_get_tuple_element(socket_term, 1));
 
     TRACE("term is a socket: %i\n", ret);
 
@@ -898,7 +898,7 @@ static term nif_socket_select_read(Context *ctx, int argc, term argv[])
 
     term select_ref_term = argv[1];
     if (select_ref_term != UNDEFINED_ATOM) {
-        VALIDATE_VALUE(select_ref_term, term_is_reference);
+        VALIDATE_VALUE(select_ref_term, term_is_local_reference);
     }
     struct SocketResource *rsrc_obj;
     if (UNLIKELY(!term_to_otp_socket(argv[0], &rsrc_obj, ctx))) {

--- a/src/libAtomVM/posix_nifs.c
+++ b/src/libAtomVM/posix_nifs.c
@@ -431,7 +431,7 @@ static term nif_atomvm_posix_select(Context *ctx, term argv[], enum ErlNifSelect
     int32_t process_pid = term_to_local_process_id(process_pid_term);
     term select_ref_term = argv[2];
     if (select_ref_term != UNDEFINED_ATOM) {
-        VALIDATE_VALUE(select_ref_term, term_is_reference);
+        VALIDATE_VALUE(select_ref_term, term_is_local_reference);
     }
     void *fd_obj_ptr;
     if (UNLIKELY(!enif_get_resource(erl_nif_env_from_context(ctx), argv[0], ctx->global->posix_fd_resource_type, &fd_obj_ptr))) {

--- a/src/libAtomVM/resources.c
+++ b/src/libAtomVM/resources.c
@@ -121,7 +121,7 @@ int enif_select(ErlNifEnv *env, ErlNifEvent event, enum ErlNifSelectFlags mode, 
     if (!(mode & (ERL_NIF_SELECT_STOP | ERL_NIF_SELECT_READ | ERL_NIF_SELECT_WRITE))) {
         return ERL_NIF_SELECT_BADARG;
     }
-    if (UNLIKELY(mode & (ERL_NIF_SELECT_READ | ERL_NIF_SELECT_WRITE) && !term_is_reference(ref) && ref != UNDEFINED_ATOM)) {
+    if (UNLIKELY(mode & (ERL_NIF_SELECT_READ | ERL_NIF_SELECT_WRITE) && !term_is_local_reference(ref) && ref != UNDEFINED_ATOM)) {
         return ERL_NIF_SELECT_BADARG;
     }
 

--- a/tests/test.c
+++ b/tests/test.c
@@ -482,7 +482,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(fail_apply_last, 17),
 
     TEST_CASE_EXPECTED(pid_to_list_test, 63),
-    TEST_CASE_EXPECTED(ref_to_list_test, 386),
+    TEST_CASE(ref_to_list_test),
     TEST_CASE_EXPECTED(test_binary_to_integer, 99),
     TEST_CASE(test_binary_to_integer_2),
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
