### PR TITLE
Fix unix socket driver listener lifecycle races

### DIFF
--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -1046,6 +1046,13 @@ static EventListener *accept_callback(GlobalContext *glb, EventListener *base_li
     socklen_t clientlen = sizeof(clientaddr);
     int fd = accept(listener->base.fd, (struct sockaddr *) &clientaddr, &clientlen);
     Context *ctx = globalcontext_get_process_lock(glb, listener->process_id);
+    if (UNLIKELY(ctx == NULL)) {
+        if (fd != -1) {
+            close(fd);
+        }
+        free(listener);
+        return NULL;
+    }
     SocketDriverData *socket_data = (SocketDriverData *) ctx->platform_data;
     EventListener *result = NULL;
     if (fd == -1) {

--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -1060,6 +1060,21 @@ static EventListener *accept_callback(GlobalContext *glb, EventListener *base_li
         TRACE("socket_driver|accept_callback: accepted connection.  fd: %i\n", fd);
 
         term pid = listener->pid;
+        if (UNLIKELY(fcntl(fd, F_SETFL, O_NONBLOCK) == -1)) {
+            int err = errno;
+            close(fd);
+            BEGIN_WITH_STACK_HEAP(12, heap);
+            term ref = term_from_ref_ticks(listener->ref_ticks, &heap);
+            term reply = port_heap_create_reply(&heap, ref, port_heap_create_sys_error_tuple(&heap, FCNTL_ATOM, err));
+            port_send_message_nolock(glb, pid, reply);
+            END_WITH_STACK_HEAP(heap, glb);
+            globalcontext_get_process_unlock(glb, ctx);
+            if (socket_data->passive_listener) {
+                socket_data->passive_listener = NULL;
+                free(listener);
+            }
+            return NULL;
+        }
         SocketDriverData *new_socket_data = socket_driver_create_data();
         new_socket_data->sockfd = fd;
         new_socket_data->proto = socket_data->proto;

--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -47,6 +47,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+void sys_unregister_listener_nolock(GlobalContext *global, struct EventListener *listener);
+
 // #define ENABLE_TRACE
 #include "trace.h"
 
@@ -1194,31 +1196,26 @@ static NativeHandlerResult socket_consume_mailbox(Context *ctx)
         TRACE("close\n");
         port_send_reply(ctx, pid, ref, OK_ATOM);
         SocketDriverData *socket_data = (SocketDriverData *) ctx->platform_data;
-        // Callbacks (active_recv_callback, passive_recv_callback) are called
-        // while glb->listeners lock is held. They may want to free the
-        // listener, causing a potential double free here.
-        // We acquire the lock on listeners here and set the listeners
-        // to NULL in the socket_data structure to prevent them from freeing
-        // the listeners.
+        // Callbacks (active_recv_callback, passive_recv_callback, accept_callback)
+        // are called while glb->listeners lock is held. They may free the
+        // listener and set the socket_data pointer to NULL.
+        // We must atomically detach the pointers AND unlink from the listeners
+        // list under the same lock hold, to prevent a race where the callback
+        // also unlinks the same listener node.
         synclist_wrlock(&glb->listeners);
         ActiveRecvListener *active_listener = socket_data->active_listener;
         PassiveRecvListener *passive_listener = socket_data->passive_listener;
         socket_data->active_listener = NULL;
         socket_data->passive_listener = NULL;
-        synclist_unlock(&glb->listeners);
         if (active_listener) {
-            // Then we unregister, which also acquires the lock. The callbacks
-            // may have returned NULL which means the listener would no longer
-            // be registered, but this will work.
-            sys_unregister_listener(glb, &active_listener->base);
-            // After the listener is unregistered, the callbacks can no longer
-            // be called, so we can eventually free the listener
-            free(active_listener);
+            sys_unregister_listener_nolock(glb, &active_listener->base);
         }
         if (passive_listener) {
-            sys_unregister_listener(glb, &passive_listener->base);
-            free(passive_listener);
+            sys_unregister_listener_nolock(glb, &passive_listener->base);
         }
+        synclist_unlock(&glb->listeners);
+        free(active_listener);
+        free(passive_listener);
         socket_driver_do_close(ctx);
         // We don't need to remove message.
         return NativeTerminate;

--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -255,8 +255,8 @@ static term init_udp_socket(Context *ctx, SocketDriverData *socket_data, term pa
             listener->base.handler = active_recvfrom_callback;
             listener->buf_size = socket_data->buffer;
             listener->process_id = ctx->process_id;
-            sys_register_listener(glb, &listener->base);
             socket_data->active_listener = listener;
+            sys_register_listener(glb, &listener->base);
         }
     }
     return ret;
@@ -340,8 +340,8 @@ static term init_client_tcp_socket(Context *ctx, SocketDriverData *socket_data, 
             listener->base.handler = active_recv_callback;
             listener->buf_size = socket_data->buffer;
             listener->process_id = ctx->process_id;
-            sys_register_listener(glb, &listener->base);
             socket_data->active_listener = listener;
+            sys_register_listener(glb, &listener->base);
         }
     }
     return ret;
@@ -1017,8 +1017,8 @@ static void do_recv(Context *ctx, term pid, term ref, term length, term timeout,
     listener->length = term_to_int(length);
     listener->buffer = socket_data->buffer;
     listener->ref_ticks = term_to_ref_ticks(ref);
-    sys_register_listener(glb, &listener->base);
     socket_data->passive_listener = listener;
+    sys_register_listener(glb, &listener->base);
 }
 
 void socket_driver_do_recvfrom(Context *ctx, term pid, term ref, term length, term timeout)
@@ -1119,8 +1119,8 @@ void socket_driver_do_accept(Context *ctx, term pid, term ref, term timeout)
     listener->length = 0;
     listener->buffer = 0;
     listener->ref_ticks = term_to_ref_ticks(ref);
-    sys_register_listener(glb, &listener->base);
     socket_data->passive_listener = listener;
+    sys_register_listener(glb, &listener->base);
 }
 
 static NativeHandlerResult socket_consume_mailbox(Context *ctx)

