### PR TITLE
Add esp:partition_read/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `net:gethostname/0` on platforms with gethostname(3).
 - Added `socket:getopt/2`
 - Added `supervisor:terminate_child/2`, `supervisor:restart_child/2` and `supervisor:delete_child/2`
+- Added `esp:partition_read/3`, and documentation for `esp:partition_erase_range/2/3` and `esp:partition_write/3`
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/libs/eavmlib/src/esp.erl
+++ b/libs/eavmlib/src/esp.erl
@@ -47,7 +47,10 @@
     nvs_erase_key/1, nvs_erase_key/2,
     nvs_erase_all/0, nvs_erase_all/1,
     nvs_reformat/0,
+    partition_erase_range/2, partition_erase_range/3,
     partition_list/0,
+    partition_read/3,
+    partition_write/3,
     rtc_slow_get_binary/0,
     rtc_slow_set_binary/1,
     freq_hz/0,
@@ -470,6 +473,42 @@ nvs_reformat() ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
+%% @param   partition_id The id of the partition to erase eg. "main.avm"
+%% @param   offset Starting offset in bytes where to begin erasing
+%% @returns ok on success, error on failure
+%% @doc     Erases a range in the specified partition. The range starts at the given
+%%          offset and continues to the end of the partition. This is equivalent to
+%%          calling partition_erase_range/3 with size set to the remaining partition
+%%          size from the offset.
+%%
+%%          Note: Erasing sets all bits in the erased range to 1s. This operation
+%%          is irreversible.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec partition_erase_range(Partition_id :: binary(), Offset :: non_neg_integer()) -> ok | error.
+partition_erase_range(Partition_id, Offset) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   partition_id The id of the partition to erase eg. "main.avm"
+%% @param   offset Starting offset in bytes where to begin erasing
+%% @param   size Number of bytes to erase
+%% @returns ok on success, error on failure
+%% @doc     Erases a range of the specified size in the partition, starting at the
+%%          given offset. The size must not exceed the partition's boundaries.
+%%
+%%          Note: Erasing sets all bits in the erased range to 1s. This operation
+%%          is irreversible. Make sure the offset and size parameters are valid for
+%%          the target partition to avoid errors.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec partition_erase_range(
+    Partition_id :: binary(), Offset :: non_neg_integer(), Size :: pos_integer()
+) -> ok | error.
+partition_erase_range(Partition_id, Offset, Size) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
 %% @returns List of partitions
 %% @doc     Gets the list of partitions as tuples, such as {name, type, subtype,
 %%          offset, size, props}. Type and subtype are integers as described in
@@ -478,6 +517,40 @@ nvs_reformat() ->
 %%-----------------------------------------------------------------------------
 -spec partition_list() -> [esp_partition()].
 partition_list() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   partition_id The id of the partition to read from eg. "main.avm"
+%% @param   offset Starting offset in bytes where to begin reading
+%% @param   read_size Number of bytes to read
+%% @returns {ok, data} on success, error on failure
+%% @doc     Read binary data from a specific partition at the given offset.
+%%
+%% @end
+%%-----------------------------------------------------------------------------
+-spec partition_read(
+    Partition_id :: binary(), Offset :: non_neg_integer(), Read_size :: non_neg_integer()
+) -> {ok, binary()} | error.
+partition_read(Partition_id, Offset, Read_size) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   partition_id The id of the partition to write to eg. "main.avm"
+%% @param   offset Starting offset in bytes where to begin writing
+%% @param   data Binary data to write to the partition
+%% @returns ok on success, error on failure
+%% @doc     Writes binary data to a specific partition at the given offset.
+%%
+%%          This function allows writing data to ESP32 flash partitions. Care must be
+%%          taken when using this function as improper writes can corrupt the partition
+%%          table or system firmware. Make sure the offset and data size do not exceed
+%%          the partition's boundaries.
+%%
+%% @end
+%%-----------------------------------------------------------------------------
+-spec partition_write(Partition_id :: binary(), Offset :: non_neg_integer(), Data :: binary()) ->
+    ok | error.
+partition_write(Partition_id, Offset, Data) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------


### PR DESCRIPTION
Primitive allowing for say copying one partition to another. Useful for developing OTA - A/B booting.

See example, that will successfully copy main.avm to second "b" partition and boot of that. (requires https://github.com/atomvm/AtomVM/pull/1502)

```elixir
    case :esp.nvs_get_binary(:atomvm, :boot_path) do
      :undefined ->
        :esp.nvs_put_binary(:atomvm, :boot_path, "/dev/partition/by-name/main.avm")
        :timer.sleep(500)
        :esp.restart()

      "/dev/partition/by-name/main.avm" ->
        chunk_size = 65536
        size = 884_736
        copy_result = copy_partition(0, size, chunk_size)
        :esp.nvs_put_binary(:atomvm, :boot_path, "/dev/partition/by-name/mainb.avm")
        IO.inspect("boot_path already set, booting to mainb.avm")
        :esp.restart()

      other ->
        IO.inspect("boot_path: #{other}")
    end
```

given this partition map:
```
# Name,   Type, SubType, Offset,  Size, Flags
# Note: if you change the phy_init or app partition offset, make sure to change the offset in Kconfig.projbuild
nvs,      data, nvs,       0x9000,     0x6000,
phy_init, data, phy,       0xf000,     0x1000,
factory,  app,  factory,  0x10000,   0x1C0000,
boot.avm,  data, phy,     0x1D0000,    0x80000,
main.avm, data, phy,     0x250000,   0x0D8000,
mainb.avm, data, phy,     0x328000,   0x0D8000

```

and this (example needs refactoring obviously)

 ```elixir
 defp copy_partition(offset, total_size, chunk_size) when offset < total_size do
    # Calculate remaining bytes
    bytes_left = total_size - offset
    # Use smaller of chunk_size or bytes_left
    read_size = min(chunk_size, bytes_left)

    case :esp.partition_read('main.avm', offset, read_size) do
      {:ok, data} ->
        case :esp.partition_write('mainb.avm', offset, data) do
          :ok ->
            copy_partition(offset + read_size, total_size, chunk_size)

          error ->
            {:error, :write_failed, error, offset}
        end

      error ->
        {:error, :read_failed, error, offset}
    end
  end

  defp copy_partition(offset, total_size, _chunk_size) do
    {:ok, :copy_complete, offset, total_size}
  end
```
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
