### PR TITLE
Fix macOS CI

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -48,18 +48,21 @@ jobs:
         submodules: 'recursive'
 
     - name: "Install deps"
-      if: matrix.otp != '24' && matrix.otp != '25
-      run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen erlang@${{ matrix.otp }} gleam ninja mbedtls rebar3
+      if: matrix.otp != '24' && matrix.otp != '25'
+      run: brew update && HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen erlang@${{ matrix.otp }} gleam mbedtls rebar3
 
     - name: "Install deps"
       if: matrix.otp == '24' || matrix.otp == '25'
       run: |
-        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen erlang@${{ matrix.otp }} gleam ninja mbedtls
+        brew update
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gperf doxygen erlang@${{ matrix.otp }} gleam mbedtls
         wget https://github.com/erlang/rebar3/releases/download/3.23.0/rebar3
         chmod +x rebar3
-        if [ -e {/usr/local,/opt/homebrew}/opt/erlang@{24,25}/bin/ ] ; then
-            sudo cp rebar3 {/usr/local,/opt/homebrew}/opt/erlang@{24,25}/bin/
-        fi
+        for bin_dir in {/usr/local,/opt/homebrew}/opt/erlang@{24,25}/bin/ ; do
+            if [ -e ${bin_dir} ]; then
+                sudo cp rebar3 ${bin_dir}
+            fi
+        done
 
     # Builder info
     - name: "System info"

--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -71,17 +71,17 @@ jobs:
           container: erlang:27
 
         # This is ARM64
-        - os: "macos-14"
-          otp: "25"
-          path_prefix: "/opt/homebrew/opt/erlang@25/bin:"
-
-        - os: "macos-14"
+        - os: "macos-15"
           otp: "26"
           path_prefix: "/opt/homebrew/opt/erlang@26/bin:"
 
-        - os: "macos-14"
+        - os: "macos-15"
           otp: "27"
           path_prefix: "/opt/homebrew/opt/erlang@27/bin:"
+
+        - os: "macos-15"
+          otp: "28"
+          path_prefix: "/opt/homebrew/opt/erlang@28/bin:"
     steps:
     # Setup
     - name: "Checkout repo"
@@ -97,7 +97,7 @@ jobs:
 
     - name: "Install deps (macOS)"
       if: runner.os == 'macOS'
-      run: brew install gperf erlang@${{ matrix.otp }} ninja mbedtls rebar3
+      run: brew update && brew install gperf erlang@${{ matrix.otp }} mbedtls rebar3
 
     # Build
     - name: "Build: create build dir"


### PR DESCRIPTION
#1680 was a failure, fix it
Also fix run tests with BEAM on macOS which were also broken by OTP28 release

<img width="766" alt="Screenshot 2025-05-30 at 07 38 07" src="https://github.com/user-attachments/assets/a2352226-763d-4f84-ae1c-0ebab9b36988" />
<img width="762" alt="Screenshot 2025-05-30 at 07 39 07" src="https://github.com/user-attachments/assets/7ebc5e65-fcee-47de-bb07-94771e109d77" />



These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
