### PR TITLE
Add UF2TOOL_PATH CMake variable to avoid download during build time

### DIFF
--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -71,6 +71,14 @@ Source code is organized as follows:
 
 The `src` directory is broken up into the core platform-independent AtomVM library (`libAtomVM`), and platform-dependent code for each of the supported platforms  (Generic UNIX, ESP32, and STM32).
 
+## External dependencies
+
+### `uf2tool`
+
+AtomVM depends on `uf2tool`. It is used to pack both native and Erlang/Elixir/Gleam code for RP2. uf2tool is downloaded automatically by `rebar3` from `hex` mirrors.
+
+It is possible to use a local copy of uf2tool by setting `UF2TOOL_PATH` variable to a path to a source checkout of [`uf2tool`](https://github.com/pguyot/uf2tool) when invoking CMake.
+
 ## Platform Specific Build Instructions
 
 * [Generic UNIX](#building-for-generic-unix)

--- a/tools/uf2tool/CMakeLists.txt
+++ b/tools/uf2tool/CMakeLists.txt
@@ -21,6 +21,13 @@
 cmake_minimum_required (VERSION 3.13)
 project (UF2Tool)
 
+set(UF2TOOL_PATH "" CACHE PATH "Path to UF2Tool source tree. If unset, hex package will be used")
+
+if(NOT UF2TOOL_PATH STREQUAL "")
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/_checkouts)
+    file(CREATE_LINK ${UF2TOOL_PATH} ${CMAKE_CURRENT_BINARY_DIR}/_checkouts/uf2tool SYMBOLIC)
+endif()
+
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/rebar.config
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
 )


### PR DESCRIPTION
By default, `uf2tool` source will be downloaded from `hex` mirrors. Setting `UF2TOOL_PATH` variable allow to use a local checkout of the source tree, thus removing this download at build time.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
