### PR TITLE
Add erlang:unique_integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `lists:dropwhile/2`.
 - Support for `float/1` BIF.
 - Added `erlang:get/0` and `erlang:erase/0`.
+- Added `erlang:unique_integer/0` and `erlang:unique_integer/1`
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -112,7 +112,9 @@
     term_to_binary/1,
     timestamp/0,
     universaltime/0,
-    localtime/0
+    localtime/0,
+    unique_integer/0,
+    unique_integer/1
 ]).
 
 -export_type([
@@ -1313,4 +1315,25 @@ universaltime() ->
 %%-----------------------------------------------------------------------------
 -spec localtime() -> calendar:datetime().
 localtime() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns A unique integer
+%% @doc     Same as erlang:unique_integer([]).
+%% @end
+%%-----------------------------------------------------------------------------
+-spec unique_integer() -> integer().
+unique_integer() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param   Options list of options.
+%% @returns a unique integer
+%% @doc     Return a unique integer. If positive is passed, returned integer is
+%%          positive. If monotonic is passed, returned integer is monotonically increasing
+%%          across all processes.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec unique_integer([monotonic | positive]) -> integer().
+unique_integer(_Options) ->
     erlang:nif_error(undefined).

--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -29,6 +29,7 @@
 #include "dictionary.h"
 #include "interop.h"
 #include "overflow_helpers.h"
+#include "smp.h"
 #include "term.h"
 #include "trace.h"
 #include "unicode.h"
@@ -341,6 +342,74 @@ term bif_erlang_map_get_2(Context *ctx, uint32_t fail_label, term arg1, term arg
         RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
     }
     return term_get_map_value(arg2, pos);
+}
+
+#ifdef AVM_NO_SMP
+static int64_t get_unique_monotonic_integer(void)
+{
+    static int64_t unique = 0;
+
+    if (UNLIKELY(unique == INT64_MAX)) {
+        AVM_ABORT();
+    }
+    return unique++;
+}
+
+#elif ATOMIC_LLONG_LOCK_FREE == 2
+
+static int64_t get_unique_monotonic_integer(void)
+{
+    static int64_t ATOMIC unique = 0;
+
+    if (UNLIKELY(unique == INT64_MAX)) {
+        AVM_ABORT();
+    }
+    return unique++;
+}
+#else
+
+static int64_t get_unique_monotonic_integer(void)
+{
+    static int64_t unique = 0;
+    static SpinLock unique_spinlock;
+
+    if (UNLIKELY(unique == INT64_MAX)) {
+        AVM_ABORT();
+    }
+
+    smp_spinlock_lock(&unique_spinlock);
+    int64_t value = unique++;
+    smp_spinlock_unlock(&unique_spinlock);
+    return value;
+}
+
+#endif
+
+term bif_erlang_unique_integer_0(Context *ctx)
+{
+    int64_t value = get_unique_monotonic_integer();
+    return term_make_maybe_boxed_int64(value, &ctx->heap);
+}
+
+term bif_erlang_unique_integer_1(Context *ctx, uint32_t fail_label, term arg1)
+{
+    int proper = 0;
+    if (UNLIKELY(!term_is_list(arg1))) {
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
+    }
+    size_t _len = term_list_length(arg1, &proper);
+    UNUSED(_len);
+    if (UNLIKELY(!proper)) {
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
+    }
+
+    // List is checked only for correctness if in the future
+    // we would like to handle monotonic and positive integers separately.
+    //
+    // Right now the implementation is backed by increasing counter
+    // that always covers both options
+    int64_t value = get_unique_monotonic_integer();
+    return term_make_maybe_boxed_int64(value, &ctx->heap);
 }
 
 static inline term make_boxed_int(Context *ctx, uint32_t fail_label, uint32_t live, avm_int_t value)

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -69,6 +69,9 @@ term bif_erlang_tuple_size_1(Context *ctx, uint32_t fail_label, term arg1);
 term bif_erlang_map_size_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 term bif_erlang_map_get_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 
+term bif_erlang_unique_integer_0(Context *ctx);
+term bif_erlang_unique_integer_1(Context *ctx, uint32_t fail_label, term arg1);
+
 term bif_erlang_add_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);
 term bif_erlang_plus_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 term bif_erlang_sub_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2);

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -91,6 +91,8 @@ erlang:element/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_
 erlang:tuple_size/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_tuple_size_1}
 erlang:map_size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_map_size_1}
 erlang:map_get/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_map_get_2}
+erlang:unique_integer/0, {.bif.base.type = BIFFunctionType, .bif.bif0_ptr = bif_erlang_unique_integer_0}
+erlang:unique_integer/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_unique_integer_1}
 erlang:min/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_min_2}
 erlang:max/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_max_2}
 erlang:size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_size_1}

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -509,6 +509,7 @@ compile_erlang(float_decode)
 compile_erlang(test_utf8_atoms)
 
 compile_erlang(twentyone_param_function)
