### PR TITLE
Add ASAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(AVM_RELEASE "Build an AtomVM release" OFF)
 option(AVM_CREATE_STACKTRACES "Create stacktraces" ON)
 option(AVM_BUILD_RUNTIME_ONLY "Only build the AtomVM runtime" OFF)
 option(COVERAGE "Build for code coverage" OFF)
+option(ENABLE_ASAN "Use Address Sanitizer" ON)
 
 if((${CMAKE_SYSTEM_NAME} STREQUAL "Darwin") OR
    (${CMAKE_SYSTEM_NAME} STREQUAL "Linux") OR

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -123,7 +123,7 @@ target_compile_features(libAtomVM PUBLIC c_std_11)
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_compile_options(libAtomVM PUBLIC -Wall ${MAYBE_PEDANTIC_FLAG} ${MAYBE_WERROR_FLAG} -Wextra -ggdb -Werror=incompatible-pointer-types)
 elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
-    target_compile_options(libAtomVM PUBLIC -Wall --extra-warnings -Werror=incompatible-pointer-types ${MAYBE_WERROR_FLAG})
+    target_compile_options(libAtomVM PUBLIC -Wall --extra-warnings -Werror=incompatible-pointer-types -g ${MAYBE_WERROR_FLAG})
 endif()
 
 if (ENABLE_REALLOC_GC)
@@ -133,6 +133,11 @@ endif()
 # AtomVM options used in libAtomVM
 if (ADVANCED_TRACING)
     target_compile_definitions(libAtomVM PUBLIC ENABLE_ADVANCED_TRACE)
+endif()
+
+if(ENABLE_ASAN)
+    target_compile_options(libAtomVM PUBLIC -fsanitize=address -fno-omit-frame-pointer)
+    target_link_options(libAtomVM PUBLIC -fsanitize=address)
 endif()
 
 target_link_libraries(libAtomVM PUBLIC m)


### PR DESCRIPTION
It was immensely helpful when developing so I'm opting to run it by default. Open to discussion, though.

On MacOS running an AVM shows a warning "malloc: nano zone abandoned due to inability to reserve vm space.". To avoid this warning, set `MallocNanoZone=0` env variable before running the VM.

Also adds debug symbols when compiling with Clang.

---
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
