### PR TITLE
Add missing reduction decrement in OP_CALL_FUN2

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -6807,6 +6807,12 @@ wait_timeout_trap_handler:
             }
 
             case OP_CALL_FUN2: {
+                #ifdef IMPL_EXECUTE_LOOP
+                    remaining_reductions--;
+                    if (UNLIKELY(!remaining_reductions)) {
+                        SCHEDULE_NEXT(mod, pc - 1);
+                    }
+                #endif
                 term tag;
                 DECODE_COMPACT_TERM(tag, pc)
                 unsigned int args_count;


### PR DESCRIPTION
Reduction decrement code was probably forgotten here.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
