### PR TITLE
Add support for ports to Elixir.Kernel.inspect

### DIFF
--- a/libs/exavmlib/lib/Kernel.ex
+++ b/libs/exavmlib/lib/Kernel.ex
@@ -60,6 +60,10 @@ defmodule Kernel do
         :erlang.pid_to_list(t)
         |> :erlang.list_to_binary()
 
+      t when is_port(t) ->
+        :erlang.port_to_list(t)
+        |> :erlang.list_to_binary()
+
       t when is_function(t) ->
         :erlang.fun_to_list(t)
         |> :erlang.list_to_binary()


### PR DESCRIPTION
Adds support for inspecting ports in Elixir, allows for `IO.puts("#{inspect(port)}")`, etc...

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
