### PR TITLE
Determine paths for ESP32 mkimage.sh at runtime

### DIFF
--- a/src/platforms/esp32/tools/CMakeLists.txt
+++ b/src/platforms/esp32/tools/CMakeLists.txt
@@ -47,7 +47,7 @@ elseif(${CONFIG_IDF_TARGET} STREQUAL "esp32p4")
     set(BOOTLOADER_OFFSET "0x2000")
 endif()
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mkimage.config.in ${CMAKE_BINARY_DIR}/mkimage.config)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mkimage.config.in ${CMAKE_BINARY_DIR}/mkimage.config @ONLY)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/dev/flash.sh ${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/flash.sh COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mkimage.erl ${CMAKE_BINARY_DIR}/mkimage.erl COPYONLY)

--- a/src/platforms/esp32/tools/mkimage.config.in
+++ b/src/platforms/esp32/tools/mkimage.config.in
@@ -22,18 +22,18 @@
     segments => [
         #{
             name => "bootloader",
-            offset => "${BOOTLOADER_OFFSET}",
-            path => ["${BUILD_DIR}/bootloader/bootloader.bin"]
+            offset => "@BOOTLOADER_OFFSET@",
+            path => ["${ROOT_DIR}/src/platforms/esp32/build/bootloader/bootloader.bin"]
         },
         #{
             name => "partition-table",
             offset => "0x8000",
-            path => ["${BUILD_DIR}/partition_table/partition-table.bin", "${BUILD_DIR}/partitions.bin"]
+            path => ["${ROOT_DIR}/src/platforms/esp32/build/partition_table/partition-table.bin"]
         },
         #{
             name => "AtomVM Virtual Machine",
             offset => "0x10000",
-            path => ["${BUILD_DIR}/atomvm-esp32.bin", "${ROOT_DIR}/src/platforms/esp32/build/atomvvm-esp32.bin"]
+            path => ["${ROOT_DIR}/src/platforms/esp32/build/atomvm-esp32.bin"]
         },
         #{
             name => "AtomVM Boot and Core BEAM Library",

--- a/src/platforms/esp32/tools/mkimage.erl
+++ b/src/platforms/esp32/tools/mkimage.erl
@@ -46,7 +46,6 @@ do_main(Argv) ->
                         BootFile = BuildDir ++ "/libs/esp32boot/esp32boot.avm",
                         mkimage(
                             RootDir,
-                            BuildDir,
                             maps:get(boot, Opts, BootFile),
                             maps:get(out, Opts, "atomvm.img"),
                             maps:get(segments, Config)
@@ -130,7 +129,7 @@ get_build_dir(Opts, RootDir) ->
     end.
 
 %% @private
-mkimage(RootDir, BuildDir, BootFile, OutputFile, Segments) ->
+mkimage(RootDir, BootFile, OutputFile, Segments) ->
     io:format("Writing output to ~s~n", [OutputFile]),
     io:format("boot file is ~s~n", [BootFile]),
     io:format("=============================================~n"),
@@ -164,11 +163,7 @@ mkimage(RootDir, BuildDir, BootFile, OutputFile, Segments) ->
                     end,
                     SegmentPaths = [
                         replace(
-                            "BUILD_DIR",
-                            BuildDir,
-                            replace(
-                                "BOOT_FILE", BootFile, replace("ROOT_DIR", RootDir, SegmentPath)
-                            )
+                            "BOOT_FILE", BootFile, replace("ROOT_DIR", RootDir, SegmentPath)
                         )
                      || SegmentPath <- maps:get(path, Segment)
                     ],
@@ -213,5 +208,5 @@ from_hex([$0, $x | Bits]) ->
 
 %% @private
 replace(VariableName, Value, String) ->
-    string:replace(String, io_lib:format("${~s}", [VariableName]), Value),
-    string:replace(String, io_lib:format("$[~s]", [VariableName]), Value).
+    String0 = string:replace(String, io_lib:format("${~s}", [VariableName]), Value),
+    string:replace(String0, io_lib:format("$[~s]", [VariableName]), Value).

--- a/src/platforms/esp32/tools/mkimage.sh.in
+++ b/src/platforms/esp32/tools/mkimage.sh.in
@@ -19,14 +19,27 @@
 # SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
 #
 
-escript "@CMAKE_BINARY_DIR@/mkimage.erl" \
-    --root_dir "@CMAKE_BINARY_DIR@/../../../.." \
-    --config "@CMAKE_BINARY_DIR@/mkimage.config" \
-    --out "@CMAKE_BINARY_DIR@/atomvm-@CONFIG_IDF_TARGET@.img" \
-    "$@"
+build_dir=$(CDPATH=; cd -- "$(dirname -- "$0")" && pwd -P)
 
-echo "============================================="
+report_success()
+{
+    echo "============================================="
+    echo ""
+    echo "AtomVM @CONFIG_IDF_TARGET@ version @ATOMVM_VERSION@ image written to:"
+    echo "${build_dir}/atomvm-@CONFIG_IDF_TARGET@.img"
+    exit 0
+}
 
-echo ""
-echo "AtomVM @CONFIG_IDF_TARGET@ version @ATOMVM_VERSION@ image written to:"
-echo "@CMAKE_BINARY_DIR@/atomvm-@CONFIG_IDF_TARGET@.img"
+fail()
+{
+    echo ""
+    echo "Failed to build image."
+    exit 1
+}
+
+escript "${build_dir}/mkimage.erl" \
+    --root_dir "${build_dir}/../../../../" \
+    --config "${build_dir}/mkimage.config" \
+    --out "${build_dir}/atomvm-@CONFIG_IDF_TARGET@.img" \
+    "$@" && report_success || fail
+


### PR DESCRIPTION
Switch from CMAKE_BINARY_DIR found when configuring with cmake to determining the paths at runtime. This allows configuring and building with the espressif/esp-idf docker image, and later running the escript in the host environment with OTP (and optionally Elixir and/or Gleam) installed.

These changes are needed for atomvm/exatomvm#65.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
