### PR TITLE
Fix `is_function/2` guard and missing BIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ with nodejs and emscripten)
 - Added memory info in `out_of_memory` crash logs to help developers fix memory issues.
 - Added documentation and function specs for uart driver
 - Added `uart:read/2` with a timeout parameter.
+- Missing `erlang:is_function/2` BIF
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ memory error
 - Fixed issues with parsing of line references for stack traces
 - Fixed memory corruption issue with `erlang:make_tuple/2`
 - Fix potential use after free with code generated from OTP <= 24
+- Fix `is_function/2` guard
 
 ### Changed
 

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -51,6 +51,7 @@ term bif_erlang_is_binary_1(Context *ctx, uint32_t fail_label, term arg1);
 term bif_erlang_is_boolean_1(Context *ctx, uint32_t fail_label, term arg1);
 term bif_erlang_is_float_1(Context *ctx, uint32_t fail_label, term arg1);
 term bif_erlang_is_function_1(Context *ctx, uint32_t fail_label, term arg1);
+term bif_erlang_is_function_2(Context *ctx, uint32_t fail_label, term arg1, term arg2);
 term bif_erlang_is_integer_1(Context *ctx, uint32_t fail_label, term arg1);
 term bif_erlang_is_list_1(Context *ctx, uint32_t fail_label, term arg1);
 term bif_erlang_is_number_1(Context *ctx, uint32_t fail_label, term arg1);

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -46,6 +46,7 @@ erlang:is_binary/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlan
 erlang:is_boolean/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_boolean_1}
 erlang:is_float/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_float_1}
 erlang:is_function/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_function_1}
+erlang:is_function/2, {.bif.base.type = BIFFunctionType, .bif.bif2_ptr = bif_erlang_is_function_2}
 erlang:is_integer/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_integer_1}
 erlang:is_list/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_list_1}
 erlang:is_number/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_number_1}

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -5353,17 +5353,19 @@ wait_timeout_trap_handler:
                 DECODE_LABEL(label, pc)
                 term arg1;
                 DECODE_COMPACT_TERM(arg1, pc)
-                unsigned int arity;
-                DECODE_INTEGER(arity, pc)
+                term arity_term;
+                DECODE_COMPACT_TERM(arity_term, pc)
 
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("is_function2/3, label=%i, arg1=%lx, arity=%i\n", label, arg1, arity);
 
-                    if (term_is_function(arg1)) {
+                    if (term_is_function(arg1) && term_is_integer(arity_term)) {
                         const term *boxed_value = term_to_const_term_ptr(arg1);
 
                         Module *fun_module = (Module *) boxed_value[1];
                         term index_or_module = boxed_value[2];
+
+                        avm_int_t arity = term_to_int(arity_term);
 
                         uint32_t fun_arity;
 
@@ -5381,7 +5383,7 @@ wait_timeout_trap_handler:
                             fun_arity = fun_arity_and_freeze - fun_n_freeze;
                         }
 
-                        if (arity != fun_arity) {
+                        if ((arity < 0) || (arity != (avm_int_t) fun_arity)) {
                             pc = mod->labels[label];
                         }
                     } else {

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -194,6 +194,7 @@ compile_erlang(test_funs8)
 compile_erlang(test_funs9)
 compile_erlang(test_funs10)
 compile_erlang(test_funs11)
+compile_erlang(test_funs12)
 
 compile_erlang(test_make_fun3)
 
@@ -668,6 +669,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_funs9.beam
     test_funs10.beam
     test_funs11.beam
+    test_funs12.beam
 
     test_make_fun3.beam
 

--- a/tests/erlang_tests/test_funs12.erl
+++ b/tests/erlang_tests/test_funs12.erl
@@ -1,0 +1,61 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_funs12).
+-export([start/0, check_guard/3, check_bool/3, discard/1, get_fun/0]).
+
+start() ->
+    CheckGuardFun = fun ?MODULE:check_guard/3,
+    SelfFun = fun erlang:self/0,
+    {A, F} = ?MODULE:get_fun(),
+    true = ?MODULE:check_guard(3, CheckGuardFun, 3),
+    false = ?MODULE:check_guard([], CheckGuardFun, []),
+    true = ?MODULE:check_bool(SelfFun, F, 1),
+    false = ?MODULE:check_bool([], {}, 1),
+    ok = expect_error(fun() -> ?MODULE:check_bool({}, [], not_integer) end, error, badarg),
+    ok = expect_error(fun() -> ?MODULE:check_bool(SelfFun, F, not_integer) end, error, badarg),
+    ok = expect_error(fun() -> ?MODULE:check_bool(SelfFun, F, -20) end, error, badarg),
+    1 = ?MODULE:check_guard(A, F, A),
+    ?MODULE:check_guard(0, SelfFun, 0).
+
+check_guard(A, B, A) when A > 1 andalso is_function(B, A) ->
+    discard(B);
+check_guard(A, B, A) when is_function(B, A) ->
+    A;
+check_guard(A, _B, A) when A < 0 ->
+    error;
+check_guard(_A, _B, _A) ->
+    false.
+
+discard(_X) ->
+    true.
+
+check_bool(A, B, C) ->
+    is_function(A, C) or is_function(B, C).
+
+get_fun() ->
+    {1, fun(X) -> X + 1 end}.
+
+expect_error(Fun, A, B) ->
+    try Fun() of
+        Result -> {error, Result}
+    catch
+        A:B -> ok
+    end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -233,6 +233,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(test_funs9, 3555),
     TEST_CASE_EXPECTED(test_funs10, 6817),
     TEST_CASE_EXPECTED(test_funs11, 817),
+    TEST_CASE(test_funs12),
     TEST_CASE(test_make_fun3),
     TEST_CASE(fun_call_bif),
 


### PR DESCRIPTION
is_function2/3 wasn't handling registers as arity argument (see #1382) and is_function/2 BIF was missing.

See also #1509

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
