### PR TITLE
Add timeouts to debug flappiness and reduce CI time

### DIFF
--- a/tests/libs/estdlib/test_gen_tcp.erl
+++ b/tests/libs/estdlib/test_gen_tcp.erl
@@ -195,6 +195,8 @@ test_listen_connect_parameters(
     receive
         {ServerPid, ready} ->
             ok
+    after 10000 ->
+        error({timeout, ?MODULE, ?LINE})
     end,
 
     {ok, Socket} = gen_tcp:connect(


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
