### PR TITLE
Fix `lists:seq/2,3` when they should return an empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug where binary matching could fail due to a missing preservation of the matched binary.
+- Fixed a bug where `lists:seq/2` wouldn't return the empty list in valid cases.
 
 ## [0.6.6] - 2025-06-23
 

--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -600,7 +600,9 @@ join_1(_Sep, []) ->
 %%-----------------------------------------------------------------------------
 -spec seq(From :: integer(), To :: integer()) -> list().
 seq(From, To) when is_integer(From) andalso is_integer(To) andalso From =< To ->
-    seq_r(From, To, 1, []).
+    seq_r(From, To, 1, []);
+seq(From, To) when is_integer(From) andalso is_integer(To) andalso From =:= To + 1 ->
+    [].
 
 %%-----------------------------------------------------------------------------
 %% @param   From    from integer
@@ -622,6 +624,8 @@ seq(From, To, Incr) when
     error(badarg);
 seq(To, To, 0) ->
     [To];
+seq(From, To, Incr) when From =:= To + Incr ->
+    [];
 seq(From, To, Incr) ->
     Last = From + ((To - From) div Incr) * Incr,
     seq_r(From, Last, Incr, []).

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -245,6 +245,8 @@ test_seq() ->
     ?ASSERT_MATCH(lists:seq(5, 1, -1), [5, 4, 3, 2, 1]),
     ?ASSERT_MATCH(lists:seq(1, 1, 0), [1]),
     ?ASSERT_MATCH(lists:seq(1, 1), [1]),
+    ?ASSERT_MATCH(lists:seq(1, 0), []),
+    ?ASSERT_MATCH(lists:seq(1, 0, 1), []),
 
     ?ASSERT_ERROR(lists:seq(foo, 1)),
     ?ASSERT_ERROR(lists:seq(1, bar)),


### PR DESCRIPTION
- `lists:seq(1, 0)` is valid and now returns an empty list
- `lists:seq(1, 0, 1)` is also valid and now returns an empty list

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
