### PR TITLE
Fix: reduce lock on registered_name process_info/2

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -554,10 +554,9 @@ int globalcontext_get_registered_process(GlobalContext *glb, int atom_index)
 
 term globalcontext_get_registered_name_process(GlobalContext *glb, int local_process_id)
 {
-    struct ListHead *registered_processes_list = synclist_wrlock(&glb->registered_processes);
+    struct ListHead *registered_processes_list = synclist_rdlock(&glb->registered_processes);
     struct ListHead *item;
-    struct ListHead *tmp;
-    MUTABLE_LIST_FOR_EACH (item, tmp, registered_processes_list) {
+    LIST_FOR_EACH (item, registered_processes_list) {
         struct RegisteredProcess *registered_process = GET_LIST_ENTRY(item, struct RegisteredProcess, registered_processes_list_head);
         if (registered_process->local_process_id == local_process_id) {
             int result = registered_process->atom_index;


### PR DESCRIPTION
Turns out there was an unnecessary write lock, which can be reduced to a rdlock.

As surfaced here https://github.com/atomvm/AtomVM/pull/1401#discussion_r1942893254 by @jakub-gonet - and confirmed by @pguyot 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
