### PR TITLE
Update CodeQL action

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: "Initialize CodeQL"
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql
@@ -74,4 +74,4 @@ jobs:
         ninja
 
     - name: "Perform CodeQL Analysis"
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
See also:
- https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/
- https://github.com/actions/runner-images/issues/10636

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
