### PR TITLE
Skip test_dir test if `atomvm:posix_opendir/1` is not available

### DIFF
--- a/libs/etest/src/etest.erl
+++ b/libs/etest/src/etest.erl
@@ -188,11 +188,16 @@ do_run_test(Test) ->
             false ->
                 ok
         end,
+        Char =
+            case Result of
+                ok -> "+";
+                skipped -> "s"
+            end,
         case erlang:system_info(machine) of
             "BEAM" ->
-                io:format("+");
+                io:format(Char);
             _ ->
-                console:puts("+"),
+                console:puts(Char),
                 console:flush()
         end,
         Result
@@ -212,6 +217,8 @@ do_run_test(Test) ->
 check_results([]) ->
     ok;
 check_results([{_Test, ok} | T]) ->
+    check_results(T);
+check_results([{_Test, skipped} | T]) ->
     check_results(T);
 check_results([Failure | _T]) ->
     {fail, Failure}.

--- a/tests/libs/eavmlib/test_dir.erl
+++ b/tests/libs/eavmlib/test_dir.erl
@@ -25,9 +25,13 @@
 -include("etest.hrl").
 
 test() ->
-    {ok, Dir} = atomvm:posix_opendir("."),
-    [eof | _Entries] = all_dir_entries(Dir, []),
-    ok = atomvm:posix_closedir(Dir).
+    case catch (atomvm:posix_opendir(".")) of
+        {ok, Dir} ->
+            [eof | _Entries] = all_dir_entries(Dir, []),
+            ok = atomvm:posix_closedir(Dir);
+        {'EXIT', _} ->
+            skipped
+    end.
 
 all_dir_entries(Dir, Acc) ->
     case atomvm:posix_readdir(Dir) of


### PR DESCRIPTION
Could happen with CI for s390x

https://github.com/atomvm/AtomVM/actions/runs/12923981002/job/36043219011?pr=1486#step:7:755

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
