### PR TITLE
Clarify STM32 build instructions

### DIFF
--- a/doc/src/build-instructions.md
+++ b/doc/src/build-instructions.md
@@ -679,6 +679,8 @@ directory:
 ### Build AtomVM with cmake toolchain file
 
 ```shell
+$ cd <atomvm-source-tree-root>
+$ cd src/platforms/stm32
 $ mkdir build
 $ cd build
 $ cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/arm-toolchain.cmake ..


### PR DESCRIPTION
Makes the working directory more explicit, incase users skim over the written sections and jump straight to the shell commands.

Closes #1967

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