--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -47,6 +47,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+void sys_register_listener_nolock(GlobalContext *global, struct EventListener *listener);
 void sys_unregister_listener_nolock(GlobalContext *global, struct EventListener *listener);
 
 // #define ENABLE_TRACE
@@ -84,6 +85,22 @@ typedef struct SocketDriverData
     ActiveRecvListener *active_listener;
     PassiveRecvListener *passive_listener;
 } SocketDriverData;
+
+static void register_active_listener(GlobalContext *glb, SocketDriverData *socket_data, ActiveRecvListener *listener)
+{
+    synclist_wrlock(&glb->listeners);
+    socket_data->active_listener = listener;
+    sys_register_listener_nolock(glb, &listener->base);
+    synclist_unlock(&glb->listeners);
+}
+
+static void register_passive_listener(GlobalContext *glb, SocketDriverData *socket_data, PassiveRecvListener *listener)
+{
+    synclist_wrlock(&glb->listeners);
+    socket_data->passive_listener = listener;
+    sys_register_listener_nolock(glb, &listener->base);
+    synclist_unlock(&glb->listeners);
+}
 
 // clang-format off
 // TODO define in defaultatoms
@@ -255,8 +272,7 @@ static term init_udp_socket(Context *ctx, SocketDriverData *socket_data, term pa
             listener->base.handler = active_recvfrom_callback;
             listener->buf_size = socket_data->buffer;
             listener->process_id = ctx->process_id;
-            socket_data->active_listener = listener;
-            sys_register_listener(glb, &listener->base);
+            register_active_listener(glb, socket_data, listener);
         }
     }
     return ret;
@@ -340,8 +356,7 @@ static term init_client_tcp_socket(Context *ctx, SocketDriverData *socket_data, 
             listener->base.handler = active_recv_callback;
             listener->buf_size = socket_data->buffer;
             listener->process_id = ctx->process_id;
-            socket_data->active_listener = listener;
-            sys_register_listener(glb, &listener->base);
+            register_active_listener(glb, socket_data, listener);
         }
     }
     return ret;
