### PR TITLE
OP_APPLY_LAST: fix stacktrace on failure

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -5384,12 +5384,12 @@ wait_timeout_trap_handler:
                 READ_ANY_XREG(function, arity + 1);
                 TRACE("apply_last/1, module=%lu, function=%lu arity=%i deallocate=%i\n", module, function, arity, n_words);
 
-                ctx->cp = ctx->e[n_words];
-                ctx->e += (n_words + 1);
-
                 if (UNLIKELY(!term_is_atom(module) || !term_is_atom(function))) {
                     RAISE_ERROR(BADARG_ATOM);
                 }
+
+                ctx->cp = ctx->e[n_words];
+                ctx->e += (n_words + 1);
 
                 AtomString module_name = globalcontext_atomstring_from_term(glb, module);
                 AtomString function_name = globalcontext_atomstring_from_term(glb, function);


### PR DESCRIPTION
Truncate stack only after checking module and function, thus generating a more helpful stacktrace, following what BEAM does.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
