### PR TITLE
Improve CI valgrind step

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -332,61 +332,61 @@ jobs:
       working-directory: build
       run: |
         ulimit -c unlimited
-        ./tests/test-erlang -s prime_smp
         valgrind --error-exitcode=1 ./tests/test-erlang -s prime_smp
+        ./tests/test-erlang -s prime_smp
 
     - name: "Test: test-enif"
       working-directory: build
       run: |
         ulimit -c unlimited
-        ./tests/test-enif
         valgrind --error-exitcode=1 ./tests/test-enif
+        ./tests/test-enif
 
     - name: "Test: test-heap"
       working-directory: build
       run: |
         ulimit -c unlimited
-        ./tests/test-heap
         valgrind --error-exitcode=1 ./tests/test-heap
+        ./tests/test-heap
 
     - name: "Test: test-mailbox"
       working-directory: build
       run: |
         ulimit -c unlimited
-        ./tests/test-mailbox
         valgrind --error-exitcode=1 ./tests/test-mailbox
+        ./tests/test-mailbox
 
     - name: "Test: test-structs"
       timeout-minutes: 10
       working-directory: build
       run: |
         ulimit -c unlimited
-        ./tests/test-structs
         valgrind --error-exitcode=1 ./tests/test-structs
+        ./tests/test-structs
 
     - name: "Test: test_estdlib.avm"
       timeout-minutes: 5
       working-directory: build
       run: |
         ulimit -c unlimited
-        ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
         valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
 
     - name: "Test: test_eavmlib.avm"
       timeout-minutes: 10
       working-directory: build
       run: |
         ulimit -c unlimited
-        ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
         valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
+        ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
 
     - name: "Test: test_alisp.avm"
       timeout-minutes: 10
       working-directory: build
       run: |
         ulimit -c unlimited
-        ./src/AtomVM ./tests/libs/alisp/test_alisp.avm
         valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/alisp/test_alisp.avm
+        ./src/AtomVM ./tests/libs/alisp/test_alisp.avm
 
     - name: "Test: Tests.avm (Elixir)"
       timeout-minutes: 10
@@ -395,8 +395,8 @@ jobs:
         ulimit -c unlimited
         if command -v elixirc &> /dev/null
         then
-          ./src/AtomVM ./tests/libs/exavmlib/Tests.avm
           valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/exavmlib/Tests.avm
+          ./src/AtomVM ./tests/libs/exavmlib/Tests.avm
         fi
 
     - name: "Install and smoke test"

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -333,28 +333,28 @@ jobs:
       run: |
         ulimit -c unlimited
         ./tests/test-erlang -s prime_smp
-        valgrind ./tests/test-erlang -s prime_smp
+        valgrind --error-exitcode=1 ./tests/test-erlang -s prime_smp
 
     - name: "Test: test-enif"
       working-directory: build
       run: |
         ulimit -c unlimited
         ./tests/test-enif
-        valgrind ./tests/test-enif
+        valgrind --error-exitcode=1 ./tests/test-enif
 
     - name: "Test: test-heap"
       working-directory: build
       run: |
         ulimit -c unlimited
         ./tests/test-heap
-        valgrind ./tests/test-heap
+        valgrind --error-exitcode=1 ./tests/test-heap
 
     - name: "Test: test-mailbox"
       working-directory: build
       run: |
         ulimit -c unlimited
         ./tests/test-mailbox
-        valgrind ./tests/test-mailbox
+        valgrind --error-exitcode=1 ./tests/test-mailbox
 
     - name: "Test: test-structs"
       timeout-minutes: 10
@@ -362,7 +362,7 @@ jobs:
       run: |
         ulimit -c unlimited
         ./tests/test-structs
-        valgrind ./tests/test-structs
+        valgrind --error-exitcode=1 ./tests/test-structs
 
     - name: "Test: test_estdlib.avm"
       timeout-minutes: 5
@@ -370,7 +370,7 @@ jobs:
       run: |
         ulimit -c unlimited
         ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
-        valgrind ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
 
     - name: "Test: test_eavmlib.avm"
       timeout-minutes: 10
@@ -378,7 +378,7 @@ jobs:
       run: |
         ulimit -c unlimited
         ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
-        valgrind ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
+        valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/eavmlib/test_eavmlib.avm
 
     - name: "Test: test_alisp.avm"
       timeout-minutes: 10
@@ -386,7 +386,7 @@ jobs:
       run: |
         ulimit -c unlimited
         ./src/AtomVM ./tests/libs/alisp/test_alisp.avm
-        valgrind ./src/AtomVM ./tests/libs/alisp/test_alisp.avm
+        valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/alisp/test_alisp.avm
 
     - name: "Test: Tests.avm (Elixir)"
       timeout-minutes: 10
@@ -396,7 +396,7 @@ jobs:
         if command -v elixirc &> /dev/null
         then
           ./src/AtomVM ./tests/libs/exavmlib/Tests.avm
-          valgrind ./src/AtomVM ./tests/libs/exavmlib/Tests.avm
+          valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/exavmlib/Tests.avm
         fi
 
     - name: "Install and smoke test"

--- a/.github/workflows/build-libraries.yaml
+++ b/.github/workflows/build-libraries.yaml
@@ -76,7 +76,7 @@ jobs:
       working-directory: build
       run: |
         ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
-        valgrind ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
 
     - name: "Rename and write sha256sum"
       working-directory: build

--- a/.github/workflows/build-libraries.yaml
+++ b/.github/workflows/build-libraries.yaml
@@ -75,8 +75,8 @@ jobs:
       timeout-minutes: 10
       working-directory: build
       run: |
-        ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
         valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
+        ./src/AtomVM ./tests/libs/estdlib/test_estdlib.avm
 
     - name: "Rename and write sha256sum"
       working-directory: build


### PR DESCRIPTION
1. fail when valgrind detects a memory error
2. run valgrind first, to make easier to deal with bugs and crashes

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
