### PR TITLE
Fix comparison between unsigned subtraction and the value 0

### DIFF
--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -167,7 +167,7 @@ enum MemoryGCResult memory_ensure_free_with_roots(Context *c, size_t size, size_
                     should_gc = ((alloc_mode == MEMORY_CAN_SHRINK) && free_space - size > maximum_free_space);
                 } break;
                 case MinimumHeapGrowth:
-                    should_gc = ((alloc_mode == MEMORY_CAN_SHRINK) && free_space - size > 0);
+                    should_gc = ((alloc_mode == MEMORY_CAN_SHRINK) && free_space > size);
                     break;
                 case FibonacciHeapGrowth: {
                     memory_size = memory_heap_memory_size(&c->heap);


### PR DESCRIPTION
Fixes a false positive critical security bug revealed by codeql in code-scanning/30.

Since it is established before this check that the size does not exceed the free_space, the check is changed to make sure `free_space - size` does not result in 0 free_space, else `should_gc` should be true.


These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
