### PR TITLE
Process.ex link/1 and unlink/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added CodeQL analysis to esp32, stm32, pico, and wasm workflows
 - Added Function.ex and Protocol.ex improving Elixir 1.18 support
 - Added WiFi support for ESP32P4 via esp-wifi-external for build with ESP-IDF v5.4 and later
+- Added Process.link/1 and unlink/1 to Elixir Process.ex
 
 ### Changed
 

--- a/libs/exavmlib/lib/Process.ex
+++ b/libs/exavmlib/lib/Process.ex
@@ -231,6 +231,12 @@ defmodule Process do
   @spec list() :: [pid]
   defdelegate list(), to: :erlang, as: :processes
 
+  @spec link(pid | port) :: true
+  defdelegate link(pid_or_port), to: :erlang
+
+  @spec unlink(pid | port) :: true
+  defdelegate unlink(pid_or_port), to: :erlang
+
   @doc """
   Register a PID or port identifier under `name`.
 


### PR DESCRIPTION
Needed for future Registry.ex

Carbon copy from Elixir source.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
