### PR TITLE
Make build-and-test-on-freebsd fail if steps do not complete successfully

### DIFF
--- a/.github/workflows/build-and-test-on-freebsd.yaml
+++ b/.github/workflows/build-and-test-on-freebsd.yaml
@@ -54,10 +54,10 @@ jobs:
         copyback: false
 
         prepare: |
-          pkg install -y curl cmake gperf erlang elixir mbedtls
+          pkg install -y curl cmake gperf erlang elixir rebar3 mbedtls
 
         run: |
-
+          set -e
           echo "%%"
           echo "%% System Info"
           echo "%%"

--- a/.github/workflows/build-and-test-on-freebsd.yaml
+++ b/.github/workflows/build-and-test-on-freebsd.yaml
@@ -34,10 +34,17 @@ concurrency:
 
 jobs:
   build-and-test-on-freebsd:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Build and test AtomVM on FreeBSD
     env:
       ATOMVM_EXAMPLE: "atomvm-example"
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os_release: ["13.4", "14.2"]
+
     steps:
 
     - uses: actions/checkout@v4
@@ -47,7 +54,7 @@ jobs:
       uses: vmactions/freebsd-vm@v1
       timeout-minutes: 20
       with:
-        release: 13.2
+        release: ${{ matrix.os_release }}
         envs: 'ATOMVM_EXAMPLE'
         usesh: true
         sync: rsync


### PR DESCRIPTION
Updates the Ubuntu host to 24.04, and changes to as matrix build with the current stable (14.2) and latest legacy release update (13.4) versions of FreeBSD.

This workflow is a different from most in that the entire build and test is done in a single script in a FreeBSB container on an Ubuntu host. Because it is one large shell script with no separate "jobs" exits needed to be added to ensure the test fails if any important steps fail to complete successfully.

Adds missing rebar3 installation required to complete the tests build.

Closes #1435

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
