### PR TITLE
CodeQL: Fix _ATOM handling in non-term-to-term-func

### DIFF
--- a/code-queries/non-term-to-term-func.ql
+++ b/code-queries/non-term-to-term-func.ql
@@ -34,6 +34,10 @@ predicate isNotTermOrAtom(Expr expr) {
       (mi.toString().matches("%_ATOM") or mi.toString().matches("TERM_%"))
     )
   ) and
+  not (
+    expr instanceof EnumConstantAccess and
+    expr.(EnumConstantAccess).getTarget().toString().matches("%_ATOM")
+  ) and
   (
     not expr instanceof ConditionalExpr
     or


### PR DESCRIPTION
After #1413, CodeQL was reporting a lot of noise.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
