### PR TITLE
Avoid feature branches showing up

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -178,10 +178,12 @@ for tag in tag_list:
         release_list.append(tag.name)
 
 omit_branch_list = [ 'release-0.5' ]
+allowed_branch_prefixes = ( 'release-', 'main' )
 branch_list = sorted(repo.branches, key=lambda t: t.commit.committed_datetime)
 for branch in branch_list:
     if branch.name not in omit_branch_list:
-        versions.append(branch.name)
+        if branch.name.startswith(allowed_branch_prefixes):
+            versions.append(branch.name)
 
 if ((repo.head.object.hexsha) == (latest_tag.commit.hexsha)):
     current_version = latest_tag.name


### PR DESCRIPTION
Filter out branches that are not release-* or main, so 'feature/' do not show up in documentation versions.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
