### PR TITLE
Fix several supervisor issues and bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ instead `badarg`.
 - Fix a memory leak in distribution when a BEAM node would monitor a process by name.
 - Fix `list_to_integer`, it was likely buggy with integers close to INT64_MAX
 - Added missing support for supervisor `one_for_all` strategy.
+- Supervisor now honors period and intensity options.
 
 ## [0.6.7] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ instead `badarg`.
 - Fixed a bug where empty atom could not be created on some platforms, thus breaking receiving a message for a registered process from an OTP node.
 - Fix a memory leak in distribution when a BEAM node would monitor a process by name.
 - Fix `list_to_integer`, it was likely buggy with integers close to INT64_MAX
+- Added missing support for supervisor `one_for_all` strategy.
 
 ## [0.6.7] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ instead `badarg`.
 - Fix `list_to_integer`, it was likely buggy with integers close to INT64_MAX
 - Added missing support for supervisor `one_for_all` strategy.
 - Supervisor now honors period and intensity options.
+- Fix supervisor crash if a `one_for_one` child fails to restart.
 
 ## [0.6.7] - Unreleased
 

--- a/libs/estdlib/src/supervisor.erl
+++ b/libs/estdlib/src/supervisor.erl
@@ -184,7 +184,7 @@ start_children([Child | T], StartedC) ->
 start_children([], StartedC) ->
     StartedC.
 
-restart_child(Pid, Reason, State) ->
+handle_child_exit(Pid, Reason, State) ->
     case lists:keyfind(Pid, #child.pid, State#state.children) of
         false ->
             {ok, State};
@@ -295,7 +295,7 @@ handle_cast(_Msg, State) ->
     {noreply, State}.
 
 handle_info({'EXIT', Pid, Reason}, State) ->
-    case restart_child(Pid, Reason, State) of
+    case handle_child_exit(Pid, Reason, State) of
         {ok, State1} ->
             {noreply, State1};
         {shutdown, State1} ->

--- a/libs/estdlib/src/supervisor.erl
+++ b/libs/estdlib/src/supervisor.erl
@@ -88,7 +88,7 @@
     start :: {module(), atom(), [any()] | undefined},
     restart :: restart(),
     shutdown :: shutdown(),
-    type :: child_type,
+    type :: child_type(),
     modules = [] :: [module()] | dynamic
 }).
 -record(state, {restart_strategy :: strategy(), children = [] :: [#child{}]}).
@@ -128,7 +128,7 @@ init({Mod, Args}) ->
             NewChildren = start_children(State#state.children, []),
             {ok, State#state{children = NewChildren}};
         Error ->
-            {stop, {bad_return, {mod, init, Error}}}
+            {stop, {bad_return, {Mod, init, Error}}}
     end.
 
 -spec child_spec_to_record(child_spec()) -> #child{}.


### PR DESCRIPTION
These changes fix several open supervisor issues, as well as a few small bugs discovered in the supervisor and test_supervisor.erl.

* Implements missing `one_for_all` restart strategy that is documented in the module.
* Supervisors now obeys `intensity` and `period` options.
* Children who fail to restart are retried until maximum restart intensity limit is reached
* Fixes edge case bug when terminating as well as several typos.
* Fixes some bugs in the test suite that left un-received messages in the test environment that would be received by additional tests added to the end of the lists in `test_supervisor:/test/0`.

Closes #1855
Closes #1915
Closed #1957

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
