### PR TITLE
Add several missing io_lib functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `lists:flatmap/2`
 - Added `io:fwrite/1,2,3` and `io:format/3` as well as few io functions required by remote shell
 - Added `code:is_loaded/1` and `code:which/1`
+- Added several `io_lib` functions including `io_lib:fwrite/2` and `io_lib:write_atom/1`
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -57,6 +57,7 @@
     list_to_integer/1,
     list_to_integer/2,
     list_to_tuple/1,
+    iolist_size/1,
     iolist_to_binary/1,
     binary_to_atom/1,
     binary_to_atom/2,
@@ -666,12 +667,23 @@ list_to_tuple(_List) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
+%% @equiv   byte_size(iolist_to_binary(IOList))
+%% @param   IOList  IO list to compute the binary size of
+%% @returns the number of bytes of IOList if it was convered to `binary()'
+%% @doc     Compute the length in bytes of the IO list or `binary()'
+%% @end
+%%-----------------------------------------------------------------------------
+-spec iolist_size(IOList :: iodata()) -> non_neg_integer().
+iolist_size(_IOList) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
 %% @param   IOList  IO list to convert to binary
 %% @returns a binary with the bytes of the IO list
 %% @doc     Convert an IO list to binary.
 %% @end
 %%-----------------------------------------------------------------------------
--spec iolist_to_binary(IOList :: iolist()) -> binary().
+-spec iolist_to_binary(IOList :: iodata()) -> binary().
 iolist_to_binary(_IOList) ->
     erlang:nif_error(undefined).
 

--- a/libs/estdlib/src/io_lib.erl
+++ b/libs/estdlib/src/io_lib.erl
@@ -27,20 +27,53 @@
 %%-----------------------------------------------------------------------------
 -module(io_lib).
 
--export([format/2, latin1_char_list/1]).
+-export([
+    write/1,
+    format/2,
+    fwrite/2,
+    latin1_char_list/1,
+    write_atom/1,
+    printable_list/1,
+    write_string/1,
+    write_string/2,
+    chars_length/1
+]).
+
+-export_type([
+    chars/0
+]).
+
+-type chars() :: [char() | chars()].
+
+%%-----------------------------------------------------------------------------
+%% @equiv format(Format, Args)
+%% @param   Format format string
+%% @param   Args format argument
+%% @returns string
+%% @doc     Format string and data to a string.
+%%          Features most of OTP `io_lib:format/2'.
+%%          Raises `badarg' error if the number of format specifiers
+%%          does not match the length of the Args.
+%% @end
+%%-----------------------------------------------------------------------------
+fwrite(Format, Args) ->
+    format(Format, Args).
 
 %%-----------------------------------------------------------------------------
 %% @param   Format format string
 %% @param   Args format argument
 %% @returns string
 %% @doc     Format string and data to a string.
-%%          Approximates features of OTP io_lib:format/2, but
-%%          only supports ~p and ~n format specifiers.
+%%          Features most of OTP `io_lib:format/2'.
 %%          Raises `badarg' error if the number of format specifiers
 %%          does not match the length of the Args.
 %% @end
 %%-----------------------------------------------------------------------------
--spec format(Format :: string(), Args :: list()) -> string().
+-spec format(Format :: io:format(), Args :: list()) -> string().
+format(Format, Args) when is_binary(Format) ->
+    format(binary_to_list(Format), Args);
+format(Format, Args) when is_atom(Format) ->
+    format(atom_to_list(Format), Args);
 format(Format, Args) ->
     {FormatTokens, Instr} = split(Format),
     case length(FormatTokens) == length(Args) + 1 of
