### PR TITLE
Fix double free of esp32 uart driver on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ certain VM instructions are used.
 - Fixed an issue where a timeout would occur immediately in a race condition
 - Fixed SPI close command
 - Added missing lock on socket structure
+- Fixed a double free when esp32 uart driver was closed, yielding an assert abort
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -178,9 +178,7 @@ void context_destroy(Context *ctx)
     // globalcontext_get_process_lock before accessing platform_data.
     // Here, the context can no longer be acquired with
     // globalcontext_get_process_lock, so it's safe to free the pointer.
-    if (ctx->platform_data) {
-        free(ctx->platform_data);
-    }
+    free(ctx->platform_data);
 
     free(ctx);
 }


### PR DESCRIPTION
- Also fix usage of memory_ensure_free in esp32 uart driver
- Also remove unnecessary condition in context_destroy

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
