### PR TITLE
Define `nif_error/1` to silence an OTP28 warning

### DIFF
--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -44,6 +44,7 @@
     min/2,
     max/2,
     memory/1,
+    nif_error/1,
     get/0,
     get/1,
     put/2,
@@ -1492,4 +1493,9 @@ unique_integer() ->
 %%-----------------------------------------------------------------------------
 -spec unique_integer([monotonic | positive]) -> integer().
 unique_integer(_Options) ->
+    erlang:nif_error(undefined).
+
+%% @private
+-spec nif_error(Reason :: any()) -> no_return().
+nif_error(_Reason) ->
     erlang:nif_error(undefined).


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
