### PR TITLE
Fix handling of filenames in stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and a race condition in otp_socket code
 memory error
 - Fixed possible concurrency problems in ESP32 UART driver
 - Fixed concurrency and memory leak related to links and monitors
+- Fixed issues with parsing of line references for stack traces
 
 ### Changed
 

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -62,7 +62,7 @@
 static struct LiteralEntry *module_build_literals_table(const void *literalsBuf);
 static void module_add_label(Module *mod, int index, const uint8_t *ptr);
 static enum ModuleLoadResult module_build_imported_functions_table(Module *this_module, uint8_t *table_data, GlobalContext *glb);
-static void parse_line_table(uint16_t **line_refs, struct ModuleFilename **filenames, uint8_t *data, size_t len);
+static void module_parse_line_table(Module *mod, const uint8_t *data, size_t len);
 
 #define IMPL_CODE_LOADER 1
 #include "opcodesswitch.h"
@@ -281,7 +281,7 @@ Module *module_new_from_iff_binary(GlobalContext *global, const void *iff_binary
         return NULL;
     }
 
-    parse_line_table(&mod->line_refs, &mod->filenames, beam_file + offsets[LINT] + 8, sizes[LINT]);
+    module_parse_line_table(mod, beam_file + offsets[LINT] + 8, sizes[LINT]);
     list_init(&mod->line_ref_offsets);
 
     if (offsets[LITT]) {
@@ -437,117 +437,187 @@ const struct ExportedFunction *module_resolve_function0(Module *mod, int import_
     }
 }
 
