### PR TITLE
Pass correct live value in BIFs

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1612,15 +1612,15 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
             const struct GCBif *gcbif = EXPORTED_FUNCTION_TO_GCBIF(exported_bif);
             switch (arity) {
                 case 1: {
-                    *return_value = gcbif->gcbif1_ptr(ctx, 0, 0, ctx->x[0]);
+                    *return_value = gcbif->gcbif1_ptr(ctx, 0, 1, ctx->x[0]);
                     return true;
                 }
                 case 2: {
-                    *return_value = gcbif->gcbif2_ptr(ctx, 0, 0, ctx->x[0], ctx->x[1]);
+                    *return_value = gcbif->gcbif2_ptr(ctx, 0, 2, ctx->x[0], ctx->x[1]);
                     return true;
                 }
                 case 3: {
-                    *return_value = gcbif->gcbif3_ptr(ctx, 0, 0, ctx->x[0], ctx->x[1], ctx->x[2]);
+                    *return_value = gcbif->gcbif3_ptr(ctx, 0, 3, ctx->x[0], ctx->x[1], ctx->x[2]);
                     return true;
                 }
             }


### PR DESCRIPTION
If BIF did GC and tried to preserve input registers and args with memory_ensure_free_with_roots(ctx, TERMS_N, live, ctx->x, MEMORY_CAN_SHRINK) it would invalidate registers anyways because live=0.

Now, GC BIFs can keep them at cost of temporary memory increase until next GC is done.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
