### PR TITLE
Fix fail cases in OP_BS_START_MATCH3 & OP_BS_START_MATCH4

### DIFF
--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -527,8 +527,18 @@ compile_erlang(maps_nifs)
 
 compile_erlang(test_raw_raise)
 
+compile_erlang(test_op_bs_start_match)
+compile_assembler(test_op_bs_start_match_asm)
 compile_erlang(test_op_bs_create_bin)
 compile_assembler(test_op_bs_create_bin_asm)
+
+if(Erlang_VERSION VERSION_GREATER_EQUAL "23")
+    set(OTP23_OR_GREATER_TESTS
+        test_op_bs_start_match_asm.beam
+    )
+else()
+    set(OTP23_OR_GREATER_TESTS)
+endif()
 
 if(Erlang_VERSION VERSION_GREATER_EQUAL "25")
     set(OTP25_OR_GREATER_TESTS
@@ -1021,7 +1031,9 @@ add_custom_target(erlang_test_modules DEPENDS
 
     test_raw_raise.beam
 
+    test_op_bs_start_match.beam
     test_op_bs_create_bin.beam
 
+    ${OTP23_OR_GREATER_TESTS}
     ${OTP25_OR_GREATER_TESTS}
 )

--- a/tests/erlang_tests/test_op_bs_start_match.erl
+++ b/tests/erlang_tests/test_op_bs_start_match.erl
@@ -1,0 +1,65 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_op_bs_start_match).
+
+-export([start/0]).
+
+start() ->
+    HasBSStartMatch4 =
+        case erlang:system_info(machine) of
+            "BEAM" ->
+                erlang:system_info(otp_release) >= "23";
+            "ATOM" ->
+                % If code was compiled with OTP < 23, we won't have bs_start_match asm file
+                ?OTP_RELEASE >= 23
+        end,
+    ok =
+        if
+            HasBSStartMatch4 ->
+                ok = test_bs_start_match3_fail_label(),
+                ok = test_bs_start_match4_fail_label(),
+                ok = test_bs_start_match4_nofail_resume();
+            true ->
+                ok
+        end,
+    0.
+
+test_bs_start_match3_fail_label() ->
+    2 = test_op_bs_start_match_asm:bs_start_match3(<<"foo">>, <<"bar">>),
+    2 = test_op_bs_start_match_asm:bs_start_match3(<<"foo">>, <<>>),
+    3 = test_op_bs_start_match_asm:bs_start_match3(foo, bar),
+    <<"foo">> = test_op_bs_start_match_asm:bs_start_match3(<<"foo">>, bar),
+    5 = test_op_bs_start_match_asm:bs_start_match3(<<"foot">>, bar),
+    ok.
+
+test_bs_start_match4_fail_label() ->
+    2 = test_op_bs_start_match_asm:bs_start_match4_label(<<"foo">>, <<"bar">>),
+    2 = test_op_bs_start_match_asm:bs_start_match4_label(<<"foo">>, <<>>),
+    3 = test_op_bs_start_match_asm:bs_start_match4_label(foo, bar),
+    <<"foo">> = test_op_bs_start_match_asm:bs_start_match4_label(<<"foo">>, bar),
+    5 = test_op_bs_start_match_asm:bs_start_match4_label(<<"foot">>, bar),
+    ok.
+
+% Other arguments will crash VM
+test_bs_start_match4_nofail_resume() ->
+    <<"foo">> = test_op_bs_start_match_asm:bs_start_match4_nofail_resume(<<"foo">>),
+    13 = test_op_bs_start_match_asm:bs_start_match4_nofail_resume(<<"foot">>),
+    ok.

--- a/tests/erlang_tests/test_op_bs_start_match_asm.S
+++ b/tests/erlang_tests/test_op_bs_start_match_asm.S
@@ -1,0 +1,82 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%% version = 0
+{module, test_op_bs_start_match_asm}.
+
+{exports, [
+    {bs_start_match3, 2},
+    {bs_start_match4_label, 2},
+    {bs_start_match4_nofail_resume, 1}
+]}.
+
+{function, bs_start_match3, 2, 2}.
+{label, 1}.
+{func_info, {atom, test_op_bs_start_match_asm}, {atom, bs_start_match3}, 2}.
+{label, 2}.
+{test, bs_start_match3, {f, 3}, 2, [{x, 0}], {x, 2}}.
+{test, bs_start_match3, {f, 4}, 3, [{x, 1}], {x, 2}}.
+{move, {integer, 2}, {x, 0}}.
+return.
+{label, 3}.
+{move, {integer, 3}, {x, 0}}.
+return.
+{label, 4}.
+{test, bs_test_tail2, {f, 5}, [{x, 2}, 24]}.
+{bs_get_tail, {x, 2}, {x, 0}, 3}.
+return.
+{label, 5}.
+{move, {integer, 5}, {x, 0}}.
+return.
+
+{function, bs_start_match4_label, 2, 7}.
+{label, 6}.
+{func_info, {atom, test_op_bs_start_match_asm}, {atom, bs_start_match4_label}, 2}.
+{label, 7}.
+{bs_start_match4, {f, 8}, 2, {x, 0}, {x, 2}}.
+{bs_start_match4, {f, 9}, 3, {x, 1}, {x, 2}}.
+{move, {integer, 2}, {x, 0}}.
+return.
+{label, 8}.
+{move, {integer, 3}, {x, 0}}.
+return.
+{label, 9}.
+{test, bs_test_tail2, {f, 10}, [{x, 2}, 24]}.
+{bs_get_tail, {x, 2}, {x, 0}, 3}.
+return.
+{label, 10}.
+{move, {integer, 5}, {x, 0}}.
+return.
+
+{function, bs_start_match4_nofail_resume, 1, 12}.
+{label, 11}.
+{func_info, {atom, test_op_bs_start_match_asm}, {atom, bs_start_match4_nofail_resume}, 1}.
+{label, 12}.
+{bs_start_match4, {atom, no_fail}, 1, {x, 0}, {x, 1}}.
+{move, {x, 1}, {x, 2}}.
+{move, nil, {x, 1}}.
+{bs_start_match4, {atom, resume}, 3, {x, 2}, {x, 1}}.
+{move, {x, 1}, {x, 2}}.
+{test, bs_test_tail2, {f, 13}, [{x, 2}, 24]}.
+{bs_get_tail, {x, 2}, {x, 0}, 3}.
+return.
+{label, 13}.
+{move, {integer, 13}, {x, 0}}.
+return.

--- a/tests/test.c
+++ b/tests/test.c
@@ -537,6 +537,7 @@ struct Test tests[] = {
 
     TEST_CASE(test_module_info),
 
+    TEST_CASE(test_op_bs_start_match),
     TEST_CASE(test_op_bs_create_bin),
 
     // noisy tests, keep them at the end


### PR DESCRIPTION
Continuation of #1731 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
