### PR TITLE
bigint: fix `list_to_integer` / test `integer_to_list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `binary_to_integer/1` no longer accepts binaries such as `<<"0xFF">>` or `<<"  123">>`
+- `binary_to_integer` and `list_to_integer` do not raise anymore `overflow` error, they raise
+instead `badarg`.
 
 ### Fixed
 
@@ -86,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - packbeam: fix memory leak preventing building with address sanitizer
 - Fixed a bug where empty atom could not be created on some platforms, thus breaking receiving a message for a registered process from an OTP node.
 - Fix a memory leak in distribution when a BEAM node would monitor a process by name.
+- Fix `list_to_integer`, it was likely buggy with integers close to INT64_MAX
 
 ## [0.6.7] - Unreleased
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -16,6 +16,9 @@ a term that can be a `port()` or a `pid()`.
 - `bsl` (Bitshift left) now checks for overflows, this shouldn't be a practical issue for existing
 code, since integers were limited to 64 bits, however make sure to bitmask values before left
 bitshifts: e.g. `(16#FFFF band 0xF) bsl 252`.
+- `binary_to_integer` and `list_to_integer` do not raise `overflow` error anymore, they instead
+raise `badarg` when trying to parse an integer that exceeds 256 bits. Update any relevant error
+handling code.
 
 ## v0.6.4 -> v0.6.5
 

--- a/tests/erlang_tests/bigint.erl
+++ b/tests/erlang_tests/bigint.erl
@@ -55,6 +55,7 @@ start() ->
         test_abs() +
         test_neg() +
         parse_bigint() +
+        test_integer_to_list() +
         test_cmp() +
         conv_to_from_float() +
         external_term_decode() +
@@ -841,6 +842,31 @@ parse_bigint() ->
             35
         )
     end),
+
+    0.
+
+test_integer_to_list() ->
+    IntMaxBin = <<"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF">>,
+    IntMax = ?MODULE:id(erlang:binary_to_integer(?MODULE:id(IntMaxBin), 16)),
+    "115792089237316195423570985008687907853269984665640564039457584007913129639935" = ?MODULE:id(
+        erlang:integer_to_list(IntMax)
+    ),
+    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" = ?MODULE:id(
+        erlang:integer_to_list(IntMax, 16)
+    ),
+
+    IntMinBin = <<"-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF">>,
+    IntMin = ?MODULE:id(erlang:binary_to_integer(?MODULE:id(IntMinBin), 16)),
+    "-115792089237316195423570985008687907853269984665640564039457584007913129639935" = ?MODULE:id(
+        erlang:integer_to_list(IntMin)
+    ),
+    "-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" = ?MODULE:id(
+        erlang:integer_to_list(IntMin, 16)
+    ),
+
+    RandBin = <<"313584127083402947713449759974837293576">>,
+    RandInt = ?MODULE:id(erlang:binary_to_integer(?MODULE:id(RandBin))),
+    "EBEA1B25A9CBB9DBC60F1D1FF7C19208" = ?MODULE:id(erlang:integer_to_list(RandInt, 16)),
 
     0.
 

--- a/tests/erlang_tests/bigint.erl
+++ b/tests/erlang_tests/bigint.erl
@@ -56,6 +56,7 @@ start() ->
         test_neg() +
         parse_bigint() +
         test_integer_to_list() +
+        test_integer_from_list() +
         test_cmp() +
         conv_to_from_float() +
         external_term_decode() +
@@ -867,6 +868,72 @@ test_integer_to_list() ->
     RandBin = <<"313584127083402947713449759974837293576">>,
     RandInt = ?MODULE:id(erlang:binary_to_integer(?MODULE:id(RandBin))),
     "EBEA1B25A9CBB9DBC60F1D1FF7C19208" = ?MODULE:id(erlang:integer_to_list(RandInt, 16)),
