### PR TITLE
Align some gen_tcp and inet funcionality and error returns with OTP

### DIFF
--- a/tests/libs/estdlib/test_gen_tcp.erl
+++ b/tests/libs/estdlib/test_gen_tcp.erl
@@ -28,6 +28,8 @@ test() ->
     ok = test_echo_server(),
     ok = test_echo_server(true),
     ok = test_listen_connect_parameters(),
+    ok = test_connect_parameters(),
+    ok = test_connect_bad_address(),
     ok = test_tcp_double_close(),
     ok.
 
@@ -346,6 +348,94 @@ test_listen_connect_parameters_server_loop(ListenMode, false = ListenActive, Soc
             end;
         Other ->
             {error, {unexpected_result, server, passive_receive, Other}}
+    end.
+
+test_connect_parameters() ->
+    IP =
+        case inet:getaddr("www.github.com", inet) of
+            {ok, IPAddress} ->
+                IPAddress;
+            Error ->
+                io:format(
+                    "Unable to resolve www.github.com, ~p; unable to complete connection tests.~n",
+                    [Error]
+                ),
+                throw(Error)
+        end,
+    Hostname = "www.atomvm.org",
+    Port = 80,
+    OptTests =
+        case get_otp_version() of
+            Version when Version =:= atomvm orelse (is_integer(Version) andalso Version >= 24) ->
+                [
+                    [{active, true}],
+                    [{active, false}],
+                    [{inet_backend, socket}, {active, true}],
+                    [{inet_backend, socket}, {active, false}]
+                ];
+            _ ->
+                [
+                    [{active, true}],
+                    [{active, false}]
+                ]
+        end,
+    test_connect_parameters(OptTests, IP, Hostname, Port, []).
+
+test_connect_parameters([], _IP, _Host, _Port, Results) ->
+    case lists:flatten(Results) of
+        [] ->
+            ok;
+        ErrorList ->
+            ErrorList
+    end;
+test_connect_parameters([Test | TestOpts], IP, Host, Port, Results) ->
+    io:format("GEN_TCP_CONNECT-TEST> IP Address=~p (www.github.com) ClientConnectOptions=~p~n", [
+        IP, Test
+    ]),
+    IpResult =
+        case gen_tcp:connect(IP, Port, Test) of
+            {ok, Soc0} ->
+                ok = gen_tcp:close(Soc0),
+                [];
+            IpErr ->
+                {error, IpErr, {ip_connect, Test}}
+        end,
+    io:format("GEN_TCP_CONNECT-TEST> Hostname=~p ClientConnectOptions=~p~n", [Host, Test]),
+    HostResult =
+        case gen_tcp:connect(Host, Port, Test) of
+            {ok, Soc1} ->
+                ok = gen_tcp:close(Soc1),
+                [];
+            HostErr ->
+                {error, HostErr, {hostname_connect, Test}}
+        end,
+    test_connect_parameters(TestOpts, IP, Host, Port, [Results, IpResult, HostResult]).
+
+test_connect_bad_address() ->
+    {error, nxdomain} = gen_tcp:connect("foo.bar.flurtleblurb", 80, []),
+    try gen_tcp:connect({532, 0, 0, 1}, 80, []) of
+        %{error, {getaddrinfo, _Er}} ->
+        %    ok;
+        {ok, Port} ->
+            gen_tcp:close(Port),
+            error(invalid_ipaddr_accepted);
+        Error ->
+            error({unexpected, Error})
+    catch
+        %& OTP
+        _:badarg ->
+            ok;
+        %& AtomVM
+        _:{badmatch, {error, {getaddrinfo, _Er}}}->
+            ok
+        %{error, {getaddrinfo, _Er}} ->
+        %    ok
+        %{getaddrinfo, _Er} ->
+        %    ok
+        %_:{error, {getaddrinfo, _Er}} ->
+        %    ok
+        %_:{getaddrinfo, _Er} ->
+        %    ok
     end.
 
 test_tcp_double_close() ->

--- a/tests/libs/estdlib/test_inet.erl
+++ b/tests/libs/estdlib/test_inet.erl
@@ -33,6 +33,10 @@ test_getaddr() ->
     % RFC8880
     {ok, {192, 0, 0, LastByte}} = inet:getaddr("ipv4only.arpa", inet),
     true = LastByte =:= 170 orelse LastByte =:= 171,
+    {error, einval} = inet:getaddr(127, inet),
+    {error, einval} = inet:getaddr({127.0, 0, 0, 1.0}, inet),
+    {error, einval} = inet:getaddr({312, 0, 0, 1}, inet),
+    {error, einval} = inet:getaddr({foo, bar}, inet),
     {error, einval} = inet:getaddr(<<"localhost">>, inet),
     {error, _} = inet:getaddr("localhost.invalid", inet),
     ok.


### PR DESCRIPTION
Align error returns from `gen_tcp_inet:connect/3` and `inet:getaddr/2` to match OTP error returns, and catch some badargs that previously were allowed. Adds ability that was documented but unimplemented to use `gen_tcp_socket:connect/3` with an `inet:hostname()` in the address parameter, previous behavior was to silently hang for infinity when a hostname was used. This bug (#1839) also affected the ahttp_client when using the `{inet_backend, socket}` option. Adds socket backend tests for ahttp_client in active and passive mode.

Closes #1839

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
