### PR TITLE
Add support for crypto with emscripten by fetching mbedtls

### DIFF
--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -47,7 +47,7 @@ jobs:
         cd build
         cmake .. -G Ninja -DAVM_WARNINGS_ARE_ERRORS=ON
         # test_eavmlib does not work with wasm due to http + ssl test
-        ninja AtomVM atomvmlib test_etest test_alisp hello_world run_script call_cast html5_events wasm_webserver
+        ninja AtomVM atomvmlib erlang_test_modules test_etest test_alisp test_estdlib hello_world run_script call_cast html5_events wasm_webserver
 
     - name: Upload AtomVM and test modules
       uses: actions/upload-artifact@v4
@@ -112,9 +112,11 @@ jobs:
         node src/AtomVM.js ../../../../build/examples/erlang/hello_world.beam  ../../../../build/libs/eavmlib/src/eavmlib.avm
         # Run tests that pass
         node src/AtomVM.js ../../../../build/tests/libs/alisp/test_alisp.avm
+        node src/AtomVM.js ../../../../build/tests/libs/estdlib/test_estdlib.avm
         # test_eavmlib does not work with wasm due to http + ssl test
         # node src/AtomVM.js ../../../../build/tests/libs/eavmlib/test_eavmlib.avm
         node src/AtomVM.js ../../../../build/tests/libs/etest/test_etest.avm
+        node src/AtomVM.js ../../../../build/tests/erlang_tests/test_crypto.beam
 
     - name: "Rename and write sha256sum (node)"
       if: startsWith(github.ref, 'refs/tags/')

--- a/CMakeModules/FetchMbedTLS.cmake
+++ b/CMakeModules/FetchMbedTLS.cmake
@@ -1,0 +1,30 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+include(FetchContent)
+
+FetchContent_Declare(
+  mbedtls
+  GIT_REPOSITORY http://github.com/mbed-TLS/mbedtls.git
+  GIT_TAG        v3.6.2
+  GIT_SHALLOW    1
+)
+
+FetchContent_MakeAvailable(mbedtls)

--- a/src/platforms/emscripten/src/lib/CMakeLists.txt
+++ b/src/platforms/emscripten/src/lib/CMakeLists.txt
@@ -20,9 +20,11 @@
 
 cmake_minimum_required (VERSION 3.13)
 project (libAtomVMPlatformEmscripten)
+include(FetchMbedTLS)
 
 set(HEADER_FILES
     emscripten_sys.h
+    "../../../../libAtomVM/otp_crypto.h"
 )
 
 set(SOURCE_FILES
@@ -30,6 +32,7 @@ set(SOURCE_FILES
     platform_nifs.c
     smp.c
     sys.c
+    "../../../../libAtomVM/otp_crypto.c"
 )
 
 set(
@@ -41,3 +44,4 @@ add_library(libAtomVM${PLATFORM_LIB_SUFFIX} ${SOURCE_FILES} ${HEADER_FILES})
 target_compile_features(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC c_std_11)
 
 target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC libAtomVM)
+target_link_libraries(libAtomVM${PLATFORM_LIB_SUFFIX} PUBLIC MbedTLS::mbedcrypto)

--- a/src/platforms/emscripten/src/lib/emscripten_sys.h
+++ b/src/platforms/emscripten/src/lib/emscripten_sys.h
@@ -33,6 +33,17 @@
 #include <emscripten/fetch.h>
 #include <emscripten/promise.h>
 
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+
+#if defined(MBEDTLS_VERSION_NUMBER) && (MBEDTLS_VERSION_NUMBER >= 0x03000000)
+#include <mbedtls/build_info.h>
+#else
+#include <mbedtls/config.h>
+#endif
+
+#include "sys_mbedtls.h"
+
 struct PromiseResource
 {
     em_promise_t promise;
@@ -104,6 +115,18 @@ struct EmscriptenPlatformData
     struct ListHead messages;
     ErlNifResourceType *promise_resource_type;
     ErlNifResourceType *htmlevent_user_data_resource_type;
+
+#ifndef AVM_NO_SMP
+    Mutex *entropy_mutex;
+#endif
+    mbedtls_entropy_context entropy_ctx;
+    bool entropy_is_initialized;
+
+#ifndef AVM_NO_SMP
+    Mutex *random_mutex;
+#endif
+    mbedtls_ctr_drbg_context random_ctx;
+    bool random_is_initialized;
 };
 
 void sys_enqueue_emscripten_cast_message(GlobalContext *glb, const char *target, const char *message);

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -25,6 +25,7 @@
 #include <interop.h>
 #include <memory.h>
 #include <nifs.h>
+#include <otp_crypto.h>
 #include <term.h>
 #include <term_typedef.h>
 
@@ -770,6 +771,9 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
     }
     if (strcmp("atomvm:random/0", nifname) == 0) {
         return &atomvm_random_nif;
+    }
+    if (memcmp("crypto:", nifname, strlen("crypro:")) == 0) {
+        return otp_crypto_nif_get_nif(nifname);
     }
     if (memcmp("emscripten:", nifname, strlen("emscripten:"))) {
         return NULL;

--- a/src/platforms/emscripten/src/lib/sys.c
+++ b/src/platforms/emscripten/src/lib/sys.c
@@ -169,6 +169,20 @@ void sys_init_platform(GlobalContext *glb)
         fprintf(stderr, "Cannot initialize promise_resource_type");
         AVM_ABORT();
     }
