### PR TITLE
Add ets:update_counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `esp:partition_read/3`, and documentation for `esp:partition_erase_range/2/3` and `esp:partition_write/3`
 - Added support for list insertion in 'ets:insert/2'.
 - Support to OTP-28
+- Added support for `ets:update_counter/3` and `ets:update_counter/4`.
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/libs/estdlib/src/ets.erl
+++ b/libs/estdlib/src/ets.erl
@@ -29,7 +29,9 @@
     insert/2,
     lookup/2,
     lookup_element/3,
-    delete/2
+    delete/2,
+    update_counter/3,
+    update_counter/4
 ]).
 
 -export_type([
@@ -100,4 +102,42 @@ lookup_element(_Table, _Key, _Pos) ->
 %%-----------------------------------------------------------------------------
 -spec delete(Table :: table(), Key :: term()) -> true.
 delete(_Table, _Key) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Table a reference to the ets table
+%% @param   Key the key used to look up the entry expecting to contain a tuple of integers or a single integer
+%% @param   Params the increment value or a tuple {Pos, Increment} or {Pos, Increment, Treshold, SetValue},
+%%         where Pos is an integer (1-based index) specifying the position in the tuple to increment. Value is clamped to SetValue if it exceeds Threshold after update.
+%% @returns the updated element's value after performing the increment, or the default value if applicable
+%% @doc Updates a counter value at Key in the table. If Params is a single integer, it increments the direct integer value at Key or the first integer in a tuple. If Params is a tuple {Pos, Increment}, it increments the integer at the specified position Pos in the tuple stored at Key.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec update_counter(
+    Table :: table(),
+    Key :: term(),
+    Params ::
+        integer() | {pos_integer(), integer()} | {pos_integer(), integer(), integer(), integer()}
+) -> integer().
+update_counter(_Table, _Key, _Params) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Table a reference to the ets table
+%% @param   Key the key used to look up the entry expecting to contain a tuple of integers or a single integer
+%% @param   Params the increment value or a tuple {Pos, Increment} or {Pos, Increment, Treshold, SetValue},
+%%         where Pos is an integer (1-based index) specifying the position in the tuple to increment. If after incrementation value exceeds the Treshold, it is set to SetValue.
+%% @param   Default the default value used if the entry at Key doesn't exist or doesn't contain a valid tuple with a sufficient size or integer at Pos
+%% @returns the updated element's value after performing the increment, or the default value if applicable
+%% @doc Updates a counter value at Key in the table. If Params is a single integer, it increments the direct integer value at Key or the first integer in a tuple. If Params is a tuple {Pos, Increment}, it increments the integer at the specified position Pos in the tuple stored at Key. If the needed element does not exist, uses Default value as a fallback.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec update_counter(
+    Table :: table(),
+    Key :: term(),
+    Params ::
+        integer() | {pos_integer(), integer()} | {pos_integer(), integer(), integer(), integer()},
+    Default :: integer()
+) -> integer().
+update_counter(_Table, _Key, _Params, _Default) ->
     erlang:nif_error(undefined).

--- a/src/libAtomVM/ets.h
+++ b/src/libAtomVM/ets.h
@@ -57,7 +57,8 @@ typedef enum EtsErrorCode
     EtsBadEntry,
     EtsAllocationFailure,
     EtsEntryNotFound,
-    EtsBadPosition
+    EtsBadPosition,
+    EtsOverlfow
 } EtsErrorCode;
 struct Ets
 {
@@ -77,7 +78,7 @@ EtsErrorCode ets_insert(term ref, term entry, Context *ctx);
 EtsErrorCode ets_lookup(term ref, term key, term *ret, Context *ctx);
 EtsErrorCode ets_lookup_element(term ref, term key, size_t pos, term *ret, Context *ctx);
 EtsErrorCode ets_delete(term ref, term key, term *ret, Context *ctx);
-
+EtsErrorCode ets_update_counter(term ref, term key, term value, term pos, term *ret, Context *ctx);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -130,6 +130,8 @@ ets:insert/2, &ets_insert_nif
 ets:lookup/2, &ets_lookup_nif
 ets:lookup_element/3, &ets_lookup_element_nif
 ets:delete/2, &ets_delete_nif
+ets:update_counter/3, &ets_update_counter_nif
+ets:update_counter/4, &ets_update_counter_nif
 atomvm:add_avm_pack_binary/2, &atomvm_add_avm_pack_binary_nif
 atomvm:add_avm_pack_file/2, &atomvm_add_avm_pack_file_nif
 atomvm:close_avm_pack/2, &atomvm_close_avm_pack_nif

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -32,6 +32,7 @@ start() ->
     ok = test_public_access(),
     ok = test_lookup_element(),
     ok = test_insert_list(),
+    ok = test_update_counter(),
     0.
 
 test_basic() ->
@@ -366,4 +367,22 @@ test_insert_list() ->
         ets:insert(Tid, [{foo, tapas}, pararara, {batat, batat}, {patat, patat}])
     end),
     expect_failure(fun() -> ets:insert(Tid, [{}]) end),
+    ok.
+
+test_update_counter() ->
+    Tid = ets:new(test_lookup_element, []),
+    true = ets:insert(Tid, {foo, 1, 2, 3}),
+    3 = ets:update_counter(Tid, foo, 2),
+    expect_failure(fun() -> ets:update_counter(Tid, tapas, 2) end),
+    5 = ets:update_counter(Tid, tapas, 2, {batat, 3}),
+    [] = ets:lookup(Tid, batat),
+    [{tapas, 5}] = ets:lookup(Tid, tapas),
+    0 = ets:update_counter(Tid, foo, {3, -2}),
+    expect_failure(fun() -> ets:update_counter(Tid, foo, {-3, -2}) end),
+    expect_failure(fun() -> ets:update_counter(Tid, foo, {30, -2}) end),
+    expect_failure(fun() -> ets:update_counter(Tid, patatas, {3, -2}, {cow, 1}) end),
+    0 = ets:update_counter(Tid, patatas, {3, -2}, {cow, 1, 2, 3}),
+    0 = ets:update_counter(Tid, patatas, {3, -2, 0, 0}),
+    10 = ets:update_counter(Tid, patatas, {3, 10, 10, 0}),
+    0 = ets:update_counter(Tid, patatas, {3, 10, 10, 0}),
     ok.


### PR DESCRIPTION
Currently this solution doesn't support list of UpdateOp to update multiple counters.
Based on:
https://github.com/atomvm/AtomVM/pull/1405

https://www.erlang.org/docs/23/man/ets#update_counter-3

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later