### PR TITLE
test_inet: use new test.atomvm.org

### DIFF
--- a/tests/libs/estdlib/test_inet.erl
+++ b/tests/libs/estdlib/test_inet.erl
@@ -29,7 +29,7 @@ test() ->
 test_getaddr() ->
     {ok, {127, 0, 0, 1}} = inet:getaddr(localhost, inet),
     {ok, {127, 0, 0, 1}} = inet:getaddr("localhost", inet),
-    {ok, {_, _, _, _}} = inet:getaddr("www.atomvm.net", inet),
+    {ok, {_, _, _, _}} = inet:getaddr("test.atomvm.org", inet),
     % RFC8880
     {ok, {192, 0, 0, LastByte}} = inet:getaddr("ipv4only.arpa", inet),
     true = LastByte =:= 170 orelse LastByte =:= 171,


### PR DESCRIPTION
Replace old domain with new test domain.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
