### PR TITLE
Fix concurrency bug related to resource monitors

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -180,8 +180,7 @@ void context_destroy(Context *ctx)
             struct Monitor *monitor = GET_LIST_ENTRY(item, struct Monitor, monitor_list_head);
             void *resource = term_to_term_ptr(monitor->monitor_obj);
             struct RefcBinary *refc = refc_binary_from_data(resource);
-            resource_type_demonitor(refc->resource_type, monitor->ref_ticks);
-            refc->resource_type->down(&env, resource, &ctx->process_id, &monitor->ref_ticks);
+            resource_type_fire_monitor(refc->resource_type, &env, resource, ctx->process_id, monitor->ref_ticks);
             free(monitor);
         }
     }

--- a/src/libAtomVM/resources.h
+++ b/src/libAtomVM/resources.h
@@ -150,6 +150,19 @@ void destroy_resource_monitors(struct RefcBinary *resource, GlobalContext *globa
 term select_event_make_notification(void *rsrc_obj, uint64_t ref_ticks, bool is_write, Heap *heap);
 
 /**
+ * @brief Call down handler for a given resource and remove monitor from list.
+ * @details handler is called while holding lock on the list of monitors and
+ * if monitor is still in the list of resource monitors, thus ensuring that
+ * the resource still exists.
+ * @param resource_type type holding the list of monitors
+ * @param env environment for calling the down handler
+ * @param resource resource that monitored the process
+ * @param process_id id of the process monitored
+ * @param ref_ticks reference of the monitor
+ */
+void resource_type_fire_monitor(struct ResourceType *resource_type, ErlNifEnv *env, void *resource, int32_t process_id, uint64_t ref_ticks);
+
+/**
  * @brief Remove monitor from list of monitors.
  * @param resource_type type holding the list of monitors
  * @param ref_ticks reference of the monitor


### PR DESCRIPTION
Use ref count and lock on list of monitors for a resource type to ensure that resource still exists when calling the monitor handler.

Should fix #1589

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
