### PR TITLE
Fix harmless typo in emscripten platform_nifs

### DIFF
--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -773,7 +773,7 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
     if (strcmp("atomvm:random/0", nifname) == 0) {
         return &atomvm_random_nif;
     }
-    if (memcmp("crypto:", nifname, strlen("crypro:")) == 0) {
+    if (memcmp("crypto:", nifname, strlen("crypto:")) == 0) {
         return otp_crypto_nif_get_nif(nifname);
     }
     if (memcmp("emscripten:", nifname, strlen("emscripten:"))) {


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
