### PR TITLE
JIT: Fix binary matching with large integers on 32bits

### DIFF
--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -2974,11 +2974,25 @@ first_pass_bs_match_equal_colon_equal(
     ]),
     MSt2 = handle_error_if({Result, '==', 0}, MMod, MSt1),
     MSt3 = cond_jump_to_label({Result, '==', ?FALSE_ATOM}, Fail, MMod, MSt2),
-    MSt4 = MMod:shift_right(MSt3, Result, 4),
-    MSt5 = cond_jump_to_label({Result, '!=', PatternValue}, Fail, MMod, MSt4),
-    MSt6 = MMod:add(MSt5, BSOffsetReg, Size),
-    MSt7 = MMod:free_native_registers(MSt6, [Result]),
-    {J0 - 3, Rest3, MatchState, BSOffsetReg, MSt7}.
+    MSt6 =
+        case MMod:word_size() of
+            4 when PatternValue bsr 28 > 0 ->
+                % PatternValue doesn't match on immediate integer, so unbox Result for comparison
+                MMod:if_block(
+                    MSt3, {Result, '&', ?TERM_PRIMARY_MASK, '!=', ?TERM_PRIMARY_BOXED}, fun(BSt0) ->
+                        MMod:jump_to_label(BSt0, Fail)
+                    end
+                ),
+                MSt4 = MMod:and_(MSt3, Result, ?TERM_PRIMARY_CLEAR_MASK),
+                {MSt5, IntValue} = MMod:get_array_element(MSt4, {free, Result}, 1),
+                cond_jump_to_label({IntValue, '!=', PatternValue}, Fail, MMod, MSt5);
+            _ ->
+                MSt4 = MMod:shift_right(MSt3, Result, 4),
+                cond_jump_to_label({Result, '!=', PatternValue}, Fail, MMod, MSt4)
+        end,
+    MSt7 = MMod:add(MSt6, BSOffsetReg, Size),
+    MSt8 = MMod:free_native_registers(MSt7, [Result]),
+    {J0 - 3, Rest3, MatchState, BSOffsetReg, MSt8}.
 
 first_pass_bs_match_skip(MatchState, BSOffsetReg, J0, Rest0, MMod, MSt0) ->
     {Stride, Rest1} = decode_literal(Rest0),


### PR DESCRIPTION
Continuation of:
- #1848 

Patterns such as:

```erlang
<<"🌑"/utf8, Moons255Str/binary>> = Moons256Str,
```

(as found in test_binary_to_atom)

do match a 32 bits integer in a binary. It is typically encoded by compiler with a 31 bits match followed by a 1 bit match, maybe because of some BEAM optimization (?).

```
{bs_start_match4,{atom,no_fail},1,{x,0},{x,1}}.
{bs_match,{f,27},
        {x,1},
        {commands,[{ensure_at_least,32,1},
                   {'=:=',nil,31,2018494024},
                   {'=:=',nil,1,1}]}}.
```

In our case, if the pattern value is larger than 28 bits, the `?PRIM_BITSTRING_EXTRACT_INTEGER` primitive will return a boxed integer on 32 bits platforms, which we need to unbox for comparison.

If we confirm the compiler always matches up to 31 bits, we could actually optimize this differently, or maybe squash the two.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
