### PR TITLE
Fix compilation with emscripten 4.0.9

### DIFF
--- a/CMakeModules/FetchMbedTLS.cmake
+++ b/CMakeModules/FetchMbedTLS.cmake
@@ -22,8 +22,9 @@ include(FetchContent)
 
 FetchContent_Declare(
   mbedtls
+  PATCH_COMMAND git apply "${CMAKE_CURRENT_LIST_DIR}/mbedtls.patch"
   GIT_REPOSITORY http://github.com/mbed-TLS/mbedtls.git
-  GIT_TAG        v3.6.2
+  GIT_TAG        v3.6.3.1
   GIT_SHALLOW    1
 )
 

--- a/CMakeModules/mbedtls.patch
+++ b/CMakeModules/mbedtls.patch
@@ -1,0 +1,15 @@
+# Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+diff --git a/framework/tests/src/psa_exercise_key.c b/framework/tests/src/psa_exercise_key.c
+index b92c1f75..eaa35527 100644
+--- a/framework/tests/src/psa_exercise_key.c
++++ b/framework/tests/src/psa_exercise_key.c
+@@ -184,7 +184,7 @@ static int exercise_cipher_key(mbedtls_svc_key_id_t key,
+     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+     psa_key_type_t key_type;
+     const unsigned char plaintext[16] = "Hello, world...";
+-    unsigned char ciphertext[32] = "(wabblewebblewibblewobblewubble)";
++    unsigned char ciphertext[33] = "(wabblewebblewibblewobblewubble)";
+     size_t ciphertext_length = sizeof(ciphertext);
+     unsigned char decrypted[sizeof(ciphertext)];
+     size_t part_length;


### PR DESCRIPTION
Patch MbedTLS to fix a legit compilation error
Also bump mbedtls to 3.6.3.1

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
