### PR TITLE
Fix use after free in `bs_append` and `bs_get_binary2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ memory error
 - Fixed concurrency and memory leak related to links and monitors
 - Fixed issues with parsing of line references for stack traces
 - Fixed memory corruption issue with `erlang:make_tuple/2`
+- Fix potential use after free with code generated from OTP <= 24
 
 ### Changed
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -4337,9 +4337,6 @@ wait_timeout_trap_handler:
                 uint32_t unit;
                 DECODE_LITERAL(unit, pc);
                 term src;
-                #ifdef IMPL_EXECUTE_LOOP
-                    const uint8_t *src_pc = pc;
-                #endif
                 DECODE_COMPACT_TERM(src, pc)
                 term flags;
                 UNUSED(flags);
@@ -4367,8 +4364,10 @@ wait_timeout_trap_handler:
 
                     size_t src_size = term_binary_size(src);
                     TRIM_LIVE_REGS(live);
+                    // there is always room for a MAX_REG + 1 register, used as working register
+                    x_regs[live] = src;
                     // TODO: further investigate extra_val
-                    if (UNLIKELY(memory_ensure_free_with_roots(ctx, src_size + term_binary_heap_size(size_val / 8) + extra_val, live, x_regs, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                    if (UNLIKELY(memory_ensure_free_with_roots(ctx, src_size + term_binary_heap_size(size_val / 8) + extra_val, live + 1, x_regs, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
                     }
                 #endif
@@ -4378,7 +4377,7 @@ wait_timeout_trap_handler:
                 
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("bs_append/8, fail=%u size=%li unit=%u src=0x%lx dreg=%c%i\n", (unsigned) fail, size_val, (unsigned) unit, src, T_DEST_REG(dreg));
-                    DECODE_COMPACT_TERM(src, src_pc)
+                    src = x_regs[live];
                     term t = term_create_empty_binary(src_size + size_val / 8, &ctx->heap, ctx->global);
                     memcpy((void *) term_binary_data(t), (void *) term_binary_data(src), src_size);
 


### PR DESCRIPTION
CI should pass also with OTP-21 now.

Note: this appears to be an OTP-21 compiler bug, however the fix is still an improvement on opcode parameters handling.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