+
+#ifndef AVM_NO_SMP
+    platform->entropy_mutex = smp_mutex_create();
+    if (IS_NULL_PTR(platform->entropy_mutex)) {
+        AVM_ABORT();
+    }
+    platform->random_mutex = smp_mutex_create();
+    if (IS_NULL_PTR(platform->random_mutex)) {
+        AVM_ABORT();
+    }
+#endif
+    platform->entropy_is_initialized = false;
+    platform->random_is_initialized = false;
+
     glb->platform_data = platform;
 }
 
@@ -177,6 +191,12 @@ void sys_free_platform(GlobalContext *glb)
     struct EmscriptenPlatformData *platform = glb->platform_data;
     pthread_cond_destroy(&platform->poll_cond);
     pthread_mutex_destroy(&platform->poll_mutex);
+    if (platform->random_is_initialized) {
+        mbedtls_ctr_drbg_free(&platform->random_ctx);
+    }
+    if (platform->entropy_is_initialized) {
+        mbedtls_entropy_free(&platform->entropy_ctx);
+    }
     free(platform);
 }
 
@@ -729,4 +749,71 @@ term sys_get_info(Context *ctx, term key)
     UNUSED(ctx);
     UNUSED(key);
     return UNDEFINED_ATOM;
+}
+
+int sys_mbedtls_entropy_func(void *entropy, unsigned char *buf, size_t size)
+{
+#ifndef MBEDTLS_THREADING_C
+    struct EmscriptenPlatformData *platform
+        = CONTAINER_OF(entropy, struct EmscriptenPlatformData, entropy_ctx);
+    SMP_MUTEX_LOCK(platform->entropy_mutex);
+    int result = mbedtls_entropy_func(entropy, buf, size);
+    SMP_MUTEX_UNLOCK(platform->entropy_mutex);
+
+    return result;
+#else
+    return mbedtls_entropy_func(entropy, buf, size);
+#endif
+}
+
+mbedtls_entropy_context *sys_mbedtls_get_entropy_context_lock(GlobalContext *global)
+{
+    struct EmscriptenPlatformData *platform = global->platform_data;
+
+    SMP_MUTEX_LOCK(platform->entropy_mutex);
+
+    if (!platform->entropy_is_initialized) {
+        mbedtls_entropy_init(&platform->entropy_ctx);
+        platform->entropy_is_initialized = true;
+    }
+
+    return &platform->entropy_ctx;
+}
+
+void sys_mbedtls_entropy_context_unlock(GlobalContext *global)
+{
+    struct EmscriptenPlatformData *platform = global->platform_data;
+    SMP_MUTEX_UNLOCK(platform->entropy_mutex);
+}
+
+mbedtls_ctr_drbg_context *sys_mbedtls_get_ctr_drbg_context_lock(GlobalContext *global)
+{
+    struct EmscriptenPlatformData *platform = global->platform_data;
+
+    SMP_MUTEX_LOCK(platform->random_mutex);
+
+    if (!platform->random_is_initialized) {
+        mbedtls_ctr_drbg_init(&platform->random_ctx);
+
+        mbedtls_entropy_context *entropy_ctx = sys_mbedtls_get_entropy_context_lock(global);
+        // Safe to unlock it now, sys_mbedtls_entropy_func will lock it again later
+        sys_mbedtls_entropy_context_unlock(global);
+
+        const char *seed = "AtomVM Mbed-TLS initial seed.";
+        int seed_len = strlen(seed);
+        int seed_err = mbedtls_ctr_drbg_seed(&platform->random_ctx, sys_mbedtls_entropy_func,
+            entropy_ctx, (const unsigned char *) seed, seed_len);
+        if (UNLIKELY(seed_err != 0)) {
+            abort();
+        }
+        platform->random_is_initialized = true;
+    }
+
+    return &platform->random_ctx;
+}
+
+void sys_mbedtls_ctr_drbg_context_unlock(GlobalContext *global)
+{
+    struct EmscriptenPlatformData *platform = global->platform_data;
+    SMP_MUTEX_UNLOCK(platform->random_mutex);
 }

