### PR TITLE
Chore: Bump esp-idf

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -39,15 +39,15 @@ jobs:
         esp-idf-target: ["esp32", "esp32c3"]
         idf-version:
          - 'v5.0.7'
-         - 'v5.1.4'
-         - 'v5.2.2'
-         - 'v5.3.1'
+         - 'v5.1.5'
+         - 'v5.2.3'
+         - 'v5.3.2'
 
         exclude:
         - esp-idf-target: "esp32c3"
           idf-version: 'v5.0.7'
         - esp-idf-target: "esp32c3"
-          idf-version: 'v5.1.4'
+          idf-version: 'v5.1.5'
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -37,7 +37,7 @@ jobs:
 
     strategy:
       matrix:
-        idf-version: ["5.3.1"]
+        idf-version: ["5.3.2"]
         cc: ["clang-14"]
         cxx: ["clang++-14"]
         cflags: ["-O3"]

--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -68,9 +68,9 @@ AtomVM currently supports the following versions of ESP-IDF:
 | IDF SDK supported versions | AtomVM support |
 |------------------------------|----------------|
 | ESP-IDF [v5.0](https://docs.espressif.com/projects/esp-idf/en/v5.0.7/esp32/get-started/index.html) | ✅ |
-| ESP-IDF [v5.1](https://docs.espressif.com/projects/esp-idf/en/v5.1.4/esp32/get-started/index.html) | ✅ |
-| ESP-IDF [v5.2](https://docs.espressif.com/projects/esp-idf/en/v5.2.2/esp32/get-started/index.html) | ✅ |
-| ESP-IDF [v5.3](https://docs.espressif.com/projects/esp-idf/en/v5.3/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.1](https://docs.espressif.com/projects/esp-idf/en/v5.1.5/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.2](https://docs.espressif.com/projects/esp-idf/en/v5.2.3/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.3](https://docs.espressif.com/projects/esp-idf/en/v5.3.2/esp32/get-started/index.html) | ✅ |
 
 Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.  We recommend you to use the latest subminor (patch) versions for source builds. You can check the current version used for testing in the [esp32-build.yaml](https://github.com/atomvm/AtomVM/actions/workflows/esp32-build.yaml) workflow.
 


### PR DESCRIPTION
Use 5.3.2 for releases.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
