### PR TITLE
Fix insufficient memory allocation in ESP32 select_thread_loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ certain VM instructions are used.
 - Fixed an issue where a timeout would occur immediately in a race condition
 - Fixed SPI close command
 - Added missing lock on socket structure
+- Fixed insufficient memory allocation in ESP32 select_thread_loop
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -677,7 +677,7 @@ static void *select_thread_loop(void *arg)
 {
     GlobalContext *glb = arg;
     struct ESP32PlatformData *platform = glb->platform_data;
-    struct pollfd *fds = malloc(0);
+    struct pollfd *fds = malloc(sizeof(struct pollfd));
     while (!platform->select_thread_exit) {
         int select_events_poll_count = platform->select_events_poll_count;
         int poll_count = 1;


### PR DESCRIPTION
Building with ESP-IDF v5.4 emmits the folowing warning:
```
/__w/AtomVM/AtomVM/src/platforms/esp32/components/avm_sys/sys.c: In function 'select_thread_loop':
/__w/AtomVM/AtomVM/src/platforms/esp32/components/avm_sys/sys.c:680:26: warning: allocation of
 insufficient size '0' for type 'struct pollfd' with size '8' [-Walloc-size]
  680 |     struct pollfd *fds = malloc(0);
      |                          ^~~~~~
```

These changes fix the problem by allocating enough memory to hold the struct.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
