### PR TITLE
Fix esp32-mkimage workflow by installing rebar3

### DIFF
--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -43,6 +43,7 @@ jobs:
         cflags: ["-O3"]
         otp: ["27"]
         elixir_version: ["1.17"]
+        rebar3_version: ["3.24.0"]
         compiler_pkgs: ["clang-14"]
         soc: ["esp32", "esp32c2", "esp32c3", "esp32s2", "esp32s3", "esp32c6", "esp32h2"]
         flavor: ["", "-elixir"]
@@ -62,6 +63,7 @@ jobs:
       with:
         otp-version: ${{ matrix.otp }}
         elixir-version: ${{ matrix.elixir_version }}
+        rebar3-version: ${{ matrix.rebar3_version }}
         hexpm-mirrors: |
           https://builds.hex.pm
           https://repo.hex.pm


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
