### PR TITLE
Fix early close of socket in http_server

### DIFF
--- a/libs/eavmlib/src/http_server.erl
+++ b/libs/eavmlib/src/http_server.erl
@@ -77,7 +77,10 @@ reply(StatusCode, ReplyBody, Conn) ->
         StatusCode, ReplyBody, [<<"Content-Type: text/html\r\nConnection: close\r\n">>], Conn
     ),
     Socket = proplists:get_value(socket, NewConn),
-    gen_tcp:close(Socket),
+    spawn_link(fun() ->
+        timer:sleep(5000),
+        gen_tcp:close(Socket)
+    end),
     ClosedConn =
         case proplists:get_value(closed, NewConn) of
             undefined -> [{closed, true} | NewConn];


### PR DESCRIPTION
The socket can close too fast for some clients, as exhibited on FreeBSD in recent failing CI tests: https://github.com/atomvm/AtomVM/actions/runs/12977426531/job/36190827478#step:3:5747 Fixed by adding a 5000 ms delay before closing the socket.

Closes #1500

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
