### PR TITLE
Add support to OTP-28 (master branch)

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -226,15 +226,12 @@ jobs:
           elixir_version: "1.14"
           rebar3_version: "3.23.0"
 
-# TODO: enable master again
-# master will not work until we don't adapt to atom table changes
-#        # master/main version of OTP/Elixir
-#        - os: "ubuntu-24.04"
-#          cc: "cc"
-#          cxx: "c++"
-#          otp: "master"
-#          elixir_version: "main"
-#          rebar3_version: "3.24.0"
+        - os: "ubuntu-24.04"
+          cc: "cc"
+          cxx: "c++"
+          otp: "master"
+          elixir_version: "main"
+          rebar3_version: "3.24.0"
 
         # Additional default compiler builds
         - os: "ubuntu-20.04"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `socket:getopt/2`
 - Added `supervisor:terminate_child/2`, `supervisor:restart_child/2` and `supervisor:delete_child/2`
 - Added `esp:partition_read/3`, and documentation for `esp:partition_erase_range/2/3` and `esp:partition_write/3`
+- Support to OTP-28
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/doc/release-notes.md.in
+++ b/doc/release-notes.md.in
@@ -33,6 +33,7 @@ AtomVM will run BEAM files that have been compiled using the following Erlang an
 | ✅ OTP 24 | ✅ 1.14 |
 | ✅ OTP 25 | ✅ 1.14 |
 | ✅ OTP 26 | ✅ 1.15 |
