### PR TITLE
Reduce memory footprint of line refs

### DIFF
--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -88,13 +88,6 @@ struct ModuleFilename
     size_t len;
 };
 
-struct LineRefOffset
-{
-    struct ListHead head;
-    unsigned int offset;
-    uint16_t line_ref;
-};
-
 struct Module
 {
 #ifdef ENABLE_ADVANCED_TRACE
@@ -113,7 +106,8 @@ struct Module
     size_t locations_count;
     const uint8_t *locations_table;
 
-    struct ListHead line_ref_offsets;
+    unsigned int *line_refs_offsets;
+    size_t line_refs_offsets_count;
 
     const struct ExportedFunction **imported_funcs;
 
@@ -390,10 +384,11 @@ bool module_get_function_from_label(Module *this_module, int label, AtomString *
  * is a no-op.
  *
  * @param mod the module
+ * @param line_refs the list of line references to append to
  * @param line_ref the line reference (index)
  * @param offset the instruction offset at which the line instruction occurred.
  */
-void module_insert_line_ref_offset(Module *mod, int line_ref, int offset);
+void module_insert_line_ref_offset(Module *mod, struct ListHead *line_refs, uint32_t line_ref, int offset);
 
 /*
  * @brief Find the latest line reference (index) before or at which the instruction offset

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1809,9 +1809,9 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 #endif
 
 #ifdef IMPL_CODE_LOADER
-    int read_core_chunk0(Module *mod);
+    int read_core_chunk0(Module *mod, struct ListHead *line_refs);
 
-    int read_core_chunk(Module *mod)
+    int read_core_chunk(Module *mod, struct ListHead *line_refs)
 #else
     #ifdef IMPL_EXECUTE_LOOP
         int context_execute_loop(Context *ctx, Module *mod, const char *function_name, int arity)
@@ -1848,7 +1848,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
     #endif
 
 #ifdef IMPL_CODE_LOADER
-    return read_core_chunk0(mod);
+    return read_core_chunk0(mod, line_refs);
 #endif
 #ifdef IMPL_EXECUTE_LOOP
     // This process is the first scheduler process
@@ -1860,7 +1860,7 @@ static bool maybe_call_native(Context *ctx, AtomString module_name, AtomString f
 }
 
 #ifdef IMPL_CODE_LOADER
-int read_core_chunk0(Module *mod)
+int read_core_chunk0(Module *mod, struct ListHead *line_refs)
 #else
 #ifdef IMPL_EXECUTE_LOOP
 HOT_FUNC int scheduler_entry_point(GlobalContext *glb)
@@ -5675,15 +5675,16 @@ wait_timeout_trap_handler:
 
             case OP_LINE: {
                 #ifdef IMPL_CODE_LOADER
-                    const uint8_t *saved_pc = pc -1;
+                    unsigned int offset = pc - code;
                 #endif
                 uint32_t line_number;
+                // This decode increments pc and ensures we can decode it
                 DECODE_LITERAL(line_number, pc);
 
                 TRACE("line/1: %i\n", line_number);
 
                 #ifdef IMPL_CODE_LOADER
-                    module_insert_line_ref_offset(mod, line_number, saved_pc - code);
+                    module_insert_line_ref_offset(mod, line_refs, line_number, offset);
                 #endif
                 break;
             }


### PR DESCRIPTION
Out of memory errors can happen when loading large modules without this fix.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
