### PR TITLE
Fix v6.6.6 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added the ability to run beams from the CLI for Generic Unix platform (it was already possible with nodejs and emscripten).
+- Added the ability to run beams from the CLI for Generic Unix platform (it was already possible
+with nodejs and emscripten)
 - Added preliminary support for ESP32P4 (no networking support yet).
 
 ### Fixed
@@ -18,11 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding missing check, passing a non numeric argument to a function expecting a floating point
 might lead to a crash in certain situations.
 - Fixed several bugs in `http_server` (#1366)
-- Fixed generic\_unix `socket_driver` to return `{gen_tcp, closed}` when socket is closed on Linux instead of `{gen_tcp, {recv, 104}}`
+- Fixed generic\_unix `socket_driver` to return `{gen_tcp, closed}` when socket is closed on Linux
+instead of `{gen_tcp, {recv, 104}}`
 - Fixed a memory leak where modules were not properly destroyed when the global context is destroyd
 - alisp: fix support to variables that are not binaries or integers.
 - Fixed destruction of ssl-related resources
-- Fix corruption when dealing with specific situations that involve more than 16 x registers when
+- Fixed corruption when dealing with specific situations that involve more than 16 x registers when
 certain VM instructions are used.
 - Fixed ESP32 GPIO interrupt trigger `none`
 - Fixed an issue where a timeout would occur immediately in a race condition
@@ -31,19 +33,19 @@ certain VM instructions are used.
 - Fixed a race condition affecting multi-core MCUs where a timeout would not be properly cleared
 - Fixed a double free when esp32 uart driver was closed, yielding an assert abort
 - Fixed compilation with latest debian gcc-arm-none-eabi
-- Fix `network:stop/0` on ESP32 so the network can be started again
-- Fix a memory corruption caused by `binary:split/2,3`
-- Fix deadlock in socket code
-- Fix bug in opcode implementation (`select_val`): when selecting a value among many others a
+- Fixed `network:stop/0` on ESP32 so the network can be started again
+- Fixed a memory corruption caused by `binary:split/2,3`
+- Fixed deadlock in socket code
+- Fixed bug in opcode implementation (`select_val`): when selecting a value among many others a
 shallow comparison was performed, so it was working just for plain values such as atoms and small
 integers
 - Fixed support for setting esp32 boot_path in NVS.
 - Fixed race conditions in network:start/stop.
 - Fixed crash calling network:sta_rssi(), when network not up.
-- Fix error handling when calling `min` and `max` with code compiled before OTP-26: there was a
-bug when handling errors from BIFs used as NIFs (when called with `CALL_EXT` and similar opcodes)`
-- Fix matching of binaries on unaligned boundaries for code compiled with older versions of OTP
-- Add missing out of memory handling in binary_to_atom
+- Fixed error handling when calling `min` and `max` with code compiled before OTP-26: there was a
+bug when handling errors from BIFs used as NIFs (when called with `CALL_EXT` and similar opcodes)
+- Fixed matching of binaries on unaligned boundaries for code compiled with older versions of OTP
+- Added missing out of memory handling in binary_to_atom
 
 ## [0.6.5] - 2024-10-15
 


### PR DESCRIPTION
Remove extra back-tick, Fix -> Fixed and reformat to 100 columns.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
