### PR TITLE
JIT: free Dest register with OP_BS_GET_POSITION

### DIFF
--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -2043,7 +2043,7 @@ first_pass(<<?OP_BS_GET_POSITION, Rest0/binary>>, MMod, MSt0, State0) ->
     MSt6 = MMod:shift_left(MSt5, Reg, 4),
     MSt7 = MMod:or_(MSt6, Reg, ?TERM_INTEGER_TAG),
     MSt8 = MMod:move_to_vm_register(MSt7, Reg, Dest),
-    MSt9 = MMod:free_native_registers(MSt8, [Reg]),
+    MSt9 = MMod:free_native_registers(MSt8, [Reg, Dest]),
     ?ASSERT_ALL_NATIVE_FREE(MSt9),
     first_pass(Rest3, MMod, MSt9, State0);
 % 168


### PR DESCRIPTION
Free Dest register if it is a pointer to an extended VM register.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
