### PR TITLE
Remove unused term_is_movable_boxed

### DIFF
--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -307,30 +307,6 @@ static inline bool term_is_boxed(term t)
 }
 
 /**
- * @brief Checks if a term is a movable boxed value
- *
- * @details Returns \c true if a term is a boxed value that can be safely copied with memcpy.
- * @param t the term that will checked.
- * @return \c true if check succeeds, \c false otherwise.
- */
-static inline bool term_is_movable_boxed(term t)
-{
-    /* boxed: 10 */
-    if ((t & 0x3) == 0x2) {
-        const term *boxed_value = term_to_const_term_ptr(t);
-        switch (boxed_value[0] & TERM_BOXED_TAG_MASK) {
-            case 0x10:
-                return true;
-
-            default:
-                return false;
-        }
-    } else {
-        return false;
-    }
-}
-
-/**
  * @brief Returns size of a boxed term from its header
  *
  * @details Returns the size that is stored in boxed term header most significant bits.


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
