### PR TITLE
Update valgrind suppressions

### DIFF
--- a/tests/valgrind-suppressions.sup
+++ b/tests/valgrind-suppressions.sup
@@ -4,23 +4,4 @@
    fun:__memcpy_chk
    fun:memmove
    fun:intn_to_string
-   fun:integer_to_buf
-   fun:nif_erlang_integer_to_binary_2
-   fun:scheduler_entry_point
-   fun:main
-}
-{
-   bogus_memcpy_overlap_tests
-   Memcheck:Overlap
-   fun:__memcpy_chk
-   fun:memmove
-   fun:intn_to_string
-   fun:integer_to_buf
-   fun:nif_erlang_integer_to_binary_2
-   fun:scheduler_entry_point
-   fun:test_atom
-   fun:test_module_execution.part.0
-   fun:test_module_execution
-   fun:test_modules_execution
-   fun:main
 }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
