### PR TITLE
Add erlang:module_loaded/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Function.ex and Protocol.ex improving Elixir 1.18 support
 - Added WiFi support for ESP32P4 via esp-wifi-external for build with ESP-IDF v5.4 and later
 - Added Process.link/1 and unlink/1 to Elixir Process.ex
+- Added `erlang:module_loaded/1`
 
 ### Changed
 

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -51,6 +51,7 @@
     erase/0,
     erase/1,
     function_exported/3,
+    module_loaded/1,
     display/1,
     list_to_atom/1,
     list_to_existing_atom/1,
@@ -601,6 +602,14 @@ erase(_Key) ->
 %%-----------------------------------------------------------------------------
 -spec function_exported(Module :: module(), Function :: atom(), Arity :: arity()) -> boolean().
 function_exported(_Module, _Function, _Arity) ->
+    erlang:nif_error(undefined).
+
+%% @param   Module name of module
+%% @returns boolean
+%% @doc     Returns true if module is loaded without attempting to do it.
+%% @end
+-spec module_loaded(Module :: atom()) -> boolean().
+module_loaded(_Module) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -189,6 +189,7 @@ static term nif_code_all_loaded(Context *ctx, int argc, term argv[]);
 static term nif_code_load_abs(Context *ctx, int argc, term argv[]);
 static term nif_code_load_binary(Context *ctx, int argc, term argv[]);
 static term nif_code_ensure_loaded(Context *ctx, int argc, term argv[]);
+static term nif_erlang_module_loaded(Context *ctx, int argc, term argv[]);
 static term nif_lists_reverse(Context *ctx, int argc, term argv[]);
 static term nif_maps_from_keys(Context *ctx, int argc, term argv[]);
 static term nif_maps_next(Context *ctx, int argc, term argv[]);
@@ -806,6 +807,13 @@ static const struct Nif code_ensure_loaded_nif =
     .base.type = NIFFunctionType,
     .nif_ptr = nif_code_ensure_loaded
 };
+
+static const struct Nif module_loaded_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_erlang_module_loaded
+};
+
 static const struct Nif lists_reverse_nif =
 {
     .base.type = NIFFunctionType,
@@ -5159,6 +5167,19 @@ static term nif_code_ensure_loaded(Context *ctx, int argc, term argv[])
     }
 
     return result;
+}
+
+static term nif_erlang_module_loaded(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+
+    term module_atom = argv[0];
+    VALIDATE_VALUE(module_atom, term_is_atom);
+
+    AtomString module_string = globalcontext_atomstring_from_term(ctx->global, module_atom);
+    Module *module = (Module *) atomshashtable_get_value(ctx->global->modules_table, module_string, (unsigned long) NULL);
+
+    return module != NULL ? TRUE_ATOM : FALSE_ATOM;
 }
 
 static term nif_lists_reverse(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -133,6 +133,7 @@ erlang:setnode/3, &setnode_3_nif
 erlang:dist_ctrl_get_data_notification/1, &dist_ctrl_get_data_notification_nif
 erlang:dist_ctrl_get_data/1, &dist_ctrl_get_data_nif
 erlang:dist_ctrl_put_data/2, &dist_ctrl_put_data_nif
+erlang:module_loaded/1,&module_loaded_nif
 erts_debug:flat_size/1, &flat_size_nif
 ets:new/2, &ets_new_nif
 ets:insert/2, &ets_insert_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -503,6 +503,7 @@ compile_erlang(test_add_avm_pack_file)
 compile_erlang(test_close_avm_pack)
 
 compile_erlang(test_module_info)
+compile_erlang(erlang_module_loaded)
 
 compile_erlang(int64_build_binary)
 
@@ -996,6 +997,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_close_avm_pack.beam
 
     test_module_info.beam
+    erlang_module_loaded.beam
 
     int64_build_binary.beam
 

--- a/tests/erlang_tests/erlang_module_loaded.erl
+++ b/tests/erlang_tests/erlang_module_loaded.erl
@@ -1,0 +1,28 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Tomasz Sobkiewicz <tomasz.sobkiewicz@swmansion.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(erlang_module_loaded).
+
+-export([start/0]).
+
+start() ->
+    true = erlang:module_loaded(?MODULE),
+    false = erlang:module_loaded(undefined_module),
+    0.

--- a/tests/test.c
+++ b/tests/test.c
@@ -542,6 +542,7 @@ struct Test tests[] = {
     TEST_CASE_ATOMVM_ONLY(test_close_avm_pack, 0),
 
     TEST_CASE(test_module_info),
+    TEST_CASE(erlang_module_loaded),
 
     // noisy tests, keep them at the end
     TEST_CASE_EXPECTED(spawn_opt_monitor_normal, 1),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
