### PR TITLE
Remove redundant assignment in if_end/0

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -3509,9 +3509,6 @@ wait_timeout_trap_handler:
                 TRACE("if_end/0\n");
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    x_regs[0] = ERROR_ATOM;
-                    x_regs[1] = IF_CLAUSE_ATOM;
-
                     RAISE_ERROR(IF_CLAUSE_ATOM);
                 #endif
                 break;


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