-static uint16_t *parse_line_refs(uint8_t **data, size_t num_refs, size_t len)
+static bool module_check_line_refs(Module *mod, const uint8_t **data, size_t len)
 {
-    uint16_t *ref_table = malloc((num_refs + 1) * sizeof(uint16_t));
-    if (IS_NULL_PTR(ref_table)) {
-        return NULL;
-    }
-
     // assert pos >= *data
-    uint8_t *pos = *data;
-    for (size_t i = 0; i < num_refs + 1; ++i) {
+    const uint8_t *pos = *data;
+    size_t i = 0;
+    while (i < mod->line_refs_count) {
         if ((size_t) (pos - *data) > len) {
             fprintf(stderr, "Invalid line_ref: expected tag.\n");
-            free(ref_table);
-            return NULL;
+            return false;
         }
         uint8_t tag = *pos;
         switch (tag & 0x0F) {
             case TAG_COMPACT_INT: {
-                uint16_t line_idx = ((tag & 0xF0) >> 4);
-                ref_table[i] = line_idx;
-                ++pos;
-                break;
-            }
-            case TAG_COMPACT_ATOM: {
-                uint16_t line_idx = ((tag & 0xF0) >> 4);
-                ref_table[i] = line_idx;
+                ++i;
                 ++pos;
                 break;
             }
             case TAG_EXTENDED_INT: {
+                ++pos;
+                if ((size_t) (pos - *data) > len) {
+                    fprintf(stderr, "Invalid line_ref: expected extended int.\n");
+                    return false;
+                }
+                ++i;
+                ++pos;
+                break;
+            }
+            case TAG_COMPACT_ATOM: {
+                uint16_t location_ix = ((tag & 0xF0) >> 4);
+                if (location_ix > mod->locations_count) {
+                    fprintf(stderr, "Invalid line_ref: location_ix = %d is greater than locations_count = %d.\n", (int) location_ix, (int) mod->locations_count);
+                    return false;
+                }
+                ++pos;
+                break;
+            }
+            case TAG_EXTENDED_ATOM: {
                 uint16_t high_order_3_bits = (tag & 0xE0);
                 ++pos;
                 if ((size_t) (pos - *data) > len) {
                     fprintf(stderr, "Invalid line_ref: expected extended int.\n");
-                    free(ref_table);
-                    return NULL;
+                    return false;
                 }
                 uint8_t next_byte = *pos;
-                uint16_t line_idx = ((high_order_3_bits << 3) | next_byte);
-                ++pos;
-                ref_table[i] = line_idx;
-                break;
-            }
-            case TAG_EXTENDED_ATOM: {
-                uint16_t file_idx = ((tag & 0xF0) >> 4);
-                ++pos;
-                if ((size_t) (pos - *data) > len) {
-                    fprintf(stderr, "Invalid line_ref: expected extended atom.\n");
-                    free(ref_table);
-                    return NULL;
+                uint16_t location_ix = ((high_order_3_bits << 3) | next_byte);
+                if (location_ix > mod->locations_count) {
+                    fprintf(stderr, "Invalid line_ref: location_ix = %d is greater than locations_count = %d.\n", (int) location_ix, (int) mod->locations_count);
+                    return false;
                 }
-                uint8_t next_byte = *pos;
-                uint16_t line_idx = ((next_byte & 0xF0) >> 4);
                 ++pos;
-                ref_table[file_idx - 1] = line_idx;
                 break;
             }
             default:
                 // TODO handle integer compact encodings > 2048
                 fprintf(stderr, "Unsupported line_ref tag: %u\n", tag);
-                free(ref_table);
-                return NULL;
+                return false;
         }
     }
 
     *data = pos;
-    return ref_table;
+    return true;
 }
 
-struct ModuleFilename *parse_filename_table(uint8_t **data, size_t num_filenames, size_t len)
+static bool module_check_locations(Module *mod, const uint8_t *data, size_t len)
 {
-    struct ModuleFilename *filenames = malloc(num_filenames * sizeof(struct ModuleFilename));
-    if (IS_NULL_PTR(filenames)) {
-        return NULL;
-    }
-
-    // assert pos >= *data
-    uint8_t *pos = *data;
-    for (size_t i = 0; i < num_filenames; ++i) {
-        if ((size_t) ((pos + 2) - *data) > len) {
+    const uint8_t *pos = data;
+    for (size_t i = 1; i <= mod->locations_count; i++) {
+        if ((size_t) ((pos + 2) - data) > len) {
             fprintf(stderr, "Invalid filename: expected 16-bit size.\n");
-            free(filenames);
-            return NULL;
+            return false;
         }
         uint16_t size = READ_16_UNALIGNED(pos);
-        pos +=2;
-        if ((size_t) ((pos + size) - *data) > len) {
+        pos += 2;
+        if ((size_t) ((pos + size) - data) > len) {
             fprintf(stderr, "Invalid filename: expected filename data (%u bytes).\n", size);
-            free(filenames);
-            return NULL;
+            return false;
         }
-        filenames[i].len = size;
-        filenames[i].data = pos;
         pos += size;
     }
 
-    *data = pos;
-    return filenames;
+    return true;
 }
 
-static void parse_line_table(uint16_t **line_refs, struct ModuleFilename **filenames, uint8_t *data, size_t len)
+static bool module_get_line_ref(Module *mod, uint16_t line_ref, uint16_t *out_line, uint16_t *out_location)
 {
+    // First is undefined
+    if (line_ref == 0) {
+        *out_line = 0;
+        *out_location = 0;
+        return true;
+    }
 
-    *line_refs = NULL;
-    *filenames = NULL;
+    const uint8_t *pos = mod->line_refs_table;
+    uint16_t location_ix = 0;
+    size_t i = 1;
+    while (i <= mod->line_refs_count) {
+        uint8_t tag = *pos;
+        switch (tag & 0x0F) {
+            case TAG_COMPACT_INT: {
+                if (i == line_ref) {
+                    uint16_t line_idx = ((tag & 0xF0) >> 4);
+                    *out_line = line_idx;
+                    *out_location = location_ix;
+                    return true;
+                }
+                ++i;
+                ++pos;
+                break;
+            }
+            case TAG_EXTENDED_INT: {
+                if (i == line_ref) {
+                    uint16_t high_order_3_bits = (tag & 0xE0);
+                    uint16_t line_idx = ((high_order_3_bits << 3) | pos[1]);
+                    *out_line = line_idx;
+                    *out_location = location_ix;
+                    return true;
+                }
+                pos += 2;
+                ++i;
+                break;
+            }
+            case TAG_COMPACT_ATOM: {
+                location_ix = ((tag & 0xF0) >> 4);
+                ++pos;
+                break;
+            }
+            case TAG_EXTENDED_ATOM: {
+                uint16_t high_order_3_bits = (tag & 0xE0);
+                location_ix = ((high_order_3_bits << 3) | pos[1]);
+                pos += 2;
+                break;
+            }
+            default:
+                // TODO handle integer compact encodings > 2048
+                return false;
+        }
+    }
 
+    return false;
+}
+
+
+static bool module_get_location(Module *mod, uint16_t location_ix, size_t *filename_len, const uint8_t **filename)
+{
+    // 0 is module.erl
+    if (location_ix == 0) {
+        *filename_len = 0;
+        if (filename) {
+            *filename = NULL;
+        }
+        return true;
+    }
+
+    const uint8_t *pos = mod->locations_table;
+    for (size_t i = 1; i <= mod->locations_count; i++) {
+        uint16_t size = READ_16_UNALIGNED(pos);
+        pos +=2;
+        if (i == location_ix) {
+            *filename_len = size;
+            if (filename) {
+                *filename = pos;
+            }
+            return true;
+        }
+        pos += size;
+    }
+
+    return false;
+}
+
+static void module_parse_line_table(Module *mod, const uint8_t *data, size_t len)
+{
     if (len == 0) {
+        mod->line_refs_count = 0;
+        mod->line_refs_table = NULL;
+        mod->locations_count = 0;
+        mod->locations_table = NULL;
         return;
     }
 
-    uint8_t *pos = data;
+    const uint8_t *pos = data;
 
     CHECK_FREE_SPACE(4, "Error reading Line chunk: version\n");
     uint32_t version = READ_32_UNALIGNED(pos);
@@ -568,28 +638,36 @@ static void parse_line_table(uint16_t **line_refs, struct ModuleFilename **filen
     pos += 4;
 
     CHECK_FREE_SPACE(4, "Error reading Line chunk: num_refs\n");
-    uint32_t num_refs = READ_32_UNALIGNED(pos);
+    mod->line_refs_count = READ_32_UNALIGNED(pos);
     pos += 4;
 
     CHECK_FREE_SPACE(4, "Error reading Line chunk: num_filenames\n");
-    uint32_t num_filenames = READ_32_UNALIGNED(pos);
+    mod->locations_count = READ_32_UNALIGNED(pos);
     pos += 4;
 
-    *line_refs = parse_line_refs(&pos, num_refs, len - (pos - data));
-    if (IS_NULL_PTR(*line_refs)) {
+    mod->line_refs_table = pos;
+
+    if (UNLIKELY(!module_check_line_refs(mod, &pos, len - (pos - data)))) {
+        mod->line_refs_count = 0;
+        mod->line_refs_table = NULL;
+        mod->locations_count = 0;
+        mod->locations_table = NULL;
         return;
     }
 
-    *filenames = parse_filename_table(&pos, num_filenames, len - (pos - data));
-    if (IS_NULL_PTR(*filenames)) {
-        free(*line_refs);
-        return;
+    mod->locations_table = pos;
+
+    if (UNLIKELY(!module_check_locations(mod, pos, len - (pos - data)))) {
+        mod->line_refs_count = 0;
+        mod->line_refs_table = NULL;
+        mod->locations_count = 0;
+        mod->locations_table = NULL;
     }
 }
 
 void module_insert_line_ref_offset(Module *mod, int line_ref, int offset)
 {
-    if (IS_NULL_PTR(mod->line_refs) || line_ref == 0) {
+    if (IS_NULL_PTR(mod->line_refs_table) || line_ref == 0) {
         return;
     }
     struct LineRefOffset *ref_offset = malloc(sizeof(struct LineRefOffset));
@@ -602,7 +680,16 @@ void module_insert_line_ref_offset(Module *mod, int line_ref, int offset)
     list_append(&mod->line_ref_offsets, &ref_offset->head);
 }
 
-int module_find_line(Module *mod, unsigned int offset)
+static bool module_find_line_ref(Module *mod, uint16_t line_ref, uint16_t *line, size_t *filename_len, const uint8_t **filename)
+{
+    uint16_t location_ix;
+    if (UNLIKELY(!module_get_line_ref(mod, line_ref, line, &location_ix))) {
+        return false;
+    }
+    return module_get_location(mod, location_ix, filename_len, filename);
+}
+
+bool module_find_line(Module *mod, unsigned int offset, uint16_t *line, size_t *filename_len, const uint8_t **filename)
 {
     int i = 0;
     struct LineRefOffset *head = GET_LIST_ENTRY(&mod->line_ref_offsets, struct LineRefOffset, head);
@@ -611,25 +698,23 @@ int module_find_line(Module *mod, unsigned int offset)
         struct LineRefOffset *ref_offset = GET_LIST_ENTRY(item, struct LineRefOffset, head);
 
         if (offset == ref_offset->offset) {
-            return mod->line_refs[ref_offset->line_ref];
+            return module_find_line_ref(mod, ref_offset->line_ref, line, filename_len, filename);
         } else if (i == 0 && offset < ref_offset->offset) {
-            return -1;
+            return false;
         } else {
 
             struct LineRefOffset *prev_ref_offset = GET_LIST_ENTRY(ref_offset->head.prev, struct LineRefOffset, head);
             if (prev_ref_offset->offset <= offset && offset < ref_offset->offset) {
-                return mod->line_refs[prev_ref_offset->line_ref];
+                return module_find_line_ref(mod, prev_ref_offset->line_ref, line, filename_len, filename);
             }
 
             struct LineRefOffset *next_ref_offset = GET_LIST_ENTRY(ref_offset->head.next, struct LineRefOffset, head);
             if (next_ref_offset == head && ref_offset->offset <= offset) {
-                return mod->line_refs[ref_offset->line_ref];
+                return module_find_line_ref(mod, ref_offset->line_ref, line, filename_len, filename);
             }
         }
 
         ++i;
     }
-    // should never occur, but return is needed to squelch compiler warnings
-    AVM_ABORT();
-    return -1;
+    return false;
 }

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -108,9 +108,11 @@ struct Module
     void *fun_table;
     void *str_table;
     size_t str_table_len;
+    size_t line_refs_count;
+    const uint8_t *line_refs_table;
+    size_t locations_count;
+    const uint8_t *locations_table;
 
-    uint16_t *line_refs;
-    struct ModuleFilename *filenames;
     struct ListHead line_ref_offsets;
 
     const struct ExportedFunction **imported_funcs;
@@ -403,16 +405,19 @@ void module_insert_line_ref_offset(Module *mod, int line_ref, int offset);
  *
  * @param mod the module
  * @param offset
- * @return the line reference
+ * @param line on output the line number or 0 for the undefined location
+ * @param filename_len on output the length of the filename or NULL if it's default "module.erl"
+ * @param filename on output the filename or NULL if it's module.erl. Can be NULL.
+ * @return \c true if the line was found
  */
-int module_find_line(Module *mod, unsigned int offset);
+bool module_find_line(Module *mod, unsigned int offset, uint16_t *line, size_t *filename_len, const uint8_t **filename);
 
 /**
  * @return true if the module has line information, false, otherwise.
  */
 static inline bool module_has_line_chunk(Module *mod)
 {
-    return mod->line_refs != NULL;
+    return mod->line_refs_table != NULL;
 }
 
 #ifdef __cplusplus

--- a/src/libAtomVM/stacktrace.c
+++ b/src/libAtomVM/stacktrace.c
@@ -76,34 +76,54 @@ static void cp_to_mod_lbl_off(term cp, Context *ctx, Module **cp_mod, int *label
     *l_off = *mod_offset - (mod->labels[*label] - code);
 }
 
-static bool is_module_member(Module *mod, Module **mods, unsigned long len)
+static bool location_sets_append(GlobalContext *global, Module *mod, const uint8_t *filename, size_t filename_len, size_t *total_filename_len, const void ***io_locations_set, size_t *io_locations_set_size)
 {
-    for (unsigned long i = 0; i < len; ++i) {
-        if (mods[i] == mod) {
+    const void **locations_set = *io_locations_set;
+    size_t locations_set_size = *io_locations_set_size;
+    const void *key = filename;
+    if (IS_NULL_PTR(filename)) {
+        key = mod;
+        AtomString module_name_atom_str = globalcontext_atomstring_from_term(global, module_get_name(mod));
+        filename_len = atom_string_len(module_name_atom_str) + 4; // ".erl"
+    }
+    for (size_t i = 0; i < locations_set_size; i++) {
+        if (locations_set[i] == key) {
             return true;
         }
     }
-    return false;
+    const void **new_locations_set = realloc(locations_set, (locations_set_size + 1) * sizeof(const uint8_t *));
+    if (IS_NULL_PTR(new_locations_set)) {
+        // Some versions of gcc don't know that if allocation fails, original pointer should still be freed
+#pragma GCC diagnostic push
+#if (defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 12)
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
+        free(locations_set);
+#pragma GCC diagnostic pop
+        *io_locations_set = NULL;
+        fprintf(stderr, "Unable to allocate space for locations set.  No stacktrace will be created\n");
+        return false;
+    }
+    *io_locations_set = new_locations_set;
+    new_locations_set[locations_set_size] = key;
+    *io_locations_set_size = locations_set_size + 1;
+    *total_filename_len += filename_len;
+
+    return true;
 }
 
 term stacktrace_create_raw(Context *ctx, Module *mod, int current_offset, term exception_class)
 {
     unsigned int num_frames = 0;
     unsigned int num_aux_terms = 0;
-    unsigned int filename_lens = 0;
+    size_t filename_lens = 0;
     Module *prev_mod = NULL;
     long prev_mod_offset = -1;
     term *ct = ctx->e;
     term *stack_base = context_stack_base(ctx);
 
-    unsigned long stack_size = context_stack_size(ctx);
-    Module **modules = malloc(stack_size * sizeof(Module *));
-    if (IS_NULL_PTR(modules)) {
-        fprintf(stderr, "Unable to allocate space for modules list.  No stacktrace will be created\n");
-        return UNDEFINED_ATOM;
-    }
-
-    size_t num_mods = 0;
+    const void **locations = NULL;
+    size_t num_locations = 0;
 
     while (ct != stack_base) {
         if (term_is_cp(*ct)) {
@@ -119,12 +139,15 @@ term stacktrace_create_raw(Context *ctx, Module *mod, int current_offset, term e
                 prev_mod = cp_mod;
                 prev_mod_offset = mod_offset;
                 if (module_has_line_chunk(cp_mod)) {
-                    if (!is_module_member(cp_mod, modules, num_mods)) {
-                        modules[num_mods] = cp_mod;
-                        filename_lens += cp_mod->filenames[0].len;
-                        num_mods++;
+                    uint16_t line;
+                    const uint8_t *filename;
+                    size_t filename_len;
+                    if (LIKELY(module_find_line(cp_mod, (unsigned int) mod_offset, &line, &filename_len, &filename))) {
+                        if (!location_sets_append(ctx->global, cp_mod, filename, filename_len, &filename_lens, &locations, &num_locations)) {
+                            return UNDEFINED_ATOM;
+                        }
+                        num_aux_terms++;
                     }
-                    num_aux_terms++;
                 }
             }
         } else if (term_is_catch_label(*ct)) {
@@ -140,12 +163,15 @@ term stacktrace_create_raw(Context *ctx, Module *mod, int current_offset, term e
                 prev_mod = cl_mod;
                 prev_mod_offset = mod_offset;
                 if (module_has_line_chunk(cl_mod)) {
-                    if (!is_module_member(cl_mod, modules, num_mods)) {
-                        modules[num_mods] = cl_mod;
-                        filename_lens += cl_mod->filenames[0].len;
-                        num_mods++;
+                    uint16_t line;
+                    const uint8_t *filename;
+                    size_t filename_len;
+                    if (LIKELY(module_find_line(cl_mod, (unsigned int) mod_offset, &line, &filename_len, &filename))) {
+                        if (!location_sets_append(ctx->global, cl_mod, filename, filename_len, &filename_lens, &locations, &num_locations)) {
+                            return UNDEFINED_ATOM;
+                        }
+                        num_aux_terms++;
                     }
-                    num_aux_terms++;
                 }
             }
         }
@@ -154,14 +180,18 @@ term stacktrace_create_raw(Context *ctx, Module *mod, int current_offset, term e
 
     num_frames++;
     if (module_has_line_chunk(mod)) {
-        if (!is_module_member(mod, modules, num_mods)) {
-            filename_lens += mod->filenames[0].len;
-            num_mods++;
+        uint16_t line;
+        const uint8_t *filename;
+        size_t filename_len;
+        if (LIKELY(module_find_line(mod, (unsigned int) current_offset, &line, &filename_len, &filename))) {
+            if (!location_sets_append(ctx->global, mod, filename, filename_len, &filename_lens, &locations, &num_locations)) {
+                return UNDEFINED_ATOM;
+            }
+            num_aux_terms++;
         }
-        num_aux_terms++;
     }
 
-    free(modules);
+    free(locations);
 
     // {num_frames, num_aux_terms, filename_lens, num_mods, [{module, offset}, ...]}
     size_t requested_size = TUPLE_SIZE(6) + num_frames * (2 + TUPLE_SIZE(2));
@@ -229,7 +259,7 @@ term stacktrace_create_raw(Context *ctx, Module *mod, int current_offset, term e
     term_put_tuple_element(stack_info, 0, term_from_int(num_frames));
     term_put_tuple_element(stack_info, 1, term_from_int(num_aux_terms));
     term_put_tuple_element(stack_info, 2, term_from_int(filename_lens));
-    term_put_tuple_element(stack_info, 3, term_from_int(num_mods));
+    term_put_tuple_element(stack_info, 3, term_from_int(num_locations));
     term_put_tuple_element(stack_info, 4, raw_stacktrace);
     term_put_tuple_element(stack_info, 5, exception_class);
 
@@ -243,14 +273,14 @@ term stacktrace_exception_class(term stack_info)
 
 struct ModulePathPair
 {
-    term module;
+    const void *key;
     term path;
 };
 
-static term find_path_created(term module_name, struct ModulePathPair *module_paths, int len)
+static term find_path_created(const void *key, struct ModulePathPair *module_paths, int len)
 {
     for (int i = 0; i < len; ++i) {
-        if (module_paths[i].module == module_name) {
+        if (module_paths[i].key == key) {
             return module_paths[i].path;
         }
     }
@@ -312,24 +342,42 @@ term stacktrace_build(Context *ctx, term *stack_info, uint32_t live)
 
         term aux_data = term_nil();
         if (module_has_line_chunk(cp_mod)) {
-            term line_tuple = term_alloc_tuple(2, &ctx->heap);
-            term_put_tuple_element(line_tuple, 0, globalcontext_make_atom(glb, ATOM_STR("\x4", "line")));
-            int line = module_find_line(cp_mod, (unsigned int) mod_offset);
-            term_put_tuple_element(line_tuple, 1, line == -1 ? UNDEFINED_ATOM : term_from_int(line));
-            aux_data = term_list_prepend(line_tuple, aux_data, &ctx->heap);
+            uint16_t line;
+            const uint8_t *filename;
+            size_t filename_len;
+            if (LIKELY(module_find_line(cp_mod, (unsigned int) mod_offset, &line, &filename_len, &filename))) {
+                term line_tuple = term_alloc_tuple(2, &ctx->heap);
+                term_put_tuple_element(line_tuple, 0, globalcontext_make_atom(glb, ATOM_STR("\x4", "line")));
+                term_put_tuple_element(line_tuple, 1, term_from_int(line));
+                aux_data = term_list_prepend(line_tuple, aux_data, &ctx->heap);
 
-            term file_tuple = term_alloc_tuple(2, &ctx->heap);
-            term_put_tuple_element(file_tuple, 0, globalcontext_make_atom(glb, ATOM_STR("\x4", "file")));
+                term file_tuple = term_alloc_tuple(2, &ctx->heap);
+                term_put_tuple_element(file_tuple, 0, globalcontext_make_atom(glb, ATOM_STR("\x4", "file")));
 
-            term path = find_path_created(module_name, module_paths, module_path_idx);
-            if (term_is_invalid_term(path)) {
-                path = term_from_string((const uint8_t *) cp_mod->filenames[0].data, cp_mod->filenames[0].len, &ctx->heap);
-                module_paths[module_path_idx].module = module_name;
-                module_paths[module_path_idx].path = path;
-                module_path_idx++;
+                const void *key = IS_NULL_PTR(filename) ? (const void *) cp_mod : (const void *) filename;
+                term path = find_path_created(key, module_paths, module_path_idx);
+                if (term_is_invalid_term(path)) {
+                    if (IS_NULL_PTR(filename)) {
+                        AtomString module_name_atom_str = globalcontext_atomstring_from_term(ctx->global, module_get_name(cp_mod));
+                        uint8_t *default_filename = malloc(atom_string_len(module_name_atom_str) + 4);
+                        if (IS_NULL_PTR(default_filename)) {
+                            free(module_paths);
+                            return OUT_OF_MEMORY_ATOM;
+                        }
+                        memcpy(default_filename, atom_string_data(module_name_atom_str), atom_string_len(module_name_atom_str));
+                        memcpy(default_filename + atom_string_len(module_name_atom_str), ".erl", 4);
+                        path = term_from_string(default_filename, atom_string_len(module_name_atom_str) + 4, &ctx->heap);
+                        free(default_filename);
+                    } else {
+                        path = term_from_string(filename, filename_len, &ctx->heap);
+                    }
+                    module_paths[module_path_idx].key = key;
+                    module_paths[module_path_idx].path = path;
+                    module_path_idx++;
+                }
+                term_put_tuple_element(file_tuple, 1, path);
+                aux_data = term_list_prepend(file_tuple, aux_data, &ctx->heap);
             }
-            term_put_tuple_element(file_tuple, 1, path);
-            aux_data = term_list_prepend(file_tuple, aux_data, &ctx->heap);
         }
         term_put_tuple_element(frame_i, 3, aux_data);
 

--- a/tests/erlang_tests/test_stacktrace.hrl
+++ b/tests/erlang_tests/test_stacktrace.hrl
@@ -1,0 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+throw_with_other_file_and_line() ->
+    throw({?FILE, ?LINE}).


### PR DESCRIPTION
- Fix a crash that happened if a stack element was in another file
- Optimize memory usage by not building lists of line references and of filenames
- Fix parsing of files with no filename at all.

This fixes most occurrences of 'unsupported line_ref tag: 0' (fixes #1388)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
