### PR TITLE
JIT: Fix decode_compact_term_integer on 32 bits platforms

### DIFF
--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -3407,7 +3407,7 @@ decode_compact_term_module_literal(LiteralIndex, MMod, MSt0, Rest) ->
     {MSt1, Reg, Rest}.
 
 decode_compact_term_integer(Value, _MMod, MSt, Rest) when
-    Value >= ?INT32_MIN andalso Value =< ?INT32_MAX
+    Value >= (?INT32_MIN bsr 4) andalso Value =< (?INT32_MAX bsr 4)
 ->
     {MSt, term_from_int(Value), Rest};
 decode_compact_term_integer(Value, MMod, MSt0, Rest) when


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
