### PR TITLE
Fix the formatting of local ports

### DIFF
--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -205,7 +205,7 @@ int term_funprint(PrinterFun *fun, term t, const GlobalContext *global)
     } else if (term_is_local_port(t)) {
         // Update also PORT_AS_CSTRING_LEN when changing this format string
         int32_t process_id = term_to_local_process_id(t);
-        return fun->print(fun, "#Port<0.%" PRIu32 ".0>", process_id);
+        return fun->print(fun, "#Port<0.%" PRIu32 ">", process_id);
 
     } else if (term_is_external_port(t)) {
         // Update also PORT_AS_CSTRING_LEN when changing this format string

--- a/tests/erlang_tests/test_binary_to_term.erl
+++ b/tests/erlang_tests/test_binary_to_term.erl
@@ -628,11 +628,11 @@ test_encode_port() ->
     ExpectedSize = byte_size(Bin),
     case SupportsV4PortEncoding of
         true ->
-            true = is_port(
-                binary_to_term(
-                    <<131, 120, 119, 13, "nonode@nohost", 1:64, 0:32>>
-                )
+            LocalPort1 = binary_to_term(
+                <<131, 120, 119, 13, "nonode@nohost", 1:64, 0:32>>
             ),
+            true = is_port(LocalPort1),
+            "#Port<0.1>" = port_to_list(LocalPort1),
             Port1 = binary_to_term(<<131, 120, 119, 4, "true", 43:64, 0:32>>),
             Port2 = binary_to_term(<<131, 120, 119, 4, "true", 43:64, 1:32>>),
             false = Port1 =:= Port2,


### PR DESCRIPTION
Corrects the format of ports to match the OTP spec (and size that was already defined correctly).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
