### PR TITLE
Fix WRITE_REGISTER_GC_SAFE memory corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ might lead to a crash in certain situations.
 - Fixed generic\_unix `socket_driver` to return `{gen_tcp, closed}` when socket is closed on Linux instead of `{gen_tcp, {recv, 104}}`
 - Fixed a memory leak where modules were not properly destroyed when the global context is destroyd
 - alisp: fix support to variables that are not binaries or integers.
+- Fix corruption when dealing with specific situations that involve more than 16 x registers when
+certain VM instructions are used.
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -6230,8 +6230,8 @@ wait_timeout_trap_handler:
 
 #if MAXIMUM_OTP_COMPILER_VERSION >= 22
             case OP_PUT_TUPLE2: {
-                GC_SAFE_DEST_REGISTER(dreg);
-                DECODE_DEST_REGISTER_GC_SAFE(dreg, pc);
+                DEST_REGISTER(dreg);
+                DECODE_DEST_REGISTER(dreg, pc);
                 DECODE_EXTENDED_LIST_TAG(pc);
                 uint32_t size;
                 DECODE_LITERAL(size, pc)
@@ -6257,7 +6257,7 @@ wait_timeout_trap_handler:
                 }
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    WRITE_REGISTER_GC_SAFE(dreg, t);
+                    WRITE_REGISTER(dreg, t);
                 #endif
                 break;
             }

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -505,6 +505,7 @@ compile_erlang(test_utf8_atoms)
 compile_erlang(twentyone_param_function)
 compile_erlang(complex_list_match_xregs)
 compile_erlang(twentyone_param_fun)
+compile_erlang(gc_safe_x_reg_write)
 
 compile_erlang(test_fun_to_list)
 compile_erlang(maps_nifs)
@@ -981,6 +982,7 @@ add_custom_target(erlang_test_modules DEPENDS
     twentyone_param_function.beam
     complex_list_match_xregs.beam
     twentyone_param_fun.beam
+    gc_safe_x_reg_write.beam
 
     test_fun_to_list.beam
     maps_nifs.beam

--- a/tests/erlang_tests/gc_safe_x_reg_write.erl
+++ b/tests/erlang_tests/gc_safe_x_reg_write.erl
@@ -1,0 +1,59 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Jakub Gonet <jakub.gonet@swmansion.com>
+% Copyright 2024 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+% This test has been made after https://github.com/atomvm/AtomVM/issues/1379
+
+-module(gc_safe_x_reg_write).
+-export([start/0]).
+-export([f/0, check/2]).
+
+start() ->
+    ?MODULE:check(?MODULE:f(), 0) - 21.
+
+f() ->
+    [
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0},
+        {f, fun f/0}
+    ].
+
+check([], Count) ->
+    Count;
+check([{f, F} | T], Count) when is_function(F) ->
+    check(T, Count + 1).

--- a/tests/test.c
+++ b/tests/test.c
@@ -564,6 +564,7 @@ struct Test tests[] = {
     TEST_CASE(twentyone_param_function),
     TEST_CASE(complex_list_match_xregs),
     TEST_CASE(twentyone_param_fun),
+    TEST_CASE(gc_safe_x_reg_write),
 
     TEST_CASE(test_fun_to_list),
     TEST_CASE(maps_nifs),


### PR DESCRIPTION
Fix #1379

In few words, `((dreg_gc_safe).base == x_regs)` is not true for x registers >= 16.

Also there is a very minor optimization.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
