### PR TITLE
Add OTP-28 to run-tests-with-beam matrix

### DIFF
--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -78,6 +78,11 @@ jobs:
           otp: "27"
           container: erlang:27
 
+        - os: "ubuntu-24.04"
+          test_erlang_opts: "-s prime_smp"
+          otp: "28"
+          container: erlang:28
+
         # This is ARM64
         - os: "macos-15"
           otp: "26"


### PR DESCRIPTION
Adds OTP 28 to the test matrix for the run-tests-with-beam.yaml workflow for the main branch.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
