### PR TITLE
CI: build-and-test-other: increase timeout to 30 minutes

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -133,7 +133,7 @@ jobs:
       uses: docker/setup-qemu-action@v3
 
     - name: "Build and Test: AtomVM on foreign arch"
-      timeout-minutes: 15
+      timeout-minutes: 30
       run: |
         docker run --platform linux/${{ matrix.platform }} --rm -v $PWD:/atomvm -w /atomvm \
         -e CFLAGS="${{ matrix.cflags }}" -e CXXFLAGS="${{ matrix.cflags }}" \


### PR DESCRIPTION
Lately it was randomly failing since it was taking more than 15 minutes. Increase timeout to 30 minutes to make sure it is not cancelled just before completion.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
