### PR TITLE
Add `doxygen` to list of RP2 prerequisites

### DIFF
--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -840,6 +840,7 @@ You can build with all boards supported by Raspberry Pi pico SDK, including Pico
 ### RP2 Prerequisites
 
 * `cmake`
+* `doxygen`
 * `ninja`
 * `Erlang/OTP`
 * `Elixir` (optional)


### PR DESCRIPTION
The `doxygen` package is also necessary to build for the Raspberry Pi Pico boards.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later

Signed-off-by: Michael Westbay <westbaystars@japanesebaseball.com>
