### PR TITLE
Fix Erlang and Elixir archive CMakeModules

### DIFF
--- a/CMakeModules/BuildElixir.cmake
+++ b/CMakeModules/BuildElixir.cmake
@@ -46,7 +46,7 @@ macro(pack_archive avm_name)
     add_custom_target(
         ${avm_name} ALL
         DEPENDS ${avm_name}_beams PackBEAM
-        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM -a ${INCLUDE_LINES} ${avm_name}.avm ${BEAMS}
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${INCLUDE_LINES} -a ${avm_name}.avm ${BEAMS}
         COMMENT "Packing archive ${avm_name}.avm"
         VERBATIM
     )
@@ -87,7 +87,7 @@ macro(pack_runnable avm_name main)
 
     add_custom_target(
         ${avm_name} ALL
-        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${INCLUDE_LINES} ${avm_name}.avm Elixir.${main}.beam ${ARCHIVES}
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${INCLUDE_LINES} -a ${avm_name}.avm Elixir.${main}.beam ${ARCHIVES}
         COMMENT "Packing runnable ${avm_name}.avm"
         VERBATIM
     )

--- a/CMakeModules/BuildErlang.cmake
+++ b/CMakeModules/BuildErlang.cmake
@@ -46,7 +46,7 @@ macro(pack_archive avm_name)
         ${avm_name} ALL
         DEPENDS ${avm_name}_beams PackBEAM
         #DEPENDS ${pack_archive_${avm_name}_beams}
-        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM -a ${INCLUDE_LINES} ${avm_name}.avm ${pack_archive_${avm_name}_beams}
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${INCLUDE_LINES} -a ${avm_name}.avm ${pack_archive_${avm_name}_beams}
         COMMENT "Packing archive ${avm_name}.avm"
         VERBATIM
     )
@@ -74,7 +74,7 @@ macro(pack_lib avm_name)
 
     add_custom_target(
         ${avm_name} ALL
-        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM -a ${INCLUDE_LINES} ${avm_name}.avm ${pack_lib_${avm_name}_archives}
+        COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${INCLUDE_LINES} -a ${avm_name}.avm ${pack_lib_${avm_name}_archives}
         COMMENT "Packing runnable ${avm_name}.avm"
         VERBATIM
     )


### PR DESCRIPTION
There were typos in both CMakeModules BuildErlang.cmake and BuildElixir.cmake that possibly lead to input modules not being found, especially when stacktrace lines are included.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
