### PR TITLE
Fix unused `Base` warning when compiling erlang.erl

### DIFF
--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -673,7 +673,7 @@ binary_to_integer(_Binary) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec binary_to_integer(Binary :: binary(), Base :: 2..36) -> integer().
-binary_to_integer(_Binary, Base) ->
+binary_to_integer(_Binary, _Base) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a warning that `Base` is unused in `erlang:binary_to_integer/2` when compiling erlang.erl.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
