### PR TITLE
Bump ESP32 test_select timeout to avoid flappiness

### DIFF
--- a/src/platforms/esp32/test/main/test_erl_sources/test_select.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_select.erl
@@ -40,7 +40,7 @@ start() ->
         receive
             {select, WrFd, SelectWriteRef, ready_output} -> ok;
             M -> {unexpected, M}
-        after 200 -> fail
+        after 1000 -> fail
         end,
     ok = atomvm:posix_select_stop(WrFd),
 
@@ -51,27 +51,27 @@ start() ->
     ok =
         receive
             {select, RdFd, SelectReadRef, ready_input} -> ok
-        after 200 -> fail
+        after 1000 -> fail
         end,
     {ok, <<42>>} = atomvm:posix_read(RdFd, 1),
     ok = atomvm:posix_select_read(RdFd, self(), SelectReadRef),
     ok =
         receive
             {select, RdFd, SelectReadRef, _} -> fail
-        after 200 -> ok
+        after 1000 -> ok
         end,
     {ok, 1} = atomvm:posix_write(WrFd, <<43>>),
     ok =
         receive
             {select, RdFd, SelectReadRef, ready_input} -> ok;
             M2 -> {unexpected, M2}
-        after 200 -> fail
+        after 1000 -> fail
         end,
     ok = atomvm:posix_select_stop(RdFd),
     ok =
         receive
             Message -> {unexpected, Message}
-        after 200 -> ok
+        after 1000 -> ok
         end,
 
     ok = atomvm:posix_close(WrFd),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
