### PR TITLE
OP_BS_MATCH: add missing TODO

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -7032,6 +7032,7 @@ wait_timeout_trap_handler:
                             DECODE_COMPACT_TERM(flags, pc);
                             j++;
                             #ifdef IMPL_EXECUTE_LOOP
+                                // TODO : determine what this is used for
                                 avm_int_t flags_value;
                                 DECODE_FLAGS_LIST(flags_value, flags, opcode)
                             #endif


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
