### PR TITLE
Fix: add missing is_number check to fconv opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed specifications of nifs from `esp_adc` module
 - ESP32: fix `gpio:init/1` on GPIO >= 32
+- Adding missing check, passing a non numeric argument to a function expecting a floating point
+might lead to a crash in certain situations.
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -5912,6 +5912,9 @@ wait_timeout_trap_handler:
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("fconv/2 %lx, fp%i\n", src_value, freg);
                     context_ensure_fpregs(ctx);
+                    if (UNLIKELY(!term_is_number(src_value))) {
+                        RAISE_ERROR(BADARITH_ATOM);
+                    }
                     ctx->fr[freg] = term_conv_to_float(src_value);
                 #endif
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -385,6 +385,7 @@ compile_erlang(floatext)
 compile_erlang(boxed_is_not_float)
 compile_erlang(float_is_float)
 compile_erlang(float_is_number)
+compile_erlang(fconv_fail_invalid)
 
 compile_erlang(float2list)
 compile_erlang(float2bin)
@@ -857,6 +858,7 @@ add_custom_target(erlang_test_modules DEPENDS
     boxed_is_not_float.beam
     float_is_float.beam
     float_is_number.beam
+    fconv_fail_invalid.beam
 
     float2list.beam
     float2bin.beam

--- a/tests/erlang_tests/fconv_fail_invalid.erl
+++ b/tests/erlang_tests/fconv_fail_invalid.erl
@@ -1,0 +1,40 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(fconv_fail_invalid).
+
+-export([start/0, deg_min_nsew_to_decimal/1]).
+
+start() ->
+    try ?MODULE:deg_min_nsew_to_decimal({5, nil, e}) of
+        _Any -> -1
+    catch
+        error:badarith -> 0
+    end.
+
+deg_min_nsew_to_decimal(Coord) ->
+    {Deg, Min, Nsew} = Coord,
+    DecimalCoord = Deg + Min / 60,
+    case Nsew of
+        n -> DecimalCoord;
+        s -> -DecimalCoord;
+        e -> DecimalCoord;
+        w -> -DecimalCoord
+    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -435,6 +435,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(boxed_is_not_float, 16),
     TEST_CASE_EXPECTED(float_is_float, 32),
     TEST_CASE_EXPECTED(float_is_number, 32),
+    TEST_CASE(fconv_fail_invalid),
 
     TEST_CASE_EXPECTED(float2bin, 31),
     TEST_CASE_EXPECTED(float2list, 31),


### PR DESCRIPTION
`fconv` takes also registers as argument, hence they might contain a value that is not a valid number term.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
