### PR TITLE
Fix invalid yaml

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -249,7 +249,7 @@ jobs:
           cmake_opts_other: "-DAVM_CREATE_STACKTRACES=off -DAVM_WARNINGS_ARE_ERRORS=ON"
           arch: "i386"
           compiler_pkgs: "gcc-10 g++-10 gcc-10-multilib g++-10-multilib libc6-dev-i386
-          libc6-dbg:i386 zlib1g-dev:i386 libmbedtls-dev:i386"
+            libc6-dbg:i386 zlib1g-dev:i386 libmbedtls-dev:i386"
 
     env:
       CC: ${{ matrix.cc }}


### PR DESCRIPTION
https://yamlchecker.com:

```
deficient indentation (287:11)

 284 |           cmake_opts_other: "-DAVM_CREATE ...
 285 |           arch: "i386"
 286 |           compiler_pkgs: "gcc-10 g++-10 g ...
 287 |           libc6-dbg:i386 zlib1g-dev:i386  ...
-----------------^
 288 |
 289 |     env:
```

Tried running `zizmor .github/workflows` but failed due to invalid yaml.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
