### PR TITLE
Standardize stm32 gpio driver error returns

### DIFF
--- a/src/platforms/stm32/src/lib/CMakeLists.txt
+++ b/src/platforms/stm32/src/lib/CMakeLists.txt
@@ -25,6 +25,7 @@ set(HEADER_FILES
     avm_devcfg.h
     avm_log.h
     gpio_driver.h
+    platform_defaultatoms.h
     stm_sys.h
     ../../../../libAtomVM/platform_nifs.h
     ../../../../libAtomVM/portnifloader.h
@@ -33,6 +34,7 @@ set(HEADER_FILES
 
 set(SOURCE_FILES
     gpio_driver.c
+    platform_defaultatoms.c
     platform_nifs.c
     sys.c
     ../../../../libAtomVM/portnifloader.c

--- a/src/platforms/stm32/src/lib/platform_defaultatoms.c
+++ b/src/platforms/stm32/src/lib/platform_defaultatoms.c
@@ -1,0 +1,49 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2019 Davide Bettio <davide@uninstall.it>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include "platform_defaultatoms.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+void platform_defaultatoms_init(GlobalContext *glb)
+{
+// About X macro: https://en.wikipedia.org/wiki/X_macro
+#define X(name, lenstr, str) \
+    lenstr str,
+
+    static const char *const atoms[] = {
+#include "platform_defaultatoms.def"
+
+        // dummy value
+        NULL
+    };
+#undef X
+
+    for (int i = 0; i < ATOM_FIRST_AVAIL_INDEX - PLATFORM_ATOMS_BASE_INDEX; i++) {
+        if (UNLIKELY((size_t) atoms[i][0] != strlen(atoms[i] + 1))) {
+            AVM_ABORT();
+        }
+
+        if (UNLIKELY(globalcontext_insert_atom(glb, atoms[i]) != i + PLATFORM_ATOMS_BASE_INDEX)) {
+            AVM_ABORT();
+        }
+    }
+}

--- a/src/platforms/stm32/src/lib/platform_defaultatoms.def
+++ b/src/platforms/stm32/src/lib/platform_defaultatoms.def
@@ -1,0 +1,30 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2019-2024 Davide Bettio <davide@uninstall.it>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"))
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+X(STM32_ATOM, "\x5", "stm32")
+
+#if !(defined(AVM_DISABLE_GPIO_PORT_DRIVER) && defined(AVM_DISABLE_GPIO_NIFS))
+X(HIGH_ATOM, "\x4", "high")
+X(LOW_ATOM, "\x3", "low")
+#if !(defined(AVM_DISABLE_GPIO_PORT_DRIVER))
+X(GPIO_ATOM, "\x4", "gpio")
+X(GPIO_INTERRUPT_ATOM, "\xE", "gpio_interrupt")
+#endif
+#endif

--- a/src/platforms/stm32/src/lib/platform_defaultatoms.h
+++ b/src/platforms/stm32/src/lib/platform_defaultatoms.h
@@ -1,0 +1,58 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Copyright 2019-2024 Davide Bettio <davide@uninstall.it>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#ifndef _PLATFORM_DEFAULTATOMS_H_
+#define _PLATFORM_DEFAULTATOMS_H_
+
+#include "defaultatoms.h"
+
+// About X macro: https://en.wikipedia.org/wiki/X_macro
+
+#define X(name, lenstr, str) \
+    name##_INDEX,
+
+enum
+{
+    PLATFORM_ATOMS_BASE_INDEX_MINUS_ONE = PLATFORM_ATOMS_BASE_INDEX - 1,
+
+#include "platform_defaultatoms.def"
+
+    ATOM_FIRST_AVAIL_INDEX
+};
+
+#undef X
+
+_Static_assert((int) ATOM_FIRST_AVAIL_INDEX > (int) PLATFORM_ATOMS_BASE_INDEX,
+    "default atoms and platform ones are overlapping");
+
+#define X(name, lenstr, str) \
+    name = TERM_FROM_ATOM_INDEX(name##_INDEX),
+
+enum
+{
+#include "platform_defaultatoms.def"
+
+    // dummy last item
+    ATOM_FIRST_AVAIL_DUMMY = TERM_FROM_ATOM_INDEX(ATOM_FIRST_AVAIL_INDEX)
+};
+
+#undef X
+
+#endif

--- a/src/platforms/stm32/src/lib/platform_nifs.c
+++ b/src/platforms/stm32/src/lib/platform_nifs.c
@@ -26,6 +26,7 @@
 //#define ENABLE_TRACE
 #include <trace.h>
 
+#include "platform_defaultatoms.h"
 #include "stm_sys.h"
 
 static term nif_atomvm_platform(Context *ctx, int argc, term argv[])

--- a/src/platforms/stm32/src/lib/stm_sys.h
+++ b/src/platforms/stm32/src/lib/stm_sys.h
@@ -24,8 +24,6 @@
 #include <portnifloader.h>
 #include <sys.h>
 
-#define STM32_ATOM globalcontext_make_atom(ctx->global, ATOM_STR("\x5", "stm32"))
-
 /*  Only on ARMv7EM and above
  *  TODO: These definitions are back-ported from libopencm3 `master`, if they ever release a new version this section should
  *  be removed, along with the included headers and replaced with only the following inclusion:

--- a/src/platforms/stm32/src/lib/sys.c
+++ b/src/platforms/stm32/src/lib/sys.c
@@ -98,15 +98,6 @@ static inline void sys_clock_gettime(struct timespec *t)
     t->tv_nsec = ((int32_t) now % 1000) * 1000000;
 }
 
-/* TODO: Needed because `defaultatoms_init` in libAtomVM/defaultatoms.c calls this function.
- * We should be able to remove this after `platform_defaulatoms.{c,h}` are removed on all platforms
- * and `defaultatoms_init` is no longer called.
- */
-void platform_defaultatoms_init(GlobalContext *glb)
-{
-    UNUSED(glb);
-}
-
 void sys_enable_core_periph_clocks()
 {
     uint32_t list[] = GPIO_CLOCK_LIST;


### PR DESCRIPTION
Standardizes stm32 gpio driver error returns. Nif functions raise `Error`, port functions return `{error, Reason}` on errors.

Handle atom creation more safely, see issue #1442

With #1408 this closes issue #894

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
