### PR TITLE
Cleanup dead code in gen_server

### DIFF
--- a/libs/estdlib/src/gen_server.erl
+++ b/libs/estdlib/src/gen_server.erl
@@ -575,12 +575,7 @@ loop(#state{mod = Mod, mod_state = ModState} = State, Timeout) ->
     end.
 
 %% @private
-do_terminate(#state{mod = Mod, name = Name} = _State, Reason, ModState) ->
-    case Name of
-        undefined -> ok;
-        %% TODO unregister
-        _Pid -> ok
-    end,
+do_terminate(#state{mod = Mod} = _State, Reason, ModState) ->
     case erlang:function_exported(Mod, terminate, 2) of
         true ->
             Mod:terminate(Reason, ModState);


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
