### PR TITLE
Fix crash when loading module fails, for example because of OOM

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -687,10 +687,7 @@ Module *globalcontext_load_module_from_avm(GlobalContext *global, const char *mo
         return NULL;
     }
 
-    Module *new_module = module_new_from_iff_binary(global, beam_module, beam_module_size);
-    new_module->module_platform_data = NULL;
-
-    return new_module;
+    return module_new_from_iff_binary(global, beam_module, beam_module_size);
 }
 
 Module *globalcontext_get_module(GlobalContext *global, AtomString module_name_atom)


### PR DESCRIPTION
Setting `module_platform_data` to NULL is not necessary as it's done by `module_new_from_iff_binary` which memsets the structure to 0. On the contrary, if `module_new_from_iff_binary` returns NULL it would crash.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
