### PR TITLE
Fix disterl example: do not start kernel

### DIFF
--- a/examples/erlang/disterl.erl
+++ b/examples/erlang/disterl.erl
@@ -23,7 +23,6 @@
 -export([start/0]).
 
 start() ->
-    {ok, _KernelPid} = kernel:start(normal, []),
     {ok, _NetKernelPid} = net_kernel:start('atomvm@127.0.0.1', #{name_domain => longnames}),
     io:format("Distribution was started\n"),
     io:format("Node is ~p\n", [node()]),

--- a/examples/erlang/esp32/epmd_disterl.erl
+++ b/examples/erlang/esp32/epmd_disterl.erl
@@ -36,7 +36,6 @@ start() ->
 
 distribution_start(Address) ->
     {ok, _EPMDPid} = epmd:start_link([]),
-    {ok, _KernelPid} = kernel:start(normal, []),
     {X, Y, Z, T} = Address,
     Node = list_to_atom(lists:flatten(io_lib:format("atomvm@~B.~B.~B.~B", [X, Y, Z, T]))),
     {ok, _NetKernelPid} = net_kernel:start(Node, #{name_domain => longnames}),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
