### PR TITLE
Fix ahttp_client on OTP

### DIFF
--- a/libs/eavmlib/src/ahttp_client.erl
+++ b/libs/eavmlib/src/ahttp_client.erl
@@ -124,7 +124,7 @@ transform_options(Options) ->
             undefined -> [{active, true} | Options];
             _OtherValue -> Options
         end,
-    [{binary, true} | WithActive].
+    [binary | WithActive].
 
 take_parse_headers(Options) ->
     case proplists:get_value(parse_headers, Options) of


### PR DESCRIPTION
OTP doesn't like `[{binary, true} | ...]`, replace it with `[binary | ...]`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
