### PR TITLE
Fix leak with disterl monitor by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `binary:replace/3`, `binary:replace/4`
 - Added `binary:match/2` and `binary:match/3`
 - Added `supervisor:which_children/1`
+- Added `monitored_by` in `process_info/2`
 
 ### Changed
 
@@ -72,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for zero count in `lists:duplicate/2`.
 - packbeam: fix memory leak preventing building with address sanitizer
 - Fixed a bug where empty atom could not be created on some platforms, thus breaking receiving a message for a registered process from an OTP node.
+- Fix a memory leak in distribution when a BEAM node would monitor a process by name.
 
 ## [0.6.7] - Unreleased
 

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -178,6 +178,9 @@
     | port()
     | atom().
 
+% Current type until we make these references
+-type resource() :: binary().
+
 %%-----------------------------------------------------------------------------
 %% @param   Time time in milliseconds after which to send the timeout message.
 %% @param   Dest Pid or server name to which to send the timeout message.
@@ -255,6 +258,7 @@ send_after(Time, Dest, Msg) ->
 %%      <li><b>message_queue_len</b> the number of messages enqueued for the process (integer)</li>
 %%      <li><b>memory</b> the estimated total number of bytes in use by the process (integer)</li>
 %%      <li><b>links</b> the list of linked processes</li>
+%%      <li><b>monitored_by</b> the list of processes, NIF resources or ports that monitor the process</li>
 %% </ul>
 %% Specifying an unsupported term or atom raises a bad_arg error.
 %%
@@ -267,7 +271,8 @@ send_after(Time, Dest, Msg) ->
     (Pid :: pid(), stack_size) -> {stack_size, non_neg_integer()};
     (Pid :: pid(), message_queue_len) -> {message_queue_len, non_neg_integer()};
     (Pid :: pid(), memory) -> {memory, non_neg_integer()};
-    (Pid :: pid(), links) -> {links, [pid()]}.
+    (Pid :: pid(), links) -> {links, [pid()]};
+    (Pid :: pid(), monitored_by) -> {monitored_by, [pid() | resource() | port()]}.
 process_info(_Pid, _Key) ->
     erlang:nif_error(undefined).
 

--- a/src/libAtomVM/defaultatoms.def
+++ b/src/libAtomVM/defaultatoms.def
@@ -190,3 +190,5 @@ X(SCOPE_ATOM, "\x5", "scope")
 X(NOMATCH_ATOM, "\x7", "nomatch")
 
 X(INIT_ATOM, "\x4", "init")
+
+X(MONITORED_BY_ATOM, "\xC", "monitored_by")

--- a/src/libAtomVM/dist_nifs.c
+++ b/src/libAtomVM/dist_nifs.c
@@ -414,12 +414,13 @@ static term nif_erlang_dist_ctrl_get_data(Context *ctx, int argc, term argv[])
 
 term dist_monitor(struct DistConnection *conn_obj, term from_pid, term target_proc, term monitor_ref, Context *ctx)
 {
-    if (term_is_atom(target_proc)) {
-        target_proc = globalcontext_get_registered_process(ctx->global, term_to_atom_index(target_proc));
-    }
     int target_process_id = 0;
-    if (term_is_local_pid(target_proc)) {
-        target_process_id = term_to_local_process_id(target_proc);
+    term target_process_pid = target_proc;
+    if (term_is_atom(target_process_pid)) {
+        target_process_pid = globalcontext_get_registered_process(ctx->global, term_to_atom_index(target_process_pid));
+    }
+    if (term_is_local_pid(target_process_pid)) {
+        target_process_id = term_to_local_process_id(target_process_pid);
     } else {
         RAISE_ERROR(BADARG_ATOM);
     }

--- a/tests/erlang_tests/test_process_info.erl
+++ b/tests/erlang_tests/test_process_info.erl
@@ -40,6 +40,11 @@ start() ->
     {links, [Self]} = process_info(Pid, links),
     unlink(Pid),
     {links, []} = process_info(Pid, links),
+    Monitor = monitor(process, Pid),
+    % Twice because of spawn_opt above
+    {monitored_by, [Self, Self]} = process_info(Pid, monitored_by),
+    demonitor(Monitor),
+    {monitored_by, [Self]} = process_info(Pid, monitored_by),
     Pid ! {Self, stop},
     _Accum =
         receive


### PR DESCRIPTION
Also add `monitored_by` in `process_info/2` to test this fix

Fix #1782 

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
