### PR TITLE
Add `ets:delete/1`, `ets:delete` refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `float/1` BIF.
 - Added `erlang:get/0` and `erlang:erase/0`.
 - Added `erlang:unique_integer/0` and `erlang:unique_integer/1`
+- Added support for 'ets:delete/1'.
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/libs/estdlib/src/ets.erl
+++ b/libs/estdlib/src/ets.erl
@@ -29,6 +29,7 @@
     insert/2,
     lookup/2,
     lookup_element/3,
+    delete/1,
     delete/2,
     update_counter/3,
     update_counter/4
@@ -140,4 +141,13 @@ update_counter(_Table, _Key, _Params) ->
     Default :: integer()
 ) -> integer().
 update_counter(_Table, _Key, _Params, _Default) ->
+    erlang:nif_error(undefined).
+%%-----------------------------------------------------------------------------
+%% @param   Table a reference to the ets table
+%% @returns true;
+%% @doc Delete an ets table.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec delete(Table :: table()) -> true.
+delete(_Table) ->
     erlang:nif_error(undefined).

--- a/src/libAtomVM/ets.h
+++ b/src/libAtomVM/ets.h
@@ -79,6 +79,7 @@ EtsErrorCode ets_lookup_maybe_gc(term ref, term key, term *ret, Context *ctx);
 EtsErrorCode ets_lookup_element_maybe_gc(term ref, term key, size_t pos, term *ret, Context *ctx);
 EtsErrorCode ets_delete(term ref, term key, term *ret, Context *ctx);
 EtsErrorCode ets_update_counter_maybe_gc(term ref, term key, term value, term pos, term *ret, Context *ctx);
+EtsErrorCode ets_drop_table(term ref, term *ret, Context *ctx);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3314,15 +3314,17 @@ static term nif_ets_lookup_element(Context *ctx, int argc, term argv[])
 
 static term nif_ets_delete(Context *ctx, int argc, term argv[])
 {
-    UNUSED(argc);
-
     term ref = argv[0];
     VALIDATE_VALUE(ref, is_ets_table_id);
-
-    term key = argv[1];
-
     term ret = term_invalid_term();
-    EtsErrorCode result = ets_delete(ref, key, &ret, ctx);
+    EtsErrorCode result;
+    if (argc == 2) {
+        term key = argv[1];
+        result = ets_delete(ref, key, &ret, ctx);
+    } else {
+        result = ets_drop_table(ref, &ret, ctx);
+    }
+
     switch (result) {
         case EtsOk:
             return ret;

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -131,6 +131,7 @@ ets:new/2, &ets_new_nif
 ets:insert/2, &ets_insert_nif
 ets:lookup/2, &ets_lookup_nif
 ets:lookup_element/3, &ets_lookup_element_nif
+ets:delete/1, &ets_delete_nif
 ets:delete/2, &ets_delete_nif
 ets:update_counter/3, &ets_update_counter_nif
 ets:update_counter/4, &ets_update_counter_nif

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -33,6 +33,7 @@ start() ->
     ok = test_lookup_element(),
     ok = test_insert_list(),
     ok = test_update_counter(),
+    ok = test_delete_table(),
     0.
 
 test_basic() ->
@@ -385,4 +386,17 @@ test_update_counter() ->
     0 = ets:update_counter(Tid, patatas, {3, -2, 0, 0}),
     10 = ets:update_counter(Tid, patatas, {3, 10, 10, 0}),
     0 = ets:update_counter(Tid, patatas, {3, 10, 10, 0}),
+    ok.
+
+test_delete_table() ->
+    Tid = ets:new(test_delete_table, []),
+    true = ets:delete(Tid),
+    ok = expect_failure(
+        fun() -> ets:insert(Tid, {gnu, gnat}) end
+    ),
+    Ntid = ets:new(test_delete_table, []),
+    true = ets:delete(Ntid),
+    ok = expect_failure(fun() -> ets:delete(Ntid) end),
+    ok = expect_failure(fun() -> ets:delete(Tid) end),
+    ok = expect_failure(fun() -> ets:delete(non_existent) end),
     ok.


### PR DESCRIPTION
See also #1509

### Changes:

- Added ets:delete/1.
- Extracted helper functions for ets:delete that will be used in future function implementations.
Based on https://github.com/atomvm/AtomVM/pull/1405.

### Use Cases for the Helper Functions:
The new helper functions can be utilized in the following ETS operations to reduce code duplication:
- ets:take/2
- ets:delete_object/2

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
