### PR TITLE
Fix localtime/1 mem leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop using deprecated `term_from_int32` on RP2 platform
 - Stop using deprecated `term_from_int32` on ESP32 platform
 - Fixed improper cast of ESP32 `event_data` for `WIFI_EVENT_AP_STA(DIS)CONNECTED` events
+- Fixed `erlang:localtime/1` memory leak, use-after-free, and TZ restore bugs on newlib/picolibc
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1949,6 +1949,64 @@ term nif_erlang_universaltime_0(Context *ctx, int argc, term argv[])
     return build_datetime_from_tm(ctx, gmtime_r(&ts.tv_sec, &broken_down_time));
 }
 
+// Workaround for newlib/picolibc setenv memory leak: use putenv with a
+// fixed-size static buffer. The buffer is installed once via putenv and then
+// modified in place so repeated TZ changes never allocate.
+// See: https://github.com/espressif/esp-idf/issues/3046
+// Both newlib and picolibc leak the old "NAME=value" string on overwrite.
+#if defined(__NEWLIB__) || defined(__PICOLIBC__)
+#define AVM_TZ_SETENV_LEAKS 1
+#else
+#define AVM_TZ_SETENV_LEAKS 0
+#endif
+
+#if AVM_TZ_SETENV_LEAKS
+
+// Max TZ value length is 60 bytes; longest POSIX TZ strings (e.g.
+// "CET-1CEST,M3.5.0/2,M10.5.0/3") are well under this limit.
+#define TZ_BUFFER_SIZE 64
+#define TZ_MAX_VALUE_LEN (TZ_BUFFER_SIZE - 4) // 3 for "TZ=" + 1 for '\0'
+
+static char tz_buffer[TZ_BUFFER_SIZE] = "TZ=";
+static bool tz_buffer_installed = false;
+// Cached pointer into the environment; assumes AtomVM is the sole user of TZ
+// (no external threads reading or writing TZ or calling time functions
+// that depend on it during the temporary override).
+static char *tz_env_value = NULL;
+
+// Write a TZ value into the static buffer. Returns false if the value is
+// too long to fit (the buffer is left unchanged in that case).
+// Caller must hold env_spinlock.
+static bool set_static_tz_value(const char *tz)
+{
+    size_t tz_len = strlen(tz);
+    if (tz_len > TZ_MAX_VALUE_LEN) {
+        return false;
+    }
+    if (!tz_buffer_installed) {
+        // Install a full-width placeholder first. Some libc implementations
+        // copy the environment string instead of keeping our static buffer, and
+        // installing just "TZ=" would leave too little storage for later
+        // in-place updates.
+        memset(tz_buffer + 3, ' ', TZ_MAX_VALUE_LEN);
+        tz_buffer[3 + TZ_MAX_VALUE_LEN] = '\0';
+        if (putenv(tz_buffer) != 0) {
+            return false;
+        }
+        tz_buffer_installed = true;
+        tz_env_value = getenv("TZ");
+        if (tz_env_value == NULL) {
+            tz_env_value = tz_buffer + 3;
+        }
+    }
+    memcpy(tz_env_value, tz, tz_len);
+    memset(tz_env_value + tz_len, 0, TZ_MAX_VALUE_LEN - tz_len);
+    tz_env_value[TZ_MAX_VALUE_LEN] = '\0';
+    return true;
+}
+
+#endif // AVM_TZ_SETENV_LEAKS
+
 term nif_erlang_localtime(Context *ctx, int argc, term argv[])
 {
     char *tz;
@@ -1972,17 +2030,55 @@ term nif_erlang_localtime(Context *ctx, int argc, term argv[])
     smp_spinlock_lock(&ctx->global->env_spinlock);
 #endif
     if (tz) {
-        char *oldtz = getenv("TZ");
+        char *oldtz = NULL;
+        char *oldtz_env = getenv("TZ");
+        if (oldtz_env) {
+            oldtz = strdup(oldtz_env);
+            if (UNLIKELY(oldtz == NULL)) {
+#ifndef AVM_NO_SMP
+                smp_spinlock_unlock(&ctx->global->env_spinlock);
+#endif
+                free(tz);
+                RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            }
+        }
+
+#if AVM_TZ_SETENV_LEAKS
+        if (!set_static_tz_value(tz)) {
+#ifndef AVM_NO_SMP
+            smp_spinlock_unlock(&ctx->global->env_spinlock);
+#endif
+            free(oldtz);
+            free(tz);
+            RAISE_ERROR(BADARG_ATOM);
+        }
+#else
         setenv("TZ", tz, 1);
+#endif
         tzset();
         localtime = localtime_r(&ts.tv_sec, &storage);
+
         if (oldtz) {
+#if AVM_TZ_SETENV_LEAKS
+            if (!set_static_tz_value(oldtz)) {
+                setenv("TZ", oldtz, 1);
+                tz_env_value = getenv("TZ");
+            }
+#else
             setenv("TZ", oldtz, 1);
+#endif
+            free(oldtz);
         } else {
             unsetenv("TZ");
+#if AVM_TZ_SETENV_LEAKS
+            // unsetenv removes our static buffer from the environment,
+            // so we must re-install it on the next call.
+            tz_buffer_installed = false;
+            tz_env_value = NULL;
+#endif
         }
+        tzset();
     } else {
-        // Call tzset to handle DST changes
         tzset();
         localtime = localtime_r(&ts.tv_sec, &storage);
     }
@@ -1991,6 +2087,11 @@ term nif_erlang_localtime(Context *ctx, int argc, term argv[])
 #endif
 
     free(tz);
+
+    if (UNLIKELY(localtime == NULL)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
     return build_datetime_from_tm(ctx, localtime);
 }
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1949,6 +1949,64 @@ term nif_erlang_universaltime_0(Context *ctx, int argc, term argv[])
     return build_datetime_from_tm(ctx, gmtime_r(&ts.tv_sec, &broken_down_time));
 }
 
