### PR TITLE
Introduce support for ESP32P4

### DIFF
--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -44,7 +44,7 @@ jobs:
         otp: ["27"]
         elixir_version: ["1.17"]
         compiler_pkgs: ["clang-14"]
-        soc: ["esp32", "esp32c2", "esp32c3", "esp32s2", "esp32s3", "esp32c6", "esp32h2"]
+        soc: ["esp32", "esp32c2", "esp32c3", "esp32s2", "esp32s3", "esp32c6", "esp32h2", "esp32p4"]
         flavor: ["", "-elixir"]
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the ability to run beams from the CLI for Generic Unix platform (it was already possible with nodejs and emscripten).
+- Added preliminary support for ESP32P4 (no networking support yet).
 
 ### Fixed
 

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -264,6 +264,7 @@ process_info(_Pid, _Key) ->
 %%      <li><b>esp32_free_heap_size</b> the number of (noncontiguous) free bytes in the ESP32 heap (integer)</li>
 %%      <li><b>esp32_largest_free_block</b> the number of the largest contiguous free bytes in the ESP32 heap (integer)</li>
 %%      <li><b>esp32_minimum_free_size</b> the smallest number of free bytes in the ESP32 heap since boot (integer)</li>
+%%      <li><b>esp32_chip_info</b> Details about the model and capabilities of the ESP32 device (map)</li>
 %% </ul>
 %%
 %% Additional keys may be supported on some platforms that are not documented here.

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -89,8 +89,8 @@ static const char *const esp32_c2_atom = "\x8" "esp32_c2";
 static const char *const esp32_c3_atom = "\x8" "esp32_c3";
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
 static const char *const esp32_c6_atom = "\x8" "esp32_c6";
-#endif
 static const char *const esp32_h2_atom = "\x8" "esp32_h2";
+#endif
 #endif
 static const char *const emb_flash_atom = "\x9" "emb_flash";
 static const char *const bgn_atom = "\x3" "bgn";
@@ -489,9 +489,9 @@ static term get_model(Context *ctx, esp_chip_model_t model)
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
         case CHIP_ESP32C6:
             return globalcontext_make_atom(ctx->global, esp32_c6_atom);
-#endif
         case CHIP_ESP32H2:
             return globalcontext_make_atom(ctx->global, esp32_h2_atom);
+#endif
         default:
             return UNDEFINED_ATOM;
     }

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -91,6 +91,9 @@ static const char *const esp32_c3_atom = "\x8" "esp32_c3";
 static const char *const esp32_c6_atom = "\x8" "esp32_c6";
 static const char *const esp32_h2_atom = "\x8" "esp32_h2";
 #endif
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+static const char *const esp32_p4_atom = "\x8" "esp32_p4";
+#endif
 #endif
 static const char *const emb_flash_atom = "\x9" "emb_flash";
 static const char *const bgn_atom = "\x3" "bgn";
@@ -491,6 +494,10 @@ static term get_model(Context *ctx, esp_chip_model_t model)
             return globalcontext_make_atom(ctx->global, esp32_c6_atom);
         case CHIP_ESP32H2:
             return globalcontext_make_atom(ctx->global, esp32_h2_atom);
+#endif
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+        case CHIP_ESP32P4:
+            return globalcontext_make_atom(ctx->global, esp32_p4_atom);
 #endif
         default:
             return UNDEFINED_ATOM;


### PR DESCRIPTION
Adds device info for `erlang:system_info(esp32_chip_info)` for the ESP32P4, as well as building release images. This does not include any network support yet.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
