### PR TITLE
Adjust estdlib tests for STM32

### DIFF
--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -31,6 +31,8 @@ start() ->
                 case atomvm:platform() of
                     emscripten ->
                         false;
+                    stm32 ->
+                        false;
                     _ ->
                         true
                 end;


### PR DESCRIPTION
Adds the stm32 platform to those that skip network tests when running the estdlib test suite.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
