### PR TITLE
Fix ESP32 SPI driver about passing a term to a function expecting a non-term

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/spi_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/spi_driver.c
@@ -658,7 +658,7 @@ static NativeHandlerResult spidriver_consume_mailbox(Context *ctx)
                 ret = OUT_OF_MEMORY_ATOM;
             }
             term unkn_a = globalcontext_make_atom(ctx->global, ATOM_STR("\xF", "unknown_command"));
-            ret = create_pair(ctx, ERROR_ATOM, esp_err_to_term(ctx->global, unkn_a));
+            ret = create_pair(ctx, ERROR_ATOM, unkn_a);
     }
 
     term ret_msg;


### PR DESCRIPTION
Removes the unnecessary use of esp_err_to_term, which takes an error integer and converts it to an atom term. The value passed was already a term (atom) and does not need any further processing before being passed to the create_pair funtion.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
