### PR TITLE
opcodesswitch: fix OP_BS_CREATE_BIN that can have an allocator list

### DIFF
--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -6576,7 +6576,7 @@ wait_timeout_trap_handler:
                 uint32_t fail;
                 DECODE_LABEL(fail, pc);
                 uint32_t alloc;
-                DECODE_LITERAL(alloc, pc);
+                DECODE_ALLOCATOR_LIST(alloc, pc);
                 uint32_t live;
                 DECODE_LITERAL(live, pc);
                 uint32_t unit;

--- a/tests/erlang_tests/test_op_bs_create_bin.erl
+++ b/tests/erlang_tests/test_op_bs_create_bin.erl
@@ -38,7 +38,8 @@ start() ->
                 ok = test_bs_create_bin_utf16(),
                 ok = test_bs_create_bin_utf32(),
                 ok = test_bs_create_bin_integer(),
-                ok = test_bs_create_bin_binary();
+                ok = test_bs_create_bin_binary(),
+                ok = test_bs_create_bin_alloc_list();
             true ->
                 ok
         end,
@@ -266,3 +267,15 @@ test_bs_create_bin_binary() ->
             error:badarg -> unexpected
         end,
     ok.
+
+test_bs_create_bin_alloc_list() ->
+    %% Test that bs_create_bin with allocator list works correctly
+    %% Expected result: <<0,0,0,42>> (42 as 32-bit big-endian integer)
+    Expected = <<0, 0, 0, 42>>,
+    Result = test_op_bs_create_bin_asm:bs_create_bin_alloc_list(42),
+    case Result of
+        Expected ->
+            ok;
+        _ ->
+            error({unexpected_result, Result, expected, Expected})
+    end.

--- a/tests/erlang_tests/test_op_bs_create_bin_asm.S
+++ b/tests/erlang_tests/test_op_bs_create_bin_asm.S
@@ -31,12 +31,13 @@
     {bs_create_bin_integer_no_fail, 3},
     {bs_create_bin_integer_fail, 3},
     {bs_create_bin_binary_no_fail, 3},
-    {bs_create_bin_binary_fail, 3}
+    {bs_create_bin_binary_fail, 3},
+    {bs_create_bin_alloc_list, 1}
 ]}.
 
 {attributes, []}.
 
-{labels, 26}.
+{labels, 28}.
 
 {function, bs_create_bin_utf8_no_fail, 3, 2}.
 {label, 1}.
@@ -121,4 +122,13 @@ return.
 return.
 {label, 26}.
 {move, {atom, fail}, {x, 0}}.
+return.
+
+{function, bs_create_bin_alloc_list, 1, 28}.
+{label, 27}.
+{func_info, {atom, test_op_bs_create_bin_asm}, {atom, bs_create_bin_alloc_list}, 1}.
+{label, 28}.
+%% Test bs_create_bin with allocator list instead of simple literal
+{bs_create_bin, {f, 0}, {alloc, [{words, 2}, {floats, 1}, {funs, 1}]}, 1, 1, {x, 0},
+    {list, [{atom, integer}, 1, 1, nil, {x, 0}, {integer, 32}]}}.
 return.


### PR DESCRIPTION
I don't seem to be able to reproduce this with Erlang code, but I have been definitely hit by this bug at some point. The test is written in assembly.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
