### PR TITLE
Add `application:get_env/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `erlang:get/0` and `erlang:erase/0`.
 - Added `erlang:unique_integer/0` and `erlang:unique_integer/1`
 - Added support for 'ets:delete/1'.
+- Added `application:get_env/2`
 
 ### Changed
 

--- a/libs/estdlib/src/application.erl
+++ b/libs/estdlib/src/application.erl
@@ -19,10 +19,22 @@
 %
 
 -module(application).
--export([get_env/3]).
+-export([get_env/2, get_env/3]).
 -export_type([start_type/0]).
 
 -type start_type() :: normal | {takeover, Node :: node()} | {failover, Node :: node()}.
+
+%%-----------------------------------------------------------------------------
+%% @param   Application application to get the parameter value of
+%% @param   Parameter parameter to get the value of
+%% @returns undefined
+%% @doc     Retrieve the value of the configuration parameter `Parameter' for
+%%          application `Application' or `undefined' if not found.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec get_env(Application :: atom(), Parameter :: atom()) -> any().
+get_env(Application, Parameter) ->
+    get_env(Application, Parameter, undefined).
 
 %%-----------------------------------------------------------------------------
 %% @param   Application application to get the parameter value of


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
