### PR TITLE
macOS CI: implement workaround for random nxdomain issue in net_kernel test

### DIFF
--- a/.github/workflows/build-and-test-macos.yaml
+++ b/.github/workflows/build-and-test-macos.yaml
@@ -65,6 +65,14 @@ jobs:
             fi
         done
 
+    - name: "Workaround for nxdomain random issues"
+      run: |
+        # https://github.com/actions/runner-images/issues/8649#issuecomment-2231240347
+        for host in "$(hostname)" "$(hostname -f)"; do
+          echo -e "$(ipconfig getifaddr en0) $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+          dscacheutil -q host -a name $(hostname -f)
+        done
+
     # Builder info
     - name: "System info"
       run: |


### PR DESCRIPTION
Many macOS CI failures seem to come from this test.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
