### PR TITLE
x86-64: add move_to_native_register/2,3 with {x_reg, extra}

### DIFF
--- a/libs/jit/src/jit_x86_64.erl
+++ b/libs/jit/src/jit_x86_64.erl
@@ -1561,6 +1561,18 @@ move_to_native_register(
         available_regs = [Reg | AvailT],
         used_regs = Used
     } = State,
+    {x_reg, extra}
+) ->
+    I1 = jit_x86_64_asm:movq(?X_REG(?MAX_REG), Reg),
+    Stream1 = StreamModule:append(Stream0, I1),
+    {State#state{stream = Stream1, used_regs = [Reg | Used], available_regs = AvailT}, Reg};
+move_to_native_register(
+    #state{
+        stream_module = StreamModule,
+        stream = Stream0,
+        available_regs = [Reg | AvailT],
+        used_regs = Used
+    } = State,
     {x_reg, X}
 ) when
     X < ?MAX_REG


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
