### PR TITLE
Run GC when there is a memory fragment to copy message data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ bug when handling errors from BIFs used as NIFs (when called with `CALL_EXT` and
 - Fixed call to funs such as fun erlang:'not'/1, that make use of BIFs
 - Fixed potential crashes or memory leaks caused by a mistake in calculation of reference counts
 and a race condition in otp_socket code
+- Fixed an out of memory issue by forcing GC to copy data from message fragments
 
 ## [0.6.5] - 2024-10-15
 

--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -158,7 +158,7 @@ enum MemoryGCResult memory_ensure_free_with_roots(Context *c, size_t size, size_
         // Target heap size depends on:
         // - alloc_mode (MEMORY_FORCE_SHRINK takes precedence)
         // - heap growth strategy
-        bool should_gc = free_space < size || (alloc_mode == MEMORY_FORCE_SHRINK);
+        bool should_gc = free_space < size || (alloc_mode == MEMORY_FORCE_SHRINK) || c->heap.root->next != NULL;
         size_t memory_size = 0;
         if (!should_gc) {
             switch (c->heap_growth_strategy) {


### PR DESCRIPTION
Fix a bug where an out of memory error could occur if a process received messages repeatedly but didn't allocate enough memory to cause a GC. Received messages would accumulate as memory fragments and never be disposed.

The fix consists in forcing a GC if there is a memory fragment, either from a message or from an allocation when running a GC was prohibited. This ensures fragments are processed and referred data from fragments are copied to the heap.

This fix has a small performance penalty as the GC is always triggered where there is a fragment, even if there was no need to run a GC based on available memory.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
