### PR TITLE
Changed memory_atom to out_of_memory atom in ets implementation

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3190,7 +3190,7 @@ static term nif_ets_new(Context *ctx, int argc, term argv[])
         case EtsTableNameInUse:
             RAISE_ERROR(BADARG_ATOM);
         case EtsAllocationFailure:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             AVM_ABORT();
     }
@@ -3219,7 +3219,7 @@ static term nif_ets_insert(Context *ctx, int argc, term argv[])
         case EtsPermissionDenied:
             RAISE_ERROR(BADARG_ATOM);
         case EtsAllocationFailure:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             AVM_ABORT();
     }
@@ -3243,7 +3243,7 @@ static term nif_ets_lookup(Context *ctx, int argc, term argv[])
         case EtsPermissionDenied:
             RAISE_ERROR(BADARG_ATOM);
         case EtsAllocationFailure:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             AVM_ABORT();
     }
@@ -3271,7 +3271,7 @@ static term nif_ets_lookup_element(Context *ctx, int argc, term argv[])
         case EtsPermissionDenied:
             RAISE_ERROR(BADARG_ATOM);
         case EtsAllocationFailure:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             AVM_ABORT();
     }
@@ -3295,7 +3295,7 @@ static term nif_ets_delete(Context *ctx, int argc, term argv[])
         case EtsPermissionDenied:
             RAISE_ERROR(BADARG_ATOM);
         case EtsAllocationFailure:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             AVM_ABORT();
     }


### PR DESCRIPTION
Fixed wrong atom in ets implementation.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
