### PR TITLE
CI: update QEMU used for build-and-test-other

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -128,7 +128,7 @@ jobs:
         path: build_tests
 
     - name: Set up QEMU
-      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      uses: docker/setup-qemu-action@v3
 
     - name: "Build and Test: AtomVM on foreign arch"
       timeout-minutes: 15


### PR DESCRIPTION
After a number of failures update QEMU to the latest version.

Compiler was segfaulting with s390 and arm64v8 builds, even after a debian image update, so it is likely a problem with user space emulation.

Replace `multiarch/qemu-user-static` with `docker/setup-qemu-action@v3`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
