### PR TITLE
CI: release-0.6 bump esp-idf patch versions

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -38,17 +38,17 @@ jobs:
       matrix:
         esp-idf-target: ["esp32", "esp32c3"]
         idf-version:
-         - 'v5.0.7'
-         - 'v5.1.5'
-         - 'v5.2.3'
-         - 'v5.3.2'
-         - 'v5.4'
+         - 'v5.0.9'
+         - 'v5.1.6'
+         - 'v5.2.5'
+         - 'v5.3.3'
+         - 'v5.4.1'
 
         exclude:
         - esp-idf-target: "esp32c3"
-          idf-version: 'v5.0.7'
+          idf-version: 'v5.0.9'
         - esp-idf-target: "esp32c3"
-          idf-version: 'v5.1.5'
+          idf-version: 'v5.1.6'
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -37,7 +37,7 @@ jobs:
 
     strategy:
       matrix:
-        idf-version: ["5.3.2"]
+        idf-version: ["5.3.3"]
         cc: ["clang-14"]
         cxx: ["clang++-14"]
         cflags: ["-O3"]

--- a/.github/workflows/esp32-simtest.yaml
+++ b/.github/workflows/esp32-simtest.yaml
@@ -75,16 +75,16 @@ jobs:
             "esp32h2",
             "esp32p4",
           ]
-        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.5", "v5.2.3", "v5.3.2", "v5.4"]')) || fromJSON('["v5.3.2"]') }}
+        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.6", "v5.2.5", "v5.3.3", "v5.4.1"]')) || fromJSON('["v5.3.3"]') }}
         exclude:
           - esp-idf-target: "esp32p4"
-            idf-version: "v5.1.5"
+            idf-version: "v5.1.6"
           - esp-idf-target: "esp32p4"
-            idf-version: "v5.2.3"
+            idf-version: "v5.2.5"
           - esp-idf-target: "esp32h2"
-            idf-version: "v5.1.5"
+            idf-version: "v5.1.6"
           - esp-idf-target: "esp32h2"
-            idf-version: "v5.2.3"
+            idf-version: "v5.2.5"
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Chore.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
