### PR TITLE
Add ESP-IDF v5.4 (official) to workflows and supported builds in release notes

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -42,6 +42,7 @@ jobs:
          - 'v5.1.5'
          - 'v5.2.3'
          - 'v5.3.2'
+         - 'v5.4'
 
         exclude:
         - esp-idf-target: "esp32c3"

--- a/.github/workflows/esp32-simtest.yaml
+++ b/.github/workflows/esp32-simtest.yaml
@@ -69,7 +69,7 @@ jobs:
             "esp32h2",
             "esp32p4",
           ]
-        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.5", "v5.2.3", "v5.3.2", "v5.4-rc1"]')) || fromJSON('["v5.3.2"]') }}
+        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.5", "v5.2.3", "v5.3.2", "v5.4"]')) || fromJSON('["v5.3.2"]') }}
         exclude:
           - esp-idf-target: "esp32p4"
             idf-version: "v5.1.5"

--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -71,6 +71,7 @@ AtomVM currently supports the following versions of ESP-IDF:
 | ESP-IDF [v5.1](https://docs.espressif.com/projects/esp-idf/en/v5.1.5/esp32/get-started/index.html) | ✅ |
 | ESP-IDF [v5.2](https://docs.espressif.com/projects/esp-idf/en/v5.2.3/esp32/get-started/index.html) | ✅ |
 | ESP-IDF [v5.3](https://docs.espressif.com/projects/esp-idf/en/v5.3.2/esp32/get-started/index.html) | ✅ |
+| ESP-IDF [v5.4](https://docs.espressif.com/projects/esp-idf/en/v5.4/esp32/get-started/index.html) | ✅ |
 
 Building the AtomVM virtual machine for ESP32 is optional.  In most cases, you can simply download a release image from the AtomVM [release](https://github.com/atomvm/AtomVM/releases) repository.  If you wish to work on development of the VM or use one on the additional drivers that are available in the [AtomVM repositories](https://github.com/atomvm) you will to build AtomVM from source.  See the [Build Instructions](build-instructions.md) for information about how to build AtomVM from source code.  We recommend you to use the latest subminor (patch) versions for source builds. You can check the current version used for testing in the [esp32-build.yaml](https://github.com/atomvm/AtomVM/actions/workflows/esp32-build.yaml) workflow.
 


### PR DESCRIPTION
Bumps version the esp32-build.yaml, and esp32-simtest.yaml for runs that include a full_sim_test to ESP-IDF v5.4.

Adds ESP-IDF v5.4 to supported build environments in the release-0.6 release notes.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
