### PR TITLE
Fix broken ESP32 gpio interrupt trigger `none`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ might lead to a crash in certain situations.
 - Fixed destruction of ssl-related resources
 - Fix corruption when dealing with specific situations that involve more than 16 x registers when
 certain VM instructions are used.
+- Fixed ESP32 GPIO interrupt trigger `none`
 
 ## [0.6.5] - 2024-10-15
 


### PR DESCRIPTION
Fixes the implementation of the `none` trigger that has been documented since release-0.5, but was apparently never tested, its use causes a error (see #1386).

Moves the main functionality from `gpiodriver_remove_int` into a new `unregister_interrupt_listener` funtion that is also used when setting the interrupt trigger to `none` to remove an interrupt.

Closes #1386

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
