### PR TITLE
Fix boot_path path loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ certain VM instructions are used.
 - Fix bug in opcode implementation (`select_val`): when selecting a value among many others a
 shallow comparison was performed, so it was working just for plain values such as atoms and small
 integers
+- Fixed support for setting esp32 boot_path in NVS.
 
 ## [0.6.5] - 2024-10-15
 

--- a/libs/esp32boot/esp32init.erl
+++ b/libs/esp32boot/esp32init.erl
@@ -85,7 +85,7 @@ get_boot_path() ->
         undefined ->
             "/dev/partition/by-name/main.avm";
         Path ->
-            Path
+            binary_to_list(Path)
     end.
 
 get_start_module() ->


### PR DESCRIPTION
the boot path is a charlist eg erlang "". https://github.com/atomvm/AtomVM/blob/ed48c7c99150e1d708183be6537e1c20c5263492/libs/esp32boot/esp32init.erl#L86

But storing it in nvs with nvs_put_binary, means it's stored as a binary.

minimal fix.

eg this code now works:

```elixir
  def start do
    case :esp.nvs_get_binary(:atomvm, :boot_path) do
      :undefined ->
        :esp.nvs_put_binary(:atomvm, :boot_path, "/dev/partition/by-name/main.avm")
        :timer.sleep(500)
        :esp.restart()

      "/dev/partition/by-name/main.avm" ->
        IO.inspect("boot_path already set")

      other ->
        IO.inspect("boot_path: #{other}")
    end
 end
```

would crash before with badarg, on the second boot with boot_path set.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
