### PR TITLE
Fix FreeBSD CI not exiting on error

### DIFF
--- a/.github/workflows/build-and-test-on-freebsd.yaml
+++ b/.github/workflows/build-and-test-on-freebsd.yaml
@@ -57,7 +57,7 @@ jobs:
           pkg install -y curl cmake gperf erlang elixir mbedtls
 
         run: |
-
+          set -e
           echo "%%"
           echo "%% System Info"
           echo "%%"


### PR DESCRIPTION
Fixes https://github.com/atomvm/AtomVM/issues/1435

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
