### PR TITLE
Add `atomvm:get_creation/0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for external pids and encoded pids in external terms
 - Added support for external refs and encoded refs in external terms
 - Introduce ports to represent native processes and added support for external ports and encoded ports in external terms
+- Added `atomvm:get_creation/0`, equivalent to `erts_internal:get_creation/0`
 
 ## [0.6.6] - Unreleased
 

--- a/libs/eavmlib/src/atomvm.erl
+++ b/libs/eavmlib/src/atomvm.erl
@@ -43,7 +43,8 @@
     posix_clock_settime/2,
     posix_opendir/1,
     posix_closedir/1,
-    posix_readdir/1
+    posix_readdir/1,
+    get_creation/0
 ]).
 
 -export_type([
@@ -334,4 +335,9 @@ posix_closedir(_Dir) ->
 -spec posix_readdir(Dir :: posix_dir()) ->
     {ok, {dirent, Inode :: integer(), Name :: binary()}} | eof | {error, posix_error()}.
 posix_readdir(_Dir) ->
+    erlang:nif_error(undefined).
+
+%% @hidden
+-spec get_creation() -> non_neg_integer().
+get_creation() ->
     erlang:nif_error(undefined).

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -1270,6 +1270,6 @@ localtime() ->
     erlang:nif_error(undefined).
 
 %% @hidden
--spec setnode(atom(), pos_integer()) -> true.
+-spec setnode(atom(), non_neg_integer()) -> true.
 setnode(_NodeName, _Creation) ->
     erlang:nif_error(undefined).

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -128,7 +128,7 @@ erlang:group_leader/0, &group_leader_nif
 erlang:group_leader/2, &group_leader_nif
 erlang:get_module_info/1, &get_module_info_nif
 erlang:get_module_info/2, &get_module_info_nif
-erlang:setnode/2, &setnode_nif
+erlang:setnode/2, &setnode_2_nif
 erts_debug:flat_size/1, &flat_size_nif
 ets:new/2, &ets_new_nif
 ets:insert/2, &ets_insert_nif
@@ -154,6 +154,7 @@ atomvm:posix_clock_settime/2, IF_HAVE_CLOCK_SETTIME_OR_SETTIMEOFDAY(&atomvm_posi
 atomvm:posix_opendir/1, IF_HAVE_OPENDIR_READDIR_CLOSEDIR(&atomvm_posix_opendir_nif)
 atomvm:posix_closedir/1, IF_HAVE_OPENDIR_READDIR_CLOSEDIR(&atomvm_posix_closedir_nif)
 atomvm:posix_readdir/1, IF_HAVE_OPENDIR_READDIR_CLOSEDIR(&atomvm_posix_readdir_nif)
+atomvm:get_creation/0, &atomvm_get_creation_nif
 code:load_abs/1, &code_load_abs_nif
 code:load_binary/3, &code_load_binary_nif
 code:all_available/0, &code_all_available_nif

--- a/tests/erlang_tests/test_node.erl
+++ b/tests/erlang_tests/test_node.erl
@@ -47,6 +47,7 @@ test_node_distribution() ->
     ),
     register(net_kernel, NetKernelPid),
     true = erlang:setnode(test@test_node, 42),
+    42 = get_creation(),
     test@test_node = node(),
     NetKernelPid ! quit,
     ok =
@@ -72,6 +73,14 @@ has_setnode_creation() ->
         "BEAM" ->
             OTPRelease = erlang:system_info(otp_release),
             OTPRelease >= "23"
+    end.
+
+get_creation() ->
+    case erlang:system_info(machine) of
+        "ATOM" ->
+            atomvm:get_creation();
+        "BEAM" ->
+            erts_internal:get_creation()
     end.
 
 sleep(Ms) ->


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
