### PR TITLE
.clang-format: enable `InsertBraces` option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -78,6 +78,7 @@ IndentCaseLabels: true
 IndentPPDirectives: None
 IndentWidth:     4
 IndentWrappedFunctionNames: false
+InsertBraces: true
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true

--- a/C_CODING_STYLE.md
+++ b/C_CODING_STYLE.md
@@ -2758,6 +2758,9 @@ BraceWrapping:
   BeforeElse: false
   BeforeWhile: false
 
+# Use braces for single-statement blocks (rule: AVMCCS-F002)
+InsertBraces: true
+
 # Spacing (rules: AVMCCS-F004, AVMCCS-F015, AVMCCS-F016, AVMCCS-F018, AVMCCS-F020)
 PointerAlignment: Right                     # AVMCCS-F004: * with variable
 SpaceAfterCStyleCast: true                  # AVMCCS-F018: Space after cast

--- a/src/libAtomVM/posix_nifs.c
+++ b/src/libAtomVM/posix_nifs.c
@@ -653,8 +653,9 @@ static term nif_atomvm_subprocess(Context *ctx, int argc, term argv[])
         closefrom(2);
 #else
         int maxfd = sysconf(_SC_OPEN_MAX);
-        for (int fd = 3; fd < maxfd; fd++)
+        for (int fd = 3; fd < maxfd; fd++) {
             close(fd);
+        }
 #endif
         execve(path, args, envp);
         exit(1);


### PR DESCRIPTION
clang-format >= 15 has `InsertBraces` option.
Enable it as described in AVMCCS-F002 rule.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
