### PR TITLE
Use signals for link/unlink/monitor/demonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and a race condition in otp_socket code
 - Fixed a bug where calling repeatedly `process_info` on a stopped process could cause an out of
 memory error
 - Fixed possible concurrency problems in ESP32 UART driver
+- Fixed concurrency and memory leak related to links and monitors
 
 ### Changed
 

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -151,6 +151,10 @@ struct Context
 typedef struct Context Context;
 #endif
 
+#define CONTEXT_MONITOR_RESOURCE_TAG 0x2
+#define CONTEXT_MONITOR_MONITORED_PID_TAG 0x3
+#define CONTEXT_MONITOR_MONITORING_PID_TAG 0x1
+
 /**
  * @brief A regular monitor or a half link.
  */
@@ -158,16 +162,7 @@ struct Monitor
 {
     struct ListHead monitor_list_head;
     uint64_t ref_ticks; // 0 for links
-    term monitor_obj;
-};
-
-/**
- * @brief A resource monitor.
- */
-struct ResourceMonitor
-{
-    struct Monitor base;
-    struct ListHead resource_list_head;
+    term monitor_obj; // pid for links, CONTEXT_MONITOR_*_TAG for monitors
 };
 
 struct ExtendedRegister
@@ -407,44 +402,76 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
 
 /**
  * @brief Half-link process to another process
- * @details Caller must hold the global process lock. This creates one half of
- * the link.
  *
- * @param ctx context to link
- * @param monitor_pid process to link ctx to
- * @return 0 on success
+ * @param monitor_pid process to link to
+ * @return the allocated monitor or NULL if allocation failed
  */
-int context_link(Context *ctx, term monitor_pid);
+struct Monitor *monitor_link_new(term monitor_pid);
 
 /**
  * @brief Create a monitor on a process.
- * @details Caller must hold the global process lock.
  *
- * @param ctx context to monitor
  * @param monitor_pid monitoring process
- * @return the ref ticks
+ * @param ref_ticks reference of the monitor
+ * @param is_monitoring if ctx is the monitoring process
+ * @return the allocated monitor or NULL if allocation failed
  */
-uint64_t context_monitor(Context *ctx, term monitor_pid);
+struct Monitor *monitor_new(term monitor_pid, uint64_t ref_ticks, bool is_monitoring);
 
 /**
- * @brief Create a resource monitor on a process.
- * @details Caller must hold the global process lock. The returned resource
- * monitor is not added to the monitors list on the resource type.
+ * @brief Create a resource monitor.
  *
- * @param ctx context to monitor
  * @param resource resource object
- * @return the resource monitor
+ * @param ref_ticks reference associated with the monitor
+ * @param process_id process being monitored
+ * @return the allocated resource monitor or NULL if allocation failed
  */
-struct ResourceMonitor *context_resource_monitor(Context *ctx, void *resource);
+struct Monitor *monitor_resource_monitor_new(void *resource, uint64_t ref_ticks);
+
 /**
- * @brief Remove a half-link from a process.
- * @details Caller must hold the global process lock. This removes one half of
- * the link.
+ * @brief Half-unlink process to another process
+ * @details Called within the process only. For the other end of the
+ * link, an UnlinkSignal is sent that calls this function.
  *
- * @param ctx context to monitor
- * @param monitor_pid process to unlink
+ * @param ctx the context being executed
+ * @param monitor_pid process to unlink from
+ * @return 0 on success
  */
 void context_unlink(Context *ctx, term monitor_pid);
+
+/**
+ * @brief Destroy a monitor on a process.
+ * @details Called within the process only. This function is called from
+ * DemonitorSignal.
+ *
+ * @param ctx the context being executed
+ * @param ref_ticks reference of the monitor to remove
+ * @return 0 on success
+ */
+void context_demonitor(Context *ctx, uint64_t ref_ticks);
+
+/**
+ * @brief Get target of a monitor.
+ *
+ * @param ctx the context being executed
+ * @param ref_ticks reference of the monitor to remove
+ * @param is_monitoring whether ctx is the monitoring process.
+ * @return pid of monitoring process, self() if process is monitoring (and not
+ * monitored) or term_invalid() if no monitor could be found.
+ */
+term context_get_monitor_pid(Context *ctx, uint64_t ref_ticks, bool *is_monitoring);
+
+/**
+ * @brief Add a monitor on a process.
+ * @details Called within the process only. This function is called from
+ * MonitorSignal. Monitor is not added if it already exists. Monitors are
+ * identified by a reference, but links have no reference and a link can
+ * only exist once.
+ *
+ * @param ctx the context being executed
+ * @param new_monitor monitor object to add
+ */
+void context_add_monitor(Context *ctx, struct Monitor *new_monitor);
 
 #ifdef __cplusplus
 }

