### PR TITLE
Fix deadlock in socket code

### DIFF
--- a/src/libAtomVM/otp_socket.c
+++ b/src/libAtomVM/otp_socket.c
@@ -1820,9 +1820,7 @@ static ssize_t do_socket_recv(struct SocketResource *rsrc_obj, uint8_t *buf, siz
 
 ssize_t socket_recv(struct SocketResource *rsrc_obj, uint8_t *buf, size_t len, int flags, term *from, Heap *heap)
 {
-    SMP_RWLOCK_RDLOCK(rsrc_obj->socket_lock);
     ssize_t result = do_socket_recv(rsrc_obj, buf, len, flags, from, heap);
-    SMP_RWLOCK_UNLOCK(rsrc_obj->socket_lock);
     return result;
 }
 


### PR DESCRIPTION
Fix a deadlock that was introduced in 555745c8a0cccdb0e1b0fade1993616a3cb16a0c and that happens on platforms without recursive locks (e.g. esp32) by removing an unnessary lock in `socket_recv`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
