### PR TITLE
clang-format: fix formatting of nifs.c

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -490,8 +490,7 @@ const struct Nif os_getenv_nif = {
     .nif_ptr = nif_os_getenv_1
 };
 
-static const struct Nif tuple_to_list_nif =
-{
+static const struct Nif tuple_to_list_nif = {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_erlang_tuple_to_list_1
 };


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
