### PR TITLE
Fix compilation of smp.h with C++ and disabled SMP

### DIFF
--- a/src/libAtomVM/smp.h
+++ b/src/libAtomVM/smp.h
@@ -273,6 +273,10 @@ bool smp_is_main_thread(GlobalContext *glb);
 #define SMP_RWLOCK_WRLOCK(lock) smp_rwlock_wrlock(lock)
 #define SMP_RWLOCK_UNLOCK(lock) smp_rwlock_unlock(lock)
 
+#ifdef __cplusplus
+}
+#endif
+
 #else
 
 #define SMP_SPINLOCK_LOCK(spinlock)
@@ -285,10 +289,6 @@ bool smp_is_main_thread(GlobalContext *glb);
 #define SMP_RWLOCK_TRYRDLOCK(lock)
 #define SMP_RWLOCK_WRLOCK(lock)
 #define SMP_RWLOCK_UNLOCK(lock)
-#endif
-
-#ifdef __cplusplus
-}
 #endif
 
 #endif


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
