### PR TITLE
CI: Adjust sim boards to upstream defaults

### DIFF
--- a/src/platforms/esp32/test/sim_boards/diagram.esp32.json
+++ b/src/platforms/esp32/test/sim_boards/diagram.esp32.json
@@ -8,7 +8,7 @@
       "id": "esp",
       "top": 0,
       "left": 0,
-      "attrs": { "cpuFrequency": "80" }
+      "attrs": { "cpuFrequency": "12" }
     },
     {
       "type": "wokwi-microsd-card",

--- a/src/platforms/esp32/test/sim_boards/diagram.esp32c6.json
+++ b/src/platforms/esp32/test/sim_boards/diagram.esp32c6.json
@@ -3,7 +3,13 @@
   "author": "Uri Shaked",
   "editor": "wokwi",
   "parts": [
-    { "type": "board-esp32-c6-devkitc-1", "id": "esp", "top": 5.29, "left": 4.12, "attrs": {} },
+    {
+      "type": "board-esp32-c6-devkitc-1",
+      "id": "esp",
+      "top": 5.29,
+      "left": 4.12,
+      "attrs": { "cpuFrequency": "32" }
+    },
     {
       "type": "wokwi-slide-potentiometer",
       "id": "pot1",
@@ -14,11 +20,11 @@
     }
   ],
   "connections": [
-    [ "esp:TX", "$serialMonitor:RX", "", [] ],
-    [ "esp:RX", "$serialMonitor:TX", "", [] ],
-    [ "esp:GND.1", "pot1:GND", "black", [ "h-28.8", "v48", "h-211.2" ] ],
-    [ "esp:3V3", "pot1:VCC", "red", [ "v0", "h-38.4", "v144" ] ],
-    [ "esp:3", "pot1:SIG", "green", [ "h0" ] ]
+    ["esp:TX", "$serialMonitor:RX", "", []],
+    ["esp:RX", "$serialMonitor:TX", "", []],
+    ["esp:GND.1", "pot1:GND", "black", ["h-28.8", "v48", "h-211.2"]],
+    ["esp:3V3", "pot1:VCC", "red", ["v0", "h-38.4", "v144"]],
+    ["esp:3", "pot1:SIG", "green", ["h0"]]
   ],
   "dependencies": {}
 }


### PR DESCRIPTION
Use the same  "cpuFrequency" as upstream does for their extensive esp-idf (wifi) testing: https://github.com/wokwi/esp32-test-binaries/blob/main/test/wifi_function/diagram.esp32c6.json

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
