### PR TITLE
JIT: optimize out calls to term compare

### DIFF
--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -528,16 +528,26 @@ first_pass(<<?OP_IS_EQ_EXACT, Rest0/binary>>, MMod, MSt0, State0) ->
     {MSt1, Arg1, Rest2} = decode_compact_term(Rest1, MMod, MSt0, State0),
     {MSt2, Arg2, Rest3} = decode_compact_term(Rest2, MMod, MSt1, State0),
     ?TRACE("OP_IS_EQ_EXACT ~p, ~p, ~p\n", [Label, Arg1, Arg2]),
-    {MSt3, ResultReg} = MMod:call_primitive(MSt2, ?PRIM_TERM_COMPARE, [
-        ctx, jit_state, {free, Arg1}, {free, Arg2}, ?TERM_COMPARE_EXACT
-    ]),
-    MSt4 = handle_error_if({'(int)', ResultReg, '==', ?TERM_COMPARE_MEMORY_ALLOC_FAIL}, MMod, MSt3),
-    MSt5 = cond_jump_to_label(
-        {{free, ResultReg}, '&', ?TERM_LESS_THAN + ?TERM_GREATER_THAN, '!=', 0},
-        Label,
-        MMod,
-        MSt4
-    ),
+    % If Arg2 is an immediate, we don't need to call term_compare
+    MSt5 =
+        if
+            is_integer(Arg2) ->
+                {MSt3, Arg1Reg} = MMod:move_to_native_register(MSt2, Arg1),
+                cond_jump_to_label({{free, Arg1Reg}, '!=', Arg2}, Label, MMod, MSt3);
+            true ->
+                {MSt3, ResultReg} = MMod:call_primitive(MSt2, ?PRIM_TERM_COMPARE, [
+                    ctx, jit_state, {free, Arg1}, {free, Arg2}, ?TERM_COMPARE_EXACT
+                ]),
+                MSt4 = handle_error_if(
+                    {'(int)', ResultReg, '==', ?TERM_COMPARE_MEMORY_ALLOC_FAIL}, MMod, MSt3
+                ),
+                cond_jump_to_label(
+                    {{free, ResultReg}, '&', ?TERM_LESS_THAN + ?TERM_GREATER_THAN, '!=', 0},
+                    Label,
+                    MMod,
+                    MSt4
+                )
+        end,
     ?ASSERT_ALL_NATIVE_FREE(MSt5),
     first_pass(Rest3, MMod, MSt5, State0);
 % 44
@@ -547,11 +557,22 @@ first_pass(<<?OP_IS_NOT_EQ_EXACT, Rest0/binary>>, MMod, MSt0, State0) ->
     {MSt1, Arg1, Rest2} = decode_compact_term(Rest1, MMod, MSt0, State0),
     {MSt2, Arg2, Rest3} = decode_compact_term(Rest2, MMod, MSt1, State0),
     ?TRACE("OP_IS_NOT_EQ_EXACT ~p, ~p, ~p\n", [Label, Arg1, Arg2]),
-    {MSt3, ResultReg} = MMod:call_primitive(MSt2, ?PRIM_TERM_COMPARE, [
-        ctx, jit_state, {free, Arg1}, {free, Arg2}, ?TERM_COMPARE_EXACT
-    ]),
-    MSt4 = handle_error_if({'(int)', ResultReg, '==', ?TERM_COMPARE_MEMORY_ALLOC_FAIL}, MMod, MSt3),
-    MSt5 = cond_jump_to_label({'(int)', {free, ResultReg}, '==', ?TERM_EQUALS}, Label, MMod, MSt4),
+    MSt5 =
+        if
+            is_integer(Arg2) ->
+                {MSt3, Arg1Reg} = MMod:move_to_native_register(MSt2, Arg1),
+                cond_jump_to_label({{free, Arg1Reg}, '==', Arg2}, Label, MMod, MSt3);
+            true ->
+                {MSt3, ResultReg} = MMod:call_primitive(MSt2, ?PRIM_TERM_COMPARE, [
+                    ctx, jit_state, {free, Arg1}, {free, Arg2}, ?TERM_COMPARE_EXACT
+                ]),
+                MSt4 = handle_error_if(
+                    {'(int)', ResultReg, '==', ?TERM_COMPARE_MEMORY_ALLOC_FAIL}, MMod, MSt3
+                ),
+                cond_jump_to_label(
+                    {'(int)', {free, ResultReg}, '==', ?TERM_EQUALS}, Label, MMod, MSt4
+                )
+        end,
     ?ASSERT_ALL_NATIVE_FREE(MSt5),
     first_pass(Rest3, MMod, MSt5, State0);
 % 45


### PR DESCRIPTION
Continuation of #1770 

Avoid calls to TERM_COMPARE primitive for comparison with literals in OP_IS_EXACT and OP_IS_NOT_EXACT.

Current benchmark:
|test                 |JIT disabled (c06edb2bca8dacc8c17661575b39bcfc2c5922ea)|HEAD~1, JIT enabled (c06edb2bca8dacc8c17661575b39bcfc2c5922ea)|This PR (9b14b166899f3248189b71c6c157c6ae110df6c4) |
|--------------|---------------- |------------------------|--------|
|erlang-tests   | 11.45s                  |  10.51s                            | 9.95s  |
|benchmark (entire run)                      | 17.03                 |  15.71 (incl. compilation)           | 15.35s
|benchmark : pingpong_speed_test | 3.59s                 |  3.20s                            | 3.23s |
|benchmark : prime_speed_test       |  0.26s                            | 0.21s           | 0.17s |
|benchmark : sudoku_solution_test |  0.26s                            | 1.35s (incl. compilation of sudoku_grid in 1.1s)         | 1.34s |
|benchmark : sudoku_puzzle_test   |    10.51s                            | 9.23s          | 9.18s |


These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