--- a/src/libAtomVM/mailbox.c
+++ b/src/libAtomVM/mailbox.c
@@ -109,15 +109,22 @@ void mailbox_message_dispose(MailboxMessage *m, Heap *heap)
             free(request_signal);
             break;
         }
-        case TrapExceptionSignal: {
-            struct BuiltInAtomSignal *atom_signal = CONTAINER_OF(m, struct BuiltInAtomSignal, base);
-            free(atom_signal);
+        case TrapExceptionSignal:
+        case UnlinkSignal: {
+            struct ImmediateSignal *immediate_signal = CONTAINER_OF(m, struct ImmediateSignal, base);
+            free(immediate_signal);
             break;
         }
         case FlushMonitorSignal:
-        case FlushInfoMonitorSignal: {
+        case FlushInfoMonitorSignal:
+        case DemonitorSignal: {
             struct RefSignal *ref_signal = CONTAINER_OF(m, struct RefSignal, base);
             free(ref_signal);
+            break;
+        }
+        case MonitorSignal: {
+            struct MonitorPointerSignal *monitor_signal = CONTAINER_OF(m, struct MonitorPointerSignal, base);
+            free(monitor_signal);
             break;
         }
         case GCSignal:
@@ -243,17 +250,17 @@ void mailbox_send_term_signal(Context *c, enum MessageType type, term t)
     mailbox_post_message(c, signal);
 }
 
-void mailbox_send_built_in_atom_signal(Context *c, enum MessageType type, term atom)
+void mailbox_send_immediate_signal(Context *c, enum MessageType type, term immediate)
 {
-    struct BuiltInAtomSignal *atom_signal = malloc(sizeof(struct BuiltInAtomSignal));
-    if (IS_NULL_PTR(atom_signal)) {
+    struct ImmediateSignal *immediate_signal = malloc(sizeof(struct ImmediateSignal));
+    if (IS_NULL_PTR(immediate_signal)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
         return;
     }
-    atom_signal->base.type = type;
-    atom_signal->atom = atom;
+    immediate_signal->base.type = type;
+    immediate_signal->immediate = immediate;
 
-    mailbox_post_message(c, &atom_signal->base);
+    mailbox_post_message(c, &immediate_signal->base);
 }
 
 void mailbox_send_built_in_atom_request_signal(
@@ -282,6 +289,19 @@ void mailbox_send_ref_signal(Context *c, enum MessageType type, uint64_t ref_tic
     ref_signal->ref_ticks = ref_ticks;
 
     mailbox_post_message(c, &ref_signal->base);
+}
+
+void mailbox_send_monitor_signal(Context *c, enum MessageType type, struct Monitor *monitor)
+{
+    struct MonitorPointerSignal *monitor_signal = malloc(sizeof(struct MonitorPointerSignal));
+    if (IS_NULL_PTR(monitor_signal)) {
+        fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
+        return;
+    }
+    monitor_signal->base.type = type;
+    monitor_signal->monitor = monitor;
+
+    mailbox_post_message(c, &monitor_signal->base);
 }
 
 void mailbox_send_empty_body_signal(Context *c, enum MessageType type)

--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -81,6 +81,9 @@ enum MessageType
     TrapExceptionSignal,
     FlushMonitorSignal,
     FlushInfoMonitorSignal,
+    MonitorSignal,
+    UnlinkSignal,
+    DemonitorSignal,
 };
 
 struct MailboxMessage
@@ -112,11 +115,11 @@ struct TermSignal
     term storage[];
 };
 
-struct BuiltInAtomSignal
+struct ImmediateSignal
 {
     MailboxMessage base;
 
-    term atom;
+    term immediate;
 };
 
 struct BuiltInAtomRequestSignal
@@ -132,6 +135,13 @@ struct RefSignal
     MailboxMessage base;
 
     uint64_t ref_ticks;
+};
+
+struct MonitorPointerSignal
+{
+    MailboxMessage base;
+
+    struct Monitor *monitor;
 };
 
 typedef struct
