### PR TITLE
Remove unnecessary computed goto

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -96,7 +96,9 @@ Context *context_new(GlobalContext *glb)
 #else
     ctx->saved_function_ptr = NULL;
 #endif
-    ctx->restore_trap_handler = NULL;
+#ifndef AVM_NO_EMU
+    ctx->waiting_with_timeout = false;
+#endif
 
     ctx->leader = 0;
 

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -139,6 +139,9 @@ struct Context
     unsigned int has_max_heap_size : 1;
 
     bool trap_exit : 1;
+#ifndef AVM_NO_EMU
+    bool waiting_with_timeout : 1;
+#endif
 #ifdef ENABLE_ADVANCED_TRACE
     unsigned int trace_calls : 1;
     unsigned int trace_call_args : 1;


### PR DESCRIPTION
The computed goto is a GCC extension that isn't implemented by clang when targeting wasm. In some cases the compiler failed to optimize it.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
