### PR TITLE
Run codeql anaysis on all platforms

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -31,12 +31,17 @@ jobs:
   esp-idf:
     runs-on: ubuntu-24.04
     container: espressif/idf:${{ matrix.idf-version }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false
 
       matrix:
         esp-idf-target: ["esp32", "esp32c3"]
+        language: ['cpp']
         idf-version:
          - 'v5.0.7'
          - 'v5.1.5'
@@ -53,6 +58,16 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
 
+    - name: "Git config safe.directory for codeql"
+      run: git config --global --add safe.directory /__w/AtomVM/AtomVM
+
+    - name: "Initialize CodeQL"
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{matrix.language}}
+        build-mode: manual
+        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql
+
     - name: Build with idf.py
       shell: bash
       working-directory: ./src/platforms/esp32/
@@ -68,6 +83,9 @@ jobs:
       run: |
         . $IDF_PATH/export.sh
         idf.py size-components
+
+    - name: "Perform CodeQL Analysis"
+      uses: github/codeql-action/analyze@v3
 
     - name: Install dependencies to build host AtomVM and run qemu
       run: |

--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -25,7 +25,9 @@ on:
       - 'src/libAtomVM/**'
 
 permissions:
+  actions: read
   contents: write
+  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref != 'refs/heads/main' && github.ref || github.run_id }}
@@ -37,6 +39,7 @@ jobs:
     strategy:
       matrix:
         board: ["pico", "pico_w", "pico2"]
+        language: ["cpp"]
 
     steps:
     - name: Checkout repo
@@ -52,6 +55,16 @@ jobs:
             libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib \
             erlang-base erlang-dev erlang-dialyzer erlang-eunit rebar3
 
+    - name: "Git config safe.directory for codeql"
+      run: git config --global --add safe.directory /__w/AtomVM/AtomVM
+
+    - name: "Initialize CodeQL"
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{matrix.language}}
+        build-mode: manual
+        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql
+
     - name: Build
       shell: bash
       working-directory: ./src/platforms/rp2/
@@ -61,6 +74,9 @@ jobs:
         cd build
         cmake .. -G Ninja -DPICO_BOARD=${{ matrix.board }}
         ninja
+
+    - name: "Perform CodeQL Analysis"
+      uses: github/codeql-action/analyze@v3
 
     - name: Install nvm and nodejs 20
       if: matrix.board != 'pico2'

--- a/.github/workflows/stm32-build.yaml
+++ b/.github/workflows/stm32-build.yaml
@@ -27,6 +27,11 @@ concurrency:
 jobs:
   stm32:
     runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
     steps:
     - uses: actions/cache@v4
       id: builddeps-cache
@@ -63,6 +68,16 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
 
+    - name: "Git config safe.directory for codeql"
+      run: git config --global --add safe.directory /__w/AtomVM/AtomVM
+
+    - name: "Initialize CodeQL"
+      uses: github/codeql-action/init@v3
+      with:
+        languages: 'cpp'
+        build-mode: manual
+        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql
+
     - name: Build
       shell: bash
       working-directory: ./src/platforms/stm32/
@@ -73,3 +88,6 @@ jobs:
         # -DAVM_WARNINGS_ARE_ERRORS=ON
         cmake .. -DCMAKE_TOOLCHAIN_FILE=cmake/arm-toolchain.cmake -DLIBOPENCM3_DIR=/home/runner/libopencm3
         make -j
+
+    - name: "Perform CodeQL Analysis"
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -30,15 +30,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   compile_tests:
+
     runs-on: ubuntu-24.04
     container: erlang:27
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["c-cpp"]
+
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
 
     - name: Install required packages
       run: apt update && apt install -y gperf zlib1g-dev cmake ninja-build
+
+    - name: "Git config safe.directory for codeql"
+      run: git config --global --add safe.directory /__w/AtomVM/AtomVM
+
+    - name: "Initialize CodeQL"
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{matrix.language}}
+        build-mode: manual
+        queries: +./code-queries/term-to-non-term-func.ql,./code-queries/non-term-to-term-func.ql
 
     - name: Compile AtomVM and test modules
       run: |
@@ -48,6 +70,9 @@ jobs:
         cmake .. -G Ninja -DAVM_WARNINGS_ARE_ERRORS=ON
         # test_eavmlib does not work with wasm due to http + ssl test
         ninja AtomVM atomvmlib erlang_test_modules test_etest test_alisp test_estdlib hello_world run_script call_cast html5_events wasm_webserver
+
+    - name: "Perform CodeQL Analysis"
+      uses: github/codeql-action/analyze@v3
 
     - name: Upload AtomVM and test modules
       uses: actions/upload-artifact@v4
@@ -80,6 +105,7 @@ jobs:
     needs: compile_tests
     runs-on: ubuntu-24.04
     container: emscripten/emsdk
+
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
@@ -145,12 +171,29 @@ jobs:
   wasm_build_web:
     runs-on: ubuntu-24.04
     container: emscripten/emsdk
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript"]
+
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
 
     - name: "Install deps"
       run: sudo apt update -y && sudo apt install -y cmake gperf
+
+    - name: "Initialize CodeQL"
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{matrix.language}}
+        build-mode: none
+        db-location: '${{ github.runner_temp }}/codeql_js_database'
 
     - name: Build wasm build for web
       shell: bash
@@ -161,6 +204,9 @@ jobs:
         cd build
         emcmake cmake .. -DAVM_EMSCRIPTEN_ENV=web
         emmake make -j
+
+    - name: "Perform CodeQL Analysis"
+      uses: github/codeql-action/analyze@v3
 
     - name: Upload wasm build for web
       uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `code:is_loaded/1` and `code:which/1`
 - Added several `io_lib` functions including `io_lib:fwrite/2` and `io_lib:write_atom/1`
 - Added `init:get_argument/1`, `init:get_plain_arguments/0` and `init:notify_when_started/1`
+- Added CodeQL analysis to esp32, stm32, pico, and wasm workflows
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.


### PR DESCRIPTION
Add codeql to esp32-build.yaml workflow
Add codeql to pico-build.yaml workflow
Add codeql to stm32-build.yaml workflow
Add codeql to wasm-build.yaml workflow

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
