### PR TITLE
Allow `subprocess` to use `environ` for environment

### DIFF
--- a/libs/eavmlib/src/atomvm.erl
+++ b/libs/eavmlib/src/atomvm.erl
@@ -347,14 +347,17 @@ get_creation() ->
 %% @param   Path    path to the command to execute
 %% @param   Args    arguments to pass to the command. First item is the name
 %%                  of the command
-%% @param   Envp    environment variables to pass to the command.
+%% @param   Envp    environment variables to pass to the command or `undefined'
+%%                  to use environ (VM environment variables)
 %% @param   Options options to run execve. Should be `[stdout]'
 %% @returns a tuple with the process id and a fd to the stdout of the process.
 %% @doc     Fork and execute a program using fork(2) and execve(2). Pipe stdout
 %%          so output of the program can be read with `atomvm:posix_read/2'.
 %% @end
 %%-----------------------------------------------------------------------------
--spec subprocess(Path :: iodata(), Args :: [iodata()], Env :: [iodata()], Options :: [stdout]) ->
+-spec subprocess(
+    Path :: iodata(), Args :: [iodata()], Env :: [iodata()] | undefined, Options :: [stdout]
+) ->
     {ok, non_neg_integer(), posix_fd()} | {error, posix_error()}.
 subprocess(_Path, _Args, _Env, _Options) ->
     erlang:nif_error(undefined).

--- a/tests/libs/eavmlib/test_file.erl
+++ b/tests/libs/eavmlib/test_file.erl
@@ -322,7 +322,7 @@ test_subprocess(true) ->
     ok.
 
 test_subprocess_echo() ->
-    {ok, _Pid, StdoutFd} = atomvm:subprocess("/bin/echo", ["echo"], [], [stdout]),
+    {ok, _Pid, StdoutFd} = atomvm:subprocess("/bin/echo", ["echo"], undefined, [stdout]),
     {ok, <<"\n">>} = atomvm:posix_read(StdoutFd, 10),
     eof = atomvm:posix_read(StdoutFd, 10),
     ok = atomvm:posix_close(StdoutFd),

--- a/tests/libs/estdlib/test_epmd.erl
+++ b/tests/libs/estdlib/test_epmd.erl
@@ -39,7 +39,9 @@ has_command("BEAM", Command) ->
     R = os:cmd("command -v " ++ Command),
     R =/= [];
 has_command("ATOM", Command) ->
-    {ok, _, Fd} = atomvm:subprocess("/bin/sh", ["sh", "-c", "command -v " ++ Command], [], [stdout]),
+    {ok, _, Fd} = atomvm:subprocess("/bin/sh", ["sh", "-c", "command -v " ++ Command], undefined, [
+        stdout
+    ]),
     Result =
         case atomvm:posix_read(Fd, 200) of
             eof -> false;
@@ -52,7 +54,7 @@ ensure_epmd("BEAM") ->
     _ = os:cmd("epmd -daemon"),
     ok;
 ensure_epmd("ATOM") ->
-    {ok, _, Fd} = atomvm:subprocess("/bin/sh", ["sh", "-c", "epmd -daemon"], [], [stdout]),
+    {ok, _, Fd} = atomvm:subprocess("/bin/sh", ["sh", "-c", "epmd -daemon"], undefined, [stdout]),
     ok = atomvm:posix_close(Fd),
     ok.
 


### PR DESCRIPTION
Typically allow subprocess to use `$PATH` to find binaries

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
