### PR TITLE
wasm CI: use docker container instead of flappy remote server

### DIFF
--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -244,6 +244,11 @@ jobs:
         name: emscripten-test-modules
         path: src/platforms/emscripten/build
 
+    - name: Start Docker echo server for CI
+      run: |
+        docker run -d --name echo-server -p 9090:8080 jmalloc/echo-server
+        sleep 5
+
     - name: Test using cypress
       shell: bash
       run: |
@@ -252,7 +257,7 @@ jobs:
         chmod +x ./src/AtomVM
         ./src/AtomVM examples/emscripten/wasm_webserver.avm &
         cd ../src/platforms/emscripten/tests/
-        docker run --network host -v $PWD:/mnt -w /mnt cypress/included:12.17.1 --browser chrome
+        docker run --network host -v $PWD:/mnt -w /mnt -e CYPRESS_CI=true cypress/included:12.17.1 --browser chrome
         killall AtomVM
 
     - name: "Publish screenshots of failures"

--- a/src/platforms/emscripten/tests/cypress/e2e/websockets.spec.cy.js
+++ b/src/platforms/emscripten/tests/cypress/e2e/websockets.spec.cy.js
@@ -19,7 +19,14 @@
  */
 describe("websockets", () => {
   beforeEach(() => {
-    cy.visit("/tests/src/test_websockets.html");
+    // Use Docker echo server in CI, otherwise use the default online server
+    const ciEnv = Cypress.env('CI');
+    const isCI = ciEnv === true || ciEnv === 'true';
+    const url = isCI
+      ? "/tests/src/test_websockets.html#echo_server=ws://localhost:9090"
+      : "/tests/src/test_websockets.html";
+
+    cy.visit(url);
   });
 
   it("should pass test", () => {

--- a/src/platforms/emscripten/tests/src/test_websockets.erl
+++ b/src/platforms/emscripten/tests/src/test_websockets.erl
@@ -21,12 +21,19 @@
 -module(test_websockets).
 -export([start/0]).
 
--define(ECHO_WEBSOCKET_URL, <<"wss://echo.websocket.org">>).
+-define(DEFAULT_ECHO_WEBSOCKET_URL, <<"wss://echo.websocket.org">>).
+
+get_echo_websocket_url() ->
+    case os:getenv("ECHO_WEBSOCKET_URL") of
+        false -> ?DEFAULT_ECHO_WEBSOCKET_URL;
+        Url -> list_to_binary(Url)
+    end.
 
 start() ->
     try
         true = websocket:is_supported(),
-        Websocket = websocket:new(?ECHO_WEBSOCKET_URL),
+        EchoUrl = get_echo_websocket_url(),
+        Websocket = websocket:new(EchoUrl),
         connecting = websocket:ready_state(Websocket),
         ok =
             receive

--- a/src/platforms/emscripten/tests/src/test_websockets.html
+++ b/src/platforms/emscripten/tests/src/test_websockets.html
@@ -28,8 +28,20 @@ SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
     // Arguments are loaded using fetch API.
     // wasm_webserver serves under /tests/build/ files in src/platform/escripten/build/tests/src subdirectory
     // and under /build/ files in build/ subdirectory.
+
+    // Check for echo_server in URL hash fragment
+    const hash = window.location.hash.substring(1); // Remove the # character
+    const hashParams = new URLSearchParams(hash);
+    const echoServer = hashParams.get('echo_server');
+
     var Module = {
-        arguments: ['/tests/build/test_websockets.beam', '/build/libs/eavmlib/src/eavmlib.avm', '/build/libs/estdlib/src/estdlib.avm']
+        arguments: ['/tests/build/test_websockets.beam', '/build/libs/eavmlib/src/eavmlib.avm', '/build/libs/estdlib/src/estdlib.avm'],
+        preRun: [function() {
+            if (echoServer) {
+                // Set environment variable for the Erlang code to read
+                ENV['ECHO_WEBSOCKET_URL'] = echoServer;
+            }
+        }]
     }
     </script>
     <script async src="/AtomVM.js"></script>


### PR DESCRIPTION
wss://echo.websocket.org works well but is sometimes unavailable from GitHub CI. Replace it with a local docker container that preforms the same echo service, leveraging os:getenv/1 to pass the URL from JS to Erlang.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