+// Workaround for newlib/picolibc setenv memory leak: use putenv with a
+// fixed-size static buffer. The buffer is installed once via putenv and then
+// modified in place so repeated TZ changes never allocate.
+// See: https://github.com/espressif/esp-idf/issues/3046
+// Both newlib and picolibc leak the old "NAME=value" string on overwrite.
+#if defined(__NEWLIB__) || defined(__PICOLIBC__)
+#define AVM_TZ_SETENV_LEAKS 1
+#else
+#define AVM_TZ_SETENV_LEAKS 0
+#endif
+
+#if AVM_TZ_SETENV_LEAKS
+
+// Max TZ value length is 60 bytes; longest POSIX TZ strings (e.g.
+// "CET-1CEST,M3.5.0/2,M10.5.0/3") are well under this limit.
+#define TZ_BUFFER_SIZE 64
+#define TZ_MAX_VALUE_LEN (TZ_BUFFER_SIZE - 4) // 3 for "TZ=" + 1 for '\0'
+
+static char tz_buffer[TZ_BUFFER_SIZE] = "TZ=";
+static bool tz_buffer_installed = false;
+// Cached pointer into the environment; assumes AtomVM is the sole user of TZ
+// (no external threads reading or writing TZ or calling time functions
+// that depend on it during the temporary override).
+static char *tz_env_value = NULL;
+
+// Write a TZ value into the static buffer. Returns false if the value is
+// too long to fit (the buffer is left unchanged in that case).
+// Caller must hold env_spinlock.
+static bool set_static_tz_value(const char *tz)
+{
+    size_t tz_len = strlen(tz);
+    if (tz_len > TZ_MAX_VALUE_LEN) {
+        return false;
+    }
+    if (!tz_buffer_installed) {
+        // Install a full-width placeholder first. Some libc implementations
+        // copy the environment string instead of keeping our static buffer, and
+        // installing just "TZ=" would leave too little storage for later
+        // in-place updates.
+        memset(tz_buffer + 3, ' ', TZ_MAX_VALUE_LEN);
+        tz_buffer[3 + TZ_MAX_VALUE_LEN] = '\0';
+        if (putenv(tz_buffer) != 0) {
+            return false;
+        }
+        tz_buffer_installed = true;
+        tz_env_value = getenv("TZ");
+        if (tz_env_value == NULL) {
+            tz_env_value = tz_buffer + 3;
+        }
+    }
+    memcpy(tz_env_value, tz, tz_len);
+    memset(tz_env_value + tz_len, 0, TZ_MAX_VALUE_LEN - tz_len);
+    tz_env_value[TZ_MAX_VALUE_LEN] = '\0';
+    return true;
+}
+
+#endif // AVM_TZ_SETENV_LEAKS
+
 term nif_erlang_localtime(Context *ctx, int argc, term argv[])
 {
     char *tz;
@@ -1972,17 +2030,62 @@ term nif_erlang_localtime(Context *ctx, int argc, term argv[])
     smp_spinlock_lock(&ctx->global->env_spinlock);
 #endif
     if (tz) {
-        char *oldtz = getenv("TZ");
+        char *oldtz = NULL;
+        char *oldtz_env = getenv("TZ");
+        if (oldtz_env) {
+            oldtz = strdup(oldtz_env);
+            if (UNLIKELY(oldtz == NULL)) {
+#ifndef AVM_NO_SMP
+                smp_spinlock_unlock(&ctx->global->env_spinlock);
+#endif
+                free(tz);
+                RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            }
+        }
+
+#if AVM_TZ_SETENV_LEAKS
+        if (!set_static_tz_value(tz)) {
+#ifndef AVM_NO_SMP
+            smp_spinlock_unlock(&ctx->global->env_spinlock);
+#endif
+            free(oldtz);
+            free(tz);
+            RAISE_ERROR(BADARG_ATOM);
+        }
+#else
         setenv("TZ", tz, 1);
+#endif
         tzset();
         localtime = localtime_r(&ts.tv_sec, &storage);
+
         if (oldtz) {
+#if AVM_TZ_SETENV_LEAKS
+            if (!set_static_tz_value(oldtz)) {
+                setenv("TZ", oldtz, 1);
+                tz_env_value = getenv("TZ");
+            }
+#else
             setenv("TZ", oldtz, 1);
+#endif
+            free(oldtz);
         } else {
+#if AVM_TZ_SETENV_LEAKS
+            // Cannot truly unset TZ with the static buffer approach;
+            // putenv does not support removal.
+            // NOTE: This is a pragmatic approximation, not a true restore.
+            // When TZ was originally unset, setting it to "UTC0" permanently
+            // changes observable process state (getenv("TZ") will return
+            // "UTC0" instead of NULL). This is acceptable on newlib/picolibc
+            // embedded targets where unset TZ already defaults to UTC.
+            if (!set_static_tz_value("UTC0")) {
+                unsetenv("TZ");
+            }
+#else
             unsetenv("TZ");
+#endif
         }
+        tzset();
     } else {
-        // Call tzset to handle DST changes
         tzset();
         localtime = localtime_r(&ts.tv_sec, &storage);
     }
@@ -1991,6 +2094,11 @@ term nif_erlang_localtime(Context *ctx, int argc, term argv[])
 #endif
 
     free(tz);
+
+    if (UNLIKELY(localtime == NULL)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
     return build_datetime_from_tm(ctx, localtime);
 }
 

--- a/src/platforms/esp32/test/main/test_erl_sources/test_tz.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_tz.erl
@@ -21,7 +21,24 @@
 -module(test_tz).
 -export([start/0]).
 
+%% Slack to absorb unrelated allocator noise / atom table growth between
+%% Before/After snapshots. The setenv leak on newlib was ~strlen("TZ=" ++ Rule)
+%% bytes per call, so 500 iterations would add up to ~10-20 KB if the leak
+%% were still present. 1024 bytes of slack is well below that.
+-define(LEAK_SLACK_BYTES, 1024).
+-define(LEAK_ITERATIONS, 500).
+
 start() ->
+    ok = test_basic(),
+    ok = test_offsets(),
+    ok = test_localtime0_after_localtime1(),
+    ok = test_badarg(),
+    ok = test_no_leak(),
+    ok.
+
+%% Original sanity check: localtime("UTC") should fall between two
+%% surrounding universaltime() snapshots.
+test_basic() ->
     UTCTime1 = erlang:universaltime(),
     LocalTimeUTC = erlang:localtime("UTC"),
     UTCTime2 = erlang:universaltime(),
@@ -30,3 +47,103 @@ start() ->
     UTCTime3 = erlang:universaltime(),
     true = UTCTime2 =/= ParisTime andalso UTCTime3 =/= ParisTime,
     ok.
+
+%% Verify that several POSIX TZ strings produce the expected offsets
+%% relative to UTC. We capture three localtime/1 calls back-to-back and
+%% allow a small drift for the wall clock advancing between calls.
+test_offsets() ->
+    UTC = erlang:localtime("UTC0"),
+    %% UTC-5, no DST
+    EST = erlang:localtime("EST5"),
+    %% UTC+9, no DST
+    JST = erlang:localtime("JST-9"),
+
+    UTCSecs = calendar:datetime_to_gregorian_seconds(UTC),
+    ESTSecs = calendar:datetime_to_gregorian_seconds(EST),
+    JSTSecs = calendar:datetime_to_gregorian_seconds(JST),
+
+    %% EST should read ~5h earlier than UTC; JST ~9h later than UTC.
+    %% Allow 5s drift for clock advance between the three calls.
+    DiffEST = UTCSecs - ESTSecs,
+    DiffJST = JSTSecs - UTCSecs,
+    true = abs(DiffEST - 5 * 3600) =< 5,
+    true = abs(DiffJST - 9 * 3600) =< 5,
+
+    %% Strict ordering: EST < UTC < JST (allowing equality due to drift).
+    true = ESTSecs =< UTCSecs,
+    true = UTCSecs =< JSTSecs,
+    ok.
+
+%% After many TZ overrides the global libc state must be back to its
+%% original timezone -- localtime/0 should still match universaltime/0
+%% (assuming the device boots with TZ unset / UTC).
+test_localtime0_after_localtime1() ->
+    _ = erlang:localtime("EST5EDT,M3.2.0/2,M11.1.0/2"),
+    _ = erlang:localtime("CET-1CEST,M3.5.0,M10.5.0/3"),
+    _ = erlang:localtime("JST-9"),
+    UTC1 = erlang:universaltime(),
+    Local = erlang:localtime(),
+    UTC2 = erlang:universaltime(),
+    %% Default TZ on ESP32 is UTC, so localtime/0 should equal universaltime/0
+    %% modulo the second tick.
+    true = UTC1 =< Local andalso Local =< UTC2,
+    ok.
+
+%% A non-string / non-list / non-binary TZ argument must raise badarg, not
+%% crash or leak. Binaries are accepted by interop_term_to_string and are
+%% therefore valid TZ inputs (verified below).
+test_badarg() ->
+    ok = expect_badarg(fun() -> erlang:localtime(42) end),
+    ok = expect_badarg(fun() -> erlang:localtime({tuple, ok}) end),
+    %% Binary TZ should be accepted (and decoded).
+    UTCTime1 = erlang:universaltime(),
+    BinUTC = erlang:localtime(<<"UTC0">>),
+    UTCTime2 = erlang:universaltime(),
+    true = UTCTime1 =< BinUTC andalso BinUTC =< UTCTime2,
+    ok.
+
+expect_badarg(F) ->
+    try F() of
+        R -> {unexpected_result, R}
+    catch
+        error:badarg -> ok
+    end.
+
+%% Memory-leak regression test for the newlib/picolibc setenv leak fix.
+%% Calls localtime/1 ?LEAK_ITERATIONS times rotating through 4 distinct
+%% TZ rules and asserts the free heap does not shrink by more than
+%% ?LEAK_SLACK_BYTES.
+test_no_leak() ->
+    %% Warm-up: trigger any one-time allocations (atom table growth,
+    %% libc internal state, etc.) before snapshotting the heap.
+    leak_loop(16),
+    erlang:garbage_collect(),
+
+    Before = erlang:system_info(esp32_free_heap_size),
+    leak_loop(?LEAK_ITERATIONS),
+    erlang:garbage_collect(),
+    After = erlang:system_info(esp32_free_heap_size),
+
+    Delta = Before - After,
+    erlang:display({tz_leak_check, before, Before, after_, After, delta, Delta}),
+
+    case Delta =< ?LEAK_SLACK_BYTES of
+        true ->
+            ok;
+        false ->
+            erlang:display({tz_leak_detected, Delta, slack, ?LEAK_SLACK_BYTES}),
+            {error, {tz_leak_detected, Delta}}
+    end.
+
+leak_loop(0) ->
+    ok;
+leak_loop(N) ->
+    TZ =
+        case N rem 4 of
+            0 -> "UTC0";
+            1 -> "EST5EDT,M3.2.0/2,M11.1.0/2";
+            2 -> "CET-1CEST,M3.5.0,M10.5.0/3";
+            3 -> "JST-9"
+        end,
+    _ = erlang:localtime(TZ),
+    leak_loop(N - 1).


### PR DESCRIPTION
Fixes https://github.com/atomvm/AtomVM/issues/2062

replicate:

```
  def myloop do
    :erlang.localtime("CET-1CEST,M3.5.0,M10.5.0/3")
    |> IO.inspect()

    :timer.sleep(100)

    :erlang.system_info(:esp32_free_heap_size)
    |> IO.inspect()

    myloop()
  end
```
And see rapidly decreasing free memory - solution inspired by https://github.com/espressif/esp-idf/issues/9764

Currently in draft, as I believe there is some issue with setting the tz to "" on generic_unix - which means it is set to utc, just need to understand that or guard it..

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
