### PR TITLE
Complete supervisor behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `registered_name` in `erlang:process_info/2` and `Process.info/2`
 - Added `net:gethostname/0` on platforms with gethostname(3).
 - Added `socket:getopt/2`
+- Added `supervisor:terminate_child/2`, `supervisor:restart_child/2` and `supervisor:delete_child/2`
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/libs/estdlib/src/gen_server.erl
+++ b/libs/estdlib/src/gen_server.erl
@@ -211,8 +211,8 @@ init_it(Starter, Module, Args, Options) ->
         end,
     case StateT of
         undefined -> ok;
-        {State, {continue, Continue}} -> loop(State, {continue, Continue});
-        {State, Timeout} -> loop(State, Timeout)
+        {State, {continue, Continue}} -> loop(Starter, State, {continue, Continue});
+        {State, Timeout} -> loop(Starter, State, Timeout)
     end.
 
 init_ack(Parent, Return) ->
@@ -499,34 +499,34 @@ reply({Pid, Ref}, Reply) ->
 %%
 
 %% @private
-loop(#state{mod = Mod, mod_state = ModState} = State, {continue, Continue}) ->
+loop(Parent, #state{mod = Mod, mod_state = ModState} = State, {continue, Continue}) ->
     case Mod:handle_continue(Continue, ModState) of
         {noreply, NewModState} ->
-            loop(State#state{mod_state = NewModState}, infinity);
+            loop(Parent, State#state{mod_state = NewModState}, infinity);
         {noreply, NewModState, {continue, NewContinue}} ->
-            loop(State#state{mod_state = NewModState}, {continue, NewContinue});
+            loop(Parent, State#state{mod_state = NewModState}, {continue, NewContinue});
         {stop, Reason, NewModState} ->
             do_terminate(State, Reason, NewModState)
     end;
-loop(#state{mod = Mod, mod_state = ModState} = State, Timeout) ->
+loop(Parent, #state{mod = Mod, mod_state = ModState} = State, Timeout) ->
     receive
         {'$call', {_Pid, _Ref} = From, Request} ->
             case Mod:handle_call(Request, From, ModState) of
                 {reply, Reply, NewModState} ->
                     ok = reply(From, Reply),
-                    loop(State#state{mod_state = NewModState}, infinity);
+                    loop(Parent, State#state{mod_state = NewModState}, infinity);
                 {reply, Reply, NewModState, {continue, Continue}} ->
                     ok = reply(From, Reply),
-                    loop(State#state{mod_state = NewModState}, {continue, Continue});
+                    loop(Parent, State#state{mod_state = NewModState}, {continue, Continue});
                 {reply, Reply, NewModState, NewTimeout} ->
                     ok = reply(From, Reply),
-                    loop(State#state{mod_state = NewModState}, NewTimeout);
+                    loop(Parent, State#state{mod_state = NewModState}, NewTimeout);
                 {noreply, NewModState} ->
-                    loop(State#state{mod_state = NewModState}, infinity);
+                    loop(Parent, State#state{mod_state = NewModState}, infinity);
                 {noreply, NewModState, {continue, Continue}} ->
-                    loop(State#state{mod_state = NewModState}, {continue, Continue});
+                    loop(Parent, State#state{mod_state = NewModState}, {continue, Continue});
                 {noreply, NewModState, NewTimeout} ->
-                    loop(State#state{mod_state = NewModState}, NewTimeout);
+                    loop(Parent, State#state{mod_state = NewModState}, NewTimeout);
                 {stop, Reason, Reply, NewModState} ->
                     ok = reply(From, Reply),
                     do_terminate(State, Reason, NewModState);
@@ -538,11 +538,11 @@ loop(#state{mod = Mod, mod_state = ModState} = State, Timeout) ->
         {'$cast', Request} ->
             case Mod:handle_cast(Request, ModState) of
                 {noreply, NewModState} ->
-                    loop(State#state{mod_state = NewModState}, infinity);
+                    loop(Parent, State#state{mod_state = NewModState}, infinity);
                 {noreply, NewModState, {continue, Continue}} ->
-                    loop(State#state{mod_state = NewModState}, {continue, Continue});
+                    loop(Parent, State#state{mod_state = NewModState}, {continue, Continue});
                 {noreply, NewModState, NewTimeout} ->
-                    loop(State#state{mod_state = NewModState}, NewTimeout);
+                    loop(Parent, State#state{mod_state = NewModState}, NewTimeout);
                 {stop, Reason, NewModState} ->
                     do_terminate(State, Reason, NewModState);
                 _ ->
@@ -550,12 +550,14 @@ loop(#state{mod = Mod, mod_state = ModState} = State, Timeout) ->
             end;
         {'$stop', Reason} ->
             do_terminate(State, Reason, ModState);
+        {'EXIT', Parent, Reason} ->
+            do_terminate(State, Reason, ModState);
         Info ->
             case Mod:handle_info(Info, ModState) of
                 {noreply, NewModState} ->
-                    loop(State#state{mod_state = NewModState}, infinity);
+                    loop(Parent, State#state{mod_state = NewModState}, infinity);
                 {noreply, NewModState, NewTimeout} ->
-                    loop(State#state{mod_state = NewModState}, NewTimeout);
+                    loop(Parent, State#state{mod_state = NewModState}, NewTimeout);
                 {stop, Reason, NewModState} ->
                     do_terminate(State, Reason, NewModState);
                 _ ->
@@ -564,9 +566,9 @@ loop(#state{mod = Mod, mod_state = ModState} = State, Timeout) ->
     after Timeout ->
         case Mod:handle_info(timeout, ModState) of
             {noreply, NewModState} ->
-                loop(State#state{mod_state = NewModState}, infinity);
+                loop(Parent, State#state{mod_state = NewModState}, infinity);
             {noreply, NewModState, NewTimeout} ->
-                loop(State#state{mod_state = NewModState}, NewTimeout);
+                loop(Parent, State#state{mod_state = NewModState}, NewTimeout);
             {stop, Reason, NewModState} ->
                 do_terminate(State, Reason, NewModState);
             _ ->

--- a/src/libAtomVM/defaultatoms.def
+++ b/src/libAtomVM/defaultatoms.def
@@ -165,3 +165,5 @@ X(EXTERNAL_ATOM, "\x8", "external")
 X(LOCAL_ATOM, "\x5", "local")
 
 X(REGISTERED_NAME_ATOM, "\xF", "registered_name")
+
+X(SHUTDOWN_ATOM, "\x8", "shutdown")

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -7053,8 +7053,8 @@ handle_error:
             }
         }
 
-        // Do not print crash dump if reason is normal.
-        if (x_regs[0] != LOWERCASE_EXIT_ATOM || x_regs[1] != NORMAL_ATOM) {
+        // Do not print crash dump if reason is normal or shutdown.
+        if (x_regs[0] != LOWERCASE_EXIT_ATOM || (x_regs[1] != NORMAL_ATOM && x_regs[1] != SHUTDOWN_ATOM)) {
             dump(ctx);
         }
 


### PR DESCRIPTION
- add missing `supervisor:terminate_child/2`, `supervisor:delete_child/2` and `supervisor:restart_child/2`
- fix termination of children of supervisor
- add more termination strategies

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
