### PR TITLE
Add float/1 BIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `ets:update_counter/3` and `ets:update_counter/4`.
 - Added `erlang:+/1`
 - Added `lists:append/1` and `lists:append/2`
+- Support for `float/1` BIF.
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -1201,6 +1201,27 @@ term bif_erlang_trunc_1(Context *ctx, uint32_t fail_label, int live, term arg1)
     }
 }
 
+term bif_erlang_float_1(Context *ctx, uint32_t fail_label, int live, term arg1)
+{
+    if (term_is_float(arg1)) {
+        return arg1;
+    }
+
+    if (!term_is_any_integer(arg1)) {
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
+    }
+
+    avm_float_t fresult = term_conv_to_float(arg1);
+    if (UNLIKELY(!isfinite(fresult))) {
+        RAISE_ERROR_BIF(fail_label, BADARITH_ATOM);
+    }
+
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, FLOAT_SIZE, live, ctx->x, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
+    }
+    return term_from_float(fresult, &ctx->heap);
+}
+
 typedef int64_t (*bitwise_op)(int64_t a, int64_t b);
 
 static inline term bitwise_helper(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2, bitwise_op op)

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -82,6 +82,7 @@ term bif_erlang_ceil_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 term bif_erlang_floor_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 term bif_erlang_round_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 term bif_erlang_trunc_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+term bif_erlang_float_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 
 term bif_erlang_bor_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
 term bif_erlang_band_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -78,6 +78,7 @@ erlang:ceil/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_er
 erlang:floor/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_floor_1}
 erlang:round/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_round_1}
 erlang:trunc/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_trunc_1}
+erlang:float/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_float_1}
 erlang:bor/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_bor_2}
 erlang:band/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_band_2}
 erlang:bxor/2, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif2_ptr = bif_erlang_bxor_2}

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -398,6 +398,7 @@ compile_erlang(float2bin2scientific)
 compile_erlang(float2bin2)
 compile_erlang(float2list2decimals)
 compile_erlang(float2list2scientific)
+compile_erlang(float_bif)
 compile_erlang(float2list2)
 compile_erlang(bin2float)
 compile_erlang(list2float)
@@ -880,6 +881,7 @@ add_custom_target(erlang_test_modules DEPENDS
     float2bin2.beam
     float2list2decimals.beam
     float2list2scientific.beam
+    float_bif.beam
     float2list2.beam
     bin2float.beam
     list2float.beam

--- a/tests/erlang_tests/float_bif.erl
+++ b/tests/erlang_tests/float_bif.erl
@@ -1,0 +1,52 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Jakub Gonet <jakub.gonet@swmansion.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(float_bif).
+
+-export([start/0]).
+% For remote function calls
+-export([id/1, check_one/1]).
+
+-define(ID(Arg), ?MODULE:id(Arg)).
+
+start() ->
+    true = 1.0 =:= float(?ID(1)),
+    true = 1.0 =:= float(?ID(1.0)),
+    ok =
+        try float(?ID("1")) of
+            _ ->
+                unreachable
+        catch
+            error:badarg ->
+                ok
+        end,
+    ok = ?MODULE:check_one(?ID(1)),
+    ok = ?MODULE:check_one(?ID(1.0)),
+    error = ?MODULE:check_one(?ID(atom)),
+    0.
+
+id(X) ->
+    X.
+
+% Tests float/1 in guards
+check_one(T) when float(T) =:= 1.0 ->
+    ok;
+check_one(_T) ->
+    error.

--- a/tests/test.c
+++ b/tests/test.c
@@ -447,6 +447,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(float2bin2decimals, 255),
     TEST_CASE_EXPECTED(float2bin2, 31),
     TEST_CASE_EXPECTED(float2list2scientific, 31),
+    TEST_CASE(float_bif),
     TEST_CASE_EXPECTED(float2list2decimals, 255),
     TEST_CASE_EXPECTED(float2list2, 31),
     TEST_CASE_EXPECTED(bin2float, 511),


### PR DESCRIPTION
See also #1509 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
