### PR TITLE
Add support for erlang:--/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the ability to run beams from the CLI for Generic Unix platform (it was already possible with nodejs and emscripten).
+- Added support for 'erlang:--/2'.
 
 ### Fixed
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -188,6 +188,7 @@ static term nif_maps_from_keys(Context *ctx, int argc, term argv[]);
 static term nif_maps_next(Context *ctx, int argc, term argv[]);
 static term nif_unicode_characters_to_list(Context *ctx, int argc, term argv[]);
 static term nif_unicode_characters_to_binary(Context *ctx, int argc, term argv[]);
+static term nif_erlang_lists_subtract(Context *ctx, int argc, term argv[]);
 
 #define DECLARE_MATH_NIF_FUN(moniker) \
     static term nif_math_##moniker(Context *ctx, int argc, term argv[]);
@@ -788,6 +789,11 @@ static const struct Nif unicode_characters_to_binary_nif =
 {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_unicode_characters_to_binary
+};
+static const struct Nif erlang_lists_subtract_nif = 
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_erlang_lists_subtract
 };
 
 #define DEFINE_MATH_NIF(moniker)                    \
@@ -5119,6 +5125,101 @@ static term nif_unicode_characters_to_binary(Context *ctx, int argc, term argv[]
     return result_tuple;
 }
 
+static term nif_erlang_lists_subtract(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc)
+
+    term list1 = argv[0];
+    term list2 = argv[1];
+
+    VALIDATE_VALUE(list1, term_is_list);
+    VALIDATE_VALUE(list2, term_is_list);
+
+    int proper;
+    int len = term_list_length(list1, &proper);
+    if (UNLIKELY(!proper)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    int proper2;
+    term_list_length(list2, &proper2);
+    if (UNLIKELY(!proper2)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    if (term_is_nil(list1)) {
+        return term_nil();
+    }
+
+    if (term_is_nil(list2)) {
+        return list1;
+    }
+
+    term *cons = malloc(len * sizeof(term));
+    if (IS_NULL_PTR(cons)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    int i = 0;
+    term list = list1;
+
+    while (!term_is_nil(list)) {
+        cons[i] = list;
+        list = term_get_list_tail(list);
+        i++;
+    }
+
+    int last_filtered_idx = -1;
+
+    while (!term_is_nil(list2)) {
+        term to_nullify = term_get_list_head(list2);
+
+        for (int i = 0; i < len; i++) {
+            if (term_is_invalid_term(cons[i])) {
+                continue;
+            }
+            term item = term_get_list_head(cons[i]);
+            TermCompareResult cmp_result = term_compare(to_nullify, item, TermCompareExact, ctx->global);
+
+            if (UNLIKELY(cmp_result == TermCompareMemoryAllocFail)) {
+                free(cons);
+                RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            }
+            if (cmp_result == TermEquals) {
+                if (last_filtered_idx < i) {
+                    last_filtered_idx = i;
+                }
+                cons[i] = term_invalid_term();
+                break;
+            }
+        }
+        list2 = term_get_list_tail(list2);
+    }
+
+    if (last_filtered_idx == -1) {
+        free(cons);
+        return list1;
+    }
+
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, (last_filtered_idx + 1) * CONS_SIZE, last_filtered_idx + 1, cons, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        free(cons);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    term result = term_nil();
+    if (last_filtered_idx < len - 1) {
+        result = cons[last_filtered_idx + 1];
+    }
+
+    for (int i = last_filtered_idx - 1; i >= 0; i--) {
+        if (!term_is_invalid_term(cons[i])) {
+            term item = term_get_list_head(cons[i]);
+            result = term_list_prepend(item, result, &ctx->heap);
+        }
+    }
+
+    free(cons);
+    return result;
+}
 //
 // MAINTENANCE NOTE: Exception handling for fp operations using math
 // error handling is designed to be thread-safe, as errors are specified

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -97,6 +97,7 @@ erlang:system_info/1, &system_info_nif
 erlang:system_flag/2, &system_flag_nif
 erlang:whereis/1, &whereis_nif
 erlang:++/2, &concat_nif
+erlang:--/2, &erlang_lists_subtract_nif
 erlang:monotonic_time/1, &monotonic_time_nif
 erlang:system_time/1, &system_time_nif
 erlang:tuple_to_list/1, &tuple_to_list_nif

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -44,6 +44,7 @@ set(ERLANG_MODULES
     test_queue
     test_timer
     test_supervisor
+    test_lists_subtraction
     test_tcp_socket
     test_udp_socket
     notify_init_server

--- a/tests/libs/estdlib/test_lists_subtraction.erl
+++ b/tests/libs/estdlib/test_lists_subtraction.erl
@@ -1,0 +1,62 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Tomasz Sobkiewicz <tomasz.sobkiewicz@swmansion.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+-module(test_lists_subtraction).
+
+-export([test/0, sub/2, start/0]).
+start() ->
+    test().
+
+test() ->
+    Tests = [
+        {[1, 2, 3], [1], [2, 3]},
+        {[1, 2, 3], [3], [1, 2]},
+        {[1, 2, 3], [5], [1, 2, 3]},
+        {[1, 2, 2, 3], [2], [1, 2, 3]},
+        {[1, 2, 3, 4], [2, 2], [1, 3, 4]},
+        {["a", 1, "b", 2], ["a", 2], [1, "b"]},
+        {[1, 2, 3], [1, 2, 3, 4, 5], []},
+        {[1, 2, 3], [], [1, 2, 3]},
+        {[], [1, 2, 3], []},
+        {[a, b, b, c], [c, b, a], [b]},
+        {[1, 2, 3, 4], [4, 3, 2, 1], []},
+        {[1, 2, 3, 4], [1, 2, 3, 4], []},
+        {[1], [1.0], [1]},
+        {[1.0], [1.0], []}
+    ],
+    ok = expect_failure(fun() -> ?MODULE:sub([a, b | c], [a]) end, badarg),
+    ok = expect_failure(fun() -> ?MODULE:sub([], [a, b | c]) end, badarg),
+    ok = expect_failure(fun() -> ?MODULE:sub([a], [a, b | c]) end, badarg),
+    run_tests(Tests).
+
+run_tests(Tests) ->
+    [Expected = A -- B || {A, B, Expected} <- Tests],
+    ok.
+
+expect_failure(Fun, Error) ->
+    try
+        Fun(),
+        fail
+    catch
+        error:Error ->
+            ok
+    end.
+
+sub(A, B) ->
+    A -- B.

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -59,5 +59,6 @@ get_tests(_OTPVersion) ->
         test_queue,
         test_timer,
         test_spawn,
-        test_supervisor
+        test_supervisor,
+        test_lists_subtraction
     ].


### PR DESCRIPTION
Add implementation for erlang:--/2.

---------
Signed-off-by: Tomasz Sobkiewicz <tomasz.sobkiewicz@swmansion.com>

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
