### PR TITLE
Fix possible crash with enif_demonitor_process

### DIFF
--- a/src/libAtomVM/erl_nif.h
+++ b/src/libAtomVM/erl_nif.h
@@ -56,7 +56,11 @@ typedef struct ResourceType ErlNifResourceType;
 /**
  * @brief Opaque monitor type
  */
-typedef uint64_t ErlNifMonitor;
+typedef struct
+{
+    struct ResourceType *resource_type;
+    uint64_t ref_ticks;
+} ErlNifMonitor;
 
 /**
  * @brief Selectable event.

--- a/tests/test-enif.c
+++ b/tests/test-enif.c
@@ -30,11 +30,11 @@
 
 static uint32_t cb_read_resource = 0;
 static int32_t down_pid = 0;
-static ErlNifMonitor down_mon = 0;
+static ErlNifMonitor down_mon = { NULL, 0 };
 
 static uint32_t cb_read_resource_two = 0;
 static int32_t down_pid_two = 0;
-static ErlNifMonitor down_mon_two = 0;
+static ErlNifMonitor down_mon_two = { NULL, 0 };
 
 static int32_t lockable_pid = 0;
 
@@ -233,7 +233,7 @@ void test_resource_monitor()
     // Monitor called on destroy
     cb_read_resource = 0;
     down_pid = 0;
-    down_mon = 0;
+    down_mon.ref_ticks = 0;
     ctx = context_new(glb);
     pid = ctx->process_id;
     monitor_result = enif_monitor_process(&env, ptr, &pid, &mon);
@@ -248,7 +248,7 @@ void test_resource_monitor()
     // Monitor not called if demonitored
     cb_read_resource = 0;
     down_pid = 0;
-    down_mon = 0;
+    down_mon.ref_ticks = 0;
     ctx = context_new(glb);
     pid = ctx->process_id;
     monitor_result = enif_monitor_process(&env, ptr, &pid, &mon);
@@ -265,7 +265,7 @@ void test_resource_monitor()
     // Monitor not called if resource is deallocated
     cb_read_resource = 0;
     down_pid = 0;
-    down_mon = 0;
+    down_mon.ref_ticks = 0;
     ctx = context_new(glb);
     pid = ctx->process_id;
     monitor_result = enif_monitor_process(&env, ptr, &pid, &mon);
@@ -317,7 +317,7 @@ void test_resource_monitor_handler_can_lock()
     // Monitor called on destroy
     cb_read_resource = 0;
     down_pid = 0;
-    down_mon = 0;
+    down_mon.ref_ticks = 0;
     ctx = context_new(glb);
     another_ctx = context_new(glb);
     lockable_pid = another_ctx->process_id;
@@ -381,8 +381,8 @@ void test_resource_monitor_two_resources_two_processes()
     cb_read_resource = 0;
     down_pid = 0;
     down_pid_two = 0;
-    down_mon = 0;
-    down_mon_two = 0;
+    down_mon.ref_ticks = 0;
+    down_mon_two.ref_ticks = 0;
     ctx_1 = context_new(glb);
     ctx_2 = context_new(glb);
     pid_1 = ctx_1->process_id;
@@ -411,7 +411,7 @@ void test_resource_monitor_two_resources_two_processes()
     cb_read_resource = 0;
     cb_read_resource_two = 0;
     down_pid = 0;
-    down_mon = 0;
+    down_mon.ref_ticks = 0;
 
     // Process #2 terminates, mon_3 is fired.
     scheduler_terminate(ctx_2);


### PR DESCRIPTION
Resource may no longer exist when enif_demonitor_process is called if the monitor was already destroyed as the resource was deallocated. Fix this by storing resource_type in ErlNifMonitor.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
