### PR TITLE
Fix SEGFAULT in `nif_lists_reverse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ memory error
 - Fixed memory corruption issue with `erlang:make_tuple/2`
 - Fix potential use after free with code generated from OTP <= 24
 - Fix `is_function/2` guard
+- Fixed segfault when calling `lists:reverse/1` (#1600)
 
 ### Changed
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -4598,7 +4598,7 @@ static term nif_lists_reverse(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_with_roots(ctx, len * CONS_SIZE, 2, argv, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, len * CONS_SIZE, argc, argv, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 


### PR DESCRIPTION
A hardcoded `2` as roots count is invalid when the NIF is called as `lists:reverse/1`, possibly resulting in a SEGFAULT or `Found unknown boxed type: C` error during GC

----

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
