### PR TITLE
Add erlang:split_binary/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a limited implementation of the OTP `ets` interface
 - Added `code:all_loaded/0` and `code:all_available/0`
+- Added `erlang:split_binary/2`
 
 ## [0.6.6] - Unreleased
 

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -105,6 +105,7 @@
     garbage_collect/1,
     binary_to_term/1,
     term_to_binary/1,
+    split_binary/2,
     timestamp/0,
     universaltime/0,
     localtime/0,
@@ -1221,6 +1222,18 @@ binary_to_term(_Binary) ->
 %%-----------------------------------------------------------------------------
 -spec term_to_binary(Term :: any()) -> binary().
 term_to_binary(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns A tuple with two subbinaries
+%% @param   Bin    binary to split
+%% @param   Pos    position to split the binary, from 0 to `byte_size(Bin)'
+%% @doc Split a binary into two sub-binaries. This operation is not destructive
+%% and will create two new binaries.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec split_binary(Bin :: binary(), Pos :: non_neg_integer()) -> {binary(), binary()}.
+split_binary(_Bin, _Pos) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -112,6 +112,7 @@ erlang:put/2, &put_nif
 erlang:binary_to_term/1, &binary_to_term_nif
 erlang:binary_to_term/2, &binary_to_term_nif
 erlang:term_to_binary/1, &term_to_binary_nif
+erlang:split_binary/2, &split_binary_nif
 erlang:throw/1, &throw_nif
 erlang:raise/3, &raise_nif
 erlang:unlink/1, &unlink_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -277,6 +277,7 @@ compile_erlang(test_unicode)
 
 compile_erlang(test_binary_part)
 compile_erlang(test_binary_split)
+compile_erlang(test_split_binary)
 
 compile_erlang(plusone)
 compile_erlang(plusone2)
@@ -753,6 +754,7 @@ add_custom_target(erlang_test_modules DEPENDS
 
     test_binary_part.beam
     test_binary_split.beam
+    test_split_binary.beam
 
     plusone.beam
     plusone2.beam

--- a/tests/erlang_tests/test_split_binary.erl
+++ b/tests/erlang_tests/test_split_binary.erl
@@ -1,0 +1,60 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_split_binary).
+
+-export([
+    start/0,
+    id/1
+]).
+
+start() ->
+    ok = test_split_binary(),
+    0.
+
+test_split_binary() ->
+    {<<"a">>, <<"bcde">>} = split_binary(?MODULE:id(<<"abcde">>), 1),
+    {<<>>, <<"abcde">>} = split_binary(?MODULE:id(<<"abcde">>), 0),
+    {<<>>, <<>>} = split_binary(?MODULE:id(<<>>), 0),
+    {<<"abcde">>, <<>>} = split_binary(?MODULE:id(<<"abcde">>), 5),
+    ok =
+        try
+            _ = split_binary(?MODULE:id(<<"abcde">>), 6),
+            unexpected
+        catch
+            error:badarg -> ok
+        end,
+    ok =
+        try
+            _ = split_binary(?MODULE:id(<<"abcde">>), -1),
+            unexpected
+        catch
+            error:badarg -> ok
+        end,
+    ok =
+        try
+            _ = split_binary(?MODULE:id(<<>>), 1),
+            unexpected
+        catch
+            error:badarg -> ok
+        end,
+    ok.
+
+id(X) -> X.

--- a/tests/test.c
+++ b/tests/test.c
@@ -319,6 +319,7 @@ struct Test tests[] = {
 
     TEST_CASE_EXPECTED(test_binary_part, 12),
     TEST_CASE_EXPECTED(test_binary_split, 16),
+    TEST_CASE(test_split_binary),
 
     TEST_CASE_COND(plusone, 134217728, LONG_MAX != 9223372036854775807),
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
