### PR TITLE
Add optimization to rp2 platform

### DIFF
--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -840,6 +840,7 @@ You can build with all boards supported by Raspberry Pi pico SDK, including Pico
 ### RP2 Prerequisites
 
 * `cmake`
+* `doxygen`
 * `ninja`
 * `Erlang/OTP`
 * `Elixir` (optional)

--- a/src/platforms/rp2/src/CMakeLists.txt
+++ b/src/platforms/rp2/src/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(AtomVM main.c)
 
 target_compile_features(AtomVM PUBLIC c_std_11)
 if(CMAKE_COMPILER_IS_GNUCC)
-    target_compile_options(AtomVM PUBLIC -ggdb)
+    target_compile_options(AtomVM PUBLIC -ggdb -Os)
     target_compile_options(AtomVM PRIVATE -Wall -pedantic -Wextra)
 endif()
 


### PR DESCRIPTION
The AtomVM revision 0.7.0-dev+git.f59734eb build was too large for the Raspberry Pi Pico.

As suggested by @UncleGrumpy in the AtomVM Discord, I added `-Os` to the compile options in the `rp2` platform's `CMakeList.txt` file.

This resulted in a much smaller AtomVM base on which the example Elixir `Blinky` would now run.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
