### PR TITLE
CI: ESP32 check memory errors

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -131,6 +131,33 @@ jobs:
             pytest-embedded-idf==1.10.3 \
             pytest-embedded-qemu==1.10.3
 
+    - name: Build ESP32 tests using idf.py with memory checks
+      working-directory: ./src/platforms/esp32/test/
+      run: |
+        set -e
+        cp sdkconfig.defaults sdkconfig.defaults.backup
+        echo "CONFIG_COMPILER_STACK_CHECK_MODE_ALL=y" >> sdkconfig.defaults
+        echo "CONFIG_COMPILER_STACK_CHECK=y" >> sdkconfig.defaults
+        echo "CONFIG_FREERTOS_WATCHPOINT_END_OF_STACK=y" >> sdkconfig.defaults
+        echo "CONFIG_HEAP_POISONING_COMPREHENSIVE=y" >> sdkconfig.defaults
+        echo "CONFIG_ESP_WIFI_IRAM_OPT=n" >> sdkconfig.defaults
+        echo "CONFIG_ESP_WIFI_RX_IRAM_OPT=n" >> sdkconfig.defaults
+        . $IDF_PATH/export.sh
+        export IDF_TARGET=${{matrix.esp-idf-target}}
+        idf.py set-target ${{matrix.esp-idf-target}}
+        idf.py build
+
+    - name: Run ESP32 tests using qemu with memory checks build
+      working-directory: ./src/platforms/esp32/test/
+      timeout-minutes: 10
+      run: |
+        set -e
+        . $IDF_PATH/export.sh
+        export PATH=/opt/qemu/bin:${PATH}
+        pytest --target=${{matrix.esp-idf-target}} --embedded-services=idf,qemu -s
+        idf.py clean
+        cp sdkconfig.defaults.backup sdkconfig.defaults
+
     - name: Build ESP32 tests using idf.py
       working-directory: ./src/platforms/esp32/test/
       run: |


### PR DESCRIPTION
Add one more step that builds ESP32 tests using a number of checks for common memory errors.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
