### PR TITLE
Add missing out-of-memory handling in binary_to_atom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ integers
 - Fix error handling when calling `min` and `max` with code compiled before OTP-26: there was a
 bug when handling errors from BIFs used as NIFs (when called with `CALL_EXT` and similar opcodes)`
 - Fix matching of binaries on unaligned boundaries for code compiled with older versions of OTP
+- Add missing out of memory handling in binary_to_atom
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2015,12 +2015,18 @@ static term binary_to_atom(Context *ctx, int argc, term argv[], int create_new)
         }
 
         atom = malloc(atom_string_len + 1);
+        if (IS_NULL_PTR(atom)) {
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
         ((uint8_t *) atom)[0] = atom_string_len;
         memcpy(((char *) atom) + 1, atom_string, atom_string_len);
     } else {
         // * 2 is the worst case size
         size_t buf_len = atom_string_len * 2;
         atom = malloc(buf_len + 1);
+        if (IS_NULL_PTR(atom)) {
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
         uint8_t *atom_data = ((uint8_t *) atom) + 1;
         size_t out_pos = 0;
         for (size_t i = 0; i < atom_string_len; i++) {


### PR DESCRIPTION
Just check malloc return value.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
