### PR TITLE
Fix broken esp32-build workflow

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -135,6 +135,7 @@ jobs:
       working-directory: ./src/platforms/esp32/test/
       run: |
         set -e
+        export PATH=${PATH}:${HOME}/.cache/rebar3/bin
         cp sdkconfig.defaults sdkconfig.defaults.backup
         echo "CONFIG_COMPILER_STACK_CHECK_MODE_ALL=y" >> sdkconfig.defaults
         echo "CONFIG_COMPILER_STACK_CHECK=y" >> sdkconfig.defaults


### PR DESCRIPTION
Fixes the failing `Build ESP32 tests using idf.py with memory checks` step by exporting the rebar3 install directory to PATH.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