+
+    0.
+
+test_integer_from_list() ->
+    RandListDec = "1731841583231287768806110493630117706",
+    RandIntDec = ?MODULE:id(erlang:list_to_integer(?MODULE:id(RandListDec))),
+    <<"14D8A61E79E0FD73F68ED4EB6E9B74A">> = erlang:integer_to_binary(?MODULE:id(RandIntDec), 16),
+
+    RandListHex = "97DD30E2C7C05611F18579A689C1A023",
+    RandIntHex = ?MODULE:id(erlang:list_to_integer(?MODULE:id(RandListHex), 16)),
+    <<"201861916492304234384630055011635798051">> = erlang:integer_to_binary(
+        ?MODULE:id(RandIntHex), 10
+    ),
+
+    IntMaxList = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+    IntMax = ?MODULE:id(erlang:list_to_integer(?MODULE:id(IntMaxList), 16)),
+    <<"115792089237316195423570985008687907853269984665640564039457584007913129639935">> = erlang:integer_to_binary(
+        ?MODULE:id(IntMax), 10
+    ),
+
+    PlusIntMaxList = "+FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+    PlusIntMax = ?MODULE:id(erlang:list_to_integer(?MODULE:id(PlusIntMaxList), 16)),
+    <<"115792089237316195423570985008687907853269984665640564039457584007913129639935">> = erlang:integer_to_binary(
+        ?MODULE:id(PlusIntMax), 10
+    ),
+
+    IntMinList = "-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+    IntMin = ?MODULE:id(erlang:list_to_integer(?MODULE:id(IntMinList), 16)),
+    <<"-115792089237316195423570985008687907853269984665640564039457584007913129639935">> = erlang:integer_to_binary(
+        ?MODULE:id(IntMin), 10
+    ),
+
+    Int0List = "8000000000000000",
+    Int0 = ?MODULE:id(erlang:list_to_integer(?MODULE:id(Int0List), 16)),
+    <<"9223372036854775808">> = erlang:integer_to_binary(?MODULE:id(Int0), 10),
+
+    Int1List = "9223372036854775808",
+    Int1 = ?MODULE:id(erlang:list_to_integer(?MODULE:id(Int1List), 10)),
+    <<"9223372036854775808">> = erlang:integer_to_binary(?MODULE:id(Int1), 10),
+
+    Int2List = "-8000000000000001",
+    Int2 = ?MODULE:id(erlang:list_to_integer(?MODULE:id(Int2List), 16)),
+    <<"-9223372036854775809">> = erlang:integer_to_binary(?MODULE:id(Int2), 10),
+
+    Int3List = "-8000000000000001",
+    Int3 = ?MODULE:id(erlang:list_to_integer(?MODULE:id(Int3List), 16)),
+    <<"-9223372036854775809">> = erlang:integer_to_binary(?MODULE:id(Int3), 10),
+
+    Int4List = "18446744073709551615",
+    Int4 = ?MODULE:id(erlang:list_to_integer(?MODULE:id(Int4List))),
+    <<"18446744073709551615">> = erlang:integer_to_binary(?MODULE:id(Int4)),
+
+    Int5List = "18446744073709551616",
+    Int5 = ?MODULE:id(erlang:list_to_integer(?MODULE:id(Int5List))),
+    <<"18446744073709551616">> = erlang:integer_to_binary(?MODULE:id(Int5)),
+
+    TooBig =
+        "473G8HGH5SHXPHL0FW40LIZSMNW3BNJ51ABCT02HG4AKRJWXWI96A1W9UG2YQ9XNJ595OFX6ZUZWLNFZ2W1RYW49ZBUWZ16GXQE",
+    ok = expect_atomvm_error(badarg, fun() ->
+        list_to_integer(
+            ?MODULE:id(
+                TooBig
+            ),
+            36
+        )
+    end),
 
     0.
 


### PR DESCRIPTION
Make sure that `list_to_integer` / test `integer_to_list` are properly tested and support big integers.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
