### PR TITLE
Add `term_is_int` as replacement for `term_is_integer`

### DIFF
--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -1719,7 +1719,7 @@ static inline int64_t int64_bsr_safe(int64_t n, unsigned int rshift)
 
 term bif_erlang_bsl_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
-    if (LIKELY(term_is_any_integer(arg1) && term_is_non_neg_integer(arg2))) {
+    if (LIKELY(term_is_any_integer(arg1) && term_is_non_neg_int(arg2))) {
         size_t arg1_size = term_is_integer(arg1) ? 0 : term_boxed_size(arg1);
         avm_int_t b = term_to_int(arg2);
         if (arg1_size <= BOXED_TERMS_REQUIRED_FOR_INT64) {
@@ -1745,7 +1745,7 @@ term bif_erlang_bsl_2(Context *ctx, uint32_t fail_label, int live, term arg1, te
 
         return make_bigint(ctx, fail_label, live, bigres, bigres_len, m_sign);
 
-    } else if (term_is_neg_integer(arg2)) {
+    } else if (term_is_neg_int(arg2)) {
         term abs_arg2 = term_from_int(-term_to_int(arg2));
         return bif_erlang_bsr_2(ctx, fail_label, live, arg1, abs_arg2);
 
@@ -1774,7 +1774,7 @@ term bif_erlang_bsl_2(Context *ctx, uint32_t fail_label, int live, term arg1, te
 
 term bif_erlang_bsr_2(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2)
 {
-    if (LIKELY(term_is_any_integer(arg1) && term_is_non_neg_integer(arg2))) {
+    if (LIKELY(term_is_any_integer(arg1) && term_is_non_neg_int(arg2))) {
         size_t arg1_size = term_is_integer(arg1) ? 0 : term_boxed_size(arg1);
 
         avm_int_t b = term_to_int(arg2);
@@ -1801,7 +1801,7 @@ term bif_erlang_bsr_2(Context *ctx, uint32_t fail_label, int live, term arg1, te
 
         return make_bigint(ctx, fail_label, live, bigres, bigres_len, m_sign);
 
-    } else if (term_is_neg_integer(arg2)) {
+    } else if (term_is_neg_int(arg2)) {
         term abs_arg2 = term_from_int(-term_to_int(arg2));
         return bif_erlang_bsl_2(ctx, fail_label, live, arg1, abs_arg2);
 

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -915,6 +915,31 @@ static inline int32_t term_to_int32(term t)
     return ((int32_t) t) >> 4;
 }
 
+/**
+ * @brief Extract \c avm_int_t value from unboxed integer term
+ *
+ * Extracts the \c avm_int_t value from a term that contains an unboxed
+ * integer. An unboxed integer is an integer value stored directly within
+ * the term itself, not as a separate allocation on the heap.
+ *
+ * @param t Term containing unboxed integer
+ * @return The extracted \c avm_int_t value
+ *
+ * @pre \c term_is_int(t) must be true
+ * @warning Undefined behavior if called on non-integer or boxed integer terms
+ *
+ * @note This function performs no type checking - validation must be done
+ *       by caller using \c term_is_int()
+ * @note Only extracts from unboxed integers (28-bit on 32-bit builds,
+ *       60-bit on 64-bit builds)
+ * @note Safe conversions: \c size_t s = term_to_int(t) is always valid
+ * @warning Unsafe conversions on 64-bit builds: \c int or \c int32_t may overflow
+ *          since \c avm_int_t can hold 60-bit values
+ *
+ * @see term_is_int() to validate term before extraction
+ * @see term_unbox_int() for extracting boxed integers
+ * @see term_maybe_unbox_int() for extracting from either unboxed or boxed integers
+ */
 static inline avm_int_t term_to_int(term t)
 {
     TERM_DEBUG_ASSERT(term_is_integer(t));
@@ -1028,6 +1053,14 @@ static inline term term_from_int(avm_int_t value)
     return (value << 4) | TERM_INTEGER_TAG;
 }
 
+/**
+ * @brief Check if term is a non-negative unboxed integer
+ *
+ * @param t Term to check
+ * @return true if term is an unboxed integer >= 0, false otherwise
+ *
+ * @see term_is_int() for unboxed integer details
+ */
 static inline bool term_is_non_neg_int(term t)
 {
     if (term_is_int(t)) {
@@ -1037,6 +1070,14 @@ static inline bool term_is_non_neg_int(term t)
     return false;
 }
 
+/**
+ * @brief Check if term is a positive (non-zero) unboxed integer
+ *
+ * @param t Term to check
+ * @return true if term is an unboxed integer > 0, false otherwise
+ *
+ * @see term_is_int() for unboxed integer details
+ */
 static inline bool term_is_pos_int(term t)
 {
     if (term_is_int(t)) {
@@ -1047,6 +1088,14 @@ static inline bool term_is_pos_int(term t)
     return false;
 }
 
+/**
+ * @brief Check if term is a negative unboxed integer
+ *
+ * @param t Term to check
+ * @return true if term is an unboxed integer < 0, false otherwise
+ *
+ * @see term_is_int() for unboxed integer details
+ */
 static inline bool term_is_neg_int(term t)
 {
     if (term_is_int(t)) {

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -504,16 +504,53 @@ static inline bool term_is_sub_binary(term t)
 }
 
 /**
- * @brief Checks if a term is an integer value
+ * @brief Check if term is an integer within platform-specific \c avm_int_t range
  *
- * @details Returns \c true if a term is an integer value, otherwise \c false.
- * @param t the term that will be checked.
- * @return \c true if check succeeds, \c false otherwise.
+ * Tests whether a term represents an integer stored directly in the term
+ * word without boxing. Returns true only for integers that fit within the
+ * platform's unboxed integer range:
+ * - 32-bit builds: [-2^28, 2^28 - 1] (28-bit signed)
+ * - 64-bit builds: [-2^60, 2^60 - 1] (60-bit signed)
+ *
+ * Integers outside these ranges are stored as boxed integers on the heap
+ * and will return false from this function.
+ *
+ * @param t Term to check
+ * @return true if term is an unboxed integer, false otherwise
+ *
+ * @note Returns false for boxed integers and big integers, even if their
+ *       values would fit in \c avm_int_t full range
+ * @note Values passing this check can be safely converted to \c avm_int_t
+ *       or \c size_t using \c term_to_int()
+ * @note Terms for which this functions returns true are not moved during
+ *       garbage collection
+ * @warning Values passing this check may NOT fit in \c int on platforms
+ *          where \c int is smaller than \c avm_int_t
+ *
+ * @see term_is_boxed_integer() for boxed integer checking
+ * @see term_is_any_integer() for checking all integer representations
+ * @see term_to_int() for extracting the integer value
  */
-static inline bool term_is_integer(term t)
+static inline bool term_is_int(term t)
 {
     /* integer: 11 11 */
     return ((t & TERM_IMMED_TAG_MASK) == TERM_INTEGER_TAG);
+}
+
+/**
+ * @brief Check if term is an integer within platform-specific \c avm_int_t range
+ *
+ * @deprecated Use \c term_is_int() instead. This function will raise a warning
+ *             in the future and will eventually be removed.
+ *
+ * @param t Term to check
+ * @return true if term is an unboxed integer, false otherwise
+ *
+ * @see term_is_int() for the replacement function
+ */
+static inline bool term_is_integer(term t)
+{
+    return term_is_int(t);
 }
 
 /**

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -1028,18 +1028,18 @@ static inline term term_from_int(avm_int_t value)
     return (value << 4) | TERM_INTEGER_TAG;
 }
 
-static inline bool term_is_non_neg_integer(term t)
+static inline bool term_is_non_neg_int(term t)
 {
-    if (term_is_integer(t)) {
+    if (term_is_int(t)) {
         avm_int_t v = term_to_int(t);
         return v >= 0;
     }
     return false;
 }
 
-static inline bool term_is_pos_integer(term t)
+static inline bool term_is_pos_int(term t)
 {
-    if (term_is_integer(t)) {
+    if (term_is_int(t)) {
         avm_int_t v = term_to_int(t);
         return v > 0;
     }
@@ -1047,9 +1047,9 @@ static inline bool term_is_pos_integer(term t)
     return false;
 }
 
-static inline bool term_is_neg_integer(term t)
+static inline bool term_is_neg_int(term t)
 {
-    if (term_is_integer(t)) {
+    if (term_is_int(t)) {
         avm_int_t v = term_to_int(t);
         return v < 0;
     }
@@ -1085,17 +1085,17 @@ static inline term_integer_sign_t term_boxed_integer_sign(term t)
 
 static inline bool term_is_any_non_neg_integer(term t)
 {
-    return term_is_non_neg_integer(t) || term_is_pos_boxed_integer(t);
+    return term_is_non_neg_int(t) || term_is_pos_boxed_integer(t);
 }
 
 static inline bool term_is_any_pos_integer(term t)
 {
-    return term_is_pos_integer(t) || term_is_pos_boxed_integer(t);
+    return term_is_pos_int(t) || term_is_pos_boxed_integer(t);
 }
 
 static inline bool term_is_any_neg_integer(term t)
 {
-    return term_is_neg_integer(t) || term_is_neg_boxed_integer(t);
+    return term_is_neg_int(t) || term_is_neg_boxed_integer(t);
 }
 
 static inline avm_int_t term_unbox_int(term boxed_int)


### PR DESCRIPTION
term_is_integer (it checks if an integer can be converted to `avm_int_t`) doesn't match existing naming:
- `term_to_int` (`term` -> `avm_int_t`)
- `term_from_int` (`avm_int_t` -> `term`)

Rename also term_is_pos_integer and similar functions.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
