### PR TITLE
OP_BS_MATCH4: fix preservation of src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.7] - Unreleased
 
+### Fixed
+
+- Fixed a bug where binary matching could fail due to a missing preservation of the matched binary.
+
 ## [0.6.6] - 2025-06-23
 
 ### Added

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -6439,15 +6439,17 @@ wait_timeout_trap_handler:
                 #endif
                 uint32_t live;
                 DECODE_LITERAL(live, pc);
-                #ifdef IMPL_EXECUTE_LOOP
-                    TRIM_LIVE_REGS(live);
-                    // MEMORY_CAN_SHRINK because bs_start_match is classified as gc in beam_ssa_codegen.erl
-                    if (memory_ensure_free_with_roots(ctx, TERM_BOXED_BIN_MATCH_STATE_SIZE, live, x_regs, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
-                        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-                    }
-                #endif
                 term src;
                 DECODE_COMPACT_TERM(src, pc);
+                #ifdef IMPL_EXECUTE_LOOP
+                    TRIM_LIVE_REGS(live);
+                    x_regs[live] = src;
+                    // MEMORY_CAN_SHRINK because bs_start_match is classified as gc in beam_ssa_codegen.erl
+                    if (memory_ensure_free_with_roots(ctx, TERM_BOXED_BIN_MATCH_STATE_SIZE, live + 1, x_regs, MEMORY_CAN_SHRINK) != MEMORY_GC_OK) {
+                        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+                    }
+                    src = x_regs[live];
+                #endif
                 DEST_REGISTER(dreg);
                 DECODE_DEST_REGISTER(dreg, pc);
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -361,6 +361,7 @@ compile_erlang(test_ordering_1)
 compile_erlang(test_bs)
 compile_erlang(test_bs_int)
 compile_erlang(test_bs_int_unaligned)
+compile_erlang(test_bs_start_match_live)
 compile_erlang(test_bs_utf)
 compile_erlang(test_catch)
 compile_erlang(test_gc)
@@ -851,6 +852,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_bs.beam
     test_bs_int.beam
     test_bs_int_unaligned.beam
+    test_bs_start_match_live.beam
     test_bs_utf.beam
     test_catch.beam
     test_gc.beam

--- a/tests/erlang_tests/test_bs_start_match_live.erl
+++ b/tests/erlang_tests/test_bs_start_match_live.erl
@@ -1,0 +1,40 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_bs_start_match_live).
+
+-export([start/0, id/1]).
+
+-define(CODE_CHUNK_0,
+    <<0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 177, 0, 0, 0, 7, 0, 0, 0, 3, 1, 16, 153, 16, 2, 18, 34, 0,
+        1, 32, 64, 50, 3, 19, 1, 48, 153, 0, 2, 18, 66, 0, 1, 64, 64, 18, 3, 78, 16, 0, 1, 80, 153,
+        0, 2, 18, 66, 16, 1, 96, 64, 3, 19, 64, 18, 3, 78, 32, 16, 3>>
+).
+
+%% This compiles to:
+%%   {move,{literal,?CODE_CHUNK_0}, {x, 0}}.
+%%   {bs_start_match4,{atom,no_fail},0,{x,0},{x,0}}.
+%% Live is 0 here, but we need to preserve {x, 0}.
+start() ->
+    <<16:32, 0:32, _OpcodeMax:32, LabelsCount:32, _FunctionsCount:32, _Opcodes/binary>> = ?CODE_CHUNK_0,
+    7 = id(LabelsCount),
+    0.
+
+id(X) -> X.

--- a/tests/test.c
+++ b/tests/test.c
@@ -398,6 +398,7 @@ struct Test tests[] = {
     TEST_CASE(test_bs),
     TEST_CASE(test_bs_int),
     TEST_CASE(test_bs_int_unaligned),
+    TEST_CASE(test_bs_start_match_live),
     TEST_CASE(test_bs_utf),
     TEST_CASE(test_catch),
     TEST_CASE(test_gc),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
