### PR TITLE
Adds OTP-27 and Elixir 1.17 for release-0.6 supported versions

### DIFF
--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -33,6 +33,7 @@ AtomVM will run BEAM files that have been compiled using the following Erlang an
 | ✅ OTP 24 | ✅ 1.14 |
 | ✅ OTP 25 | ✅ 1.14 |
 | ✅ OTP 26 | ✅ 1.15 |
+| ✅ OTP 27 | ✅ 1.17 |
 
 ```{note}
 Versions of Elixir that are compatible with a particular OTP version may work.  This table reflects the versions that are tested.


### PR DESCRIPTION
Adds missing note about support for OTP-27 and Elixir 1.17 to the release-0.6 branch.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
