### PR TITLE
Utilize reserved `phy_init` partition on ESP32 for wifi calibration data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.
+- Utilize reserved `phy_init` partition on ESP32 to store wifi calibration for faster connections.
 
 ## [0.6.6] - Unreleased
 

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -690,7 +690,7 @@ static void start_network(Context *ctx, term pid, term ref, term config)
         port_send_reply(ctx, pid, ref, error);
         return;
     }
-    if (UNLIKELY((err = esp_wifi_set_storage(WIFI_STORAGE_RAM)) != ESP_OK)) {
+    if (UNLIKELY((err = esp_wifi_set_storage(WIFI_STORAGE_FLASH)) != ESP_OK)) {
         ESP_LOGE(TAG, "Failed to set ESP WiFi storage");
         term error = port_create_error_tuple(ctx, term_from_int(err));
         port_send_reply(ctx, pid, ref, error);


### PR DESCRIPTION
The `phy_init` partition has been reserved, but not used. By using the `WIFI_STORAGE_FLASH` location the calibration data is preserved across restarts in flash significantly improving connection times. The data stored using `WIFI_STORAGE_RAM` is lost at boot up and needs to be recalibrated, the option `WIFI_STORAGE_FLASH` will still load the data into ram from flash, but this is much faster than performing a full calibration every boot, and should significantly help battery powered devices that spend time in deep sleep and only wake to collect and relay sensor data to the network.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
