### PR TITLE
Update "alpha status" to pre 1.0 status in release-0.6 docs

### DIFF
--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -16,7 +16,7 @@ AtomVM is a lightweight implementation of the the Bogdan Erlang Abstract Machine
 
 AtomVM includes many advanced features, including process spawning, monitoring, message passing, pre-emptive scheduling, and efficient garbage collection.  It can also interface directly with peripherals and protocols supported on micro-controllers, such as GPIO, I2C, SPI, and UART.  It also supports WiFi networking on devices that support it, such as the Espressif ESP32.   All of this on a device that can cost as little as $2!
 
-.. warning:: AtomVM is currently in Alpha status.  Software may contain bugs and should not be used for mission-critical applications.  Application Programming Interfaces may change without warning.
+.. warning:: AtomVM is currently in `v0.x stage <https://semver.org/#spec-item-4>`_. Software may contain bugs and should not be used for mission-critical applications.  Application Programming Interfaces may change without warning.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Updates documentation to no longer use "alpha" status to describe the current state of AtomVM, instead warning that APIs may sill be unstable due to the pre 1.0 status of the project.

This change has already been made in the main branch, but should be included in future 0.6.x releases as well.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
