### PR TITLE
JIT: optimize term to int using types

### DIFF
--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -24,7 +24,7 @@
     stream/1,
     backend/1,
     beam_chunk_header/3,
-    compile/5
+    compile/6
 ]).
 
 % NIFs
@@ -98,7 +98,8 @@
     line_offsets :: [{integer(), integer()}],
     labels_count :: pos_integer(),
     atom_resolver :: fun((integer()) -> atom()),
-    literal_resolver :: fun((integer()) -> any())
+    literal_resolver :: fun((integer()) -> any()),
+    type_resolver :: fun((integer()) -> any())
 }).
 
 -type stream() :: any().
@@ -130,6 +131,7 @@ compile(
     <<16:32, 0:32, OpcodeMax:32, LabelsCount:32, _FunctionsCount:32, Opcodes/binary>>,
     AtomResolver,
     LiteralResolver,
+    TypeResolver,
     MMod,
     MSt0
 ) when OpcodeMax =< ?OPCODE_MAX ->
@@ -138,7 +140,8 @@ compile(
         line_offsets = [],
         labels_count = LabelsCount,
         atom_resolver = AtomResolver,
-        literal_resolver = LiteralResolver
+        literal_resolver = LiteralResolver,
+        type_resolver = TypeResolver
     },
     {State1, MSt2} = first_pass(Opcodes, MMod, MSt1, State0),
     MSt3 = second_pass(MMod, MSt2, State1),
@@ -147,11 +150,12 @@ compile(
     <<16:32, 0:32, OpcodeMax:32, _LabelsCount:32, _FunctionsCount:32, _Opcodes/binary>>,
     _AtomResolver,
     _LiteralResolver,
+    _TypeResolver,
     _MMod,
     _MSt
 ) ->
     error(badarg, [OpcodeMax]);
-compile(CodeChunk, _AtomResolver, _LiteralResolver, _MMod, _MSt) ->
+compile(CodeChunk, _AtomResolver, _LiteralResolver, _TypeResolver, _MMod, _MSt) ->
     error(badarg, [CodeChunk]).
 
 % 1
@@ -1143,7 +1147,7 @@ first_pass(<<?OP_IS_FUNCTION2, Rest0/binary>>, MMod, MSt0, State0) ->
     ?ASSERT_ALL_NATIVE_FREE(MSt0),
     {Label, Rest1} = decode_label(Rest0),
     {MSt1, Arg1, Rest2} = decode_compact_term(Rest1, MMod, MSt0, State0),
-    {MSt2, ArityTerm, Rest3} = decode_compact_term(Rest2, MMod, MSt1, State0),
+    {MSt2, ArityTerm, Rest3} = decode_typed_compact_term(Rest2, MMod, MSt1, State0),
     ?TRACE("OP_IS_FUNCTION2 ~p,~p,~p\n", [Label, Arg1, ArityTerm]),
     {MSt3, FuncPtr} = term_is_boxed_with_tag_and_get_ptr(Label, Arg1, ?TERM_BOXED_FUN, MMod, MSt2),
     {MSt4, Arity} = term_to_int(ArityTerm, Label, MMod, MSt3),
@@ -1174,7 +1178,7 @@ first_pass(<<?OP_BS_GET_INTEGER2, Rest0/binary>>, MMod, MSt0, State0) ->
     {Fail, Rest1} = decode_label(Rest0),
     {MSt1, Src, Rest2} = decode_compact_term(Rest1, MMod, MSt0, State0),
     {_Live, Rest3} = decode_literal(Rest2),
-    {MSt2, Size, Rest4} = decode_compact_term(Rest3, MMod, MSt1, State0),
+    {MSt2, Size, Rest4} = decode_typed_compact_term(Rest3, MMod, MSt1, State0),
     {Unit, Rest5} = decode_literal(Rest4),
     {FlagsValue, Rest6} = decode_literal(Rest5),
     {MSt3, SrcReg} = MMod:move_to_native_register(MSt2, Src),
@@ -1213,7 +1217,7 @@ first_pass(<<?OP_BS_GET_FLOAT2, Rest0/binary>>, MMod, MSt0, State0) ->
     {Fail, Rest1} = decode_label(Rest0),
     {MSt1, Src, Rest2} = decode_compact_term(Rest1, MMod, MSt0, State0),
     {_Live, Rest3} = decode_literal(Rest2),
