### PR TITLE
Fix compilation for RP2

### DIFF
--- a/src/platforms/rp2/tests/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/rp2/tests/test_erl_sources/CMakeLists.txt
@@ -22,7 +22,7 @@ include(ExternalProject)
 ExternalProject_Add(HostAtomVM
     SOURCE_DIR ../../../../../../
     INSTALL_COMMAND cmake -E echo "Skipping install step."
-    BUILD_COMMAND cmake --build . --target=atomvmlib --target=PackBEAM --target=uf2tool
+    BUILD_COMMAND cmake --build . --target=atomvmlib --target=PackBEAM --target=UF2Tool
 )
 
 function(compile_erlang module_name module_src_dir)


### PR DESCRIPTION
Fix name of UF2Tool target that was renamed in #1668

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
