### PR TITLE
Fix advanced tracing

### DIFF
--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -159,7 +159,7 @@ enum ModuleLoadResult
  * @param module_atom module name atom string.
  * @param function_atom function name atom string.
  */
-void module_get_imported_function_module_and_name(const Module *this_module, int index, AtomString *module_atom, AtomString *function_atom);
+void module_get_imported_function_module_and_name(const Module *this_module, int index, AtomString *module_atom, AtomString *function_atom, GlobalContext *glb);
 #endif
 
 /**

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1696,7 +1696,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
         if (UNLIKELY(ctx->trace_calls)) {
             AtomString module_name;
             AtomString function_name;
-            module_get_imported_function_module_and_name(mod, index, &module_name, &function_name);
+            module_get_imported_function_module_and_name(mod, index, &module_name, &function_name, ctx->global);
             trace_apply(ctx, call_type, module_name, function_name, arity);
         }
     }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
