### PR TITLE
Remove unnecessary argc check

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3003,9 +3003,7 @@ static term nif_erlang_binary_to_term(Context *ctx, int argc, term argv[])
 
 static term nif_erlang_term_to_binary(Context *ctx, int argc, term argv[])
 {
-    if (argc != 1) {
-        RAISE_ERROR(BADARG_ATOM);
-    }
+    UNUSED(argc);
     term t = argv[0];
     term ret = externalterm_to_binary(ctx, t);
     if (term_is_invalid_term(ret)) {


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
