### PR TITLE
Run qemu on Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -63,7 +63,9 @@ jobs:
 
   build-and-test-other:
     needs: compile_tests
-    runs-on: ubuntu-24.04
+    # GCC on qemu segfaults on s390x and arm64v8 when using 24.04
+    # See also https://github.com/actions/runner-images/issues/11471
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
See also:
- https://github.com/actions/runner-images/issues/11471
- https://github.com/docker/setup-qemu-action/issues/188
- https://github.com/docker/setup-qemu-action/issues/198

Upgrading to QEMU v8.1.5 doesn't seem to help, so
closes #1529

I runt the CI multiple times and it always worked, so I think this downgrade really "fixes" the issue.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
