### PR TITLE
Fix network.erl race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ certain VM instructions are used.
 shallow comparison was performed, so it was working just for plain values such as atoms and small
 integers
 - Fixed support for setting esp32 boot_path in NVS.
+- Fixed race conditions in network:start/stop.
+- Fixed crash calling network:sta_rssi(), when network not up.
 
 ## [0.6.5] - 2024-10-15
 

--- a/libs/eavmlib/src/network.erl
+++ b/libs/eavmlib/src/network.erl
@@ -295,13 +295,17 @@ stop() ->
 %%-----------------------------------------------------------------------------
 -spec sta_rssi() -> {ok, Rssi :: db()} | {error, Reason :: term()}.
 sta_rssi() ->
-    Port = get_port(),
-    Ref = make_ref(),
-    Port ! {self(), Ref, rssi},
-    receive
-        {Ref, {error, Reason}} -> {error, Reason};
-        {Ref, {rssi, Rssi}} -> {ok, Rssi};
-        Other -> {error, Other}
+    case whereis(network_port) of
+        undefined ->
+            {error, network_down};
+        Port ->
+            Ref = make_ref(),
+            Port ! {self(), Ref, rssi},
+            receive
+                {Ref, {error, Reason}} -> {error, Reason};
+                {Ref, {rssi, Rssi}} -> {ok, Rssi};
+                Other -> {error, Other}
+            end
     end.
 
 %%

--- a/src/platforms/esp32/test/main/test_erl_sources/test_wifi_example.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_wifi_example.erl
@@ -25,6 +25,8 @@
 start() ->
     case verify_platform(atomvm:platform()) of
         ok ->
+            % test that sta_rssi() can be safely called, when network is not started
+            {error, network_down} = network:sta_rssi(),
             ok = start_network(),
             ok = network:stop(),
             start_network(),
@@ -59,7 +61,11 @@ start_network() ->
     ],
     case network:start(Config) of
         {ok, _Pid} ->
-            io:format("Network started.~n");
+            % test that sta_rssi() can be safely called
+            % when network is just started, but may not yet be connected.
+            network:sta_rssi(),
+            io:format("Network started.~n"),
+            ok;
         Error ->
             Error
     end.


### PR DESCRIPTION
As evidenced by failing simtest CI on release-0.6 etc.

1. startup should use continue/handle_continue and avoid races + cleaner DRY code.

2. network:stop was using nonblocking call to stop network_port- so rapid stop/start would give the last network:start an old whereis(network_port) that was still shutting down, and lead to errors.

3. somewhat unrelated: sta_rssi was using get_port(), and would crash on no network started - guarded it erlang side, added test.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
