### PR TITLE
Add missing `context_destroy` in error handling

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1232,6 +1232,7 @@ static term do_spawn(Context *ctx, Context *new_ctx, size_t arity, size_t n_free
         valid_request = true;
         group_leader = term_get_tuple_element(request_term, 3);
     } else {
+        context_destroy(new_ctx);
         RAISE_ERROR(BADARG_ATOM);
     }
 


### PR DESCRIPTION
Fix PR #1650.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