@@ -202,13 +212,13 @@ void mailbox_send(Context *c, term t);
 void mailbox_send_term_signal(Context *c, enum MessageType type, term t);
 
 /**
- * @brief Sends a built-in atom signal to a certain mailbox.
+ * @brief Sends an immediate signal to a certain mailbox.
  *
  * @param c the process context.
  * @param type the type of the signal
- * @param atom the built-in atom
+ * @param immediate the immediate term to send (atom or pid)
  */
-void mailbox_send_built_in_atom_signal(Context *c, enum MessageType type, term atom);
+void mailbox_send_immediate_signal(Context *c, enum MessageType type, term immediate);
 
 /**
  * @brief Sends a built-in atom-based request signal to a certain mailbox.
@@ -229,6 +239,15 @@ void mailbox_send_built_in_atom_request_signal(
  * @param ref_ticks the ref
  */
 void mailbox_send_ref_signal(Context *c, enum MessageType type, uint64_t ref_ticks);
+
+/**
+ * @brief Sends a ref immediate signal to a certain mailbox.
+ *
+ * @param c the process context.
+ * @param type the type of the signal
+ * @param monitor the monitor
+ */
+void mailbox_send_monitor_signal(Context *c, enum MessageType type, struct Monitor *monitor);
 
 /**
  * @brief Sends an empty body signal to a certain mailbox.

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1034,9 +1034,9 @@ static void destroy_extended_registers(Context *ctx, unsigned int live)
                     break;                                                                      \
                 }                                                                               \
                 case TrapExceptionSignal: {                                                     \
-                    struct BuiltInAtomSignal *trap_exception                                    \
-                        = CONTAINER_OF(signal_message, struct BuiltInAtomSignal, base);         \
-                    SET_ERROR(trap_exception->atom);                                            \
+                    struct ImmediateSignal *trap_exception                                      \
+                        = CONTAINER_OF(signal_message, struct ImmediateSignal, base);           \
+                    SET_ERROR(trap_exception->immediate);                                       \
                     next_label = &&handle_error;                                                \
                     break;                                                                      \
                 }                                                                               \
@@ -1046,6 +1046,24 @@ static void destroy_extended_registers(Context *ctx, unsigned int live)
                         = CONTAINER_OF(signal_message, struct RefSignal, base);                 \
                     bool info = signal_message->type == FlushInfoMonitorSignal;                 \
                     context_process_flush_monitor_signal(ctx, flush_signal->ref_ticks, info);   \
+                    break;                                                                      \
+                }                                                                               \
+                case UnlinkSignal: {                                                            \
+                    struct ImmediateSignal *immediate_signal                                    \
+                        = CONTAINER_OF(signal_message, struct ImmediateSignal, base);           \
+                    context_unlink(ctx, immediate_signal->immediate);                           \
+                    break;                                                                      \
+                }                                                                               \
+                case MonitorSignal: {                                                           \
+                    struct MonitorPointerSignal *monitor_signal                                 \
+                        = CONTAINER_OF(signal_message, struct MonitorPointerSignal, base);      \
+                    context_add_monitor(ctx, monitor_signal->monitor);                          \
+                    break;                                                                      \
+                }                                                                               \
+                case DemonitorSignal: {                                                         \
+                    struct RefSignal *ref_signal                                                \
+                        = CONTAINER_OF(signal_message, struct RefSignal, base);                 \
+                    context_demonitor(ctx, ref_signal->ref_ticks);                              \
                     break;                                                                      \
                 }                                                                               \
                 case NormalMessage: {                                                           \

--- a/src/libAtomVM/resources.c
+++ b/src/libAtomVM/resources.c
@@ -26,8 +26,10 @@
 #include "defaultatoms.h"
 #include "erl_nif.h"
 #include "erl_nif_priv.h"
+#include "globalcontext.h"
 #include "refc_binary.h"
 #include "resources.h"
+#include "synclist.h"
 #include "sys.h"
 #include "utils.h"
 
@@ -43,7 +45,7 @@ ErlNifResourceType *enif_init_resource_type(ErlNifEnv *env, const char *name, co
     result->name = strdup(name);
     result->global = env->global;
     list_init(&result->head);
-    list_init(&result->monitors);
+    synclist_init(&result->monitors);
     result->dtor = NULL;
     result->stop = NULL;
     result->down = NULL;
@@ -320,72 +322,112 @@ void select_event_count_and_destroy_closed(struct ListHead *select_events, size_
 int enif_monitor_process(ErlNifEnv *env, void *obj, const ErlNifPid *target_pid, ErlNifMonitor *mon)
 {
     struct RefcBinary *resource = refc_binary_from_data(obj);
-    if (resource->resource_type == NULL || resource->resource_type->down == NULL) {
+    struct ResourceType *resource_type = resource->resource_type;
+    if (resource_type == NULL || resource_type->down == NULL) {
+        return -1;
+    }
+
+    struct ResourceMonitor *resource_monitor = malloc(sizeof(struct ResourceMonitor));
+    if (IS_NULL_PTR(resource_monitor)) {
+        return 1;
+    }
+    uint64_t ref_ticks = globalcontext_get_ref_ticks(env->global);
+    resource_monitor->resource = resource;
+    resource_monitor->ref_ticks = ref_ticks;
+    resource_monitor->process_id = *target_pid;
+
+    struct Monitor *monitor = monitor_resource_monitor_new(obj, ref_ticks);
+    if (IS_NULL_PTR(monitor)) {
+        free(resource_monitor);
         return -1;
     }
 
     Context *target = globalcontext_get_process_lock(env->global, *target_pid);
     if (IS_NULL_PTR(target)) {
+        free(resource_monitor);
+        free(monitor);
         return 1;
     }
 
-    struct ResourceMonitor *monitor = context_resource_monitor(target, obj);
-    list_append(&resource->resource_type->monitors, &monitor->resource_list_head);
+    synclist_append(&resource_type->monitors, &resource_monitor->resource_list_head);
+    mailbox_send_monitor_signal(target, MonitorSignal, monitor);
     globalcontext_get_process_unlock(env->global, target);
 
     if (mon) {
-        *mon = monitor->base.ref_ticks;
+        *mon = ref_ticks;
     }
 
     return 0;
+}
+
+void resource_type_demonitor(struct ResourceType *resource_type, uint64_t ref_ticks)
+{
+    struct ListHead *monitors = synclist_wrlock(&resource_type->monitors);
+    struct ListHead *item;
+    LIST_FOR_EACH (item, monitors) {
+        struct ResourceMonitor *monitor = GET_LIST_ENTRY(item, struct ResourceMonitor, resource_list_head);
+        if (monitor->ref_ticks == ref_ticks) {
+            list_remove(&monitor->resource_list_head);
+            free(monitor);
+            break;
+        }
+    }
+
+    synclist_unlock(&resource_type->monitors);
 }
 
 int enif_demonitor_process(ErlNifEnv *env, void *obj, const ErlNifMonitor *mon)
 {
     GlobalContext *global = env->global;
     struct RefcBinary *resource = refc_binary_from_data(obj);
-    if (resource->resource_type == NULL || resource->resource_type->down == NULL) {
+    struct ResourceType *resource_type = resource->resource_type;
+    if (resource_type == NULL || resource_type->down == NULL) {
         return -1;
     }
 
-    struct ListHead *processes_table_list = synclist_wrlock(&global->processes_table);
-    UNUSED(processes_table_list);
-
+    struct ListHead *monitors = synclist_wrlock(&resource_type->monitors);
     struct ListHead *item;
-    LIST_FOR_EACH (item, &resource->resource_type->monitors) {
+    LIST_FOR_EACH (item, monitors) {
         struct ResourceMonitor *monitor = GET_LIST_ENTRY(item, struct ResourceMonitor, resource_list_head);
-        if (monitor->base.ref_ticks == *mon) {
+        if (monitor->ref_ticks == *mon) {
+            Context *target = globalcontext_get_process_lock(global, monitor->process_id);
+            if (target) {
+                mailbox_send_ref_signal(target, DemonitorSignal, monitor->ref_ticks);
+                globalcontext_get_process_unlock(global, target);
+            }
+
             list_remove(&monitor->resource_list_head);
-            list_remove(&monitor->base.monitor_list_head);
             free(monitor);
-            synclist_unlock(&global->processes_table);
+            synclist_unlock(&resource_type->monitors);
             return 0;
         }
     }
 
-    synclist_unlock(&global->processes_table);
+    synclist_unlock(&resource_type->monitors);
 
     return -1;
 }
 
 void destroy_resource_monitors(struct RefcBinary *resource, GlobalContext *global)
 {
-    struct ListHead *processes_table_list = synclist_wrlock(&global->processes_table);
-    UNUSED(processes_table_list);
-    term monitor_obj = ((term) resource->data) | TERM_BOXED_VALUE_TAG;
-
+    struct ResourceType *resource_type = resource->resource_type;
+    struct ListHead *monitors = synclist_wrlock(&resource_type->monitors);
     struct ListHead *item;
     struct ListHead *tmp;
-    MUTABLE_LIST_FOR_EACH (item, tmp, &resource->resource_type->monitors) {
+    MUTABLE_LIST_FOR_EACH (item, tmp, monitors) {
         struct ResourceMonitor *monitor = GET_LIST_ENTRY(item, struct ResourceMonitor, resource_list_head);
-        if (monitor->base.monitor_obj == monitor_obj) {
+        if (monitor->resource == resource) {
+            Context *target = globalcontext_get_process_lock(global, monitor->process_id);
+            if (target) {
+                mailbox_send_ref_signal(target, DemonitorSignal, monitor->ref_ticks);
+                globalcontext_get_process_unlock(global, target);
+            }
             list_remove(&monitor->resource_list_head);
-            list_remove(&monitor->base.monitor_list_head);
             free(monitor);
         }
     }
 
-    synclist_unlock(&global->processes_table);
+    synclist_unlock(&resource_type->monitors);
 }
 
 int enif_compare_monitors(const ErlNifMonitor *monitor1, const ErlNifMonitor *monitor2)

--- a/src/libAtomVM/resources.h
+++ b/src/libAtomVM/resources.h
@@ -26,6 +26,7 @@
 #include "erl_nif.h"
 #include "list.h"
 #include "memory.h"
+#include "synclist.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,10 +52,21 @@ struct ResourceType
     struct ListHead head;
     const char *name;
     GlobalContext *global;
-    struct ListHead monitors;
+    struct SyncList monitors;
     ErlNifResourceDtor *dtor;
     ErlNifResourceStop *stop;
     ErlNifResourceDown *down;
+};
+
+/**
+ * @brief A resource monitor.
+ */
+struct ResourceMonitor
+{
+    struct ListHead resource_list_head;
+    struct RefcBinary *resource;
+    uint64_t ref_ticks;
+    int32_t process_id;
 };
 
 /**
@@ -136,6 +148,13 @@ void destroy_resource_monitors(struct RefcBinary *resource, GlobalContext *globa
  * available (see SELECT_EVENT_NOTIFICATION_SIZE)
  */
 term select_event_make_notification(void *rsrc_obj, uint64_t ref_ticks, bool is_write, Heap *heap);
