### PR TITLE
Fix LEDC.ex low_speed_mode()

### DIFF
--- a/libs/exavmlib/lib/LEDC.ex
+++ b/libs/exavmlib/lib/LEDC.ex
@@ -344,18 +344,23 @@ defmodule LEDC do
     do: throw(:nif_error)
 
   @doc """
-  Convenience function for setting ledc speed mode
+  Convenience function for setting ledc speed mode, note that not all targets support high speed mode.
+  Function returns low speed mode on boards that do not support high speed mode.
   """
   @spec high_speed_mode() :: 0
   def high_speed_mode(),
     do: 0
 
   @doc """
-  Convenience function for setting ledc speed mode
+  Convenience function for setting ledc low speed mode.
   """
-  @spec low_speed_mode() :: 1
-  def low_speed_mode(),
-    do: 1
+  @spec low_speed_mode() :: 0 | 1
+  def low_speed_mode() do
+    case :erlang.system_info(:esp32_chip_info) do
+      %{model: :esp32} -> 1
+      _ -> 0
+    end
+  end
 
   @doc """
   Convenience function for setting ledc fade mode


### PR DESCRIPTION
On boards with no high speed mode, the low_speed_mode is (enum) 0.

All boards except for esp32 only has one mode, so the convenience function 0/1 is wrong for all other boards than esp32.

Fixes https://github.com/atomvm/AtomVM/issues/1816

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
