### PR TITLE
Added lists:member/2 nif

### DIFF
--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -127,12 +127,8 @@ last([_H | T]) -> last(T).
 %% @end
 %%-----------------------------------------------------------------------------
 -spec member(E :: term(), L :: list()) -> boolean().
-member(_, []) ->
-    false;
-member(E, [E | _]) ->
-    true;
-member(E, [_ | T]) ->
-    member(E, T).
+member(_E, _T) ->
+    erlang:nif_error().
 
 %%-----------------------------------------------------------------------------
 %% @param   E the member to delete

--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -128,7 +128,7 @@ last([_H | T]) -> last(T).
 %%-----------------------------------------------------------------------------
 -spec member(E :: term(), L :: list()) -> boolean().
 member(_E, _T) ->
-    erlang:nif_error().
+    erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   E the member to delete

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -4877,7 +4877,8 @@ static term nif_lists_member(Context *ctx, int argc, term argv[])
 
         if (cmp_result == TermEquals) {
             return TRUE_ATOM;
-        } else if (UNLIKELY(cmp_result == TermCompareMemoryAllocFail)) {
+        }
+        if (UNLIKELY(cmp_result == TermCompareMemoryAllocFail)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -4863,6 +4863,7 @@ static term nif_lists_member(Context *ctx, int argc, term argv[])
     UNUSED(argc)
     term elem = argv[0];
     term list = argv[1];
+    VALIDATE_VALUE(list, term_is_list);
 
     int proper;
     term_list_length(list, &proper);

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -163,6 +163,7 @@ base64:encode_to_string/1, &base64_encode_to_string_nif
 base64:decode_to_string/1, &base64_decode_to_string_nif
 lists:reverse/1, &lists_reverse_nif
 lists:reverse/2, &lists_reverse_nif
+lists:member/2, &lists_member_nif
 maps:from_keys/2, &maps_from_keys_nif
 maps:next/1, &maps_next_nif
 unicode:characters_to_list/1, &unicode_characters_to_list_nif

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -44,6 +44,7 @@ set(ERLANG_MODULES
     test_queue
     test_timer
     test_supervisor
+    test_lists_member
     test_tcp_socket
     test_udp_socket
     notify_init_server

--- a/tests/libs/estdlib/test_lists_member.erl
+++ b/tests/libs/estdlib/test_lists_member.erl
@@ -1,0 +1,33 @@
+-module(test_lists_member).
+
+-export([test/0, start/0]).
+
+start() ->
+    test().
+
+test() ->
+    true = test_member_with_existing_element(),
+    true = test_member_with_existing_element_on_heterogenous_list(),
+    false = test_member_with_non_existing_element(),
+    false = test_member_in_empty_list(),
+    ok.
+
+test_member_with_existing_element() ->
+    Element = 5,
+    List = [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    lists:member(Element, List).
+
+test_member_with_existing_element_on_heterogenous_list() ->
+    Element = key,
+    List = [1, "a", 3, "b", 5, 6, "cd", 8, key],
+    lists:member(Element, List).
+
+test_member_with_non_existing_element() ->
+    Element = 10,
+    List = [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    lists:member(Element, List).
+
+test_member_in_empty_list() ->
+    Element = element,
+    List = [],
+    lists:member(Element, List).

--- a/tests/libs/estdlib/test_lists_member.erl
+++ b/tests/libs/estdlib/test_lists_member.erl
@@ -1,9 +1,6 @@
 -module(test_lists_member).
 
--export([test/0, start/0]).
-
-start() ->
-    test().
+-export([test/0]).
 
 test() ->
     true = test_member_with_existing_element(),

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -59,5 +59,6 @@ get_tests(_OTPVersion) ->
         test_queue,
         test_timer,
         test_spawn,
-        test_supervisor
+        test_supervisor,
+        test_lists_member
     ].


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
Added nif for https://www.erlang.org/docs/23/man/lists#member-2.