@@ -733,10 +748,10 @@ static EventListener *active_recv_callback(GlobalContext *glb, EventListener *ba
         port_send_message_nolock(glb, pid, msg);
         mailbox_send(ctx, globalcontext_make_atom(glb, close_internal));
         // See socket_consume_mailbox close path below
-        if (socket_data->active_listener) {
+        if (socket_data->active_listener == listener) {
             socket_data->active_listener = NULL;
-            free(listener);
         }
+        free(listener);
         result = NULL;
         END_WITH_STACK_HEAP(heap, glb);
     } else {
@@ -837,12 +852,12 @@ static EventListener *passive_recv_callback(GlobalContext *glb, EventListener *b
         port_send_message_nolock(glb, pid, reply);
         memory_destroy_heap(&heap, glb);
     }
-    globalcontext_get_process_unlock(glb, ctx);
     // See socket_consume_mailbox close path below
-    if (socket_data->passive_listener) {
+    if (socket_data->passive_listener == listener) {
         socket_data->passive_listener = NULL;
-        free(listener);
     }
+    globalcontext_get_process_unlock(glb, ctx);
+    free(listener);
     free(buf);
     // remove the EventListener from the global list
     return NULL;
@@ -977,12 +992,12 @@ static EventListener *passive_recvfrom_callback(GlobalContext *glb, EventListene
         port_send_message_nolock(glb, pid, reply);
         memory_destroy_heap(&heap, glb);
     }
-    globalcontext_get_process_unlock(glb, ctx);
     // See socket_consume_mailbox close path below
-    if (socket_data->passive_listener) {
+    if (socket_data->passive_listener == listener) {
         socket_data->passive_listener = NULL;
-        free(listener);
     }
+    globalcontext_get_process_unlock(glb, ctx);
+    free(listener);
     free(buf);
     // remove the EventListener from the global list and clean up
     return NULL;
@@ -1017,8 +1032,7 @@ static void do_recv(Context *ctx, term pid, term ref, term length, term timeout,
     listener->length = term_to_int(length);
     listener->buffer = socket_data->buffer;
     listener->ref_ticks = term_to_ref_ticks(ref);
-    socket_data->passive_listener = listener;
-    sys_register_listener(glb, &listener->base);
+    register_passive_listener(glb, socket_data, listener);
 }
 
 void socket_driver_do_recvfrom(Context *ctx, term pid, term ref, term length, term timeout)
@@ -1075,11 +1089,11 @@ static EventListener *accept_callback(GlobalContext *glb, EventListener *base_li
             term reply = port_heap_create_reply(&heap, ref, port_heap_create_sys_error_tuple(&heap, FCNTL_ATOM, err));
             port_send_message_nolock(glb, pid, reply);
             END_WITH_STACK_HEAP(heap, glb);
-            globalcontext_get_process_unlock(glb, ctx);
-            if (socket_data->passive_listener) {
+            if (socket_data->passive_listener == listener) {
                 socket_data->passive_listener = NULL;
-                free(listener);
             }
+            globalcontext_get_process_unlock(glb, ctx);
+            free(listener);
             return NULL;
         }
         SocketDriverData *new_socket_data = socket_driver_create_data();
@@ -1094,9 +1108,12 @@ static EventListener *accept_callback(GlobalContext *glb, EventListener *base_li
         Context *new_ctx = create_accepting_socket(glb, new_socket_data);
         ctx = globalcontext_get_process_lock(glb, listener->process_id);
         if (UNLIKELY(ctx == NULL)) {
+            socket_driver_do_close(new_ctx);
+            scheduler_terminate(new_ctx);
             free(listener);
             return NULL;
         }
+        socket_data = (SocketDriverData *) ctx->platform_data;
         if (new_socket_data->active) {
             result = &create_accepting_socket_listener(new_ctx, new_socket_data)->base;
         }
@@ -1110,12 +1127,12 @@ static EventListener *accept_callback(GlobalContext *glb, EventListener *base_li
         port_send_message_nolock(glb, pid, reply);
         END_WITH_STACK_HEAP(heap, glb);
     }
-    globalcontext_get_process_unlock(glb, ctx);
     // See socket_consume_mailbox close path below
-    if (socket_data->passive_listener) {
+    if (socket_data->passive_listener == listener) {
         socket_data->passive_listener = NULL;
-        free(listener);
     }
+    globalcontext_get_process_unlock(glb, ctx);
+    free(listener);
     // remove the EventListener from the global list and replace it if needed
     return result;
 }
@@ -1141,8 +1158,7 @@ void socket_driver_do_accept(Context *ctx, term pid, term ref, term timeout)
     listener->length = 0;
     listener->buffer = 0;
     listener->ref_ticks = term_to_ref_ticks(ref);
-    socket_data->passive_listener = listener;
-    sys_register_listener(glb, &listener->base);
+    register_passive_listener(glb, socket_data, listener);
 }
 
 static NativeHandlerResult socket_consume_mailbox(Context *ctx)

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -698,6 +698,12 @@ void sys_unregister_listener(GlobalContext *global, struct EventListener *listen
     synclist_remove(&global->listeners, &listener->listeners_list_head);
 }
 
+void sys_unregister_listener_nolock(GlobalContext *global, struct EventListener *listener)
+{
+    listener_event_remove_from_polling_set(listener->fd, global);
+    list_remove(&listener->listeners_list_head);
+}
+
 void sys_register_select_event(GlobalContext *global, ErlNifEvent event, bool is_write)
 {
     struct GenericUnixPlatformData *platform = global->platform_data;

--- a/src/platforms/generic_unix/lib/sys.c
+++ b/src/platforms/generic_unix/lib/sys.c
@@ -660,9 +660,8 @@ void event_listener_add_to_polling_set(struct EventListener *listener, GlobalCon
 #endif
 }
 
-void sys_register_listener(GlobalContext *global, struct EventListener *listener)
+void sys_register_listener_nolock(GlobalContext *global, struct EventListener *listener)
 {
-    struct ListHead *listeners = synclist_wrlock(&global->listeners);
     event_listener_add_to_polling_set(listener, global);
 #ifndef AVM_NO_SMP
 #ifndef HAVE_KQUEUE
@@ -670,7 +669,13 @@ void sys_register_listener(GlobalContext *global, struct EventListener *listener
     sys_signal(global);
 #endif
 #endif
-    list_append(listeners, &listener->listeners_list_head);
+    list_append(synclist_nolock(&global->listeners), &listener->listeners_list_head);
+}
+
+void sys_register_listener(GlobalContext *global, struct EventListener *listener)
+{
+    synclist_wrlock(&global->listeners);
+    sys_register_listener_nolock(global, listener);
     synclist_unlock(&global->listeners);
 }
 
@@ -692,16 +697,17 @@ static void listener_event_remove_from_polling_set(listener_event_t listener_fd,
 #endif
 }
 
-void sys_unregister_listener(GlobalContext *global, struct EventListener *listener)
-{
-    listener_event_remove_from_polling_set(listener->fd, global);
-    synclist_remove(&global->listeners, &listener->listeners_list_head);
-}
-
 void sys_unregister_listener_nolock(GlobalContext *global, struct EventListener *listener)
 {
     listener_event_remove_from_polling_set(listener->fd, global);
     list_remove(&listener->listeners_list_head);
+}
+
+void sys_unregister_listener(GlobalContext *global, struct EventListener *listener)
+{
+    synclist_wrlock(&global->listeners);
+    sys_unregister_listener_nolock(global, listener);
+    synclist_unlock(&global->listeners);
 }
 
 void sys_register_select_event(GlobalContext *global, ErlNifEvent event, bool is_write)


### PR DESCRIPTION
https://ampcode.com/threads/T-019cb8b8-9e4c-7316-9566-c7e3f5f2b6db

Claims to fix https://github.com/atomvm/AtomVM/issues/2155

# 1
Fix a use-after-free race condition in the generic_unix socket driver's close handler, detected by Valgrind during CI gen_tcp tests.

The close handler in socket_consume_mailbox used a two-phase locking pattern: it acquired the glb->listeners lock to NULL-out the socket_data listener pointers, released it, then called sys_unregister_listener (which re-acquires the lock) to remove the listener from the linked list. Between the unlock and re-lock, the event loop thread could also unlink the same listener node via process_listener_handler after the callback returned NULL. The subsequent list_remove in sys_unregister_listener then operated on stale prev/next pointers, corrupting the list or writing to freed memory.

The fix makes the pointer detach and list unlink atomic under a single lock hold by introducing sys_unregister_listener_nolock, a variant that assumes the caller already holds the glb->listeners write lock. The close handler now NULLs the pointers, unlinks the listeners, and releases the lock before freeing the memory.

# 2
Follow-up analysis also found a separate listener publication race in the same generic_unix socket driver path. Several active and passive listener setup paths registered a listener in the global listener list before publishing the corresponding socket_data->{active,passive}_listener pointer. If the event loop processed that listener in the small window before the pointer assignment, the callback could consume, free, or replace the listener first, and the later assignment would leave socket_data pointing at stale listener memory. That race could surface as random hangs or corruption in CI gen_tcp tests.

Together, these fixes make listener publication, teardown, and unlinking consistent with the event loop's locking model on generic_unix. 

This pattern is specific to generic_unix; ESP32 and RP2 use a single global listener for the socket driver subsystem and are not affected.

# 3
Configure newly accepted TCP sockets as nonblocking before publishing them to the socket driver machinery. Without this, an accepted fd inherits the listening socket's flags, which may be blocking at the point of accept(). Subsequent non-blocking I/O on that connection (active-mode recv, passive recv with timeout) could then block the event loop thread indefinitely.

If fcntl fails, the accepted fd is closed and an error reply is sent to the caller so no partially initialized connection is ever observed. The error path mirrors the existing accept-failure handling and is consistent with otp_socket.c, which already sets accepted fds nonblocking.

# 4
Fix a NULL pointer dereference in accept_callback when the owning process terminates between the accept() syscall and the globalcontext_get_process_lock() call. The code previously dereferenced ctx->platform_data unconditionally; if the process had already exited, ctx would be NULL and the VM would segfault.

Add a NULL check consistent with other callbacks in the same file (e.g. recv_callback): close the accepted fd if valid, free the listener, and return NULL to remove the event listener from the global list.


These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
