### PR TITLE
Fix CMake targets to avoid useless rebuilds

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -159,6 +159,7 @@ jobs:
         mkdir -p build &&
         cd build &&
         cmake .. ${{ matrix.cmake_opts }} &&
+        make PackBEAM &&
         cp ../build_tests/tests/erlang_tests/*.beam tests/erlang_tests/ &&
         cp ../build_tests/tests/erlang_tests/code_load/*.{avm,beam,hrl} tests/erlang_tests/code_load/ &&
         mkdir -p tests/erlang_tests/code_load/beams/ &&
@@ -167,6 +168,8 @@ jobs:
         cp ../build_tests/tests/libs/estdlib/*.avm tests/libs/estdlib/  &&
         cp ../build_tests/tests/libs/eavmlib/*.avm tests/libs/eavmlib/ &&
         cp ../build_tests/tests/libs/alisp/*.avm tests/libs/alisp/ &&
+        touch tests/erlang_tests/code_load/code_load_pack.avm &&
+        touch tests/erlang_tests/code_load/code_load_pack_data.hrl &&
         make AtomVM &&
         make test-erlang &&
         make test-enif &&

--- a/CMakeModules/BuildElixir.cmake
+++ b/CMakeModules/BuildElixir.cmake
@@ -43,15 +43,18 @@ macro(pack_archive avm_name)
         set(INCLUDE_LINES "-i")
     endif()
 
-    add_custom_target(
-        ${avm_name} ALL
+    add_custom_command(
+        OUTPUT ${avm_name}.avm
         DEPENDS ${avm_name}_beams PackBEAM
         COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM -a ${INCLUDE_LINES} ${avm_name}.avm ${BEAMS}
         COMMENT "Packing archive ${avm_name}.avm"
         VERBATIM
     )
-    add_dependencies(${avm_name} ${avm_name}_beams PackBEAM)
 
+    add_custom_target(
+        ${avm_name} ALL
+        DEPENDS ${avm_name}.avm
+    )
 endmacro()
 
 macro(pack_runnable avm_name main)
@@ -85,13 +88,18 @@ macro(pack_runnable avm_name main)
         set(ARCHIVE_TARGETS ${ARCHIVE_TARGETS} ${archive_name})
     endforeach()
 
-    add_custom_target(
-        ${avm_name} ALL
+    add_custom_command(
+        OUTPUT ${avm_name}.avm
+        DEPENDS ${avm_name}_main ${ARCHIVE_TARGETS} PackBEAM
         COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${INCLUDE_LINES} ${avm_name}.avm Elixir.${main}.beam ${ARCHIVES}
         COMMENT "Packing runnable ${avm_name}.avm"
         VERBATIM
     )
-    add_dependencies(${avm_name} ${avm_name}_main ${ARCHIVE_TARGETS} PackBEAM)
+
+    add_custom_target(
+        ${avm_name} ALL
+        DEPENDS ${avm_name}.avm
+    )
 
 endmacro()
 
@@ -146,12 +154,16 @@ macro(pack_test avm_name main)
         endif()
     endforeach()
 
-    add_custom_target(
-        ${avm_name} ALL
+    add_custom_command(
+        OUTPUT ${avm_name}.avm
+        DEPENDS ${avm_name}_main ${avm_name}_tests ${ARCHIVE_TARGETS} PackBEAM
         COMMAND ${CMAKE_BINARY_DIR}/tools/packbeam/PackBEAM ${INCLUDE_LINES} ${avm_name}.avm Elixir.${main}.beam ${TEST_BEAMS} ${ARCHIVES}
         COMMENT "Packing test ${avm_name}.avm"
         VERBATIM
     )
-    add_dependencies(${avm_name} ${avm_name}_main ${avm_name}_tests ${ARCHIVE_TARGETS} PackBEAM)
 
+    add_custom_target(
+        ${avm_name} ALL
+        DEPENDS ${avm_name}.avm
+    )
 endmacro()

--- a/tests/erlang_tests/code_load/CMakeLists.txt
+++ b/tests/erlang_tests/code_load/CMakeLists.txt
@@ -27,8 +27,6 @@ compile_erlang(export_test_module)
 generate_hrl(export_test_module_data.hrl EXPORT_TEST_MODULE_DATA export_test_module.beam)
 
 pack_archive(code_load_pack export_test_module)
-# workaround since generate_hrl requires a file name, but pack_archive target is not
-add_custom_target(code_load_pack.avm DEPENDS code_load_pack)
 generate_hrl(code_load_pack_data.hrl CODE_LOAD_PACK_DATA code_load_pack.avm)
 
 add_custom_target(code_load_files DEPENDS

--- a/tools/uf2tool/CMakeLists.txt
+++ b/tools/uf2tool/CMakeLists.txt
@@ -32,8 +32,13 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/rebar.config
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-add_custom_target(
-    uf2tool ALL
+add_custom_command(
+    OUTPUT uf2tool
     COMMAND rebar3 escriptize && cp _build/default/bin/uf2tool .
     VERBATIM
+)
+
+add_custom_target(
+    UF2Tool ALL
+    DEPENDS uf2tool
 )


### PR DESCRIPTION
Use add_custom_command to ensure we don't rebuild files

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
