### PR TITLE
Fix specification of distribution nifs

### DIFF
--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -1320,17 +1320,17 @@ setnode(_TargetNode, _ConnPid, _TargetFlagsCreation) ->
     erlang:nif_error(undefined).
 
 %% @hidden
--spec dist_ctrl_get_data_notification(reference()) -> ok.
+-spec dist_ctrl_get_data_notification(binary()) -> ok.
 dist_ctrl_get_data_notification(_DHandle) ->
     erlang:nif_error(undefined).
 
 %% @hidden
--spec dist_ctrl_get_data(reference()) -> none | binary().
+-spec dist_ctrl_get_data(binary()) -> none | binary().
 dist_ctrl_get_data(_DHandle) ->
     erlang:nif_error(undefined).
 
 %% @hidden
--spec dist_ctrl_put_data(reference(), binary()) -> ok.
+-spec dist_ctrl_put_data(binary(), binary()) -> ok.
 dist_ctrl_put_data(_DHandle, _Packet) ->
     erlang:nif_error(undefined).
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