+compile_erlang(unique)
 compile_erlang(complex_list_match_xregs)
 compile_erlang(twentyone_param_fun)
 compile_erlang(gc_safe_x_reg_write)
@@ -995,6 +996,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_utf8_atoms.beam
 
     twentyone_param_function.beam
+    unique.beam
     complex_list_match_xregs.beam
     twentyone_param_fun.beam
     gc_safe_x_reg_write.beam

--- a/tests/erlang_tests/unique.erl
+++ b/tests/erlang_tests/unique.erl
@@ -1,0 +1,116 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2024 Jakub Gonet <jakub.gonet@swmansion.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(unique).
+
+-export([start/0]).
+
+start() ->
+    ok = unique_0(),
+    ok = unique_positive(),
+    ok = unique_monotonic(),
+    ok = unique_positive_monotonic(),
+    ok = unique_monotonic_processes(),
+
+    Self = self(),
+    N = length([
+        spawn_opt(fun() -> Self ! {ok, unique_0()} end, []),
+        spawn_opt(fun() -> Self ! {ok, unique_positive()} end, []),
+        spawn_opt(fun() -> Self ! {ok, unique_monotonic()} end, []),
+        spawn_opt(fun() -> Self ! {ok, unique_positive_monotonic()} end, [])
+    ]),
+    receive_messages(N),
+    0.
+
+unique_0() ->
+    A = erlang:unique_integer(),
+    B = erlang:unique_integer(),
+    C = erlang:unique_integer(),
+    Valid = (A =/= B) and (A =/= C),
+    true = Valid,
+    ok.
+
+unique_positive() ->
+    A = erlang:unique_integer([positive]),
+    B = erlang:unique_integer([positive]),
+    C = erlang:unique_integer([positive]),
+    Valid = (A > 0) and (B > 0) and (C > 0) and (A =/= B) and (B =/= C),
+    true = Valid,
+    ok.
+
+unique_monotonic() ->
+    A = erlang:unique_integer([monotonic]),
+    B = erlang:unique_integer([monotonic]),
+    C = erlang:unique_integer([monotonic]),
+    Valid = (A < B) and (B < C),
+    true = Valid,
+    ok.
+
+unique_positive_monotonic() ->
+    A = erlang:unique_integer([positive, monotonic]),
+    B = erlang:unique_integer([positive, monotonic]),
+    C = erlang:unique_integer([positive, monotonic]),
+    Valid = (A > 0) and (A < B) and (B < C),
+    true = Valid,
+    ok.
+
+unique_monotonic_processes() ->
+    Self = self(),
+    spawn_opt(
+        fun() ->
+            n_times(50, fun() -> Self ! {a, erlang:unique_integer([monotonic])} end)
+        end,
+        []
+    ),
+    spawn_opt(
+        fun() ->
+            n_times(100, fun() -> Self ! {b, erlang:unique_integer([monotonic])} end)
+        end,
+        []
+    ),
+    Msgs = receive_messages(150),
+    NumA = [Num || {a, Num} <- Msgs],
+    NumB = [Num || {b, Num} <- Msgs],
+    true = increasing(NumA),
+    true = increasing(NumB),
+    ok.
+
+receive_messages(N) ->
+    receive_messages(N, []).
+receive_messages(0, Msgs) ->
+    reverse(Msgs);
+receive_messages(N, Msgs) ->
+    receive
+        Msg -> receive_messages(N - 1, [Msg | Msgs])
+    end.
+
+reverse(List) -> reverse(List, []).
+reverse([], Acc) -> Acc;
+reverse([H | T], Acc) -> reverse(T, [H | Acc]).
+
+n_times(0, _F) ->
+    ok;
+n_times(N, F) ->
+    F(),
+    n_times(N - 1, F).
+
+increasing([_]) -> true;
+increasing([A, B | T]) when A < B -> increasing([B | T]);
+increasing(_) -> false.

--- a/tests/test.c
+++ b/tests/test.c
@@ -568,6 +568,7 @@ struct Test tests[] = {
     TEST_CASE(test_utf8_atoms),
 
     TEST_CASE(twentyone_param_function),
+    TEST_CASE(unique),
     TEST_CASE(complex_list_match_xregs),
     TEST_CASE(twentyone_param_fun),
     TEST_CASE(gc_safe_x_reg_write),


### PR DESCRIPTION
- Implementation and testing are a bit simplistic, I tried to cover multiple access in tests but we don't have a nice way to poke at VM internals to e.g. test what happens when unique counter is high enough.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
