### PR TITLE
CI: Containerize ubuntu 20

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -34,7 +34,8 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os || 'ubuntu-24.04' }}
+    container: ${{ matrix.container }}
     strategy:
 
       fail-fast: false
@@ -56,17 +57,17 @@ jobs:
         - cc: "gcc-7"
           cxx: "g++-7"
           compiler_pkgs: "gcc-7 g++-7"
-          os: "ubuntu-20.04"
+          container: "ubuntu:20.04"
           otp: "27"
         - cc: "gcc-8"
           cxx: "g++-8"
           compiler_pkgs: "gcc-8 g++-8"
-          os: "ubuntu-20.04"
+          container: "ubuntu:20.04"
           otp: "27"
         - cc: "gcc-9"
           cxx: "g++-9"
           compiler_pkgs: "gcc-9 g++-9"
-          os: "ubuntu-20.04"
+          container: "ubuntu:20.04"
           # otp: all
         - cc: "gcc-10"
           cxx: "g++-10"
@@ -108,13 +109,13 @@ jobs:
           cxx: "clang++-10"
           compiler_pkgs: "clang-10"
           cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
-          os: "ubuntu-20.04"
+          container: "ubuntu:20.04"
           # otp: all
         - cc: "clang-11"
           cxx: "clang++-11"
           compiler_pkgs: "clang-11"
           cmake_opts_other: "-DAVM_WARNINGS_ARE_ERRORS=ON"
-          os: "ubuntu-20.04"
+          container: "ubuntu:20.04"
           otp: "27"
         - cc: "clang-12"
           cxx: "clang++-12"
@@ -169,33 +170,37 @@ jobs:
           elixir_version: "1.17"
 
         # Old versions of OTP/Elixir
-        - os: "ubuntu-20.04"
+        - container: "ubuntu:20.04"
           cc: "cc"
           cxx: "c++"
           otp: "21"
           cflags: ""
           elixir_version: "1.7"
+          compiler_pkgs: "g++"
 
-        - os: "ubuntu-20.04"
+        - container: "ubuntu:20.04"
           cc: "cc"
           cxx: "c++"
           otp: "22"
           cflags: ""
           elixir_version: "1.8"
+          compiler_pkgs: "g++"
 
-        - os: "ubuntu-20.04"
+        - container: "ubuntu:20.04"
           cc: "cc"
           cxx: "c++"
           otp: "23"
           cflags: ""
           elixir_version: "1.11"
+          compiler_pkgs: "g++"
 
-        - os: "ubuntu-22.04"
+        - container: "ubuntu:20.04"
           cc: "cc"
           cxx: "c++"
           otp: "24"
           cflags: ""
           elixir_version: "1.14"
+          compiler_pkgs: "g++"
 
 # TODO: enable master again
 # master will not work until we don't adapt to atom table changes
@@ -207,12 +212,13 @@ jobs:
 #          elixir_version: "main"
 
         # Additional default compiler builds
-        - os: "ubuntu-20.04"
+        - container: "ubuntu:20.04"
           cc: "cc"
           cxx: "c++"
           otp: "27"
           cflags: ""
           elixir_version: "1.17"
+          compiler_pkgs: "g++"
 
         - os: "ubuntu-22.04"
           cc: "cc"
@@ -239,7 +245,7 @@ jobs:
           compiler_pkgs: "clang-18"
 
         # Additional 32 bits build
-        - os: "ubuntu-20.04"
+        - container: "ubuntu:20.04"
           cc: "gcc-10"
           cxx: "g++-10"
           cflags: "-m32 -O3"
@@ -252,13 +258,30 @@ jobs:
             libc6-dbg:i386 zlib1g-dev:i386 libmbedtls-dev:i386"
 
     env:
+      ImageOS: ${{ matrix.container == 'ubuntu:20.04' && 'ubuntu20' || matrix.os == 'ubuntu-20.04' && 'ubuntu20' || matrix.os == 'ubuntu-22.04' && 'ubuntu22' || matrix.os == 'ubuntu-24.04' && 'ubuntu24' || 'ubuntu24' }}
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
       CFLAGS: ${{ matrix.cflags }}
       CXXFLAGS: ${{ matrix.cflags }}
+      DEBIAN_FRONTEND: noninteractive
+      TZ: "Etc/UTC"
 
     steps:
     # Setup
+    - name: "Install deps for containers"
+      if: matrix.container != ''
+      run: apt-get update && apt-get install -y --no-install-recommends sudo unzip git tzdata
+
+    - name: "Add i386 architecture"
+      if: matrix.arch == 'i386'
+      run: sudo dpkg --add-architecture i386
+
+    - name: "APT update"
+      run: sudo apt update -y
+
+    - name: "Install deps"
+      run: sudo apt install -y ${{ matrix.compiler_pkgs}} cmake gperf zlib1g-dev doxygen valgrind libmbedtls-dev
+
     - name: "Checkout repo"
       uses: actions/checkout@v4
       with:
@@ -272,16 +295,6 @@ jobs:
           https://builds.hex.pm
           https://repo.hex.pm
           https://cdn.jsdelivr.net/hex
-
-    - name: "Add i386 architecture"
-      if: matrix.arch == 'i386'
-      run: sudo dpkg --add-architecture i386
-
-    - name: "APT update"
-      run: sudo apt update -y
-
-    - name: "Install deps"
-      run: sudo apt install -y ${{ matrix.compiler_pkgs}} cmake gperf zlib1g-dev doxygen valgrind libmbedtls-dev
 
     # Builder info
     - name: "System info"
@@ -393,10 +406,12 @@ jobs:
       working-directory: build
       run: |
         ulimit -c unlimited
-        if command -v elixirc &> /dev/null
+        if command -v elixirc >/dev/null 2>&1 && command -v elixir >/dev/null 2>&1
         then
           valgrind --error-exitcode=1 ./src/AtomVM ./tests/libs/exavmlib/Tests.avm
           ./src/AtomVM ./tests/libs/exavmlib/Tests.avm
+        else
+          echo "Elixir not installed, skipping Elixir tests"
         fi
 
     - name: "Install and smoke test"


### PR DESCRIPTION
Github is sunsetting the ubuntu20 runner on april 15th, so it needs to be in containers.

https://github.com/actions/runner-images/issues/11101

<img width="495" alt="Screenshot 2025-04-08 at 19 48 55" src="https://github.com/user-attachments/assets/0ab100ac-35fe-4f35-a5bd-88543cf5ac0b" />

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
