### PR TITLE
Remove macos-12 from CI as it is deprecated

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-12", "macos-13", "macos-14", "macos-15"]
+        os: ["macos-13", "macos-14", "macos-15"]
         otp: ["24", "25", "26", "27"]
 
     steps:


### PR DESCRIPTION
See: https://github.com/actions/runner-images/issues/10721

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
