### PR TITLE
Add os:getenv/1

### DIFF
--- a/libs/estdlib/src/os.erl
+++ b/libs/estdlib/src/os.erl
@@ -1,0 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Jakub Gonet <jakub.gonet@swmansion.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+-module(os).
+
+-export([getenv/1]).
+
+%%-----------------------------------------------------------------------------
+%% @param   Name name of the environment variable
+%% @returns the value of environment variable or false if unset
+%% @doc     Get an environment variable value if defined
+%% @end
+%%-----------------------------------------------------------------------------
+-spec getenv(Name :: string()) -> string() | false.
+getenv(_VarName) ->
+    erlang:nif_error(undefined).

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -100,6 +100,7 @@ static term nif_binary_split(Context *ctx, int argc, term argv[]);
 static term nif_binary_replace(Context *ctx, int argc, term argv[]);
 static term nif_binary_match(Context *ctx, int argc, term argv[]);
 static term nif_calendar_system_time_to_universal_time_2(Context *ctx, int argc, term argv[]);
+static term nif_os_getenv_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_delete_element_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_atom_to_binary(Context *ctx, int argc, term argv[]);
 static term nif_erlang_atom_to_list_1(Context *ctx, int argc, term argv[]);
@@ -533,6 +534,11 @@ static const struct Nif system_time_to_universal_time_nif =
 {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_calendar_system_time_to_universal_time_2
+};
+
+const struct Nif os_getenv_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_os_getenv_1
 };
 
 static const struct Nif tuple_to_list_nif =
@@ -1799,6 +1805,32 @@ term nif_calendar_system_time_to_universal_time_2(Context *ctx, int argc, term a
 
     struct tm broken_down_time;
     return build_datetime_from_tm(ctx, gmtime_r(&ts.tv_sec, &broken_down_time));
+}
+
+static term nif_os_getenv_1(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+
+    term env_var_list = argv[0];
+    VALIDATE_VALUE(env_var_list, term_is_list);
+
+    int ok;
+    const char *env_var = interop_list_to_utf8_string(env_var_list, &ok);
+    if (UNLIKELY(!ok)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    const char *env_var_value = getenv(env_var);
+    if (IS_NULL_PTR(env_var_value)) {
+        return FALSE_ATOM;
+    }
+
+    size_t len = strlen(env_var_value);
+    if (UNLIKELY(memory_ensure_free_opt(ctx, LIST_SIZE(len, 1), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    return interop_bytes_to_list(env_var_value, len, &ctx->heap);
 }
 
 static term nif_erlang_make_tuple_2(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -44,6 +44,7 @@ binary:replace/4, &binary_replace_nif
 binary:match/2, &binary_match_nif
 binary:match/3, &binary_match_nif
 calendar:system_time_to_universal_time/2, &system_time_to_universal_time_nif
+os:getenv/1, &os_getenv_nif
 erlang:atom_to_binary/1, &atom_to_binary_nif
 erlang:atom_to_binary/2, &atom_to_binary_nif
 erlang:atom_to_list/1, &atom_to_list_nif

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -39,6 +39,7 @@ set(ERLANG_MODULES
     test_maps
     test_net
     test_net_kernel
+    test_os
     test_sets
     test_spawn
     test_ssl

--- a/tests/libs/estdlib/test_os.erl
+++ b/tests/libs/estdlib/test_os.erl
@@ -1,0 +1,40 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Jakub Gonet <jakub.gonet@swmansion.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_os).
+
+-export([test/0]).
+
+-include("etest.hrl").
+
+test() ->
+    ok = test_os_getenv(),
+    ok.
+
+test_os_getenv() ->
+    true =
+        case atomvm:platform() of
+            generic_unix ->
+                is_list(os:getenv("PATH"));
+            _ ->
+                true
+        end,
+    false = os:getenv("NON_EXISTENT_PATH_VAR"),
+    ok.

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -80,7 +80,8 @@ get_non_networking_tests(_OTPVersion) ->
         test_timer,
         test_spawn,
         test_supervisor,
-        test_lists_subtraction
+        test_lists_subtraction,
+        test_os
     ].
 
 get_networking_tests(OTPVersion) when


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later

---------

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
