### PR TITLE
Force git clone of Pico-SDK

### DIFF
--- a/src/platforms/rp2040/pico_sdk_import.cmake
+++ b/src/platforms/rp2040/pico_sdk_import.cmake
@@ -27,10 +27,11 @@
 # This can be dropped into an external project to help locate this SDK
 # It should be include()ed prior to project()
 
-if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
-    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
-    message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
-endif ()
+# Commented to ensure fork is picked up as we need some changes that are not available upstream yet
+# if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
+#     set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+#     message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
+# endif ()
 
 if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT} AND (NOT PICO_SDK_FETCH_FROM_GIT))
     set(PICO_SDK_FETCH_FROM_GIT $ENV{PICO_SDK_FETCH_FROM_GIT})


### PR DESCRIPTION
Avoid issues where PICO_SDK_PATH is accidentally set in the environment. Users could still force `PICO_SDK_PATH` using CMake defines.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
