### PR TITLE
Use `setup-qemu-action` in `build-linux-artifacts`

### DIFF
--- a/.github/workflows/build-linux-artifacts.yaml
+++ b/.github/workflows/build-linux-artifacts.yaml
@@ -188,7 +188,7 @@ jobs:
         path: build_tests
 
     - name: Set up QEMU
-      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      uses: docker/setup-qemu-action@v3
 
     - name: Build AtomVM using docker
       timeout-minutes: 15


### PR DESCRIPTION
Use qemu action (as we do in build-and-test-other) rather the previous one. This should fix a segfault that has been observed.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
