### PR TITLE
Fix warning about implicit functions on stm32 platform

### DIFF
--- a/src/platforms/stm32/src/lib/stm_sys.h
+++ b/src/platforms/stm32/src/lib/stm_sys.h
@@ -164,5 +164,7 @@ void sys_enable_flash_cache(void);
 void *_sbrk_r(struct _reent *, ptrdiff_t);
 // This function may be defined to relocate the heap.
 void local_heap_setup(uint8_t **start, uint8_t **end);
+void sys_enable_core_periph_clocks();
+bool sys_lock_pin(GlobalContext *glb, uint32_t gpio_bank, uint16_t pin_num);
 
 #endif /* _STM_SYS_H_ */


### PR DESCRIPTION
Adds missing function declarations to stm32/src/lib/stm_sys.h for several platform functions used in main.c from sys.c.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