@@ -236,11 +269,7 @@ format_string(Format, T) ->
 format_spw(#format{control = s}, T) when is_atom(T) ->
     erlang:atom_to_list(T);
 format_spw(_Format, T) when is_atom(T) ->
-    AtomStr = erlang:atom_to_list(T),
-    case atom_requires_quotes(T, AtomStr) of
-        false -> AtomStr;
-        true -> [$', AtomStr, $']
-    end;
+    write_atom(T);
 format_spw(#format{control = s, mod = t} = Format, T) when is_binary(T) ->
     case unicode:characters_to_list(T, utf8) of
         L when is_list(L) -> L;
@@ -254,8 +283,8 @@ format_spw(#format{control = Control, mod = t} = Format, T) when is_binary(T) ->
         L when is_list(L) ->
             FormattedStr =
                 case {Control, test_string_class(L)} of
-                    {p, latin1_printable} -> format_p_string(L, []);
-                    {p, unicode} -> [format_p_string(L, []), "/utf8"];
+                    {p, latin1_printable} -> write_string(L, $");
+                    {p, unicode} -> [write_string(L, $"), "/utf8"];
                     _ -> lists:join($,, [integer_to_list(B) || B <- L])
                 end,
             [$<, $<, FormattedStr, $>, $>];
@@ -266,7 +295,7 @@ format_spw(#format{control = Control, mod = undefined}, T) when is_binary(T) ->
     L = erlang:binary_to_list(T),
     FormattedStr =
         case {Control, test_string_class(L)} of
-            {p, latin1_printable} -> format_p_string(L, []);
+            {p, latin1_printable} -> write_string(L, $");
             _ -> lists:join($,, [integer_to_list(B) || B <- L])
         end,
     [$<, $<, FormattedStr, $>, $>];
@@ -279,7 +308,7 @@ format_spw(#format{control = s, mod = Mod}, L) when is_list(L) ->
     end;
 format_spw(#format{control = p} = Format, L) when is_list(L) ->
     case test_string_class(L) of
-        latin1_printable -> format_p_string(L, []);
+        latin1_printable -> write_string(L, $");
         _ -> [$[, lists:join($,, [format_spw(Format, E) || E <- L]), $]]
     end;
 format_spw(#format{control = w} = Format, L) when is_list(L) ->
@@ -314,7 +343,6 @@ format_spw(#format{mod = Mod} = Format, T) when is_map(T) ->
         $}
     ].
 
-%% We will probably need to add 'maybe' with OTP 27
 -define(RESERVED_KEYWORDS, [
     'after',
     'and',
@@ -334,6 +362,7 @@ format_spw(#format{mod = Mod} = Format, T) when is_map(T) ->
     'fun',
     'if',
     'let',
+    'maybe',
     'not',
     'of',
     'or',
@@ -345,23 +374,38 @@ format_spw(#format{mod = Mod} = Format, T) when is_map(T) ->
     'xor'
 ]).
 
-%% @private
-atom_requires_quotes(Atom, AtomStr) ->
+-spec write_atom(Atom :: atom()) -> chars().
+write_atom(Atom) ->
+    AtomStr = erlang:atom_to_list(Atom),
     case lists:member(Atom, ?RESERVED_KEYWORDS) of
-        true -> true;
-        false -> atom_requires_quotes0(AtomStr)
+        true -> [$', AtomStr, $'];
+        false -> write_atom_maybe_quote_escape(AtomStr)
     end.
 
-atom_requires_quotes0([C | _T]) when C < $a orelse C > $z -> true;
-atom_requires_quotes0([_C | T]) -> atom_requires_quotes1(T).
+%% @private
+write_atom_maybe_quote_escape([C | _T] = AtomStr) when C < $a orelse C > $z ->
+    write_atom_maybe_quote_escape(AtomStr, true, []);
+write_atom_maybe_quote_escape(AtomStr) ->
+    write_atom_maybe_quote_escape(AtomStr, false, []).
 
-atom_requires_quotes1([]) -> false;
-atom_requires_quotes1([$@ | T]) -> atom_requires_quotes1(T);
-atom_requires_quotes1([$_ | T]) -> atom_requires_quotes1(T);
-atom_requires_quotes1([C | T]) when C >= $A andalso C =< $Z -> atom_requires_quotes1(T);
-atom_requires_quotes1([C | T]) when C >= $0 andalso C =< $9 -> atom_requires_quotes1(T);
-atom_requires_quotes1([C | T]) when C >= $a andalso C =< $z -> atom_requires_quotes1(T);
-atom_requires_quotes1(_) -> true.
+write_atom_maybe_quote_escape([], false, Acc) ->
+    lists:reverse(Acc);
+write_atom_maybe_quote_escape([], true, Acc) ->
+    [$' | lists:reverse([$' | Acc])];
+write_atom_maybe_quote_escape([$@ | T], Quote, Acc) ->
+    write_atom_maybe_quote_escape(T, Quote, [$@ | Acc]);
+write_atom_maybe_quote_escape([$_ | T], Quote, Acc) ->
+    write_atom_maybe_quote_escape(T, Quote, [$_ | Acc]);
+write_atom_maybe_quote_escape([C | T], Quote, Acc) when C >= $A andalso C =< $Z ->
+    write_atom_maybe_quote_escape(T, Quote, [C | Acc]);
+write_atom_maybe_quote_escape([C | T], Quote, Acc) when C >= $0 andalso C =< $9 ->
+    write_atom_maybe_quote_escape(T, Quote, [C | Acc]);
+write_atom_maybe_quote_escape([C | T], Quote, Acc) when C >= $a andalso C =< $z ->
+    write_atom_maybe_quote_escape(T, Quote, [C | Acc]);
+write_atom_maybe_quote_escape([$' | T], _Quote, Acc) ->
+    write_atom_maybe_quote_escape(T, true, [$', $\\ | Acc]);
+write_atom_maybe_quote_escape([C | T], _Quote, Acc) ->
+    write_atom_maybe_quote_escape(T, true, [C | Acc]).
 
 %% @private
 format_integer(#format{control = C, precision = Precision0}, T0) when
@@ -447,8 +491,8 @@ format_char(_, _) ->
 %% @private
 %% String classes:
 %% latin1_printable
-%% latin1_unprintable
 %% unicode
+%% unprintable
 %% io_lib doesn't distinguish between valid unicode and invalid unicode
 %% characters. This is done with io, though, when actually writing the string.
 %% Compare:
@@ -464,9 +508,9 @@ test_string_class([H | T], Class) when is_integer(H) andalso H >= 0 ->
         case {Class, char_class(H)} of
             {_, latin1_printable} -> Class;
             {latin1_printable, CharClass} -> CharClass;
-            {_, latin1_unprintable} -> Class;
-            {latin1_unprintable, CharClass} -> CharClass;
-            _ -> unicode
+            {_, unicode} -> Class;
+            {unicode, CharClass} -> CharClass;
+            _ -> unprintable
         end,
     test_string_class(T, NewClass);
 test_string_class([], Class) ->
@@ -474,28 +518,81 @@ test_string_class([], Class) ->
 test_string_class(_String, _Class) ->
     not_a_string.
 
-char_class(H) when H >= 0 andalso H < 8 -> latin1_unprintable;
+char_class(H) when H >= 0 andalso H < 8 -> unprintable;
 char_class(27) -> latin1_printable;
-char_class(H) when H >= 14 andalso H < 32 -> latin1_unprintable;
+char_class(H) when H >= 14 andalso H < 32 -> unprintable;
 char_class(H) when H < 256 -> latin1_printable;
 char_class(_H) -> unicode.
 
+%%-----------------------------------------------------------------------------
+%% @equiv write_string(String, $")
+%% @param String string to print
+%% @doc Returns the list of characters needed to print String as a string.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec write_string(string()) -> chars().
+write_string(String) ->
+    write_string(String, $").
+
 %% @private
-format_p_string([], Acc) ->
-    [$", lists:reverse(Acc), $"];
-format_p_string([8 | T], Acc) ->
-    format_p_string(T, ["\\b" | Acc]);
-format_p_string([9 | T], Acc) ->
-    format_p_string(T, ["\\t" | Acc]);
-format_p_string([10 | T], Acc) ->
-    format_p_string(T, ["\\n" | Acc]);
-format_p_string([11 | T], Acc) ->
-    format_p_string(T, ["\\v" | Acc]);
-format_p_string([12 | T], Acc) ->
-    format_p_string(T, ["\\f" | Acc]);
-format_p_string([13 | T], Acc) ->
-    format_p_string(T, ["\\r" | Acc]);
-format_p_string([27 | T], Acc) ->
-    format_p_string(T, ["\\e" | Acc]);
-format_p_string([H | T], Acc) ->
-    format_p_string(T, [H | Acc]).
+-spec write_string(string(), char()) -> chars().
+write_string(String, $") ->
+    format_p_string(String, $", []).
+
+%% @private
+format_p_string([], Q, Acc) ->
+    [Q, lists:reverse(Acc), Q];
+format_p_string([8 | T], Q, Acc) ->
+    format_p_string(T, Q, ["\\b" | Acc]);
+format_p_string([9 | T], Q, Acc) ->
+    format_p_string(T, Q, ["\\t" | Acc]);
+format_p_string([10 | T], Q, Acc) ->
+    format_p_string(T, Q, ["\\n" | Acc]);
+format_p_string([11 | T], Q, Acc) ->
+    format_p_string(T, Q, ["\\v" | Acc]);
+format_p_string([12 | T], Q, Acc) ->
+    format_p_string(T, Q, ["\\f" | Acc]);
+format_p_string([13 | T], Q, Acc) ->
+    format_p_string(T, Q, ["\\r" | Acc]);
+format_p_string([27 | T], Q, Acc) ->
+    format_p_string(T, Q, ["\\e" | Acc]);
+format_p_string([Q | T], Q, Acc) ->
+    format_p_string(T, Q, ["\\", Q | Acc]);
+format_p_string([H | T], Q, Acc) ->
+    format_p_string(T, Q, [H | Acc]).
+
+%%-----------------------------------------------------------------------------
+%% @param List term to test
+%% @doc Determine if `List' is a flat list of printable characters
+%% @end
+%%-----------------------------------------------------------------------------
+-spec printable_list(List :: any()) -> boolean().
+printable_list(List) ->
+    StringClass = test_string_class(List),
+    case {StringClass, io:printable_range()} of
+        {not_a_string, _} -> false;
+        {unprintable, _} -> false;
+        {latin1_printable, _} -> true;
+        {unicode, unicode} -> true;
+        {unicode, latin1} -> false
+    end.
+
+%% @private
+-spec chars_length(chars()) -> non_neg_integer().
+chars_length(S) ->
+    try
+        iolist_size(S)
+    catch
+        _:_ ->
+            string:length(S)
+    end.
+
+%%-----------------------------------------------------------------------------
+%% @equiv forma("~w", [Term])
+%% @param Term term to represent
+%% @doc Returns a character list that represents Term
+%% @end
+%%-----------------------------------------------------------------------------
+-spec write(any()) -> chars().
+write(Term) ->
+    format("~w", [Term]).

--- a/libs/estdlib/src/string.erl
+++ b/libs/estdlib/src/string.erl
@@ -27,7 +27,7 @@
 %%-----------------------------------------------------------------------------
 -module(string).
 
--export([to_upper/1, to_lower/1, split/2, split/3, trim/1, trim/2, find/2, find/3]).
+-export([to_upper/1, to_lower/1, split/2, split/3, trim/1, trim/2, find/2, find/3, length/1]).
 
 %%-----------------------------------------------------------------------------
 %% @param Input a string or character to convert
@@ -251,3 +251,14 @@ find_list([_C | Rest] = String, SearchPattern, leading) ->
     end;
 find_list([], _SearchPattern, leading) ->
     nomatch.
+
+%%-----------------------------------------------------------------------------
+%% @param String string to compute the length of
+%% @doc Return the length of the string in characters.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec length(String :: unicode:chardata()) -> non_neg_integer().
+length(String) when is_list(String) ->
+    erlang:length(String);
+length(String) when is_binary(String) ->
+    erlang:length(unicode:characters_to_list(String)).

--- a/tests/libs/estdlib/test_string.erl
+++ b/tests/libs/estdlib/test_string.erl
@@ -29,6 +29,7 @@ test() ->
     ok = test_split(),
     ok = test_trim(),
     ok = test_find(),
+    ok = test_length(),
     ok.
 
 test_to_upper() ->
@@ -88,6 +89,16 @@ test_find() ->
     ?ASSERT_MATCH(string:find(<<"foobar">>, "ba"), <<"bar">>),
     ?ASSERT_MATCH(string:find("foobar", <<"ba">>), "bar"),
     ?ASSERT_MATCH(string:find(<<"foobar">>, <<"ba">>), <<"bar">>),
+
+    ok.
+
+test_length() ->
+    ?ASSERT_MATCH(string:length(""), 0),
+    ?ASSERT_MATCH(string:length(<<>>), 0),
+    ?ASSERT_MATCH(string:length("foo"), 3),
+    ?ASSERT_MATCH(string:length(<<"foo">>), 3),
+    ?ASSERT_MATCH(string:length("アトム"), 3),
+    ?ASSERT_MATCH(string:length(<<"アトム"/utf8>>), 3),
 
     ok.
 


### PR DESCRIPTION
Add support for:
- `io_lib:chars_length/1`
- `io_lib:fwrite/2`
- `io_lib:printable_list/1`
- `io_lib:write/1`
- `io_lib:write_atom/1`
- `io_lib:write_string/1` and `io_lib:write_string/2`

See also #1509 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
