### PR TITLE
Fix for PANIC if using sntp with pico-w (#1588)

### DIFF
--- a/src/platforms/rp2/src/lib/lwipopts.h
+++ b/src/platforms/rp2/src/lib/lwipopts.h
@@ -106,4 +106,12 @@ void sntp_set_system_time_us(unsigned long sec, unsigned long usec);
 #define SNTP_SET_SYSTEM_TIME_US(sec, usec) sntp_set_system_time_us(sec, usec)
 
 #define TCP_LISTEN_BACKLOG 1
+
+// See https://github.com/atomvm/AtomVM/issues/1588
+// if we have UDP we assume we also have SNTP; lwip needs one more timer,
+// but doesn't account for it
+#if LWIP_UDP > 0
+#define MEMP_NUM_SYS_TIMEOUT (LWIP_NUM_SYS_TIMEOUT_INTERNAL + 1)
+#endif
+
 #endif /* __LWIPOPTS_H__ */


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later

See [#1588](https://github.com/atomvm/AtomVM/issues/1588).

I compiled (and run) this change with src/platforms/rp2 for pico and pico_w. I really would like to test this with pico2_w, but this platform seems not available at the moment, because _deps/pico_sdk-src is a little bit older or not available right now.

I learned about lwip and LWIP_NUM_SYS_TIMEOUT_INTERNAL and how it is calculated. AtomVM is a little bit different in this regard, because sntp is optional for the VM user. I hope it is acceptable to waste one lwip memory slot if sntp is not used at all. 

If needed, I think I can test this change in the release-0.6 branch. Tried this already, but had some troubles with a not set doxygen-found variable in the build script.

This is my first pull request, so please be kind ;) All infos are appreciated and I will try to follow them.