### PR TITLE
Add mock implementation for process_info(Pid, current_stacktrace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `binary:match/2` and `binary:match/3`
 - Added `supervisor:which_children/1`
 - Added `monitored_by` in `process_info/2`
+- Added mock implementation for `current_stacktrace` in `process_info`
 
 ### Changed
 

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -505,6 +505,10 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
             }
             break;
         }
+        case CURRENT_STACKTRACE_ATOM: {
+            ret_size = TUPLE_SIZE(2);
+            break;
+        }
         default:
             if (out != NULL) {
                 *out = BADARG_ATOM;
@@ -611,6 +615,14 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
                 }
             }
             term_put_tuple_element(ret, 1, list);
+            break;
+        }
+
+        case CURRENT_STACKTRACE_ATOM: {
+            term_put_tuple_element(ret, 0, CURRENT_STACKTRACE_ATOM);
+            // FIXME: since it's not possible how to build stacktrace here with the current API,
+            // this mock implementation returns an empty list
+            term_put_tuple_element(ret, 1, term_nil());
             break;
         }
 

--- a/src/libAtomVM/defaultatoms.def
+++ b/src/libAtomVM/defaultatoms.def
@@ -192,3 +192,5 @@ X(NOMATCH_ATOM, "\x7", "nomatch")
 X(INIT_ATOM, "\x4", "init")
 
 X(MONITORED_BY_ATOM, "\xC", "monitored_by")
+
+X(CURRENT_STACKTRACE_ATOM, "\x12", "current_stacktrace")


### PR DESCRIPTION
This PR adds a mock implementation for `process_info(Pid, current_stacktrace)`, which always returns an empty list. The OTP calls it in various places and crashes, because the current implementation returns `badarg`. I'd be happy to provide an actual implementation, but, to my knowledge, it's not possible with the current internal API for creating stacktraces.


These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
