### PR TITLE
JIT: Fix unserialization of functions

### DIFF
--- a/src/libAtomVM/jit.c
+++ b/src/libAtomVM/jit.c
@@ -962,6 +962,10 @@ static Context *jit_call_fun(Context *ctx, JITState *jit_state, int offset, term
             }
         }
     } else {
+        if (term_is_atom(boxed_value[1])) {
+            set_error(ctx, jit_state, 0, UNDEF_ATOM);
+            return jit_handle_error(ctx, jit_state, 0);
+        }
         fun_module = (Module *) boxed_value[1];
         uint32_t fun_index = term_to_int(index_or_function);
         uint32_t fun_arity_and_freeze;


### PR DESCRIPTION
PR #1784 and PR#1770 were concurrently merged but unserialization of functions required a change to jit primitives that mirrored the change in opcodesswitch

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
