### PR TITLE
Add `net:gethostname/0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added menuconfig option for enabling USE_USB_SERIAL, eg. serial over USB for certain ESP32-S2 boards etc.
 - Partial support for `erlang:fun_info/2`
 - Added support for `registered_name` in `erlang:process_info/2` and `Process.info/2`
+- Added `net:gethostname/0` on platforms with gethostname(3).
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/libs/estdlib/src/net.erl
+++ b/libs/estdlib/src/net.erl
@@ -20,7 +20,7 @@
 
 -module(net).
 
--export([getaddrinfo/1, getaddrinfo/2]).
+-export([getaddrinfo/1, getaddrinfo/2, gethostname/0]).
 
 %% nif call (so we can use guards at the API)
 -export([getaddrinfo_nif/2]).
@@ -77,4 +77,13 @@ getaddrinfo(Host, Service) when
 
 %% @hidden
 getaddrinfo_nif(_Host, _Service) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns The (usually short) name of the host.
+%% @doc     Get the hostname
+%% @end
+%%-----------------------------------------------------------------------------
+-spec gethostname() -> {ok, string()} | {error, any()}.
+gethostname() ->
     erlang:nif_error(undefined).

--- a/src/platforms/esp32/components/avm_sys/CMakeLists.txt
+++ b/src/platforms/esp32/components/avm_sys/CMakeLists.txt
@@ -70,6 +70,10 @@ set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${soc_target_include_dir}
 include(CheckSymbolExists)
 include(CheckCSourceCompiles)
 
+# Both don't exist in ESP32 at the moment
+define_if_function_exists(libAtomVM${PLATFORM_LIB_SUFFIX} getservbyname "netdb.h" PRIVATE HAVE_SERVBYNAME)
+define_if_function_exists(libAtomVM${PLATFORM_LIB_SUFFIX} gethostname "unistd.h" PRIVATE HAVE_GETHOSTNAME)
+
 if ("${pthread_srcs}" MATCHES pthread_rwlock.c)
 set(HAVE_PTHREAD_RWLOCK YES)
 message(STATUS "pthread component includes pthread_rwlock.c, assuming it is available")

--- a/src/platforms/generic_unix/lib/CMakeLists.txt
+++ b/src/platforms/generic_unix/lib/CMakeLists.txt
@@ -58,6 +58,7 @@ endif()
 include(DefineIfExists)
 define_if_function_exists(libAtomVM${PLATFORM_LIB_SUFFIX} signal "signal.h" PRIVATE HAVE_SIGNAL)
 define_if_function_exists(libAtomVM${PLATFORM_LIB_SUFFIX} getservbyname "netdb.h" PRIVATE HAVE_SERVBYNAME)
+define_if_function_exists(libAtomVM${PLATFORM_LIB_SUFFIX} gethostname "unistd.h" PRIVATE HAVE_GETHOSTNAME)
 
 target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC libAtomVM)
 include_directories(${CMAKE_SOURCE_DIR}/src/platforms/generic_unix/lib)

--- a/src/platforms/rp2/src/lib/CMakeLists.txt
+++ b/src/platforms/rp2/src/lib/CMakeLists.txt
@@ -102,6 +102,11 @@ if (PICO_CYW43_SUPPORTED)
             otp_net_lwip_raw.h)
     target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC pico_cyw43_arch_lwip_threadsafe_background pico_lwip_sntp INTERFACE pan_lwip_dhserver)
     target_link_options(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC "SHELL:-Wl,-u -Wl,networkregister_port_driver -Wl,-u -Wl,otp_socket_nif -Wl,-u -Wl,otp_net_nif -Wl,-u -Wl,otp_ssl_nif")
+
+    include(CheckSymbolExists)
+
+    define_if_function_exists(libAtomVM${PLATFORM_LIB_SUFFIX} getservbyname "netdb.h" PRIVATE HAVE_SERVBYNAME)
+    define_if_function_exists(libAtomVM${PLATFORM_LIB_SUFFIX} gethostname "unistd.h" PRIVATE HAVE_GETHOSTNAME)
 endif()
 
 target_link_options(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC "SHELL:-Wl,-u -Wl,gpio_nif -Wl,-u -Wl,otp_crypto_nif")

--- a/tests/libs/estdlib/test_net.erl
+++ b/tests/libs/estdlib/test_net.erl
@@ -25,6 +25,7 @@
 test() ->
     ok = test_getaddrinfo(),
     ok = test_getaddrinfo2(),
+    ok = test_gethostname(),
     ok.
 
 test_getaddrinfo() ->
@@ -141,3 +142,7 @@ get_addr(AddrInfo) ->
         _ ->
             maps:get(addr, maps:get(address, AddrInfo))
     end.
+
+test_gethostname() ->
+    {ok, [_ | _]} = net:gethostname(),
+    ok.


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
