### PR TITLE
CI: Add Elixir pack_test

### DIFF
--- a/tests/libs/exavmlib/Some.Submodule.ex
+++ b/tests/libs/exavmlib/Some.Submodule.ex
@@ -18,12 +18,8 @@
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-project(test_exavmlib)
-
-include(BuildElixir)
-
-set(TEST_MODULES
-    Some.Submodule
-)
-
-pack_test(Tests Tests ${TEST_MODULES})
+defmodule Some.Submodule do
+  def start do
+    :ok
+  end
+end

--- a/tests/libs/exavmlib/Tests.ex
+++ b/tests/libs/exavmlib/Tests.ex
@@ -28,6 +28,7 @@ defmodule Tests do
 
   def start() do
     :ok = IO.puts("Running Elixir tests")
+    :ok = Some.Submodule.start()
     :ok = test_enum()
     :ok = test_exception()
     :ok = test_chars_protocol()


### PR DESCRIPTION
Need the ability to add extra modules to Elixir testing eg for GenServer tests (https://github.com/atomvm/AtomVM/pull/1476) etc.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