-    {MSt2, Size, Rest4} = decode_compact_term(Rest3, MMod, MSt1, State0),
+    {MSt2, Size, Rest4} = decode_typed_compact_term(Rest3, MMod, MSt1, State0),
     {Unit, Rest5} = decode_literal(Rest4),
     {FlagsValue, Rest6} = decode_literal(Rest5),
     {MSt3, SrcReg} = MMod:move_to_native_register(MSt2, Src),
@@ -1338,7 +1342,7 @@ first_pass(<<?OP_BS_SKIP_BITS2, Rest0/binary>>, MMod, MSt0, State0) ->
     ?ASSERT_ALL_NATIVE_FREE(MSt0),
     {Fail, Rest1} = decode_label(Rest0),
     {MSt1, Src, Rest2} = decode_compact_term(Rest1, MMod, MSt0, State0),
-    {MSt2, Size, Rest3} = decode_compact_term(Rest2, MMod, MSt1, State0),
+    {MSt2, Size, Rest3} = decode_typed_compact_term(Rest2, MMod, MSt1, State0),
     {Unit, Rest4} = decode_literal(Rest3),
     {_FlagsValue, Rest5} = decode_literal(Rest4),
     ?TRACE("OP_BS_SKIP_BITS2 ~p, ~p, ~p, ~p, ~p\n", [Fail, Src, Size, Unit, _FlagsValue]),
@@ -2071,7 +2075,7 @@ first_pass(<<?OP_BS_GET_POSITION, Rest0/binary>>, MMod, MSt0, State0) ->
 first_pass(<<?OP_BS_SET_POSITION, Rest0/binary>>, MMod, MSt0, State0) ->
     ?ASSERT_ALL_NATIVE_FREE(MSt0),
     {MSt1, Src, Rest1} = decode_compact_term(Rest0, MMod, MSt0, State0),
-    {MSt2, Pos, Rest2} = decode_compact_term(Rest1, MMod, MSt1, State0),
+    {MSt2, Pos, Rest2} = decode_typed_compact_term(Rest1, MMod, MSt1, State0),
     ?TRACE("OP_BS_SET_POSITION ~p, ~p\n", [Src, Pos]),
     {MSt3, MatchStateReg} = MMod:move_to_native_register(MSt2, Src),
     {MSt4, MatchStateRegPtr} = verify_is_match_state_and_get_ptr(MMod, MSt3, {free, MatchStateReg}),
