### PR TITLE
Context: add missing const to read-only ctx parameter

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -294,7 +294,7 @@ bool context_process_signal_trap_answer(Context *ctx, struct TermSignal *signal)
     return true;
 }
 
-bool context_process_signal_set_group_leader(Context *ctx, struct TermSignal *signal)
+bool context_process_signal_set_group_leader(Context *ctx, const struct TermSignal *signal)
 {
     size_t leader_term_size = memory_estimate_usage(signal->signal_term);
     ctx->group_leader = UNDEFINED_ATOM;

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -421,7 +421,7 @@ void context_process_flush_monitor_signal(Context *ctx, uint64_t ref_ticks, bool
  * @param signal the message with the group leader term
  * @return \c true if successful, \c false in case of memory error
  */
-bool context_process_signal_set_group_leader(Context *ctx, struct TermSignal *signal);
+bool context_process_signal_set_group_leader(Context *ctx, const struct TermSignal *signal);
 
 /**
  * @brief Process a link exit signal.


### PR DESCRIPTION
Chage `context_process_signal_set_group_leader` `ctx` parameter to `const` since we are just reading it.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
