### PR TITLE
Fix memory corruption in `ets_update_counter`

### DIFF
--- a/src/libAtomVM/ets.h
+++ b/src/libAtomVM/ets.h
@@ -71,14 +71,14 @@ struct Ets
 void ets_init(struct Ets *ets);
 void ets_destroy(struct Ets *ets, GlobalContext *global);
 
-EtsErrorCode ets_create_table(term name, bool is_named, EtsTableType table_type, EtsAccessType access_type, size_t keypos, term *ret, Context *ctx);
+EtsErrorCode ets_create_table_maybe_gc(term name, bool is_named, EtsTableType table_type, EtsAccessType access_type, size_t keypos, term *ret, Context *ctx);
 void ets_delete_owned_tables(struct Ets *ets, int32_t process_id, GlobalContext *global);
 
 EtsErrorCode ets_insert(term ref, term entry, Context *ctx);
-EtsErrorCode ets_lookup(term ref, term key, term *ret, Context *ctx);
-EtsErrorCode ets_lookup_element(term ref, term key, size_t pos, term *ret, Context *ctx);
+EtsErrorCode ets_lookup_maybe_gc(term ref, term key, term *ret, Context *ctx);
+EtsErrorCode ets_lookup_element_maybe_gc(term ref, term key, size_t pos, term *ret, Context *ctx);
 EtsErrorCode ets_delete(term ref, term key, term *ret, Context *ctx);
-EtsErrorCode ets_update_counter(term ref, term key, term value, term pos, term *ret, Context *ctx);
+EtsErrorCode ets_update_counter_maybe_gc(term ref, term key, term value, term pos, term *ret, Context *ctx);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3192,7 +3192,7 @@ static term nif_ets_new(Context *ctx, int argc, term argv[])
     }
 
     term table = term_invalid_term();
-    EtsErrorCode result = ets_create_table(name, is_named == TRUE_ATOM, EtsTableSet, access, term_to_int(keypos) - 1, &table, ctx);
+    EtsErrorCode result = ets_create_table_maybe_gc(name, is_named == TRUE_ATOM, EtsTableSet, access, term_to_int(keypos) - 1, &table, ctx);
     switch (result) {
         case EtsOk:
             return table;
@@ -3244,7 +3244,7 @@ static term nif_ets_lookup(Context *ctx, int argc, term argv[])
     term key = argv[1];
 
     term ret = term_invalid_term();
-    EtsErrorCode result = ets_lookup(ref, key, &ret, ctx);
+    EtsErrorCode result = ets_lookup_maybe_gc(ref, key, &ret, ctx);
     switch (result) {
         case EtsOk:
             return ret;
@@ -3270,7 +3270,7 @@ static term nif_ets_lookup_element(Context *ctx, int argc, term argv[])
     VALIDATE_VALUE(pos, term_is_integer);
 
     term ret = term_invalid_term();
-    EtsErrorCode result = ets_lookup_element(ref, key, term_to_int(pos), &ret, ctx);
+    EtsErrorCode result = ets_lookup_element_maybe_gc(ref, key, term_to_int(pos), &ret, ctx);
     switch (result) {
         case EtsOk:
             return ret;
@@ -3326,7 +3326,7 @@ static term nif_ets_update_counter(Context *ctx, int argc, term argv[])
         default_value = term_invalid_term();
     }
     term ret;
-    EtsErrorCode result = ets_update_counter(ref, key, operation, default_value, &ret, ctx);
+    EtsErrorCode result = ets_update_counter_maybe_gc(ref, key, operation, default_value, &ret, ctx);
     switch (result) {
         case EtsOk:
             return ret;


### PR DESCRIPTION
Fixes #1553

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
