### PR TITLE
Fix http_client.erl example for active mode

### DIFF
--- a/examples/erlang/http_client.erl
+++ b/examples/erlang/http_client.erl
@@ -52,7 +52,10 @@ loop(Conn) ->
                     ok;
                 {ok, UpdatedConn, Responses} ->
                     io:format("Got: ~p~n", [Responses]),
-                    loop(UpdatedConn);
+                    case maybe_terminate(Responses, UpdatedConn) of
+                        ok -> loop(UpdatedConn);
+                        closed -> ok
+                    end;
                 unknown ->
                     io:format("Unexpected message: ~p~n", [Message]),
                     error


### PR DESCRIPTION
Fix http_client.erl example so that the connection is closed and the application can exit after sucessfully receiving the web page when compiled with `{active, true}`.

Closes #1842

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
