### PR TITLE
Add option to insert list in ets:insert, ets:lookup refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `socket:getopt/2`
 - Added `supervisor:terminate_child/2`, `supervisor:restart_child/2` and `supervisor:delete_child/2`
 - Added `esp:partition_read/3`, and documentation for `esp:partition_erase_range/2/3` and `esp:partition_write/3`
+- Added support for list insertion in 'ets:insert/2'.
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/libs/estdlib/src/ets.erl
+++ b/libs/estdlib/src/ets.erl
@@ -63,7 +63,7 @@ new(_Name, _Options) ->
 %% @doc Insert an entry into an ets table.
 %% @end
 %%-----------------------------------------------------------------------------
--spec insert(Table :: table(), Entry :: tuple()) -> true.
+-spec insert(Table :: table(), Entry :: tuple() | [tuple()]) -> true.
 insert(_Table, _Entry) ->
     erlang:nif_error(undefined).
 

--- a/src/libAtomVM/ets_hashtable.h
+++ b/src/libAtomVM/ets_hashtable.h
@@ -52,9 +52,11 @@ typedef enum EtsHashtableErrorCode
 struct EtsHashTable *ets_hashtable_new();
 void ets_hashtable_destroy(struct EtsHashTable *hash_table, GlobalContext *global);
 
-EtsHashtableErrorCode ets_hashtable_insert(struct EtsHashTable *hash_table, term key, term entry, EtsHashtableOptions opts, Heap *heap, GlobalContext *global);
+EtsHashtableErrorCode ets_hashtable_insert(struct EtsHashTable *hash_table, struct HNode *new_node, EtsHashtableOptions opts, GlobalContext *global);
 term ets_hashtable_lookup(struct EtsHashTable *hash_table, term key, size_t keypos, GlobalContext *global);
 bool ets_hashtable_remove(struct EtsHashTable *hash_table, term key, size_t keypos, GlobalContext *global);
+struct HNode *ets_hashtable_new_node(term entry, int keypos);
+void ets_hashtable_free_node_array(struct HNode **allocated, size_t len, GlobalContext *global);
 
 #ifdef __cplusplus
 }

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3327,10 +3327,6 @@ static term nif_ets_insert(Context *ctx, int argc, term argv[])
     VALIDATE_VALUE(ref, is_ets_table_id);
 
     term entry = argv[1];
-    VALIDATE_VALUE(entry, term_is_tuple);
-    if (term_get_tuple_arity(entry) < 1) {
-        RAISE_ERROR(BADARG_ATOM);
-    }
 
     EtsErrorCode result = ets_insert(ref, entry, ctx);
     switch (result) {

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -31,7 +31,7 @@ start() ->
     ok = test_protected_access(),
     ok = test_public_access(),
     ok = test_lookup_element(),
-
+    ok = test_insert_list(),
     0.
 
 test_basic() ->
@@ -351,4 +351,18 @@ test_lookup_element() ->
     expect_failure(fun() -> ets:lookup_element(Tid, bar, 1) end),
     expect_failure(fun() -> ets:lookup_element(Tid, foo, 3) end),
     expect_failure(fun() -> ets:lookup_element(Tid, foo, 0) end),
+    ok.
+
+test_insert_list() ->
+    Tid = ets:new(test_insert_list, []),
+    true = ets:insert(Tid, [{foo, tapas}, {batat, batat}, {patat, patat}]),
+    [{patat, patat}] = ets:lookup(Tid, patat),
+    [{batat, batat}] = ets:lookup(Tid, batat),
+    true = ets:insert(Tid, []),
+    expect_failure(fun() -> ets:insert(Tid, [{foo, tapas} | {patat, patat}]) end),
+    expect_failure(fun() -> ets:insert(Tid, [{foo, tapas}, {batat, batat}, {patat, patat}, {}]) end),
+    expect_failure(fun() ->
+        ets:insert(Tid, [{foo, tapas}, pararara, {batat, batat}, {patat, patat}])
+    end),
+    expect_failure(fun() -> ets:insert(Tid, [{}]) end),
     ok.

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -356,6 +356,7 @@ test_lookup_element() ->
 test_insert_list() ->
     Tid = ets:new(test_insert_list, []),
     true = ets:insert(Tid, [{foo, tapas}, {batat, batat}, {patat, patat}]),
+    true = ets:insert(Tid, [{foo, tapas}, {batat, batat}, {patat, patat}]),
     [{patat, patat}] = ets:lookup(Tid, patat),
     [{batat, batat}] = ets:lookup(Tid, batat),
     true = ets:insert(Tid, []),


### PR DESCRIPTION
### Changes:

- Enabled ets:insert/2 to accept lists for bulk insertion.
- Extracted helper functions for ets:lookup/2 and ets:insert/2 that do not apply table locks.

### Use Cases for the Helper Functions:
The new helper functions can be utilized in the following ETS operations to reduce code duplication:
- ets:update_element/3
- ets:insert_new/2
- ets:update_counter/3
- ets:update_counter/4
- ets:take/2
- ets:delete_object/2

Every mentioned function will be implemented after merging of this PR.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later