### PR TITLE
Fix race condition in timeout handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ certain VM instructions are used.
 - Fixed an issue where a timeout would occur immediately in a race condition
 - Fixed SPI close command
 - Added missing lock on socket structure
+- Fixed a race condition affecting multi-core MCUs where a timeout would not be properly cleared
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/libAtomVM/scheduler.c
+++ b/src/libAtomVM/scheduler.c
@@ -414,11 +414,11 @@ void scheduler_cancel_timeout(Context *ctx)
 {
     GlobalContext *glb = ctx->global;
 
-    context_update_flags(ctx, ~(WaitingTimeout | WaitingTimeoutExpired), NoFlags);
-
     struct TimerList *tw = &glb->timer_list;
 
     SMP_SPINLOCK_LOCK(&glb->timer_spinlock);
     timer_list_remove(tw, &ctx->timer_list_head);
     SMP_SPINLOCK_UNLOCK(&glb->timer_spinlock);
+
+    context_update_flags(ctx, ~(WaitingTimeout | WaitingTimeoutExpired), NoFlags);
 }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
