### PR TITLE
Fix a bug where empty atom could not be decoded on esp32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilize reserved `phy_init` partition on ESP32 to store wifi calibration for faster connections.
 - Support for zero count in `lists:duplicate/2`.
 - packbeam: fix memory leak preventing building with address sanitizer
+- Fixed a bug where empty atom could not be created on some platforms, thus breaking receiving a message for a registered process from an OTP node.
 
 ## [0.6.7] - Unreleased
 

--- a/src/libAtomVM/atom_table.c
+++ b/src/libAtomVM/atom_table.c
@@ -388,11 +388,13 @@ enum AtomTableEnsureAtomResult atom_table_ensure_atom(struct AtomTable *table, c
 
     if (opts & AtomTableCopyAtom) {
         uint8_t *buf = malloc(atom_len);
-        if (IS_NULL_PTR(buf)) {
-            SMP_UNLOCK(table);
-            return AtomTableEnsureAtomAllocFail;
+        if (atom_len > 0) {
+            if (IS_NULL_PTR(buf)) {
+                SMP_UNLOCK(table);
+                return AtomTableEnsureAtomAllocFail;
+            }
+            memcpy(buf, atom_data, atom_len);
         }
-        memcpy(buf, atom_data, atom_len);
         atom_data = buf;
     }
 

--- a/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
+++ b/src/platforms/esp32/test/main/test_erl_sources/CMakeLists.txt
@@ -40,6 +40,7 @@ endfunction()
 compile_erlang(test_esp_partition)
 compile_erlang(test_file)
 compile_erlang(test_wifi_example)
+compile_erlang(test_list_to_atom)
 compile_erlang(test_list_to_binary)
 compile_erlang(test_md5)
 compile_erlang(test_crypto)
@@ -61,6 +62,7 @@ add_custom_command(
         test_esp_partition.beam
         test_file.beam
         test_wifi_example.beam
+        test_list_to_atom.beam
         test_list_to_binary.beam
         test_md5.beam
         test_crypto.beam
@@ -79,6 +81,7 @@ add_custom_command(
         "${CMAKE_CURRENT_BINARY_DIR}/test_esp_partition.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_wifi_example.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_file.beam"
+        "${CMAKE_CURRENT_BINARY_DIR}/test_list_to_atom.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_list_to_binary.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_md5.beam"
         "${CMAKE_CURRENT_BINARY_DIR}/test_crypto.beam"

--- a/src/platforms/esp32/test/main/test_erl_sources/test_list_to_atom.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_list_to_atom.erl
@@ -1,0 +1,36 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_list_to_atom).
+
+-export([start/0]).
+
+start() ->
+    ok = test_empty_list_to_atom(),
+    ok.
+
+test_empty_list_to_atom() ->
+    Atom = erlang:list_to_atom(id([])),
+    true = is_atom(id(Atom)),
+    [] = erlang:atom_to_list(id(Atom)),
+    ok.
+
+id(X) ->
+    X.

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -289,6 +289,12 @@ TEST_CASE("test_file", "[test_run]")
 }
 #endif
 
+TEST_CASE("test_list_to_atom", "[test_run]")
+{
+    term ret_value = avm_test_case("test_list_to_atom.beam");
+    TEST_ASSERT(ret_value == OK_ATOM);
+}
+
 TEST_CASE("test_list_to_binary", "[test_run]")
 {
     term ret_value = avm_test_case("test_list_to_binary.beam");


### PR DESCRIPTION
malloc(0) can return NULL on some platforms, including esp-idf, and this was wrongly interpreted as an error

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
