### PR TITLE
WIP: term_list_length-use-bool

### DIFF
--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -1380,7 +1380,7 @@ static inline term term_list_prepend(term head, term tail, Heap *heap)
  * @details Counts the number of list items
  * @return number of list items
  */
-static inline int term_list_length(term t, int *proper)
+static inline int term_list_length(term t, bool *proper)
 {
     int len = 0;
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
