### PR TITLE
Fix a crash when a module has no line information

### DIFF
--- a/src/libAtomVM/module.c
+++ b/src/libAtomVM/module.c
@@ -323,19 +323,21 @@ Module *module_new_from_iff_binary(GlobalContext *global, const void *iff_binary
             num_offsets++;
             item = item->next;
         }
-        mod->line_refs_offsets = malloc(num_offsets * sizeof(unsigned int));
-        if (IS_NULL_PTR(mod->line_refs_offsets)) {
-            fprintf(stderr, "Warning: Unable to allocate space for line refs offset, module has %zu offsets.  Line information in stacktraces may be missing\n", num_offsets);
-        } else {
-            size_t index = 0;
-            item = line_refs.next;
-            while (item != &line_refs) {
-                struct LineRefOffset *offset = CONTAINER_OF(item, struct LineRefOffset, head);
-                mod->line_refs_offsets[index] = offset->offset;
-                index++;
-                item = item->next;
+        if (num_offsets > 0) {
+            mod->line_refs_offsets = malloc(num_offsets * sizeof(unsigned int));
+            if (IS_NULL_PTR(mod->line_refs_offsets)) {
+                fprintf(stderr, "Warning: Unable to allocate space for line refs offset, module has %zu offsets.  Line information in stacktraces may be missing\n", num_offsets);
+            } else {
+                size_t index = 0;
+                item = line_refs.next;
+                while (item != &line_refs) {
+                    struct LineRefOffset *offset = CONTAINER_OF(item, struct LineRefOffset, head);
+                    mod->line_refs_offsets[index] = offset->offset;
+                    index++;
+                    item = item->next;
+                }
+                mod->line_refs_offsets_count = num_offsets;
             }
-            mod->line_refs_offsets_count = num_offsets;
         }
     }
     // Empty the list


### PR DESCRIPTION
An assembly module can have a line_refs_table but no line information at all.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
