### PR TITLE
Docs - eavmlib ex_doc: add needed include, ex_doc

### DIFF
--- a/libs/eavmlib/rebar.config
+++ b/libs/eavmlib/rebar.config
@@ -18,10 +18,18 @@
 % SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 %
 
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info, {i, "../include"}]}.
 {deps, []}.
-{plugins, [rebar3_hex]}.
+{plugins, [rebar3_hex, rebar3_ex_doc]}.
 
 {shell, [
     {apps, [eavmlib]}
+]}.
+{ex_doc, [
+    {version, "0.1.0"},
+    {source_url, "https://github.com/atomvm/AtomVM"},
+    {extras, []},
+    {main, "atomvm"},
+    {output, "doc"},
+    {api_reference, true}
 ]}.


### PR DESCRIPTION
Enables `rebar3 ex_doc` to succeed for eavmlib.

For version it seems to be manual replace in rebar.config eg:

`sed -i "" "s/{version, .*}/{version, \"0.6.5\"}/" rebar.config && rebar3 ex_doc`

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
