### PR TITLE
Doc: fix Sphinx config

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -205,12 +205,12 @@ html_context['version'] = current_version
 html_context['versions'] = list()
 for version in versions:
     if ((version) == ('main')):
-        html_context['versions'].append( (version + ' branch (unstable)', '/doc/' +version+ '/') )
+        html_context['versions'].append( (version + ' branch (unstable)', '/' +version+ '/') )
     else:
         if (version not in release_list):
-            html_context['versions'].append( (version + ' branch (unreleased)', '/doc/' +version+ '/') )
+            html_context['versions'].append( (version + ' branch (unreleased)', '/' +version+ '/') )
         else:
-            html_context['versions'].append( (version, '/doc/' +version+ '/') )
+            html_context['versions'].append( (version, '/' +version+ '/') )
 
 html_sidebars = {
     '**': [
@@ -220,8 +220,8 @@ html_sidebars = {
 
 # POPULATE LINKS TO OTHER FORMATS/DOWNLOADS
 html_context['downloads'] = list()
-html_context['downloads'].append( ('pdf', '/doc/' +download_version+ '/pdf/' +project+ '-' +download_version+ '.pdf') )
-html_context['downloads'].append( ('epub', '/doc/' +download_version+ '/epub/' +project+ '-' +download_version+ '.epub') )
+html_context['downloads'].append( ('pdf', '/' +download_version+ '/pdf/' +project+ '-' +download_version+ '.pdf') )
+html_context['downloads'].append( ('epub', '/' +download_version+ '/epub/' +project+ '-' +download_version+ '.epub') )
 
 # -- Options for PDF output -------------------------------------------------
 


### PR DESCRIPTION
There is no more "/doc" path prefix: every version is published on the root.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
