### PR TITLE
ESP32: CI: esp32-simtest: install missing deps

### DIFF
--- a/.github/workflows/esp32-simtest.yaml
+++ b/.github/workflows/esp32-simtest.yaml
@@ -77,6 +77,8 @@ jobs:
           apt update
           DEBIAN_FRONTEND=noninteractive apt install -y -q \
               doxygen erlang-base erlang-dev erlang-dialyzer erlang-eunit \
+              erlang-asn1 erlang-common-test erlang-crypto erlang-edoc \
+              erlang-parsetools erlang-reltool erlang-syntax-tools erlang-tools \
               libglib2.0-0 libpixman-1-0 \
               gcc g++ zlib1g-dev libsdl2-2.0-0 libslirp0 libmbedtls-dev
           wget --no-verbose https://github.com/erlang/rebar3/releases/download/3.18.0/rebar3


### PR DESCRIPTION
rebar3 requires deps such as erlang-asn1.
Install same dependencies as esp32-build.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
