### PR TITLE
Implement `erlang:nif_error/1`

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -174,6 +174,7 @@ static term nif_base64_decode_to_string(Context *ctx, int argc, term argv[]);
 static term nif_code_load_abs(Context *ctx, int argc, term argv[]);
 static term nif_code_load_binary(Context *ctx, int argc, term argv[]);
 static term nif_code_ensure_loaded(Context *ctx, int argc, term argv[]);
+static term nif_erlang_nif_error(Context *ctx, int argc, term argv[]);
 static term nif_lists_reverse(Context *ctx, int argc, term argv[]);
 static term nif_maps_from_keys(Context *ctx, int argc, term argv[]);
 static term nif_maps_next(Context *ctx, int argc, term argv[]);
@@ -715,6 +716,13 @@ static const struct Nif code_ensure_loaded_nif =
     .base.type = NIFFunctionType,
     .nif_ptr = nif_code_ensure_loaded
 };
+
+static const struct Nif nif_error_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_erlang_nif_error
+};
+
 static const struct Nif lists_reverse_nif =
 {
     .base.type = NIFFunctionType,
@@ -4593,6 +4601,14 @@ static term nif_code_ensure_loaded(Context *ctx, int argc, term argv[])
     }
 
     return result;
+}
+
+static term nif_erlang_nif_error(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    UNUSED(argv);
+
+    RAISE_ERROR(UNDEF_ATOM);
 }
 
 static term nif_lists_reverse(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -126,6 +126,7 @@ erlang:group_leader/0, &group_leader_nif
 erlang:group_leader/2, &group_leader_nif
 erlang:get_module_info/1, &get_module_info_nif
 erlang:get_module_info/2, &get_module_info_nif
+erlang:nif_error/1,&nif_error_nif
 erts_debug:flat_size/1, &flat_size_nif
 atomvm:add_avm_pack_binary/2, &atomvm_add_avm_pack_binary_nif
 atomvm:add_avm_pack_file/2, &atomvm_add_avm_pack_file_nif


### PR DESCRIPTION
Throw undef when the function is called, as it means the NIF was not found.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
