### PR TITLE
Rewrite packbeam

### DIFF
--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -219,25 +219,6 @@ static void *pack_beam_fun(void *accum, const void *section_ptr, uint32_t sectio
     return accum;
 }
 
-FileData read_file_data(FILE *file)
-{
-    fseek(file, 0, SEEK_END);
-    size_t size = ftell(file);
-    fseek(file, 0, SEEK_SET);
-    uint8_t *data = malloc(size);
-    if (!data) {
-        packbeam_internal_error("Unable to allocate %zu bytes.", size);
-        exit(EXIT_FAILURE);
-    }
-    assert_fread(data, size, file);
-
-    FileData file_data = {
-        .data = data,
-        .size = size
-    };
-    return file_data;
-}
-
 static bool validate_pack_files(char *output_file, char **input_files, size_t files_n)
 {
     FileData file_data = (FileData){ .data = NULL, .size = 0 };

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -29,8 +29,8 @@
 #include <zlib.h>
 #endif
 
-#include "iff.c"
 #include "avmpack.h"
+#include "iff.c"
 #include "mapped_file.h"
 
 #define LITT_UNCOMPRESSED_SIZE_OFFSET 8
@@ -41,9 +41,10 @@
 #define BEAM_CODE_FLAG 2
 #define BUF_SIZE 1024
 
-typedef struct FileData {
+typedef struct FileData
+{
     uint8_t *data;
-    size_t   size;
+    size_t size;
 } FileData;
 
 static void pad_and_align(FILE *f);
@@ -54,7 +55,8 @@ static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const c
 static int do_pack(int argc, char **argv, int is_archive, bool include_lines);
 static int do_list(int argc, char **argv);
 
-static void usage3(FILE *out, const char *program, const char *msg) {
+static void usage3(FILE *out, const char *program, const char *msg)
+{
     if (!IS_NULL_PTR(msg)) {
         fprintf(out, "%s\n", msg);
     }
@@ -62,15 +64,13 @@ static void usage3(FILE *out, const char *program, const char *msg) {
     fprintf(out, "    -h                                                Print this help menu.\n");
     fprintf(out, "    -i                                                Include file and line information.\n");
     fprintf(out, "    -l <input-avm-file>                               List the contents of an AVM file.\n");
-    fprintf(out, "    [-a] <output-avm-file> <input-beam-or-avm-file>+  Create an AVM file (archive if -a specified).\n"
-    );
+    fprintf(out, "    [-a] <output-avm-file> <input-beam-or-avm-file>+  Create an AVM file (archive if -a specified).\n");
 }
 
 static void usage(const char *program)
 {
     usage3(stdout, program, NULL);
 }
-
 
 int main(int argc, char **argv)
 {
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
     int is_archive = 0;
     bool include_lines = false;
     while ((opt = getopt(argc, argv, "hail")) != -1) {
-        switch(opt) {
+        switch (opt) {
             case 'h':
                 usage(argv[0]);
                 return EXIT_SUCCESS;
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
         }
     }
 
-    int new_argc    = argc - optind;
+    int new_argc = argc - optind;
     char **new_argv = argv + optind;
 
     if (new_argc < 1) {
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
     }
 }
 
-static void assert_fread(void *buffer, size_t size, FILE* file)
+static void assert_fread(void *buffer, size_t size, FILE *file)
 {
     size_t r = fread(buffer, sizeof(uint8_t), size, file);
     if (r != size) {
@@ -130,7 +130,7 @@ static void assert_fread(void *buffer, size_t size, FILE* file)
     }
 }
 
-static void assert_fwrite(const void *buffer, size_t size, FILE* file)
+static void assert_fwrite(const void *buffer, size_t size, FILE *file)
 {
     size_t r = fwrite(buffer, 1, size, file);
     if (r != size) {
@@ -148,7 +148,7 @@ static void *pack_beam_fun(void *accum, const void *section_ptr, uint32_t sectio
         return NULL;
     }
 
-    FILE *pack = (FILE *)accum;
+    FILE *pack = (FILE *) accum;
     size_t r = fwrite(section_ptr, sizeof(unsigned char), section_size, pack);
     if (r != section_size) {
         return NULL;
@@ -191,9 +191,9 @@ static bool is_beam_file(FILE *file)
     return ret;
 }
 
-static void validate_pack_options(int argc, char ** argv)
+static void validate_pack_options(int argc, char **argv)
 {
-    for (int i = 0;  i < argc;  ++i) {
+    for (int i = 0; i < argc; ++i) {
         const char *filename = argv[i];
         FILE *file = fopen(filename, "r");
         if (i == 0) {
@@ -231,8 +231,7 @@ static int do_pack(int argc, char **argv, int is_archive, bool include_lines)
         return EXIT_FAILURE;
     }
 
-    const unsigned char pack_header[24] =
-    {
+    const unsigned char pack_header[24] = {
         0x23, 0x21, 0x2f, 0x75,
         0x73, 0x72, 0x2f, 0x62,
         0x69, 0x6e, 0x2f, 0x65,
@@ -254,7 +253,6 @@ static int do_pack(int argc, char **argv, int is_archive, bool include_lines)
         fseek(file, 0, SEEK_END);
         size_t file_size = ftell(file);
         fseek(file, 0, SEEK_SET);
-
 
         uint8_t *file_data = malloc(file_size);
         if (!file_data) {
@@ -290,8 +288,7 @@ static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const c
     }
 
     int written_beam_header_pos = ftell(pack);
-    const unsigned char beam_header[12] =
-    {
+    const unsigned char beam_header[12] = {
         0x46, 0x4f, 0x52, 0x31,
         0x00, 0x00, 0x00, 0x00,
         0x42, 0x45, 0x41, 0x4d
@@ -362,10 +359,9 @@ static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const c
     int beam_written_size = end_of_module_pos - written_beam_header_pos;
     uint32_t beam_written_size_field = ENDIAN_SWAP_32(beam_written_size);
     fseek(pack, written_beam_header_pos + 4, SEEK_SET);
-    assert_fwrite(&beam_written_size_field , sizeof(uint32_t), pack);
+    assert_fwrite(&beam_written_size_field, sizeof(uint32_t), pack);
     fseek(pack, end_of_module_pos, SEEK_SET);
 }
-
 
 static void *print_section(void *accum, const void *section_ptr, uint32_t section_size, const void *beam_ptr, uint32_t flags, const char *section_name)
 {

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -186,15 +186,6 @@ cleanup:
     return EXIT_FAILURE;
 }
 
-static void assert_fread(void *buffer, size_t size, FILE *file)
-{
-    size_t r = fread(buffer, sizeof(uint8_t), size, file);
-    if (r != size) {
-        packbeam_internal_error("Unable to read, wanted to read %zu bytes, read %zu bytes.", size, r);
-        exit(EXIT_FAILURE);
-    }
-}
-
 static void assert_fwrite(const void *buffer, size_t size, FILE *file)
 {
     size_t r = fwrite(buffer, 1, size, file);

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -221,7 +221,6 @@ static bool validate_pack_files(char *output_file, char **input_files, size_t fi
         bool is_valid_avm = avmpack_is_valid(file_data.data, file_data.size);
         bool is_valid_beam = has_iff_header(file_data.data, file_data.size);
         if (!(is_valid_avm || is_valid_beam)) {
-            printf("ZZZ: %i, %i\n", is_valid_avm, is_valid_beam);
             packbeam_error("Invalid AVM or BEAM file '%s'.", filename);
             goto cleanup;
         }

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -34,6 +34,11 @@
 #include "iff.c"
 #include "mapped_file.h"
 
+#define TRY(expr)     \
+    if (!(expr)) {    \
+        goto cleanup; \
+    }
+
 #define LITT_UNCOMPRESSED_SIZE_OFFSET 8
 #define LITT_HEADER_SIZE 12
 
@@ -52,8 +57,6 @@ static void pad_and_align(FILE *f);
 static void *uncompress_literals(const uint8_t *litT, int size, size_t *uncompressedSize);
 static void add_module_header(FILE *f, const char *module_name, uint32_t flags);
 static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const char *filename, int is_entrypoint, bool include_lines);
-
-static void validate_list_options(const char *filename);
 
 static int do_pack(char *output_avm_file, char **input_files, size_t files_n, int is_archive, bool include_lines);
 static int do_list(const char *avm_path);
@@ -137,37 +140,38 @@ int main(int argc, char **argv)
     return do_pack(output_avm_file, input_files, n, is_archive, include_lines);
 }
 
-static void validate_list_options(const char *filename)
+static void *print_section(void *accum, const void *section_ptr, uint32_t section_size, const void *beam_ptr, uint32_t flags, const char *section_name)
 {
-    FILE *file = fopen(filename, "r");
-    if (!file) {
-        packbeam_error("%s does not exist.", filename);
-        exit(EXIT_FAILURE);
-    } else if (!is_avm_file(file)) {
-        packbeam_error("Invalid AVM file: %s.", filename);
-        exit(EXIT_FAILURE);
-    }
+    UNUSED(section_ptr);
+    UNUSED(section_size);
+    UNUSED(beam_ptr);
+    printf("%s %s\n", section_name, flags & BEAM_START_FLAG ? "*" : "");
+    return accum;
 }
 
 static int do_list(const char *avm_path)
 {
-    validate_list_options(avm_path);
-
-    MappedFile *mapped_file = mapped_file_open_beam(avm_path);
-    if (IS_NULL_PTR(mapped_file)) {
-        packbeam_internal_error("Cannot open AVM file %s.", avm_path);
-        return EXIT_FAILURE;
-    }
-
     int ret = EXIT_SUCCESS;
-    if (avmpack_is_valid(mapped_file->mapped, mapped_file->size)) {
-        avmpack_fold(NULL, mapped_file->mapped, print_section);
-    } else {
+
+    // TODO: mapped_file_open_beam prints unnecessary warnings
+    MappedFile *mapped_file = mapped_file_open_beam(avm_path);
+    if (mapped_file == NULL) {
+        packbeam_error("Cannot open AVM file %s", avm_path);
+        ret = EXIT_FAILURE;
+        goto cleanup;
+    }
+    if (!avmpack_is_valid(mapped_file->mapped, mapped_file->size)) {
         packbeam_error("%s is not an AVM file.", avm_path);
         ret = EXIT_FAILURE;
+        goto cleanup;
     }
-    mapped_file_close(mapped_file);
 
+    avmpack_fold(NULL, mapped_file->mapped, print_section);
+
+cleanup:
+    if (mapped_file != NULL) {
+        mapped_file_close(mapped_file);
+    }
     return ret;
 }
 
@@ -403,15 +407,6 @@ static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const c
     fseek(pack, written_beam_header_pos + 4, SEEK_SET);
     assert_fwrite(&beam_written_size_field, sizeof(uint32_t), pack);
     fseek(pack, end_of_module_pos, SEEK_SET);
-}
-
-static void *print_section(void *accum, const void *section_ptr, uint32_t section_size, const void *beam_ptr, uint32_t flags, const char *section_name)
-{
-    UNUSED(section_ptr);
-    UNUSED(section_size);
-    UNUSED(beam_ptr);
-    printf("%s %s\n", section_name, flags & BEAM_START_FLAG ? "*" : "");
-    return accum;
 }
 
 static void *uncompress_literals(const uint8_t *litT, int size, size_t *uncompressedSize)

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -25,9 +25,10 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#ifdef WITH_ZLIB
+// TODO: Remove this when the code is refactored
+// #ifdef WITH_ZLIB
 #include <zlib.h>
-#endif
+// #endif
 
 #include "avmpack.h"
 #include "iff.c"

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -162,28 +162,26 @@ static void *print_section(void *accum, const void *section_ptr, uint32_t sectio
 
 static int do_list(const char *avm_path)
 {
-    int ret = EXIT_SUCCESS;
 
     // TODO: mapped_file_open_beam prints unnecessary warnings
     MappedFile *mapped_file = mapped_file_open_beam(avm_path);
     if (mapped_file == NULL) {
         packbeam_error("Cannot open AVM file %s", avm_path);
-        ret = EXIT_FAILURE;
         goto cleanup;
     }
     if (!avmpack_is_valid(mapped_file->mapped, mapped_file->size)) {
         packbeam_error("%s is not an AVM file.", avm_path);
-        ret = EXIT_FAILURE;
         goto cleanup;
     }
 
     avmpack_fold(NULL, mapped_file->mapped, print_section);
+    return EXIT_SUCCESS;
 
 cleanup:
     if (mapped_file != NULL) {
         mapped_file_close(mapped_file);
     }
-    return ret;
+    return EXIT_FAILURE;
 }
 
 static void assert_fread(void *buffer, size_t size, FILE *file)


### PR DESCRIPTION
I went and implemented my suggestion from #1394.
I didn't do any thorough checks yet since I want to get feedback first (`make -j` in `build/` doesn't crash on my machine).
Worked on original file, slowly refactoring to what I had in mind. Do we have tests for packbeam or we only check it by usage?

1. Added `TRY` macro that checks bool output from expression and if `false`, stops the execution of current function.
2. Various functions have additional `bool` output to check for errors.
3. Refactored error output, printing usage when it makes sense (maybe should've used `perror` for internals?).
4. Added TODOs for things that would change the structure stronger that I wanted for now.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
