### PR TITLE
Enable forgotten test bs_append_extra_words

### DIFF
--- a/tests/test.c
+++ b/tests/test.c
@@ -402,6 +402,7 @@ struct Test tests[] = {
     TEST_CASE(test_bs_int_unaligned),
     TEST_CASE(test_bs_start_match_live),
     TEST_CASE(test_bs_utf),
+    TEST_CASE_EXPECTED(bs_append_extra_words, 1),
     TEST_CASE(test_catch),
     TEST_CASE(test_gc),
     TEST_CASE_EXPECTED(test_raise, 7),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