@@ -2814,7 +2818,7 @@ first_pass_bs_match_integer(
     {_Live, Rest1} = decode_literal(Rest0),
     {Flags, Rest2} = decode_compile_time_literal(Rest1, State0),
     {MSt1, FlagsValue} = decode_flags_list(Flags, MMod, MSt0),
-    {MSt2, Size, Rest3} = decode_compact_term(Rest2, MMod, MSt0, State0),
+    {MSt2, Size, Rest3} = decode_typed_compact_term(Rest2, MMod, MSt0, State0),
     {Unit, Rest4} = decode_literal(Rest3),
     ?TRACE("{integer,~p,~p,~p, ", [Flags, Size, Unit]),
     {MSt3, SizeReg} = term_to_int(Size, 0, MMod, MSt1),
@@ -3168,6 +3172,14 @@ term_to_int(Term, _FailLabel, _MMod, MSt0) when is_integer(Term) ->
     {MSt0, Term bsr 4};
 term_to_int({literal, Val}, _FailLabel, _MMod, MSt0) when is_integer(Val) ->
     {MSt0, Val};
+% Optimized case: when we have type information showing this is an integer, skip the type check
+term_to_int({typed, Term, {t_integer, _Range}}, _FailLabel, MMod, MSt0) ->
+    {MSt1, Reg} = MMod:move_to_native_register(MSt0, Term),
+    MSt2 = MMod:shift_right(MSt1, Reg, 4),
+    {MSt2, Reg};
+term_to_int({typed, Term, _NonIntegerType}, FailLabel, MMod, MSt0) ->
+    % Type information shows it's not an integer, fall back to generic path
+    term_to_int(Term, FailLabel, MMod, MSt0);
 term_to_int(Term, FailLabel, MMod, MSt0) ->
     {MSt1, Reg} = MMod:move_to_native_register(MSt0, Term),
     MSt2 = cond_raise_badarg_or_jump_to_fail_label(
@@ -3339,6 +3351,17 @@ decode_compact_term(<<_Value:5, ?COMPACT_LITERAL:3, _Rest/binary>> = Binary, _MM
     {MSt0, {literal, Value}, Rest};
 decode_compact_term(Other, MMod, MSt, _State) ->
     decode_dest(Other, MMod, MSt).
+
+% Decode compact term with type information awareness
+decode_typed_compact_term(<<?COMPACT_EXTENDED_TYPED_REGISTER, Rest0/binary>>, MMod, MSt0, #state{
+    type_resolver = TypeResover
+}) ->
+    {MSt1, Dest, Rest1} = decode_dest(Rest0, MMod, MSt0),
+    {TypeIx, Rest2} = decode_literal(Rest1),
+    Type = TypeResover(TypeIx),
+    {MSt1, {typed, Dest, Type}, Rest2};
+decode_typed_compact_term(Other, MMod, MSt, State) ->
+    decode_compact_term(Other, MMod, MSt, State).
 
 skip_compact_term(<<_:4, ?COMPACT_INTEGER:4, _Rest/binary>> = Bin) ->
     {_Value, Rest} = decode_value64(Bin),

--- a/src/libAtomVM/iff.c
+++ b/src/libAtomVM/iff.c
@@ -100,6 +100,9 @@ void scan_iff(const void *iff_binary, int buf_size, unsigned long *offsets, unsi
         } else if (!memcmp(current_record->name, "avmN", 4)) {
             offsets[AVMN] = current_pos;
             sizes[AVMN] = ENDIAN_SWAP_32(current_record->size);
+        } else if (!memcmp(current_record->name, "Type", 4)) {
+            offsets[TYPE] = current_pos;
+            sizes[TYPE] = ENDIAN_SWAP_32(current_record->size);
         }
 
         current_pos += iff_align(ENDIAN_SWAP_32(current_record->size) + 8);

--- a/src/libAtomVM/iff.h
+++ b/src/libAtomVM/iff.h
@@ -58,11 +58,13 @@ extern "C" {
 #define LINT 9
 /** Native code section */
 #define AVMN 10
+/** Type table section */
+#define TYPE 11
 
 /** Required size for offsets array */
-#define MAX_OFFS 11
+#define MAX_OFFS 12
 /** Required size for sizes array */
-#define MAX_SIZES 11
+#define MAX_SIZES 12
 
 /** sizeof IFF section header in bytes */
 #define IFF_SECTION_HEADER_SIZE 8

--- a/src/libAtomVM/module.h
+++ b/src/libAtomVM/module.h
@@ -150,6 +150,8 @@ struct Module
 
     struct LiteralEntry *literals_table;
 
+    void *types_data;
+
     atom_index_t *local_atoms_to_global_table;
 
     void *module_platform_data;
@@ -260,6 +262,16 @@ Module *module_new_from_iff_binary(GlobalContext *global, const void *iff_binary
  * @param ctx the target context.
  */
 term module_load_literal(Module *mod, int index, Context *ctx);
+
+/**
+ * @brief Gets type information for the given type index
+ *
+ * @details Loads and parses type information from the Type chunk and returns the type.
+ * @param mod The module that owns the type information.
+ * @param type_index a valid type index.
+ * @param ctx the target context.
+ */
+term module_get_type_by_index(const Module *mod, int type_index, Context *ctx);
 
 /**
  * @brief Gets a term for the given local atom id

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -202,6 +202,7 @@ static term nif_code_server_resume(Context *ctx, int argc, term argv[]);
 static term nif_code_server_code_chunk(Context *ctx, int argc, term argv[]);
 static term nif_code_server_atom_resolver(Context *ctx, int argc, term argv[]);
 static term nif_code_server_literal_resolver(Context *ctx, int argc, term argv[]);
+static term nif_code_server_type_resolver(Context *ctx, int argc, term argv[]);
 static term nif_code_server_set_native_code(Context *ctx, int argc, term argv[]);
 #endif
 static term nif_erlang_module_loaded(Context *ctx, int argc, term argv[]);
@@ -767,6 +768,10 @@ static const struct Nif code_server_atom_resolver_nif = {
 static const struct Nif code_server_literal_resolver_nif = {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_code_server_literal_resolver
+};
+static const struct Nif code_server_type_resolver_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_code_server_type_resolver
 };
 static const struct Nif code_server_set_native_code_nif = {
     .base.type = NIFFunctionType,
@@ -5598,6 +5603,21 @@ static term nif_code_server_literal_resolver(Context *ctx, int argc, term argv[]
     }
     int literal_index = term_to_int(argv[1]);
     return module_load_literal(mod, literal_index, ctx);
+}
+
+static term nif_code_server_type_resolver(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    VALIDATE_VALUE(argv[0], term_is_atom);
+    VALIDATE_VALUE(argv[1], term_is_integer);
+
+    term module_name = argv[0];
+    Module *mod = globalcontext_get_module(ctx->global, term_to_atom_index(module_name));
+    if (IS_NULL_PTR(mod)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    int type_index = term_to_int(argv[1]);
+    return module_get_type_by_index(mod, type_index, ctx);
 }
 
 static term nif_code_server_set_native_code(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -182,6 +182,7 @@ code_server:resume/2, &code_server_resume_nif
 code_server:code_chunk/1, IF_HAVE_JIT(&code_server_code_chunk_nif)
 code_server:atom_resolver/2, IF_HAVE_JIT(&code_server_atom_resolver_nif)
 code_server:literal_resolver/2, IF_HAVE_JIT(&code_server_literal_resolver_nif)
+code_server:type_resolver/2, IF_HAVE_JIT(&code_server_type_resolver_nif)
 code_server:set_native_code/3, IF_HAVE_JIT(&code_server_set_native_code_nif)
 console:print/1, &console_print_nif
 base64:encode/1, &base64_encode_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -574,6 +574,8 @@ compile_erlang(test_raw_raise)
 compile_erlang(test_ets)
 compile_erlang(test_node)
 
+compile_erlang(test_code_server_nifs)
+
 compile_erlang(test_op_bs_start_match)
 compile_assembler(test_op_bs_start_match_asm)
 compile_erlang(test_op_bs_create_bin)
@@ -1101,11 +1103,12 @@ set(erlang_test_beams
     test_ets.beam
     test_node.beam
 
-
     test_list_to_bitstring.beam
     test_lists_member.beam
     test_lists_keymember.beam
     test_lists_keyfind.beam
+
+    test_code_server_nifs.beam
 
     test_op_bs_start_match.beam
     test_op_bs_create_bin.beam

--- a/tests/erlang_tests/test_code_server_nifs.erl
+++ b/tests/erlang_tests/test_code_server_nifs.erl
@@ -1,0 +1,129 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_code_server_nifs).
+
+-export([start/0, test_literals/0]).
+
+start() ->
+    case erlang:system_info(machine) of
+        "BEAM" ->
+            OTPRelease = erlang:system_info(otp_release),
+            if
+                OTPRelease >= "26" ->
+                    ok = test_is_loaded();
+                true ->
+                    ok
+            end,
+            ok;
+        "ATOM" ->
+            ok = test_is_loaded(),
+            case erlang:system_info(emu_flavor) of
+                jit ->
+                    ok = test_atom_resolver(),
+                    ok = test_literal_resolver(),
+                    ok = test_type_resolver(),
+                    ok = test_error_cases();
+                emu ->
+                    ok
+            end
+    end,
+    0.
+
+%% Test code_server:is_loaded/1
+test_is_loaded() ->
+    M = code_server:is_loaded(?MODULE),
+    % On BEAM, this undocumented function returns {file, _Path}, not true
+    true = M =/= false,
+    false = code_server:is_loaded(non_existent_module_12345),
+    ok.
+
+%% Test code_server:atom_resolver/2
+test_atom_resolver() ->
+    % The first atom (index 1) should be the module name
+    ModuleName = code_server:atom_resolver(?MODULE, 1),
+    true = is_atom(ModuleName),
+    ?MODULE = ModuleName,
+
+    % Test some other atoms that should exist in this module
+    Atom2 = code_server:atom_resolver(?MODULE, 2),
+    true = is_atom(Atom2),
+    start = Atom2,
+    ok.
+
+%% Test code_server:literal_resolver/2
+test_literal_resolver() ->
+    try
+        Literal0 = code_server:literal_resolver(?MODULE, 0),
+        Literal1 = code_server:literal_resolver(?MODULE, 1),
+        true = Literal0 =/= Literal1,
+        ok
+    catch
+        % If there are no literals, that's also acceptable
+        error:badarg -> ok
+    end,
+    ok.
+
+%% Test code_server:type_resolver/2
+test_type_resolver() ->
+    any = code_server:type_resolver(?MODULE, 0),
+    t_atom = code_server:type_resolver(?MODULE, 1),
+    true = test_type_resolver0(2),
+    ok.
+
+test_type_resolver0(N) ->
+    case code_server:type_resolver(?MODULE, N) of
+        any -> false;
+        % We know N >= 2
+        {t_integer, {2, '+inf'}} -> true;
+        _Other -> test_type_resolver0(N + 1)
+    end.
+
+%% Test error cases
+test_error_cases() ->
+    % Test with invalid module
+    try
+        code_server:atom_resolver(non_existent_module, 1),
+        error(should_have_failed)
+    catch
+        error:badarg -> ok
+    end,
+
+    try
+        code_server:literal_resolver(non_existent_module, 0),
+        error(should_have_failed)
+    catch
+        error:badarg -> ok
+    end,
+
+    try
+        code_server:type_resolver(non_existent_module, 0),
+        error(should_have_failed)
+    catch
+        error:badarg -> ok
+    end,
+    ok.
+
+%% Function with literals for testing
+test_literals() ->
+    List = [1, 2, 3, atom, "string"],
+    Tuple = {hello, world, 42, 3.14159},
+    Map = #{key => value, number => 123},
+    {List, Tuple, Map}.

--- a/tests/libs/jit/jit_tests.erl
+++ b/tests/libs/jit/jit_tests.erl
@@ -32,6 +32,22 @@
         0, 2, 18, 66, 16, 1, 96, 64, 3, 19, 64, 18, 3, 78, 32, 16, 3>>
 ).
 
+% Code chunk with typed register from test_term_to_int.erl
+% Contains bs_get_binary2 opcode with typed register that uses term_to_int optimization
+-define(CODE_CHUNK_1,
+    <<0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 182, 0, 0, 0, 4, 0, 0, 0, 1, 1, 16, 153, 16, 2, 18, 34, 32,
+        1, 32, 45, 21, 19, 166, 53, 3, 32, 35, 117, 53, 87, 35, 16, 48, 87, 19, 32, 16, 0, 19, 182,
+        53, 35, 23, 32, 50, 0, 64, 19, 3, 19, 1, 48, 153, 32, 72, 3, 3>>
+).
+-define(ATU8_CHUNK_1,
+    <<255, 255, 255, 253, 8, 16, 116, 101, 115, 116, 95, 116, 101, 114, 109, 95, 116, 111, 95, 105,
+        110, 116, 144, 101, 120, 116, 114, 97, 99, 116, 95, 105, 224, 101, 110, 115, 117, 114, 101,
+        95, 101, 120, 97, 99, 116, 108, 121>>
+).
+-define(TYPE_CHUNK_1,
+    <<0, 0, 0, 3, 0, 0, 0, 3, 15, 255, 0, 2, 0, 32>>
+).
+
 compile_minimal_x86_64_test() ->
     Stream0 = jit_stream_binary:new(0),
     <<16:32, 0:32, _OpcodeMax:32, LabelsCount:32, _FunctionsCount:32, _Opcodes/binary>> = ?CODE_CHUNK_0,
@@ -40,7 +56,12 @@ compile_minimal_x86_64_test() ->
     ),
     Stream2 = jit_x86_64:new(?JIT_VARIANT_PIC, jit_stream_binary, Stream1),
     {_LabelsCount, Stream3} = jit:compile(
-        ?CODE_CHUNK_0, fun(_) -> undefined end, fun(_) -> undefined end, jit_x86_64, Stream2
+        ?CODE_CHUNK_0,
+        fun(_) -> undefined end,
+        fun(_) -> undefined end,
+        fun(_) -> any end,
+        jit_x86_64,
+        Stream2
     ),
     Stream4 = jit_x86_64:stream(Stream3),
     <<16:32, LabelsCount:32, ?JIT_FORMAT_VERSION:16, 1:16, ?JIT_ARCH_X86_64:16, ?JIT_VARIANT_PIC:16,
@@ -69,3 +90,42 @@ check_labels_table0(_, <<>>) -> ok;
 check_labels_table0(N, <<N:16, _Offset:32, Rest/binary>>) -> check_labels_table0(N + 1, Rest).
 
 check_lines_table(<<LinesCount:16, _Lines:(LinesCount * 6)/binary>>) -> ok.
+
+% Test term_to_int optimization with typed registers using real BEAM code
+term_to_int_typed_optimization_x86_64_test() ->
+    % Compile CODE_CHUNK_1 which contains a typed register for term_to_int optimization
+    Stream0 = jit_stream_binary:new(0),
+    <<16:32, 0:32, _OpcodeMax:32, LabelsCount:32, _FunctionsCount:32, _Opcodes/binary>> = ?CODE_CHUNK_1,
+    Stream1 = jit_stream_binary:append(
+        Stream0, jit:beam_chunk_header(LabelsCount, ?JIT_ARCH_X86_64, ?JIT_VARIANT_PIC)
+    ),
+    Stream2 = jit_x86_64:new(?JIT_VARIANT_PIC, jit_stream_binary, Stream1),
+
+    AtomResolver = jit_precompile:atom_resolver(?ATU8_CHUNK_1),
+    LiteralResolver = fun(_) -> test_literal end,
+    TypeResolver = jit_precompile:type_resolver(?TYPE_CHUNK_1),
+
+    % Compile with typed register support
+    {_LabelsCount, Stream3} = jit:compile(
+        ?CODE_CHUNK_1, AtomResolver, LiteralResolver, TypeResolver, jit_x86_64, Stream2
+    ),
+    CompiledCode = jit_x86_64:stream(Stream3),
+
+    % Check the reading of x[1] is immediatly followed by a shift right.
+    % 15c:	4c 8b 5f 38          	mov    0x38(%rdi),%r11
+    % 160:	49 c1 eb 04          	shr    $0x4,%r11
+
+    % As opposed to testing its type
+    % 15c:	4c 8b 5f 38          	mov    0x38(%rdi),%r11
+    % 160:	4d 89 da             	mov    %r11,%r10
+    % 163:	41 80 e2 0f          	and    $0xf,%r10b
+    % 167:	41 80 fa 0f          	cmp    $0xf,%r10b
+    % 16b:	74 05                	je     0x172
+    % 16d:	e9 ab 00 00 00       	jmpq   0x21d
+    % 172:	49 c1 eb 04          	shr    $0x4,%r11
+    ?assertMatch(
+        {_, 8},
+        binary:match(CompiledCode, <<16#4c, 16#8b, 16#5f, 16#38, 16#49, 16#c1, 16#eb, 16#04>>)
+    ),
+
+    ok.

--- a/tests/test.c
+++ b/tests/test.c
@@ -555,6 +555,8 @@ struct Test tests[] = {
     TEST_CASE(test_op_bs_start_match),
     TEST_CASE(test_op_bs_create_bin),
 
+    TEST_CASE(test_code_server_nifs),
+
     // noisy tests, keep them at the end
     TEST_CASE_EXPECTED(spawn_opt_monitor_normal, 1),
     TEST_CASE_EXPECTED(spawn_opt_link_normal, 1),

--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -341,6 +341,10 @@ static void pack_beam_file(FILE *pack, const uint8_t *data, size_t size, const c
         assert_fwrite(data + offsets[AVMN], sizes[AVMN] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);
     }
+    if (offsets[TYPE]) {
+        assert_fwrite(data + offsets[TYPE], sizes[TYPE] + IFF_SECTION_HEADER_SIZE, pack);
+        pad_and_align(pack);
+    }
     if (offsets[LINT] && include_lines) {
         assert_fwrite(data + offsets[LINT], sizes[LINT] + IFF_SECTION_HEADER_SIZE, pack);
         pad_and_align(pack);


### PR DESCRIPTION
Continuation of:
-  #1770 
- #1833

First optimization using type information: simplify some term_to_int implementations.

Current benchmark:
|test                 |JIT disabled (c06edb2bca8dacc8c17661575b39bcfc2c5922ea)|HEAD~1, JIT enabled (9b14b166899f3248189b71c6c157c6ae110df6c4)|This PR (b775240224693b873ed69c74f08673e0d30f9ec3) |
|--------------|---------------- |------------------------|--------|
|erlang-tests   | 11.45s                  | 9.95s  | 9.94s |
|benchmark (entire run)                      | 17.03s                 | 15.35s | 15.52s |
|benchmark : pingpong_speed_test | 3.59s                 | 3.23s | 3.38s |
|benchmark : prime_speed_test       |  0.26s                            | 0.17s | 0.17s |
|benchmark : sudoku_solution_test |  0.26s                            | 1.34s | 1.36s |
|benchmark : sudoku_puzzle_test   |    10.51s                            | 9.18s | 9.22s |

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
