### PR TITLE
ESP32: Avoid compiler warnings for esp_wifi_remote

### DIFF
--- a/src/platforms/esp32/components/avm_builtins/idf_component.yml
+++ b/src/platforms/esp32/components/avm_builtins/idf_component.yml
@@ -17,4 +17,5 @@ dependencies:
 
   espressif/esp_wifi_remote:
     rules:
-     - if: "idf_version >= 5.4"
+      - if: "idf_version >= 5.4"
+      - if: target in ["esp32p4"]


### PR DESCRIPTION
The recent esp_wifi_remote for esp32p4 addition would yield ~400 lines of compiler warnings on non esp32p4 targets:
(In CI and local builds)

https://github.com/atomvm/AtomVM/actions/runs/15377792692/job/43264664739#step:13:1501

Docs for conditional deps:
https://docs.espressif.com/projects/idf-component-manager/en/latest/reference/manifest_file.html#conditional-dependencies

Avoids warnings: 
https://github.com/petermm/AtomVM/actions/runs/15403605453/job/43341673287#step:13:72

includes esp_wifi_remote for esp32p4:
https://github.com/petermm/AtomVM/actions/runs/15403605453/job/43341673307#step:13:65

cc @UncleGrumpy 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
