### PR TITLE
Fix bs_skip_bits2 flags usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ integer (this never happens with integers < 28 bits)
 used the same "PicoW" dhcp hostname, causing collisions when multiple rp2040 are on the same
 network. (See issue #1094)
 - Fixed possible memory corruption when doing binary matching.
+- Fixed an issue related to binary matching and more precisely endianness of bit skipping with OTP 25 and lower
 
 ### Changed
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -4995,10 +4995,7 @@ wait_timeout_trap_handler:
                 #ifdef IMPL_EXECUTE_LOOP
                     VERIFY_IS_MATCH_STATE(src, "bs_skip_bits2", 0);
                     VERIFY_IS_INTEGER(size, "bs_skip_bits2", 0);
-                    if (flags_value != 0) {
-                        TRACE("bs_skip_bits2: neither signed nor native or little endian encoding supported.\n");
-                        RAISE_ERROR(UNSUPPORTED_ATOM);
-                    }
+                    // Ignore flags value as skipping bits is the same whatever the endianness
                     avm_int_t size_val = term_to_int(size);
 
                     TRACE("bs_skip_bits2/5, fail=%u src=%p size=0x%lx unit=%u flags=%x\n", (unsigned) fail, (void *) src, (unsigned long) size_val, (unsigned) unit, (int) flags_value);

--- a/tests/erlang_tests/test_bs.erl
+++ b/tests/erlang_tests/test_bs.erl
@@ -97,6 +97,8 @@ start() ->
     ok = test_copy_bits_string(),
     ok = test_bs_match_string_select(),
 
+    ok = test_bs_skip_bits2_little(),
+
     0.
 
 test_pack_small_ints({A, B, C}, Expect) ->
@@ -426,6 +428,15 @@ test_bs_match_string_select() ->
             _Other -> ok
         end,
     id(Z).
+
+% With OTP25 and lower, this generates bs_skip_init2 with flags equal to 2 (little)
+% More recent versions of OTP use bs_match
+test_bs_skip_bits2_little() ->
+    ok = check_x86_64_jt(id(<<16#e9, 0:32>>)).
+
+check_x86_64_jt(<<>>) -> ok;
+check_x86_64_jt(<<16#e9, _Offset:32/little, Tail/binary>>) -> check_x86_64_jt(Tail);
+check_x86_64_jt(Bin) -> {unexpected, Bin}.
 
 id(X) -> X.
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
