### PR TITLE
Fix error result in esp32 spi_driver

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -630,7 +630,7 @@ static NativeHandlerResult consume_gpio_mailbox(Context *ctx)
     }
 
     term ret_msg;
-    if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &ret, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, TUPLE_SIZE(2), 1, &ret, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         ret_msg = OUT_OF_MEMORY_ATOM;
     } else {
         ret_msg = create_pair(ctx, gen_message.ref, ret);

--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -655,14 +655,14 @@ static NativeHandlerResult spidriver_consume_mailbox(Context *ctx)
         default:
             TRACE("spi: error: unrecognized command.\n");
             if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
-                return OUT_OF_MEMORY_ATOM;
+                ret = OUT_OF_MEMORY_ATOM;
             }
             term unkn_a = globalcontext_make_atom(ctx->global, ATOM_STR("\xF", "unknown_command"));
-            return create_pair(ctx, ERROR_ATOM, esp_err_to_term(ctx->global, unkn_a));
+            ret = create_pair(ctx, ERROR_ATOM, esp_err_to_term(ctx->global, unkn_a));
     }
 
     term ret_msg;
-    if (UNLIKELY(memory_ensure_free_with_roots(ctx, 3, 1, &ret, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, TUPLE_SIZE(2), 1, &ret, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         ret_msg = OUT_OF_MEMORY_ATOM;
     } else {
         ret_msg = create_pair(ctx, gen_message.ref, ret);


### PR DESCRIPTION
Also replace 3 with TUPLE_SIZE(2) for clarity

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
