### PR TITLE
Fix GPIO port driver

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -315,7 +315,8 @@ Context *gpio_driver_create_port(GlobalContext *global, term opts)
     term reg_name_term = globalcontext_make_atom(global, gpio_atom);
     int atom_index = term_to_atom_index(reg_name_term);
 
-    if (UNLIKELY(!globalcontext_register_process(ctx->global, atom_index, ctx->process_id))) {
+    term local_port_id = term_port_from_local_process_id(ctx->process_id);
+    if (UNLIKELY(!globalcontext_register_process(ctx->global, atom_index, local_port_id))) {
         scheduler_terminate(ctx);
         ESP_LOGE(TAG, "Only a single GPIO driver can be opened.");
         return NULL;

--- a/src/platforms/stm32/src/lib/gpio_driver.c
+++ b/src/platforms/stm32/src/lib/gpio_driver.c
@@ -558,7 +558,8 @@ static Context *gpio_driver_create_port(GlobalContext *global, term opts)
     term reg_name_term = globalcontext_make_atom(global, gpio_atom);
     int atom_index = term_to_atom_index(reg_name_term);
 
-    if (UNLIKELY(!globalcontext_register_process(ctx->global, atom_index, ctx->process_id))) {
+    term local_port_id = term_port_from_local_process_id(ctx->process_id);
+    if (UNLIKELY(!globalcontext_register_process(ctx->global, atom_index, local_port_id))) {
         scheduler_terminate(ctx);
         AVM_LOGE(TAG, "Only a single GPIO driver can be opened.");
         return NULL;


### PR DESCRIPTION
Fix bug introduced with af32e1213.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
