### PR TITLE
Use new arm64 runners for Linux tests

### DIFF
--- a/.github/workflows/build-and-test-other.yaml
+++ b/.github/workflows/build-and-test-other.yaml
@@ -100,12 +100,6 @@ jobs:
           cflags: "-mcpu=cortex-a7 -mfloat-abi=hard -O2 -mthumb -mthumb-interwork -D_FILE_OFFSET_BITS=64"
           cmake_opts: "-DAVM_WARNINGS_ARE_ERRORS=ON"
 
-        - arch: "arm64v8"
-          platform: "arm64/v8"
-          tag: "bookworm"
-          cflags: "-O2"
-          cmake_opts: "-DAVM_WARNINGS_ARE_ERRORS=ON"
-
         # Required for testing big endian archs
         - arch: "s390x"
           platform: "s390x"

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -300,6 +300,14 @@ jobs:
           rebar3_version: "3.24.0"
           cmake_opts_other: "-DAVM_DISABLE_JIT=OFF"
 
+        # arm64 build
+        - os: "ubuntu-24.04-arm"
+          container: "elixir:otp-28"
+          cc: "cc"
+          cxx: "c++"
+          cflags: ""
+          otp: "28"
+
     env:
       ImageOS: ${{ matrix.container == 'ubuntu:20.04' && 'ubuntu20' || matrix.os == 'ubuntu-20.04' && 'ubuntu20' || matrix.os == 'ubuntu-22.04' && 'ubuntu22' || matrix.os == 'ubuntu-24.04' && 'ubuntu24' || 'ubuntu24' }}
       CC: ${{ matrix.cc }}
@@ -331,6 +339,7 @@ jobs:
         submodules: 'recursive'
 
     - uses: erlef/setup-beam@v1
+      if: matrix.container != 'elixir:otp-28'
       with:
         otp-version: ${{ matrix.otp }}
         elixir-version: ${{ matrix.elixir_version }}


### PR DESCRIPTION
Currently as a draft because tests don't pass on Linux AArch64

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
