### PR TITLE
Add support for UDP Multicast to lwIP-based sockets (Pico-W)

### DIFF
--- a/src/platforms/rp2/src/lib/lwipopts.h
+++ b/src/platforms/rp2/src/lib/lwipopts.h
@@ -60,6 +60,7 @@
 #define LWIP_TCP 1
 #define LWIP_UDP 1
 #define LWIP_DNS 1
+#define LWIP_IGMP 1
 #define LWIP_TCP_KEEPALIVE 1
 #define LWIP_NETIF_TX_SINGLE_PBUF 1
 #define DHCP_DOES_ARP_CHECK 0


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
