### PR TITLE
Add `erlang:system_info/1` additions for remote shell

### DIFF
--- a/src/libAtomVM/defaultatoms.def
+++ b/src/libAtomVM/defaultatoms.def
@@ -181,3 +181,7 @@ X(TIMEOUT_ATOM, "\x7", "timeout")
 X(DIST_DATA_ATOM, "\x9", "dist_data")
 X(REQUEST_ATOM, "\x7", "request")
 X(CONNECT_ATOM, "\x7", "connect")
+
+X(SYSTEM_VERSION_ATOM, "\xE", "system_version")
+X(OTP_RELEASE_ATOM, "\xB", "otp_release")
+X(BREAK_IGNORED_ATOM, "\xD", "break_ignored")

--- a/src/libAtomVM/dist_nifs.h
+++ b/src/libAtomVM/dist_nifs.h
@@ -34,6 +34,8 @@
 extern "C" {
 #endif
 
+#define DIST_OTP_RELEASE "27"
+
 extern const ErlNifResourceTypeInit dist_connection_resource_type_init;
 
 extern const struct Nif setnode_3_nif;

--- a/tests/erlang_tests/test_system_info.erl
+++ b/tests/erlang_tests/test_system_info.erl
@@ -35,19 +35,31 @@ start() ->
         _ ->
             assert(is_binary(erlang:system_info(system_architecture)))
     end,
+    SystemVersion = erlang:system_info(system_version),
+    true = is_list(SystemVersion),
+    case Machine of
+        "BEAM" ->
+            "Erlang/OTP " ++ _ = SystemVersion;
+        _ ->
+            "AtomVM " ++ _ = SystemVersion
+    end,
+    OTPRelease = erlang:system_info(otp_release),
+    true = is_list(OTPRelease),
+    OTPReleaseInt = list_to_integer(OTPRelease),
+    true = OTPReleaseInt > 20,
     case Machine of
         "BEAM" ->
             % beam raises badarg, and probably so should AtomVM.
             ok =
                 try
-                    erlang:system_info(some_wierd_unused_key),
+                    erlang:system_info(some_weird_unused_key),
                     unexpected
                 catch
                     error:badarg ->
                         ok
                 end;
         _ ->
-            assert(erlang:system_info(some_wierd_unused_key) =:= undefined)
+            assert(erlang:system_info(some_weird_unused_key) =:= undefined)
     end,
     0.
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
