### PR TITLE
alisp: fix: allow variables with any kind of value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ might lead to a crash in certain situations.
 - Fixed several bugs in `http_server` (#1366)
 - Fixed generic\_unix `socket_driver` to return `{gen_tcp, closed}` when socket is closed on Linux instead of `{gen_tcp, {recv, 104}}`
 - Fixed a memory leak where modules were not properly destroyed when the global context is destroyd
+- alisp: fix support to variables that are not binaries or integers.
 
 ## [0.6.5] - 2024-10-15
 

--- a/libs/alisp/src/alisp.erl
+++ b/libs/alisp/src/alisp.erl
@@ -34,10 +34,6 @@ eval(S) when is_atom(S) ->
         undefined -> throw({unbound, S});
         Val -> Val
     end;
-eval(I) when is_integer(I) ->
-    I;
-eval(B) when is_binary(B) ->
-    B;
 eval(['do', Vars, [_TestExpr, _ReturnExpr] | _Exprs] = Do) ->
     Restore = put_do_vars(Vars),
     execute_do(Do, Restore);
@@ -68,7 +64,9 @@ eval([[symbol_pair, Module, Fn] | Args]) when is_atom(Module) andalso is_atom(Fn
     fapply(Module, Fn, EvaluatedArgs);
 eval([Fn | Args]) when is_atom(Fn) ->
     EvaluatedArgs = eval_args(Args),
-    func_eval(Fn, EvaluatedArgs).
+    func_eval(Fn, EvaluatedArgs);
+eval(NotList) when not is_list(NotList) ->
+    NotList.
 
 func_eval('funcall', [Lambda | Args]) ->
     fapply(Lambda, Args);

--- a/tests/libs/alisp/test_alisp.erl
+++ b/tests/libs/alisp/test_alisp.erl
@@ -30,6 +30,7 @@ test() ->
 
 test_snippet0() ->
     ?ASSERT_MATCH(alisp:run(snippet0()), 25),
+    ?ASSERT_MATCH(alisp:run(snippet1()), 1),
     ok.
 
 snippet0() ->
@@ -57,3 +58,11 @@ snippet0() ->
     "            \n"
     "        (length (primes 100))\n"
     "    )\n".
+
+snippet1() ->
+    "\n"
+    "      (progn\n"
+    "          (setq mylambda (lambda (a b) (- a b)))\n"
+    "          (funcall mylambda 1 2)\n"
+    "          (funcall (lambda ()\n"
+    "                       (funcall mylambda 4 3))))\n".


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