+| ✅ OTP 28 | ✅ 1.17 |
 
 ```{note}
 Versions of Elixir that are compatible with a particular OTP version may work.  This table reflects the versions that are tested.

--- a/src/libAtomVM/atom_table.h
+++ b/src/libAtomVM/atom_table.h
@@ -31,8 +31,15 @@ extern "C" {
 
 #define ATOM_TABLE_NOT_FOUND -1
 #define ATOM_TABLE_ALLOC_FAIL -2
+#define ATOM_TABLE_INVALID_LEN -3
 
 struct AtomTable;
+
+enum EnsureAtomsOpt
+{
+    EnsureAtomsNoOpts = 0,
+    EnsureLongEncoding = 1
+};
 
 enum AtomTableCopyOpt
 {
@@ -56,8 +63,8 @@ AtomString atom_table_get_atom_string(struct AtomTable *table, long index);
 
 long atom_table_get_index(struct AtomTable *table, AtomString string);
 
-int atom_table_ensure_atoms(
-    struct AtomTable *table, const void *atoms, int count, int *translate_table);
+int atom_table_ensure_atoms(struct AtomTable *table, const void *atoms, int count,
+    int *translate_table, enum EnsureAtomsOpt opts);
 
 int atom_table_cmp_using_atom_index(
     struct AtomTable *table, int t_atom_index, int other_atom_index);

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -112,6 +112,14 @@ term bif_erlang_max_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 
 term bif_erlang_size_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 
+term bif_erlang_list_to_atom_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+term bif_erlang_list_to_existing_atom_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+term bif_erlang_binary_to_atom_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+term bif_erlang_binary_to_existing_atom_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
+
+// helpers:
+term binary_to_atom(Context *ctx, term a_binary, term encoding, bool create_new, term *error_reason);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -92,3 +92,7 @@ erlang:map_get/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_
 erlang:min/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_min_2}
 erlang:max/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_max_2}
 erlang:size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_size_1}
+erlang:list_to_atom/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_list_to_atom_1}
+erlang:list_to_existing_atom/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_list_to_existing_atom_1}
+erlang:binary_to_atom/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_binary_to_atom_2}
+erlang:binary_to_existing_atom/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_binary_to_existing_atom_2}

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -144,7 +144,8 @@ typedef struct Module Module;
 enum ModuleLoadResult
 {
     MODULE_LOAD_OK = 0,
-    MODULE_ERROR_FAILED_ALLOCATION = 1
+    MODULE_ERROR_FAILED_ALLOCATION = 1,
+    MODULE_ERROR_INVALID = 2
 };
 
 #ifdef ENABLE_ADVANCED_TRACE

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -43,14 +43,12 @@ calendar:system_time_to_universal_time/2, &system_time_to_universal_time_nif
 erlang:atom_to_binary/1, &atom_to_binary_nif
 erlang:atom_to_binary/2, &atom_to_binary_nif
 erlang:atom_to_list/1, &atom_to_list_nif
-erlang:binary_to_atom/1, &binary_to_atom_nif
-erlang:binary_to_atom/2, &binary_to_atom_nif
+erlang:binary_to_atom/1, &binary_to_atom_1_nif
 erlang:binary_to_float/1, &binary_to_float_nif
 erlang:binary_to_integer/1, &binary_to_integer_nif
 erlang:binary_to_integer/2, &binary_to_integer_nif
 erlang:binary_to_list/1, &binary_to_list_nif
-erlang:binary_to_existing_atom/1, &binary_to_existing_atom_nif
-erlang:binary_to_existing_atom/2, &binary_to_existing_atom_nif
+erlang:binary_to_existing_atom/1, &binary_to_existing_atom_1_nif
 erlang:delete_element/2, &delete_element_nif
 erlang:erase/1, &erase_nif
 erlang:error/1, &error_nif
@@ -65,8 +63,6 @@ erlang:float_to_list/1, &float_to_list_nif
 erlang:float_to_list/2, &float_to_list_nif
 erlang:fun_info/2, &fun_info_nif
 erlang:insert_element/3, &insert_element_nif
-erlang:list_to_atom/1, &list_to_atom_nif
-erlang:list_to_existing_atom/1, &list_to_existing_atom_nif
 erlang:integer_to_binary/1, &integer_to_binary_nif
 erlang:integer_to_binary/2, &integer_to_binary_nif
 erlang:integer_to_list/1, &integer_to_list_nif

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -2010,6 +2010,31 @@ schedule_in:
 
                             break;
                         }
+                        case GCBIFFunctionType: {
+                            // Support compilers < OTP28 that generate CALL_EXT
+                            // for binary_to_(existing_)atom/1,2 and list_to_(existing_)atom/1
+                            // functions.
+                            // Regular CALL_EXTs to those functions are generated as well
+                            // even on OTP28, so it is required to allow calling them using
+                            // CALL_EXT even on OTP28: BIFs are used for try ... catch.
+                            const struct GCBif *gcbif = EXPORTED_FUNCTION_TO_GCBIF(func);
+                            term return_value;
+                            switch (arity) {
+                                case 1:
+                                    return_value = gcbif->gcbif1_ptr(ctx, 0, 0, x_regs[0]);
+                                    break;
+                                case 2:
+                                    return_value = gcbif->gcbif2_ptr(ctx, 0, 0, x_regs[0], x_regs[1]);
+                                    break;
+                                default:
+                                    fprintf(stderr, "Invalid arity %" PRIu32 " for bif\n", arity);
+                                    AVM_ABORT();
+                            }
+                            PROCESS_MAYBE_TRAP_RETURN_VALUE_RESTORE_PC(return_value, orig_pc);
+                            x_regs[0] = return_value;
+
+                            break;
+                        }
                         default: {
                             fprintf(stderr, "Invalid function type %i at index: %" PRIu32 "\n", func->type, index);
                             AVM_ABORT();
@@ -2104,6 +2129,36 @@ schedule_in:
                                     break;
                                 case 2:
                                     return_value = bif->bif2_ptr(ctx, 0, x_regs[0], x_regs[1]);
+                                    break;
+                                default:
+                                    fprintf(stderr, "Invalid arity %" PRIu32 " for bif\n", arity);
+                                    AVM_ABORT();
+                            }
+                            PROCESS_MAYBE_TRAP_RETURN_VALUE_LAST(return_value);
+                            x_regs[0] = return_value;
+
+                            DO_RETURN();
+
+                            break;
+                        }
+                        case GCBIFFunctionType: {
+                            // Support compilers < OTP28 that generate CALL_EXT_LAST
+                            // for binary_to_(existing_)atom/1,2 and list_to_(existing_)atom/1
+                            // functions.
+                            // Regular CALL_EXT_LASTs to those functions are generated as well
+                            // even on OTP28, so it is required to allow calling them using
+                            // CALL_EXT_LAST even on OTP28: BIFs are used for try ... catch.
+                            ctx->cp = ctx->e[n_words];
+                            ctx->e += (n_words + 1);
+
+                            const struct GCBif *gcbif = EXPORTED_FUNCTION_TO_GCBIF(func);
+                            term return_value;
+                            switch (arity) {
+                                case 1:
+                                    return_value = gcbif->gcbif1_ptr(ctx, 0, 0, x_regs[0]);
+                                    break;
+                                case 2:
+                                    return_value = gcbif->gcbif2_ptr(ctx, 0, 0, x_regs[0], x_regs[1]);
                                     break;
                                 default:
                                     fprintf(stderr, "Invalid arity %" PRIu32 " for bif\n", arity);
@@ -3559,6 +3614,33 @@ wait_timeout_trap_handler:
                                     break;
                                 case 2:
                                     return_value = bif->bif2_ptr(ctx, 0, x_regs[0], x_regs[1]);
+                                    break;
+                                default:
+                                    fprintf(stderr, "Invalid arity %" PRIu32 " for bif\n", arity);
+                                    AVM_ABORT();
+                            }
+                            PROCESS_MAYBE_TRAP_RETURN_VALUE_LAST(return_value);
+                            x_regs[0] = return_value;
+
+                            DO_RETURN();
+
+                            break;
+                        }
+                        case GCBIFFunctionType: {
+                            // Support compilers < OTP28 that generate CALL_EXT_ONLY
+                            // for binary_to_(existing_)atom/1,2 and list_to_(existing_)atom/1
+                            // functions.
+                            // Regular CALL_EXT_ONLYs to those functions are generated as well
+                            // even on OTP28, so it is required to allow calling them using
+                            // CALL_EXT_ONLY even on OTP28: BIFs are used for try ... catch.
+                            const struct GCBif *gcbif = EXPORTED_FUNCTION_TO_GCBIF(func);
+                            term return_value;
+                            switch (arity) {
+                                case 1:
+                                    return_value = gcbif->gcbif1_ptr(ctx, 0, 0, x_regs[0]);
+                                    break;
+                                case 2:
+                                    return_value = gcbif->gcbif2_ptr(ctx, 0, 0, x_regs[0], x_regs[1]);
                                     break;
                                 default:
                                     fprintf(stderr, "Invalid arity %" PRIu32 " for bif\n", arity);


### PR DESCRIPTION
Enable again tests against OTP from master branch.

In order to support what will be released as OTP-28 some changes have been required:
- New encoding for atoms
- Uncompressed literals
- to_atom NIFs (`binary_to_atom`, etc...) are now BIFs when used in guards (hence support for GCBIFs in CALL_EXT related opcodes has been introduced for OTP < 28 support and when this optimization is not applied) 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
