### PR TITLE
esp32-simtest: add erlang-dev

### DIFF
--- a/.github/workflows/esp32-simtest.yaml
+++ b/.github/workflows/esp32-simtest.yaml
@@ -76,7 +76,7 @@ jobs:
           set -eu
           apt update
           DEBIAN_FRONTEND=noninteractive apt install -y -q \
-              doxygen erlang-base erlang-dialyzer erlang-eunit \
+              doxygen erlang-base erlang-dev erlang-dialyzer erlang-eunit \
               libglib2.0-0 libpixman-1-0 \
               gcc g++ zlib1g-dev libsdl2-2.0-0 libslirp0 libmbedtls-dev
 


### PR DESCRIPTION
Make similar changes to the ones done to esp32-build.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
