### PR TITLE
x86-64: fix register exhaustion issue

### DIFF
--- a/libs/jit/src/jit_x86_64.erl
+++ b/libs/jit/src/jit_x86_64.erl
@@ -397,7 +397,7 @@ call_primitive(
                 {free, Temp},
                 Args
             );
-        [] when length(Args) >= 3 ->
+        [] ->
             % No register left, we'll use the stack to save NATIVE_INTERFACE_REG
             % and rax when calling function.
             call_func_ptr(State, {primitive, Primitive}, Args)


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