--- a/src/platforms/emscripten/src/main.c
+++ b/src/platforms/emscripten/src/main.c
@@ -104,7 +104,7 @@ static int start(void)
     fprintf(stdout, "\n");
 
     int status;
-    if (ret_value == OK_ATOM) {
+    if (ret_value == OK_ATOM || ret_value == term_from_int(0)) {
         status = EXIT_SUCCESS;
     } else {
         status = EXIT_FAILURE;

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -23,7 +23,26 @@
 -export([start/0]).
 
 start() ->
-    ok = etest:test(get_tests(get_otp_version())).
+    OTPVersion = get_otp_version(),
+    NonNetworkingTests = get_non_networking_tests(OTPVersion),
+    Networking =
+        case OTPVersion of
+            atomvm ->
+                case atomvm:platform() of
+                    emscripten ->
+                        false;
+                    _ ->
+                        true
+                end;
+            _ ->
+                true
+        end,
+    NetworkingTests =
+        if
+            Networking -> get_networking_tests(OTPVersion);
+            true -> []
+        end,
+    ok = etest:test(NonNetworkingTests ++ NetworkingTests).
 
 get_otp_version() ->
     case erlang:system_info(machine) of
@@ -33,16 +52,12 @@ get_otp_version() ->
             atomvm
     end.
 
-get_tests(OTPVersion) when
-    (is_integer(OTPVersion) andalso OTPVersion >= 27) orelse OTPVersion == atomvm
+% test_sets heavily relies on is_equal that is from OTP-27
+get_non_networking_tests(OTPVersion) when
+    (is_integer(OTPVersion) andalso OTPVersion >= 27) orelse OTPVersion =:= atomvm
 ->
-    [test_tcp_socket, test_udp_socket, test_net, test_ssl, test_sets | get_tests(undefined)];
-get_tests(OTPVersion) when
-    (is_integer(OTPVersion) andalso OTPVersion >= 24)
-->
-    % test_sets heavily relies on is_equal that is from OTP-27
-    [test_tcp_socket, test_udp_socket, test_net, test_ssl | get_tests(undefined)];
-get_tests(_OTPVersion) ->
+    [test_sets | get_non_networking_tests(undefined)];
+get_non_networking_tests(_OTPVersion) ->
     [
         test_apply,
         test_lists,
@@ -50,8 +65,6 @@ get_tests(_OTPVersion) ->
         test_gen_event,
         test_gen_server,
         test_gen_statem,
-        test_gen_udp,
-        test_gen_tcp,
         test_io_lib,
         test_logger,
         test_maps,
@@ -62,3 +75,10 @@ get_tests(_OTPVersion) ->
         test_supervisor,
         test_lists_subtraction
     ].
+
+get_networking_tests(OTPVersion) when
+    (is_integer(OTPVersion) andalso OTPVersion >= 24) orelse OTPVersion =:= atomvm
+->
+    [test_tcp_socket, test_udp_socket, test_net, test_ssl | get_networking_tests(undefined)];
+get_networking_tests(_OTPVersion) ->
+    [test_gen_udp, test_gen_tcp].


### PR DESCRIPTION
This effectively adds support for `erlang:md5/1` on emscripten as listed in #1509

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
