### PR TITLE
Small fixes to opcodeswitch

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -5036,6 +5036,7 @@ wait_timeout_trap_handler:
                 term src;
                 DECODE_COMPACT_TERM(src, pc);
                 uint32_t live;
+                UNUSED(live);
                 DECODE_LITERAL(live, pc);
                 term size;
                 DECODE_COMPACT_TERM(size, pc);
@@ -5088,8 +5089,9 @@ wait_timeout_trap_handler:
                 DECODE_LABEL(fail, pc)
                 term src;
                 DECODE_COMPACT_TERM(src, pc);
-                term arg2;
-                DECODE_COMPACT_TERM(arg2, pc);
+                uint32_t live;
+                UNUSED(live);
+                DECODE_LITERAL(live, pc);
                 term size;
                 DECODE_COMPACT_TERM(size, pc);
                 uint32_t unit;
@@ -5719,7 +5721,7 @@ wait_timeout_trap_handler:
 
                 #ifdef IMPL_EXECUTE_LOOP
                     //
-                    // Maybe GC, and reset the src term in case it changed
+                    // Maybe GC
                     //
                     size_t src_size = term_get_map_size(src);
                     size_t new_map_size = src_size + new_entries;
@@ -5847,7 +5849,7 @@ wait_timeout_trap_handler:
 
                 #ifdef IMPL_EXECUTE_LOOP
                     //
-                    // Maybe GC, and reset the src term in case it changed
+                    // Maybe GC
                     //
                     size_t src_size = term_get_map_size(src);
                     TRIM_LIVE_REGS(live);


### PR DESCRIPTION
- `OP_BS_GET_INTEGER2` : live is unused
- `OP_BS_GET_FLOAT2` : arg2 is live, is a literal and is unused
- `OP_PUT_MAP_ASSOC` and `OP_PUT_MAP_EXACT` : fix comments that are outdated since we have memory_ensure_free_with_roots

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
