### PR TITLE
Fix memory leak in `packbeam.c`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32: improved sntp sync speed from a cold boot.
 - Utilize reserved `phy_init` partition on ESP32 to store wifi calibration for faster connections.
 - Support for zero count in `lists:duplicate/2`.
+- packbeam: fix memory leak preventing building with address sanitizer
 
 ## [0.6.6] - Unreleased
 

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -266,12 +266,14 @@ static int do_pack(int argc, char **argv, int is_archive, bool include_lines)
         if (avmpack_is_valid(file_data, file_size)) {
             void *result = avmpack_fold(pack, file_data, pack_beam_fun);
             if (result == NULL) {
+                free(file_data);
                 return EXIT_FAILURE;
             }
         } else {
             char *filename = basename(argv[i]);
             pack_beam_file(pack, file_data, file_size, filename, !is_archive && i == 1, include_lines);
         }
+        free(file_data);
     }
 
     add_module_header(pack, "end", END_OF_FILE);


### PR DESCRIPTION
The memory leak in `do_pack` prevented successful building with address sanitizer (`-fsanitize=address`) enabled

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
