### PR TITLE
Make `globalcontext_make_atom` safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `net:gethostname/0` on platforms with gethostname(3).
 - Added `socket:getopt/2`
 
+### Changed
+- `globalcontext_make_atom` might return an invalid term when memory allocation fails. Therefore
+return value must be checked (e.g. using `term_is_invalid_term()`)
+
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.
 

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -412,11 +412,15 @@ static inline bool globalcontext_is_term_equal_to_atom_string(GlobalContext *glo
  *          global context.
  * @param glb pointer to the global context
  * @param string an AtomString
- * @return an atom term formed from the supplied atom string.
+ * @return an atom term formed from the supplied atom string, or an invalid term when out of memory
  */
 static inline term globalcontext_make_atom(GlobalContext *glb, AtomString string)
 {
     int global_atom_index = globalcontext_insert_atom(glb, string);
+    if (UNLIKELY(global_atom_index < 0)) {
+        return term_invalid_term();
+    }
+
     return term_from_atom_index(global_atom_index);
 }
 

--- a/src/libAtomVM/nifs.h
+++ b/src/libAtomVM/nifs.h
@@ -46,6 +46,12 @@ extern "C" {
     ctx->x[1] = (error_type_atom);   \
     return term_invalid_term();
 
+#define REQUIRE_ATOM(name, lenstr, str, glb) \
+    term name = globalcontext_make_atom(glb, lenstr str); \
+    if (UNLIKELY(term_is_invalid_term(name))) { \
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM); \
+    }
+
 const struct Nif *nifs_get(AtomString module, AtomString function, int arity);
 
 #ifdef __cplusplus


### PR DESCRIPTION
See also: #1442

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
