### PR TITLE
Fix ESP32 build CI by installing missing rebar3 dependency

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -74,8 +74,14 @@ jobs:
         apt update
         DEBIAN_FRONTEND=noninteractive apt install -y -q \
             doxygen erlang-base erlang-dev erlang-dialyzer erlang-eunit \
+            erlang-asn1 erlang-common-test erlang-crypto erlang-edoc \
+            erlang-parsetools erlang-reltool erlang-syntax-tools erlang-tools \
             libglib2.0-0 libpixman-1-0 \
             gcc g++ zlib1g-dev libsdl2-2.0-0 libslirp0 libmbedtls-dev
+        # ESP-IDF 5.0.7 comes with Ubuntu focal which has Erlang/OTP 22
+        wget --no-verbose https://github.com/erlang/rebar3/releases/download/3.18.0/rebar3
+        chmod +x rebar3
+        ./rebar3 local install
 
     - name: Install qemu binary from espressif/qemu esp32
       if: runner.arch != 'ARM64' && runner.os == 'Linux' && matrix.esp-idf-target == 'esp32'
@@ -137,6 +143,7 @@ jobs:
         set -e
         . $IDF_PATH/export.sh
         export IDF_TARGET=${{matrix.esp-idf-target}}
+        export PATH=${PATH}:${HOME}/.cache/rebar3/bin
         idf.py set-target ${{matrix.esp-idf-target}}
         idf.py build
 

--- a/CMakeModules/BuildErlang.cmake
+++ b/CMakeModules/BuildErlang.cmake
@@ -92,7 +92,7 @@ macro(pack_lib avm_name)
         COMMENT "Creating UF2 file ${avm_name}.uf2"
         VERBATIM
     )
-    add_dependencies(${avm_name}-pico.uf2 ${avm_name})
+    add_dependencies(${avm_name}-pico.uf2 ${avm_name} uf2tool)
 
     add_custom_target(
         ${avm_name}-pico2.uf2 ALL
@@ -100,7 +100,7 @@ macro(pack_lib avm_name)
         COMMENT "Creating UF2 file ${avm_name}.uf2"
         VERBATIM
     )
-    add_dependencies(${avm_name}-pico2.uf2 ${avm_name})
+    add_dependencies(${avm_name}-pico2.uf2 ${avm_name} uf2tool)
 
 endmacro()
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
