### PR TITLE
Fix ESP32 network:stop/0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ certain VM instructions are used.
 - Fixed an issue where a timeout would occur immediately in a race condition
 - Fixed SPI close command
 - Added missing lock on socket structure
+- Fix `network:stop/0` on ESP32 so the network can be started again
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -811,6 +811,9 @@ static void stop_network(Context *ctx)
 {
     // Stop unregister event callbacks so they dont trigger during shutdown.
     esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler);
+    esp_event_handler_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, &event_handler);
+    esp_event_handler_unregister(IP_EVENT, IP_EVENT_AP_STAIPASSIGNED, &event_handler);
+    esp_event_handler_unregister(sntp_event_base, SNTP_EVENT_BASE_SYNC, &event_handler);
 
     esp_netif_t *sta_wifi_interface = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
     esp_netif_t *ap_wifi_interface = esp_netif_get_handle_from_ifkey("WIFI_AP_DEF");
@@ -829,12 +832,6 @@ static void stop_network(Context *ctx)
 
     // Stop sntp (ignore OK, or not configured error)
     esp_sntp_stop();
-
-    // Delete network event loop
-    esp_err_t err = esp_event_loop_delete_default();
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "Invalid state error while deleting event loop, continuing network shutdown...");
-    }
 
     // Destroy existing netif interfaces
     if (ap_wifi_interface != NULL) {

--- a/src/platforms/esp32/test/main/test_erl_sources/test_wifi_example.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_wifi_example.erl
@@ -25,6 +25,8 @@
 start() ->
     case verify_platform(atomvm:platform()) of
         ok ->
+            ok = start_network(),
+            ok = network:stop(),
             start_network(),
             loop(0);
         Error ->


### PR DESCRIPTION
Removes all of the registered event handlers when the driver is stopped.

Fixes the incorrect deletion on the default event loop when the driver is stopped.

Closes #1449

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
