### PR TITLE
Use ADC_ATTEN_DB_12 for ESP-IDF v5.1.3+ instead of v5.1.1+

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/adc_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/adc_driver.c
@@ -106,7 +106,7 @@ static const AtomStringIntPair attenuation_table[] = {
     { ATOM_STR("\x4", "db_0"), ADC_ATTEN_DB_0 },
     { ATOM_STR("\x6", "db_2_5"), ADC_ATTEN_DB_2_5 },
     { ATOM_STR("\x4", "db_6"), ADC_ATTEN_DB_6 },
-#if (ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 1, 0))
+#if (ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 1, 2))
     { ATOM_STR("\x5", "db_11"), ADC_ATTEN_DB_11 },
 #else
     { ATOM_STR("\x5", "db_12"), ADC_ATTEN_DB_12 },
@@ -175,7 +175,7 @@ static int approximate_millivolts(int adc_reading, adc_atten_t attenuation, adc_
         case ADC_ATTEN_DB_6:
             millivolt_max = 1750;
             break;
-#if (ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 1, 0))
+#if (ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 1, 2))
         case ADC_ATTEN_DB_11:
             millivolt_max = 2450;
             break;


### PR DESCRIPTION
The code currently retains the use of ADC_ATTEN_DB_11 until ESP-IDF v5.1.0, but
the first version using ADC_ATTEN_DB_12 is actually ESP-IDF v5.1.3.
Source: https://github.com/espressif/esp-idf/commit/6de9757a4b036dde8db943c8686acd1eeca1fce6

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
