### PR TITLE
Fix read 32 bits accesses to modules to be unaligned

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -94,7 +94,7 @@ jobs:
 
         - arch: "arm32v7"
           platform: "arm/v7"
-          tag: "bullseye"
+          tag: "bookworm"
           # -D_FILE_OFFSET_BITS=64 is required for making atomvm:posix_readdir/1 test work
           # otherwise readdir will fail due to 64 bits inode numbers with 32 bit ino_t
           cflags: "-mcpu=cortex-a7 -mfloat-abi=hard -O2 -mthumb -mthumb-interwork -D_FILE_OFFSET_BITS=64"

--- a/src/libAtomVM/iff.c
+++ b/src/libAtomVM/iff.c
@@ -50,7 +50,7 @@ void scan_iff(const void *iff_binary, int buf_size, unsigned long *offsets, unsi
 
     int current_pos = 12;
 
-    uint32_t iff_size = READ_32_ALIGNED(data + 4);
+    uint32_t iff_size = READ_32_UNALIGNED(data + 4);
     int file_size = iff_size;
     if (UNLIKELY(buf_size < file_size)) {
         fprintf(stderr, "error: buffer holding IFF is smaller than IFF size: %i\n", buf_size);

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -323,7 +323,7 @@ static inline term module_address(unsigned int module_index, unsigned int instru
 static inline uint32_t module_get_fun_freeze(const Module *this_module, int fun_index)
 {
     const uint8_t *table_data = (const uint8_t *) this_module->fun_table;
-    int funs_count = READ_32_ALIGNED(table_data + 8);
+    int funs_count = READ_32_UNALIGNED(table_data + 8);
 
     if (UNLIKELY(fun_index >= funs_count)) {
         AVM_ABORT();
@@ -333,7 +333,7 @@ static inline uint32_t module_get_fun_freeze(const Module *this_module, int fun_
     // arity
     // label
     // index
-    uint32_t n_freeze = READ_32_ALIGNED(table_data + fun_index * 24 + 16 + 12);
+    uint32_t n_freeze = READ_32_UNALIGNED(table_data + fun_index * 24 + 16 + 12);
     // ouniq
 
     return n_freeze;
@@ -342,17 +342,17 @@ static inline uint32_t module_get_fun_freeze(const Module *this_module, int fun_
 static inline void module_get_fun(const Module *this_module, int fun_index, uint32_t *label, uint32_t *arity, uint32_t *n_freeze)
 {
     const uint8_t *table_data = (const uint8_t *) this_module->fun_table;
-    int funs_count = READ_32_ALIGNED(table_data + 8);
+    int funs_count = READ_32_UNALIGNED(table_data + 8);
 
     if (UNLIKELY(fun_index >= funs_count)) {
         AVM_ABORT();
     }
 
     // fun atom index
-    *arity = READ_32_ALIGNED(table_data + fun_index * 24 + 4 + 12);
-    *label = READ_32_ALIGNED(table_data + fun_index * 24 + 8 + 12);
+    *arity = READ_32_UNALIGNED(table_data + fun_index * 24 + 4 + 12);
+    *label = READ_32_UNALIGNED(table_data + fun_index * 24 + 8 + 12);
     // index
-    *n_freeze = READ_32_ALIGNED(table_data + fun_index * 24 + 16 + 12);
+    *n_freeze = READ_32_UNALIGNED(table_data + fun_index * 24 + 16 + 12);
     // ouniq
 }
 


### PR DESCRIPTION
Modules can be unaligned when they are loaded from a binary and reads should therefore be unaligned. This yielded a crash on arm32v7 CI.

Also update arm32v7 CI to use bookworm debian image

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
