### PR TITLE
CI: fix wasm-build.yaml release step

### DIFF
--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -123,9 +123,6 @@ jobs:
         ATOMVM_JS=AtomVM-node-${{ github.ref_name }}.js
         mv AtomVM.js "${ATOMVM_JS}"
         sha256sum "${ATOMVM_JS}" > "${ATOMVM_JS}.sha256"
-        ATOMVM_WORKER_JS=AtomVM.worker-node-${{ github.ref_name }}.js
-        mv AtomVM.worker.js "${ATOMVM_WORKER_JS}"
-        sha256sum "${ATOMVM_WORKER_JS}" > "${ATOMVM_WORKER_JS}.sha256"
         ATOMVM_WASM=AtomVM-node-${{ github.ref_name }}.wasm
         mv AtomVM.wasm "${ATOMVM_WASM}"
         sha256sum "${ATOMVM_WASM}" > "${ATOMVM_WASM}.sha256"
@@ -139,8 +136,6 @@ jobs:
         files: |
           src/platforms/emscripten/build/src/AtomVM-node-${{ github.ref_name }}.js
           src/platforms/emscripten/build/src/AtomVM-node-${{ github.ref_name }}.js.sha256
-          src/platforms/emscripten/build/src/AtomVM.worker-node-${{ github.ref_name }}.js
-          src/platforms/emscripten/build/src/AtomVM.worker-node-${{ github.ref_name }}.js.sha256
           src/platforms/emscripten/build/src/AtomVM-node-${{ github.ref_name }}.wasm
           src/platforms/emscripten/build/src/AtomVM-node-${{ github.ref_name }}.wasm.sha256
 
@@ -226,9 +221,6 @@ jobs:
         ATOMVM_JS=AtomVM-web-${{ github.ref_name }}.js
         mv AtomVM.js "${ATOMVM_JS}"
         sha256sum "${ATOMVM_JS}" > "${ATOMVM_JS}.sha256"
-        ATOMVM_WORKER_JS=AtomVM.worker-web-${{ github.ref_name }}.js
-        mv AtomVM.worker.js "${ATOMVM_WORKER_JS}"
-        sha256sum "${ATOMVM_WORKER_JS}" > "${ATOMVM_WORKER_JS}.sha256"
         ATOMVM_WASM=AtomVM-web-${{ github.ref_name }}.wasm
         mv AtomVM.wasm "${ATOMVM_WASM}"
         sha256sum "${ATOMVM_WASM}" > "${ATOMVM_WASM}.sha256"
@@ -242,7 +234,5 @@ jobs:
         files: |
           src/platforms/emscripten/build/src/AtomVM-web-${{ github.ref_name }}.js
           src/platforms/emscripten/build/src/AtomVM-web-${{ github.ref_name }}.js.sha256
-          src/platforms/emscripten/build/src/AtomVM.worker-web-${{ github.ref_name }}.js
-          src/platforms/emscripten/build/src/AtomVM.worker-web-${{ github.ref_name }}.js.sha256
           src/platforms/emscripten/build/src/AtomVM-web-${{ github.ref_name }}.wasm
           src/platforms/emscripten/build/src/AtomVM-web-${{ github.ref_name }}.wasm.sha256


### PR DESCRIPTION
Fix CI issue that appeared while releasing v0.6.5.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
