### PR TITLE
Test esp-idf v5.4-rc1 in sim_test

### DIFF
--- a/.github/workflows/esp32-simtest.yaml
+++ b/.github/workflows/esp32-simtest.yaml
@@ -59,13 +59,26 @@ jobs:
       fail-fast: false
       # focus on device diversity.
       matrix:
-        esp-idf-target: ["esp32", "esp32s2", "esp32s3", "esp32c3", "esp32c6"]
-        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.5", "v5.2.3", "v5.3.2", "v5.4-beta1"]')) || fromJSON('["v5.3.2"]') }}
-        include:
+        esp-idf-target:
+          [
+            "esp32",
+            "esp32s2",
+            "esp32s3",
+            "esp32c3",
+            "esp32c6",
+            "esp32h2",
+            "esp32p4",
+          ]
+        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.5", "v5.2.3", "v5.3.2", "v5.4-rc1"]')) || fromJSON('["v5.3.2"]') }}
+        exclude:
           - esp-idf-target: "esp32p4"
-            idf-version: "v5.3.2"
+            idf-version: "v5.1.5"
+          - esp-idf-target: "esp32p4"
+            idf-version: "v5.2.3"
           - esp-idf-target: "esp32h2"
-            idf-version: "v5.3.2"
+            idf-version: "v5.1.5"
+          - esp-idf-target: "esp32h2"
+            idf-version: "v5.2.3"
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Future proof logic around esp32p4/h2, so they are also expanded for a full_sim_test.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
