### PR TITLE
Add missing `include(ExternalProject)`

### DIFF
--- a/src/platforms/rp2/tests/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/rp2/tests/test_erl_sources/CMakeLists.txt
@@ -18,6 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
+include(ExternalProject)
 ExternalProject_Add(HostAtomVM
     SOURCE_DIR ../../../../../../
     INSTALL_COMMAND cmake -E echo "Skipping install step."


### PR DESCRIPTION
It can bite in some condition when rebuilding for rp2 target.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
