### PR TITLE
module: do not abort when OOM while loading literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ memory error
 - Fixed nif_atomvm_posix_read GC bug
 - Fixed `erlang:is_number/1` function, now returns true also for floats
 - Fixed unlink protocol and add support for `link/1` on ports
+- Do not abort when an out of memory happens while loading a literal value
 
 ### Changed
 

--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -426,9 +426,8 @@ term module_load_literal(Module *mod, int index, Context *ctx)
 {
     term t = externalterm_to_term(mod->literals_table[index].data, mod->literals_table[index].size,
         ctx, ExternalTermToHeapFragment);
-    if (term_is_invalid_term(t)) {
-        fprintf(stderr, "Invalid term reading literals_table[%i] from module\n", index);
-        AVM_ABORT();
+    if (UNLIKELY(term_is_invalid_term(t))) {
+        fprintf(stderr, "Either OOM or invalid term while reading literals_table[%i] from module\n", index);
     }
     return t;
 }


### PR DESCRIPTION
Literals are encoded as external terms, so they might make use of heap fragments and their memory allocation might fail. Existing code already deal with this, so we can just raise instead of abort().

There is still a very very low change we found a corrupt external term, but we are not able to distinguish the situations, so we also print a warning.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
