### PR TITLE
Fix OTP version inconsistency on macOS CI workflow

### DIFF
--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -73,15 +73,15 @@ jobs:
         # This is ARM64
         - os: "macos-14"
           otp: "25"
-          path_prefix: "/opt/homebrew/opt/erlang@24/bin:"
-
-        - os: "macos-14"
-          otp: "26"
           path_prefix: "/opt/homebrew/opt/erlang@25/bin:"
 
         - os: "macos-14"
-          otp: "27"
+          otp: "26"
           path_prefix: "/opt/homebrew/opt/erlang@26/bin:"
+
+        - os: "macos-14"
+          otp: "27"
+          path_prefix: "/opt/homebrew/opt/erlang@27/bin:"
     steps:
     # Setup
     - name: "Checkout repo"


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
