### PR TITLE
Fix term asserts

### DIFF
--- a/src/libAtomVM/memory.c
+++ b/src/libAtomVM/memory.c
@@ -961,7 +961,7 @@ void memory_sweep_mso_list(term mso_list, GlobalContext *global, bool from_task)
     while (l != term_nil()) {
         term h = term_get_list_head(l);
         // the mso list only contains boxed values; each refc is unique
-        TERM_DEBUG_ASSERT(term_is_boxed(h))
+        TERM_DEBUG_ASSERT(term_is_boxed(h));
         term *boxed_value = term_to_term_ptr(h);
         if (memory_is_moved_marker(boxed_value)) {
             h = memory_dereference_moved_marker(boxed_value);

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -1683,7 +1683,7 @@ static inline void term_put_tuple_element(term t, uint32_t elem_index, term put_
 
     term *boxed_value = term_to_term_ptr(t);
 
-    TERM_DEBUG_ASSERT(((boxed_value[0] & TERM_BOXED_TAG_MASK) == 0) && (elem_index < (boxed_value[0] >> 6)));
+    TERM_DEBUG_ASSERT((size_t) elem_index < term_get_size_from_boxed_header(boxed_value[0]));
 
     boxed_value[elem_index + 1] = put_value;
 }
@@ -1702,7 +1702,7 @@ static inline term term_get_tuple_element(term t, int elem_index)
 
     const term *boxed_value = term_to_const_term_ptr(t);
 
-    TERM_DEBUG_ASSERT(((boxed_value[0] & TERM_BOXED_TAG_MASK) == 0) && (elem_index < (boxed_value[0] >> 6)));
+    TERM_DEBUG_ASSERT((size_t) elem_index < term_get_size_from_boxed_header(boxed_value[0]));
 
     return boxed_value[elem_index + 1];
 }


### PR DESCRIPTION
`memory.c` had a missing semicolon, `get/put_tuple_element` in `term.h` unpacked header directly instead of using function. Additionally, first condition is already checked by term_is_tuple().

There's one unfixed assert `TERM_DEBUG_ASSERT((t & 0x3) == 0x2);`
but fixing it would create conflicts with #1701 (changes magic values to macros).

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
