### PR TITLE
ESP32: "default" to esp-idf v5.4.1

### DIFF
--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -32,12 +32,12 @@ concurrency:
 
 jobs:
   esp32-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: espressif/idf:v${{ matrix.idf-version }}
 
     strategy:
       matrix:
-        idf-version: ["5.3.3"]
+        idf-version: ["5.4.1"]
         cc: ["clang-14"]
         cxx: ["clang++-14"]
         cflags: ["-O3"]
@@ -52,7 +52,7 @@ jobs:
       CXX: ${{ matrix.cxx }}
       CFLAGS: ${{ matrix.cflags }}
       CXXFLAGS: ${{ matrix.cflags }}
-      ImageOS: "ubuntu22"
+      ImageOS: "ubuntu24"
 
     steps:
     - name: Checkout repo

--- a/.github/workflows/esp32-simtest.yaml
+++ b/.github/workflows/esp32-simtest.yaml
@@ -75,7 +75,7 @@ jobs:
             "esp32h2",
             "esp32p4",
           ]
-        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.6", "v5.2.5", "v5.3.3", "v5.4.1"]')) || fromJSON('["v5.3.3"]') }}
+        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.1.6", "v5.2.5", "v5.3.3", "v5.4.1"]')) || fromJSON('["v5.4.1"]') }}
         exclude:
           - esp-idf-target: "esp32p4"
             idf-version: "v5.1.6"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ network. (See issue #1094)
 ### Changed
 
 - ESP32 UART driver no longer aborts because of badargs in configuration, instead raising an error
+- ESP32: `v0.6.6` uses esp-idf v5.4.1 for pre-built images and `v5.4.x` is the suggested release
+also for custom builds
 
 ## [0.6.5] - 2024-10-15
 


### PR DESCRIPTION
Use esp-idf v5.4.1 for both simtest and mkimage, so it will be used for released images.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
