### PR TITLE
Minor update to gen_tcp docs

### DIFF
--- a/libs/estdlib/src/gen_tcp.erl
+++ b/libs/estdlib/src/gen_tcp.erl
@@ -31,7 +31,6 @@
 %% Caveats:
 %% <ul>
 %%     <li>Limited support for socket tuning parameters</li>
-%%     <li>No support for <b>controlling_process/2</b></li>
 %% </ul>
 %%
 %% <em><b>Note.</b>  Port drivers for this interface are not supported


### PR DESCRIPTION
Removes "No support for controlling_process/2" from caveats in module doc section since this is already supported.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
