### PR TITLE
Add `erlang:get/0` and `erlang:erase/0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `erlang:spawn_monitor/1`, `erlang:spawn_monitor/3`
 - Added `lists:dropwhile/2`.
 - Support for `float/1` BIF.
+- Added `erlang:get/0` and `erlang:erase/0`.
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -43,8 +43,10 @@
     min/2,
     max/2,
     memory/1,
+    get/0,
     get/1,
     put/2,
+    erase/0,
     erase/1,
     function_exported/3,
     display/1,
@@ -507,6 +509,15 @@ monotonic_time(_Unit) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
+%% @returns the process directory
+%% @doc     Return all values from the process dictionary
+%% @end
+%%-----------------------------------------------------------------------------
+-spec get() -> [{any(), any()}].
+get() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
 %% @param   Key     key in the process dictionary
 %% @returns value associated with this key or undefined
 %% @doc     Return a value associated with a given key in the process dictionary
@@ -525,6 +536,15 @@ get(_Key) ->
 %%-----------------------------------------------------------------------------
 -spec put(Key :: any(), Value :: any()) -> any().
 put(_Key, _Value) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns the previous process dictionary.
+%% @doc     Erase all keys from the process dictionary.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec erase() -> [{any(), any()}].
+erase() ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -50,7 +50,8 @@ erlang:binary_to_integer/2, &binary_to_integer_nif
 erlang:binary_to_list/1, &binary_to_list_nif
 erlang:binary_to_existing_atom/1, &binary_to_existing_atom_1_nif
 erlang:delete_element/2, &delete_element_nif
-erlang:erase/1, &erase_nif
+erlang:erase/0, &erase_0_nif
+erlang:erase/1, &erase_1_nif
 erlang:error/1, &error_nif
 erlang:error/2, &error_nif
 erlang:error/3, &error_nif
@@ -106,6 +107,7 @@ erlang:process_flag/2, &process_flag_nif
 erlang:process_flag/3, &process_flag_nif
 erlang:processes/0, &processes_nif
 erlang:process_info/2, &process_info_nif
+erlang:get/0, &get_0_nif
 erlang:put/2, &put_nif
 erlang:binary_to_term/1, &binary_to_term_nif
 erlang:binary_to_term/2, &binary_to_term_nif

--- a/tests/erlang_tests/test_dict.erl
+++ b/tests/erlang_tests/test_dict.erl
@@ -23,6 +23,7 @@
 -export([start/0, put_int/1, stringize/1, factorial/1, id/1, the_get/1, the_erase/1]).
 
 start() ->
+    ok = test_get_0_erase_0(),
     put_int(0),
     X = put_int(1),
     put_int(2),
@@ -79,4 +80,13 @@ test_put_get_erase() ->
     2 = apply(erlang, list_to_atom("get"), [{any_term}]),
     2 = apply(erlang, list_to_atom("erase"), [{any_term}]),
     undefined = erase({any_term}),
+    ok.
+
+test_get_0_erase_0() ->
+    [] = get(),
+    undefined = put({any_term}, 1),
+    [{{any_term}, 1}] = get(),
+    [{{any_term}, 1}] = erase(),
+    [] = get(),
+    [] = erase(),
     ok.


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
