### PR TITLE
esp32-simtest: add rebar3

### DIFF
--- a/.github/workflows/esp32-simtest.yaml
+++ b/.github/workflows/esp32-simtest.yaml
@@ -79,6 +79,9 @@ jobs:
               doxygen erlang-base erlang-dev erlang-dialyzer erlang-eunit \
               libglib2.0-0 libpixman-1-0 \
               gcc g++ zlib1g-dev libsdl2-2.0-0 libslirp0 libmbedtls-dev
+        wget --no-verbose https://github.com/erlang/rebar3/releases/download/3.18.0/rebar3
+        chmod +x rebar3
+        ./rebar3 local install
 
       - name: Install the Wokwi CLI
         run: curl -L https://wokwi.com/ci/install.sh | sh
@@ -97,6 +100,7 @@ jobs:
         working-directory: ./src/platforms/esp32/test/
         run: |
           set -e
+          export PATH=${PATH}:${HOME}/.cache/rebar3/bin
           . $IDF_PATH/export.sh
           idf.py -DSDKCONFIG_DEFAULTS='sdkconfig.ci.wokwi' set-target ${{matrix.esp-idf-target}}
           idf.py build


### PR DESCRIPTION
Make similar changes to the ones done to esp32-build.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
