### PR TITLE
Remove unused reductions in Context

### DIFF
--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -119,8 +119,6 @@ struct Context
     // Ports support
     native_handler_f native_handler;
 
-    uint64_t reductions;
-
     unsigned int leader : 1;
     unsigned int has_min_heap_size : 1;
     unsigned int has_max_heap_size : 1;

--- a/src/libAtomVM/scheduler.c
+++ b/src/libAtomVM/scheduler.c
@@ -281,8 +281,6 @@ Context *scheduler_run(GlobalContext *global)
 
 Context *scheduler_next(GlobalContext *global, Context *c)
 {
-    c->reductions += DEFAULT_REDUCTIONS_AMOUNT;
-
     // Remove c from running and append it at the end of ready list
     // c could already be in ready queue, if it received a message.
     SMP_SPINLOCK_LOCK(&global->processes_spinlock);


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
