### PR TITLE
Add gen_server support for OTP-28 timeout tuple return actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for big integers up to 256-bit (sign + 256-bit magnitude)
 - Added support for big integers in `binary_to_term/1` and `term_to_binary/1,2`
 - Added `proc_lib`
+- Added gen_server support for timeout tuples in callback return actions introduced in OTP-28.
 
 ### Changed
 


### PR DESCRIPTION
Adds support for timeout tuples in the form of `{timeout, Time :: timeout(), InfoMessage :: any()}` in gen_server callback return `action()`. These callback return actions were introduced in OTP-28. They work similarly to `timeout()` actions, except insead of `timeout` handle_info/2 will receive the `InfoMessage`.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
