### PR TITLE
Update documentaion builds to OTP 28

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -60,8 +60,7 @@ jobs:
         os: [ ubuntu-24.04 ]
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
-    # Documentation currently fails to build with OTP-27 and recent OTP-26.
-    container: erlang:26.0.2
+    container: erlang:28.1
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -48,7 +48,7 @@ jobs:
         os: [ ubuntu-24.04 ]
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
-    container: erlang:26.0.2
+    container: erlang:28.1
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
The bug in uwiger/edown#34 was fixed in uwiger/edown#35 so the documentaton can now be built with the latest OTP release.

Closes #1774

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
