### PR TITLE
Replace quick_sort with merge_sort for lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `lists:keysort/2`
+- Added `lists:merge/2,3`
 
 ### Fixed
 
 - Fixed a bug where binary matching could fail due to a missing preservation of the matched binary.
+
+### Changed
+
+- lists sort function now use a stable merge sort implementation instead of quick sort
 
 ## [0.6.6] - 2025-06-23
 

--- a/tests/libs/estdlib/test_lists.erl
+++ b/tests/libs/estdlib/test_lists.erl
@@ -131,6 +131,34 @@ test_keysort() ->
     ?ASSERT_MATCH(lists:keysort(2, [{foo, 2}, {bar, 1}]), [{bar, 1}, {foo, 2}]),
     ?ASSERT_ERROR(lists:keysort(1, [1, 2])),
     ?ASSERT_ERROR(lists:keysort(3, [{1, bar}, {2, foo}])),
+
+    % Our sort is always stable, but older versions of OTP only have
+    % keysort/2 documented as stable
+    ?ASSERT_MATCH(
+        lists:keysort(1, [
+            {3, a}, {2, c}, {1, z}, {2, b}, {2, a}
+        ]),
+        [{1, z}, {2, c}, {2, b}, {2, a}, {3, a}]
+    ),
+    ?ASSERT_MATCH(
+        lists:keysort(1, [
+            {3, a}, {1, z}, {2, c}, {2, b}, {2, a}
+        ]),
+        [{1, z}, {2, c}, {2, b}, {2, a}, {3, a}]
+    ),
+    ?ASSERT_MATCH(
+        lists:keysort(1, [
+            {3, a}, {2, c}, {2, b}, {1, z}, {2, a}
+        ]),
+        [{1, z}, {2, c}, {2, b}, {2, a}, {3, a}]
+    ),
+    ?ASSERT_MATCH(
+        lists:keysort(1, [
+            {3, a}, {2, c}, {2, b}, {2, a}, {1, z}
+        ]),
+        [{1, z}, {2, c}, {2, b}, {2, a}, {3, a}]
+    ),
+
     ok.
 
 test_keystore() ->


### PR DESCRIPTION
Quick sort is way too slow when sorting labels and lines during jit compilation.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
