### PR TITLE
Fix possible memory corruption in `erlang:make_tuple/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ memory error
 - Fixed possible concurrency problems in ESP32 UART driver
 - Fixed concurrency and memory leak related to links and monitors
 - Fixed issues with parsing of line references for stack traces
+- Fixed memory corruption issue with `erlang:make_tuple/2`
 
 ### Changed
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1658,7 +1658,7 @@ static term nif_erlang_make_tuple_2(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, count_elem + 1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, TUPLE_SIZE(count_elem), 1, argv + 1, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term new_tuple = term_alloc_tuple(count_elem, &ctx->heap);

--- a/tests/erlang_tests/test_make_tuple.erl
+++ b/tests/erlang_tests/test_make_tuple.erl
@@ -20,19 +20,18 @@
 
 -module(test_make_tuple).
 
--export([start/0, f/1, g/1]).
+-export([start/0, f/1, g/2]).
 
 start() ->
-    g(f(2)) + g(f(0)).
+    {} = ?MODULE:f(0),
+    {hello, hello} = ?MODULE:f(2),
+    % There are 35 terms available on heap.
+    R = ?MODULE:g(34, ?MODULE:f(2)),
+    {R} = ?MODULE:g(1, R),
+    0.
 
 f(N) ->
     erlang:make_tuple(N, hello).
 
-g({}) ->
-    1;
-g({hello}) ->
-    2;
-g({hello, hello}) ->
-    3;
-g(_) ->
-    100.
+g(N, Elem) ->
+    erlang:make_tuple(N, Elem).

--- a/tests/test.c
+++ b/tests/test.c
@@ -178,7 +178,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(test_insert_element, 121),
     TEST_CASE_EXPECTED(test_delete_element, 421),
     TEST_CASE_EXPECTED(test_tuple_to_list, 300),
-    TEST_CASE_EXPECTED(test_make_tuple, 4),
+    TEST_CASE(test_make_tuple),
     TEST_CASE_EXPECTED(test_make_list, 5),
     TEST_CASE_EXPECTED(test_list_gc, 2),
     TEST_CASE_EXPECTED(test_list_processes, 3),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
