### PR TITLE
ESP32: SPI: fix spi close command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ might lead to a crash in certain situations.
 certain VM instructions are used.
 - Fixed ESP32 GPIO interrupt trigger `none`
 - Fixed an issue where a timeout would occur immediately in a race condition
+- Fixed SPI close command
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -672,7 +672,7 @@ static NativeHandlerResult spidriver_consume_mailbox(Context *ctx)
     globalcontext_get_process_unlock(ctx->global, target);
     mailbox_remove_message(&ctx->mailbox, &ctx->heap);
 
-    return cmd == CLOSE_ATOM ? NativeTerminate : NativeContinue;
+    return cmd == SPICloseCmd ? NativeTerminate : NativeContinue;
 }
 
 bool spi_driver_get_peripheral(term spi_port, spi_host_device_t *host_dev, GlobalContext *global)


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
