### PR TITLE
Add AVM_PRINT_PROCESS_CRASH_DUMPS option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `binary:match/2` and `binary:match/3`
 - Added `supervisor:which_children/1`
 - Added `monitored_by` in `process_info/2`
+- Added `AVM_PRINT_PROCESS_CRASH_DUMPS` option
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ option(AVM_RELEASE "Build an AtomVM release" OFF)
 option(AVM_CREATE_STACKTRACES "Create stacktraces" ON)
 option(AVM_BUILD_RUNTIME_ONLY "Only build the AtomVM runtime" OFF)
 option(COVERAGE "Build for code coverage" OFF)
+option(AVM_PRINT_PROCESS_CRASH_DUMPS "Print crash reports when processes die with non-standard reasons" ON)
 
 if((${CMAKE_SYSTEM_NAME} STREQUAL "Darwin") OR
    (${CMAKE_SYSTEM_NAME} STREQUAL "Linux") OR

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -166,6 +166,10 @@ if(HAVE_PLATFORM_ATOMIC_H)
     target_compile_definitions(libAtomVM PUBLIC HAVE_PLATFORM_ATOMIC_H)
 endif()
 
+if (AVM_PRINT_PROCESS_CRASH_DUMPS)
+    target_compile_definitions(libAtomVM PUBLIC AVM_PRINT_PROCESS_CRASH_DUMPS)
+endif()
+
 # Platforms that run select in a task must set this option
 if(AVM_SELECT_IN_TASK)
     target_compile_definitions(libAtomVM PUBLIC AVM_SELECT_IN_TASK)

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -7181,10 +7181,12 @@ handle_error:
             }
         }
 
+#ifdef AVM_PRINT_PROCESS_CRASH_DUMPS
         // Do not print crash dump if reason is normal or shutdown.
         if (x_regs[0] != LOWERCASE_EXIT_ATOM || (x_regs[1] != NORMAL_ATOM && x_regs[1] != SHUTDOWN_ATOM)) {
             context_dump(ctx);
         }
+#endif
 
         if (x_regs[0] == LOWERCASE_EXIT_ATOM) {
             ctx->exit_reason = x_regs[1];


### PR DESCRIPTION
This PR adds an option to disable process dumps. The problem with process dumps is that they're printed whenever the process exits with a non-standard reason, and this doesn't necessarily mean that the process terminated unexpectedly. For example, some of the Elixir compiler processes exit with `{:ok, atom(), binary()}` and that's the expected behaviour. The OTP relies on the logger to print information about abruptly terminated processes, and so we try to do in Popcorn, thus we need to disable the crash dumps.



These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