+
+/**
+ * @brief Remove monitor from list of monitors.
+ * @param resource_type type holding the list of monitors
+ * @param ref_ticks reference of the monitor
+ */
+void resource_type_demonitor(struct ResourceType *resource_type, uint64_t ref_ticks);
 
 #ifdef __cplusplus
 }

--- a/src/libAtomVM/scheduler.c
+++ b/src/libAtomVM/scheduler.c
@@ -88,6 +88,14 @@ static void scheduler_process_native_signal_messages(Context *ctx)
             struct BuiltInAtomRequestSignal *request_signal
                 = CONTAINER_OF(signal_message, struct BuiltInAtomRequestSignal, base);
             context_process_process_info_request_signal(ctx, request_signal);
+        } else if (signal_message->type == MonitorSignal) {
+            struct MonitorPointerSignal *monitor_signal
+                = CONTAINER_OF(signal_message, struct MonitorPointerSignal, base);
+            context_add_monitor(ctx, monitor_signal->monitor);
+        } else if (signal_message->type == DemonitorSignal) {
+            struct RefSignal *ref_signal
+                = CONTAINER_OF(signal_message, struct RefSignal, base);
+            context_demonitor(ctx, ref_signal->ref_ticks);
         }
         MailboxMessage *next = signal_message->next;
         mailbox_message_dispose(signal_message, &ctx->heap);


### PR DESCRIPTION
Fix concurrency issues and memory leaks related to a poor usage of list of monitors that was accessed by other processes (fix #1384)
Fix semantics of monitor where self cannot monitor itself and a monitor cannot be removed from another process.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
