### PR TITLE
Add workaround for latest debian gcc-arm-none-eabi

### DIFF
--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   pico:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         board: ["pico", "pico_w"]

--- a/.github/workflows/stm32-build.yaml
+++ b/.github/workflows/stm32-build.yaml
@@ -44,17 +44,6 @@ jobs:
           https://repo.hex.pm
           https://cdn.jsdelivr.net/hex
 
-    - name: Install arm-embedded toolchain
-      if: ${{ steps.builddeps-cache.outputs.cache-hit != 'true' }}
-      working-directory: /home/runner
-      run: |
-        set -euo pipefail
-        cd /home/runner
-        wget https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz \
-        --output-document=$RUNNER_TEMP/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz
-        tar xJf $RUNNER_TEMP/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz
-        pwd && ls
-
     - name: Checkout and build libopencm3
       if: ${{ steps.builddeps-cache.outputs.cache-hit != 'true' }}
       working-directory: /home/runner
@@ -71,7 +60,7 @@ jobs:
       run: sudo apt update
 
     - name: "Install deps"
-      run: sudo apt install -y cmake gperf
+      run: sudo apt install -y cmake gperf gcc-arm-none-eabi
 
     - name: Checkout repo
       uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ certain VM instructions are used.
 - Fixed an issue where a timeout would occur immediately in a race condition
 - Fixed SPI close command
 - Added missing lock on socket structure
+- Fixed compilation with latest debian gcc-arm-none-eabi
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -28,6 +28,9 @@
 #ifndef _TERM_H_
 #define _TERM_H_
 
+// gcc-arm-none-eabi 13.2.1 with newlib requires this first
+#include <sys/types.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
Fixes #1445

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
