### PR TITLE
Use QEMU from `tonistiigi/binfmt:qemu-v8.1.5`

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -129,6 +129,12 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # GCC on qemu segfaults on s390x and arm64v8 when using 24.04
+        # See also https://github.com/actions/runner-images/issues/11471
+        # qemu-v8.1.5 seem to fix the issue without downgrading Ubuntu
+        # https://github.com/docker/setup-qemu-action/issues/188
+        image: tonistiigi/binfmt:qemu-v8.1.5
 
     - name: "Build and Test: AtomVM on foreign arch"
       timeout-minutes: 15


### PR DESCRIPTION
See also:
- https://github.com/actions/runner-images/issues/11471
- https://github.com/docker/setup-qemu-action/issues/188
- https://github.com/docker/setup-qemu-action/issues/198

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
