### PR TITLE
Fix comparison in `select_val` opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ certain VM instructions are used.
 - Fixed compilation with latest debian gcc-arm-none-eabi
 - Fix `network:stop/0` on ESP32 so the network can be started again
 - Fix a memory corruption caused by `binary:split/2,3`
+- Fix bug in opcode implementation (`select_val`): when selecting a value among many others a
+shallow comparison was performed, so it was working just for plain values such as atoms and small
+integers
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -3107,8 +3107,14 @@ wait_timeout_trap_handler:
                     #endif
 
                     #ifdef IMPL_EXECUTE_LOOP
-                        if (!jump_to_address && (src_value == cmp_value)) {
-                            jump_to_address = mod->labels[jmp_label];
+                        if (!jump_to_address) {
+                            TermCompareResult result = term_compare(
+                                src_value, cmp_value, TermCompareExact, ctx->global);
+                            if (result == TermEquals) {
+                                jump_to_address = mod->labels[jmp_label];
+                            } else if (UNLIKELY(result == TermCompareMemoryAllocFail)) {
+                                RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+                            }
                         }
                     #endif
                 }

--- a/tests/erlang_tests/selval.erl
+++ b/tests/erlang_tests/selval.erl
@@ -1,7 +1,7 @@
 %
 % This file is part of AtomVM.
 %
-% Copyright 2017 Davide Bettio <davide@uninstall.it>
+% Copyright 2017-2024 Davide Bettio <davide@uninstall.it>
 %
 % Licensed under the Apache License, Version 2.0 (the "License");
 % you may not use this file except in compliance with the License.
@@ -20,9 +20,11 @@
 
 -module(selval).
 
--export([start/0, selval/1]).
+-export([start/0, selval/1, as_float/1, selval2/1, safe_selval2/1]).
 
-start() -> selval(2).
+start() ->
+    ?MODULE:selval(2) - ?MODULE:selval2(?MODULE:as_float(<<"5.0">>)) +
+        ?MODULE:safe_selval2(1).
 
 selval(0) ->
     7;
@@ -34,3 +36,23 @@ selval(7) ->
     10;
 selval(_) ->
     0.
+
+as_float(X) ->
+    binary_to_float(X).
+
+selval2(1.0) -> -1;
+selval2(2.0) -> -2;
+selval2(3.0) -> -3;
+selval2(4.0) -> -4;
+selval2(5.0) -> 9;
+selval2(6.0) -> -6;
+selval2(7.0) -> -7;
+selval2(8.0) -> -8.
+
+safe_selval2(X) ->
+    try selval2(X) of
+        _R -> -1000
+    catch
+        error:function_clause -> 0;
+        _:_ -> -2000
+    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -113,6 +113,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(moreintegertests, 32),
     TEST_CASE_EXPECTED(send_receive, 18),
     TEST_CASE_EXPECTED(send_to_dead_process, 20),
+    TEST_CASE(selval),
     TEST_CASE_EXPECTED(byte_size_test, 10),
     TEST_CASE_EXPECTED(tuple, 6),
     TEST_CASE_EXPECTED(len_test, 5),


### PR DESCRIPTION
Fix bug that was making code such as [1] not working.

[1]:
```erl
selval2(1.0) -> -1;
selval2(2.0) -> -2;
selval2(3.0) -> -3;
selval2(4.0) -> -4;
selval2(5.0) -> 9;
selval2(6.0) -> -6;
selval2(7.0) -> -7;
selval2(8.0) -> -8.
```

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
