### PR TITLE
Fix destruction of SSL-related resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ might lead to a crash in certain situations.
 - Fixed generic\_unix `socket_driver` to return `{gen_tcp, closed}` when socket is closed on Linux instead of `{gen_tcp, {recv, 104}}`
 - Fixed a memory leak where modules were not properly destroyed when the global context is destroyd
 - alisp: fix support to variables that are not binaries or integers.
+- Fixed destruction of ssl-related resources
 
 ## [0.6.5] - 2024-10-15
 


### PR DESCRIPTION
Ensure that ctr_drbg resource is held by ssl context, fixing dependency of resources and destructor chain

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
