### PR TITLE
Fix nif_atomvm_posix_read GC bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ memory error
 - Fixed memory corruption issue with `erlang:make_tuple/2`
 - Fix potential use after free with code generated from OTP <= 24
 - Fix `is_function/2` guard
+- Fixed nif_atomvm_posix_read GC bug
 
 ### Changed
 


### PR DESCRIPTION
We've been getting ASAN errors in the calls to `nif_atomvm_posix_read`, and it seems it's because when GC moves things around, it also moves what the `fd_obj_ptr` variable points to. The proposed solution is to move the GC before `enif_get_resource`. We haven't encountered the error after the fix, but please verify that it makes sense.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
