### PR TITLE
Remove unnecessary check in OP_SELECT_TUPLE_ARITY

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -3260,7 +3260,7 @@ wait_timeout_trap_handler:
                 #endif
 
                 #ifdef IMPL_EXECUTE_LOOP
-                if (LIKELY(term_is_tuple(src_value))) {
+                    assert(term_is_tuple(src_value));
                     int arity = term_get_tuple_arity(src_value);
                 #endif
 
@@ -3280,9 +3280,6 @@ wait_timeout_trap_handler:
                             }
                         #endif
                     }
-                #ifdef IMPL_EXECUTE_LOOP
-                }
-                #endif
 
                 #ifdef IMPL_EXECUTE_LOOP
                     if (!jump_to_address) {


### PR DESCRIPTION
Compiler always emit a OP_IS_TUPLE before OP_SELECT_TUPLE_ARITY. Replace check with an assert that can be disabled on release builds.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
