### PR TITLE
Update ESP32 Elixir support build instruction and partion documentation

### DIFF
--- a/doc/src/atomvm-tooling.md
+++ b/doc/src/atomvm-tooling.md
@@ -347,11 +347,6 @@ For instructions about how to install AtomVM on the `generic_unix` platform, see
 
 The [`ExAtomVM`](https://github.com/atomvm/ExAtomVM) plugin supports flash targets for various device types.  These targets are described in more detail below.
 
-```{attention}
-Currently, the [`ExAtomVM`](https://github.com/atomvm/ExAtomVM) tool only supports flash targets for the ESP32 and
-STM32 platforms.
-```
-
 #### ESP32 flash task
 
 To flash AtomVM packbeam file to an ESP32 device, use the `mix.esp32.flash` target.  Users will typically specify the device port and baud rate as command-line options to this target.
@@ -401,7 +396,7 @@ You can now use a serial console program such as [minicom](https://en.wikipedia.
     I (922) AtomVM: Starting esp32init.beam...
     ---
     AtomVM init.
-    I (932) sys: Loaded BEAM partition main.avm at address 0x210000 (size=1048576 bytes)
+    I (932) sys: Loaded BEAM partition main.avm at address 0x250000 (size=1048576 bytes)
     Starting application...
     Hello World
     AtomVM finished with return value: ok

--- a/doc/src/getting-started-guide.md
+++ b/doc/src/getting-started-guide.md
@@ -56,7 +56,7 @@ AtomVM developers will typically write their applications in Erlang or Elixir.  
 The following diagram provides a simplified overview of the layout of the AtomVM virtual machine and Erlang/Elixir applications on the ESP32 flash module.
 
     |               |
-    +---------------+  ----------- 0x1000
+    +---------------+  ----------- 0x0 | 0x1000 | 0x2000 (varies by esp32 flavor)
     | boot loader   |           ^
     +---------------+           |
     | partition map |           | AtomVM
@@ -66,8 +66,8 @@ The following diagram provides a simplified overview of the layout of the AtomVM
     |   Virtual     |           |
     |   Machine     |           |
     |               |           v
-    +---------------+  ----------- 0x210000
-    |               |           ^
+    +---------------+  ----------- 0x210000 for thin images or
+    |               |           ^  0x250000 for images with Elixir modules
     |               |           |
     |     data      |           | Erlang/Elixir
     |   partition   |           | Application
@@ -173,9 +173,7 @@ The chart below lists the bootloader offset for the various ESP32 family of chip
 | ESP32-C3 | `0x0` |
 | ESP32-C6 | `0x0` |
 | ESP32-H2 | `0x0` |
-<!-- TODO: Pending chip release and support
 | ESP32-P4 | `0x2000` |
--->
 
 Once completed, your ESP32 device is ready to run Erlang or Elixir programs targeted for AtomVM.
 
@@ -187,7 +185,7 @@ Instructions for building AtomVM from source are covered in the AtomVM [Build In
 
 ### Deploying an AtomVM application for ESP32
 
-An AtomVM application is a collection of BEAM files, which have been compiled using the Erlang or Elixir compiler.  These BEAM files are assembled into an AtomVM "packbeam" (`.avm`) file, which in turn is flashed to the `main` data partition on the ESP32 flash module, starting at address `0x210000`.
+An AtomVM application is a collection of BEAM files, which have been compiled using the Erlang or Elixir compiler.  These BEAM files are assembled into an AtomVM "packbeam" (`.avm`) file, which in turn is flashed to the `main` data partition on the ESP32 flash module, starting at address `0x210000` if you are using a thin image, or `0x250000` for images with Elixir support.
 
 When the AtomVM virtual machine starts, it will search for the first module that contains an exported `start/0` function in this partition, and it will begin execution of the BEAM bytecode at that function.
 


### PR DESCRIPTION
Updates build instructions for Elixir images on the ESP32 platform.

Updates documentation about partitions on ESP32 to reflect the new offsets used on Elixir enabled images as well as update old references to `lib.avm` to the new `boot.avm` partition name, and updates bootloader offset references with newer esp32 chips.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
