### PR TITLE
Fix possible memory corruption with OP_BS_START_MATCH{2,4}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ integer (this never happens with integers < 28 bits)
 - Correctly set Pico-W unique dhcp hostname when using the default, previously all rp2040 devices
 used the same "PicoW" dhcp hostname, causing collisions when multiple rp2040 are on the same
 network. (See issue #1094)
+- Fixed possible memory corruption when doing binary matching.
 
 ### Changed
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -4670,17 +4670,17 @@ wait_timeout_trap_handler:
                 DECODE_LITERAL(live, pc);
                 term slots_term;
                 DECODE_COMPACT_TERM(slots_term, pc);
-                DEST_REGISTER(dreg);
-                DECODE_DEST_REGISTER(dreg, pc);
+                GC_SAFE_DEST_REGISTER(dreg);
+                DECODE_DEST_REGISTER_GC_SAFE(dreg, pc);
 
                 #ifdef IMPL_CODE_LOADER
                     TRACE("bs_start_match2/5\n");
                 #endif
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    TRACE("bs_start_match2/5, fail=%i src=0x%lx live=%u arg3=0x%lx dreg=%c%i\n", fail, src, (unsigned) live, slots_term, T_DEST_REG(dreg));
+                    TRACE("bs_start_match2/5, fail=%i src=0x%lx live=%u arg3=0x%lx dreg=%c%i\n", fail, src, (unsigned) live, slots_term, T_DEST_REG_GC_SAFE(dreg));
                     if (!(term_is_binary(src) || term_is_match_state(src))) {
-                        WRITE_REGISTER(dreg, src);
+                        WRITE_REGISTER_GC_SAFE(dreg, src);
                         pc = mod->labels[fail];
                     } else {
                         int slots = term_to_int(slots_term);
@@ -4695,7 +4695,7 @@ wait_timeout_trap_handler:
 
                         term match_state = term_alloc_bin_match_state(src, slots, &ctx->heap);
 
-                        WRITE_REGISTER(dreg, match_state);
+                        WRITE_REGISTER_GC_SAFE(dreg, match_state);
                     }
                 #endif
                 break;
@@ -6459,15 +6459,15 @@ wait_timeout_trap_handler:
                 DECODE_LITERAL(live, pc);
                 term src;
                 DECODE_COMPACT_TERM(src, pc);
-                DEST_REGISTER(dreg);
-                DECODE_DEST_REGISTER(dreg, pc);
+                GC_SAFE_DEST_REGISTER(dreg);
+                DECODE_DEST_REGISTER_GC_SAFE(dreg, pc);
 
                 #ifdef IMPL_CODE_LOADER
                     TRACE("bs_start_match4/4\n");
                 #endif
 
                 #ifdef IMPL_EXECUTE_LOOP
-                    TRACE("bs_start_match4/4, fail_atom=%u fail_label=%u live=%u src=%p dreg=%c%i\n", (unsigned) fail_atom, (unsigned) fail_label, (unsigned) live, (void *) src, T_DEST_REG(dreg));
+                    TRACE("bs_start_match4/4, fail_atom=%u fail_label=%u live=%u src=%p dreg=%c%i\n", (unsigned) fail_atom, (unsigned) fail_label, (unsigned) live, (void *) src, T_DEST_REG_GC_SAFE(dreg));
 
                     // no_fail: we know it's a binary or a match_state
                     // resume: we know it's a match_state
@@ -6485,7 +6485,7 @@ wait_timeout_trap_handler:
                         src = x_regs[live];
                         term match_state = term_alloc_bin_match_state(src, 0, &ctx->heap);
 
-                        WRITE_REGISTER(dreg, match_state);
+                        WRITE_REGISTER_GC_SAFE(dreg, match_state);
                     }
                 #endif
                 break;


### PR DESCRIPTION
Fix a bug where result of bs_start_match2 and bs_start_match4 could be written at the wrong address if a GC occurred.

Only witnessed with serialized funs PR on armv5/v7

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
