### PR TITLE
Support integer parts-per-second time unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0-beta.0] - Unreleased
 
+### Added
+
+- Added support for integer parts-per-second timeunit, with `badarg` raised on int64 overflow
+
 ## [0.7.0-alpha.1] - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for configuring pins and width for sdmmc on ESP32
 - Added support for map comprehensions
 - Added USB CDC port drivers for ESP32, RP2, and STM32 platforms
+- Added support for integer parts-per-second time unit, with `badarg` raised on int64 overflow
 
 ### Changed
 - Updated network type db() to dbm() to reflect the actual representation of the type

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -189,7 +189,7 @@
 -type atom_encoding() :: latin1 | utf8 | unicode.
 
 -type mem_type() :: binary.
--type time_unit() :: second | millisecond | microsecond | nanosecond | native.
+-type time_unit() :: second | millisecond | microsecond | nanosecond | native | pos_integer().
 -type timestamp() :: {
     MegaSecs :: non_neg_integer(), Secs :: non_neg_integer(), MicroSecs :: non_neg_integer
 }.

--- a/libs/exavmlib/lib/System.ex
+++ b/libs/exavmlib/lib/System.ex
@@ -26,6 +26,7 @@ defmodule System do
           | :millisecond
           | :microsecond
           | :nanosecond
+          | pos_integer()
 
   @doc """
   Returns the current monotonic time in the `:native` time unit.

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1867,6 +1867,30 @@ term nif_erlang_monotonic_time_1(Context *ctx, int argc, term argv[])
     } else if (unit == NANOSECOND_ATOM || unit == NATIVE_ATOM) {
         return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * INT64_C(1000000000) + ts.tv_nsec);
 
+    } else if (term_is_int64(unit)) {
+        avm_int64_t parts_per_second = term_maybe_unbox_int64(unit);
+        if (UNLIKELY(parts_per_second <= 0)) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        if (UNLIKELY(
+                ((ts.tv_sec > 0) && ((avm_int64_t) ts.tv_sec > INT64_MAX / parts_per_second))
+                || ((ts.tv_sec < 0) && ((avm_int64_t) ts.tv_sec < INT64_MIN / parts_per_second)))) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        avm_int64_t second_part = (avm_int64_t) ts.tv_sec * parts_per_second;
+        avm_int64_t quotient = parts_per_second / INT64_C(1000000000);
+        avm_int64_t remainder = parts_per_second % INT64_C(1000000000);
+        avm_int64_t fractional_high = (avm_int64_t) ts.tv_nsec * quotient;
+        avm_int64_t fractional_low = ((avm_int64_t) ts.tv_nsec * remainder) / INT64_C(1000000000);
+        if (UNLIKELY(fractional_high > INT64_MAX - fractional_low)) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        avm_int64_t fractional_part = fractional_high + fractional_low;
+        if (UNLIKELY(second_part > INT64_MAX - fractional_part)) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        return make_maybe_boxed_int64(ctx, second_part + fractional_part);
+
     } else {
         RAISE_ERROR(BADARG_ATOM);
     }
@@ -1897,6 +1921,30 @@ term nif_erlang_system_time_1(Context *ctx, int argc, term argv[])
 
     } else if (unit == NANOSECOND_ATOM || unit == NATIVE_ATOM) {
         return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * INT64_C(1000000000) + ts.tv_nsec);
+
+    } else if (term_is_int64(unit)) {
+        avm_int64_t parts_per_second = term_maybe_unbox_int64(unit);
+        if (UNLIKELY(parts_per_second <= 0)) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        if (UNLIKELY(
+                ((ts.tv_sec > 0) && ((avm_int64_t) ts.tv_sec > INT64_MAX / parts_per_second))
+                || ((ts.tv_sec < 0) && ((avm_int64_t) ts.tv_sec < INT64_MIN / parts_per_second)))) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        avm_int64_t second_part = (avm_int64_t) ts.tv_sec * parts_per_second;
+        avm_int64_t quotient = parts_per_second / INT64_C(1000000000);
+        avm_int64_t remainder = parts_per_second % INT64_C(1000000000);
+        avm_int64_t fractional_high = (avm_int64_t) ts.tv_nsec * quotient;
+        avm_int64_t fractional_low = ((avm_int64_t) ts.tv_nsec * remainder) / INT64_C(1000000000);
+        if (UNLIKELY(fractional_high > INT64_MAX - fractional_low)) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        avm_int64_t fractional_part = fractional_high + fractional_low;
+        if (UNLIKELY(second_part > INT64_MAX - fractional_part)) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        return make_maybe_boxed_int64(ctx, second_part + fractional_part);
 
     } else {
         RAISE_ERROR(BADARG_ATOM);
@@ -2011,7 +2059,6 @@ term nif_calendar_system_time_to_universal_time_2(Context *ctx, int argc, term a
     UNUSED(argc);
 
     struct timespec ts;
-
     avm_int64_t value = term_maybe_unbox_int64(argv[0]);
 
     if (argv[1] == SECOND_ATOM) {
@@ -2029,6 +2076,20 @@ term nif_calendar_system_time_to_universal_time_2(Context *ctx, int argc, term a
     } else if (argv[1] == NANOSECOND_ATOM || argv[1] == NATIVE_ATOM) {
         ts.tv_sec = (time_t) (value / INT64_C(1000000000));
         ts.tv_nsec = value % INT64_C(1000000000);
+
+    } else if (term_is_int64(argv[1])) {
+        avm_int64_t parts_per_second = term_maybe_unbox_int64(argv[1]);
+        if (UNLIKELY(parts_per_second <= 0)) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        if (UNLIKELY(!term_is_int64(argv[0]))) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        ts.tv_sec = (time_t) (value / parts_per_second);
+        if ((value % parts_per_second) < 0) {
+            ts.tv_sec -= 1;
+        }
+        ts.tv_nsec = 0;
 
     } else {
         RAISE_ERROR(BADARG_ATOM);

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2055,45 +2055,38 @@ term nif_erlang_timestamp_0(Context *ctx, int argc, term argv[])
 
 term nif_calendar_system_time_to_universal_time_2(Context *ctx, int argc, term argv[])
 {
-    UNUSED(ctx);
     UNUSED(argc);
 
-    struct timespec ts;
+    if (UNLIKELY(!term_is_int64(argv[0]))) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
     avm_int64_t value = term_maybe_unbox_int64(argv[0]);
 
+    avm_int64_t divisor;
     if (argv[1] == SECOND_ATOM) {
-        ts.tv_sec = (time_t) value;
-        ts.tv_nsec = 0;
-
+        divisor = 1;
     } else if (argv[1] == MILLISECOND_ATOM) {
-        ts.tv_sec = (time_t) (value / 1000);
-        ts.tv_nsec = (value % 1000) * 1000000;
-
+        divisor = 1000;
     } else if (argv[1] == MICROSECOND_ATOM) {
-        ts.tv_sec = (time_t) (value / 1000000);
-        ts.tv_nsec = (value % 1000000) * 1000;
-
+        divisor = INT64_C(1000000);
     } else if (argv[1] == NANOSECOND_ATOM || argv[1] == NATIVE_ATOM) {
-        ts.tv_sec = (time_t) (value / INT64_C(1000000000));
-        ts.tv_nsec = value % INT64_C(1000000000);
-
+        divisor = INT64_C(1000000000);
     } else if (term_is_int64(argv[1])) {
-        avm_int64_t parts_per_second = term_maybe_unbox_int64(argv[1]);
-        if (UNLIKELY(parts_per_second <= 0)) {
+        divisor = term_maybe_unbox_int64(argv[1]);
+        if (UNLIKELY(divisor <= 0)) {
             RAISE_ERROR(BADARG_ATOM);
         }
-        if (UNLIKELY(!term_is_int64(argv[0]))) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-        ts.tv_sec = (time_t) (value / parts_per_second);
-        if ((value % parts_per_second) < 0) {
-            ts.tv_sec -= 1;
-        }
-        ts.tv_nsec = 0;
-
     } else {
         RAISE_ERROR(BADARG_ATOM);
     }
+
+    // Floor division: round negative fractional seconds toward negative infinity
+    avm_int64_t quotient = value / divisor;
+    avm_int64_t remainder = value % divisor;
+    struct timespec ts = {
+        .tv_sec = (time_t) (quotient - (remainder < 0)),
+        .tv_nsec = 0
+    };
 
     struct tm broken_down_time;
     return build_datetime_from_tm(ctx, gmtime_r(&ts.tv_sec, &broken_down_time));

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1841,10 +1841,122 @@ term nif_erlang_make_ref_0(Context *ctx, int argc, term argv[])
     return term_from_ref_ticks(ref_ticks, &ctx->heap);
 }
 
+static bool time_unit_to_parts_per_second(term unit, avm_int64_t *parts_per_second)
+{
+    if (unit == SECOND_ATOM) {
+        *parts_per_second = 1;
+    } else if (unit == MILLISECOND_ATOM) {
+        *parts_per_second = 1000;
+    } else if (unit == MICROSECOND_ATOM) {
+        *parts_per_second = INT64_C(1000000);
+    } else if (unit == NANOSECOND_ATOM || unit == NATIVE_ATOM) {
+        *parts_per_second = INT64_C(1000000000);
+    } else if (term_is_int64(unit)) {
+        *parts_per_second = term_maybe_unbox_int64(unit);
+        if (UNLIKELY(*parts_per_second <= 0)) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    return true;
+}
+
+// Convert nanoseconds to parts using: parts = nanoseconds * pps / 1e9
+// Splits into high/low to avoid intermediate overflow.
+// Caller must ensure 0 <= nanoseconds < 1e9 and pps > 0.
+static bool nanoseconds_to_parts_per_second(
+    avm_int64_t nanoseconds, avm_int64_t parts_per_second, bool round_up, avm_int64_t *parts)
+{
+    avm_int64_t quotient = parts_per_second / INT64_C(1000000000);
+    avm_int64_t remainder = parts_per_second % INT64_C(1000000000);
+    avm_int64_t fractional_high = nanoseconds * quotient;
+    avm_int64_t remainder_product = nanoseconds * remainder;
+    avm_int64_t fractional_low = remainder_product / INT64_C(1000000000);
+
+    if (round_up && (remainder_product % INT64_C(1000000000)) != 0) {
+        fractional_low += 1;
+    }
+
+    if (UNLIKELY(fractional_high > INT64_MAX - fractional_low)) {
+        return false;
+    }
+
+    *parts = fractional_high + fractional_low;
+    return true;
+}
+
+// Convert a normalized timespec (0 <= tv_nsec < 1e9) to integer parts.
+// Uses floor semantics for negative timestamps with non-zero tv_nsec.
+static bool timespec_to_parts_per_second(
+    const struct timespec *ts, avm_int64_t parts_per_second, avm_int64_t *parts)
+{
+    avm_int64_t seconds = (avm_int64_t) ts->tv_sec;
+    avm_int64_t fractional_part;
+
+    if (ts->tv_nsec == 0 || seconds >= 0) {
+        if (UNLIKELY(
+                ((seconds > 0) && (seconds > INT64_MAX / parts_per_second))
+                || ((seconds < 0) && (seconds < INT64_MIN / parts_per_second)))) {
+            return false;
+        }
+
+        if (UNLIKELY(!nanoseconds_to_parts_per_second(
+                (avm_int64_t) ts->tv_nsec, parts_per_second, false, &fractional_part))) {
+            return false;
+        }
+
+        avm_int64_t second_part = seconds * parts_per_second;
+        if (UNLIKELY(second_part > INT64_MAX - fractional_part)) {
+            return false;
+        }
+
+        *parts = second_part + fractional_part;
+        return true;
+    }
+
+    // Preserve floor semantics for normalized negative timespecs such as {-2, 999999999}.
+    avm_int64_t adjusted_seconds = seconds + 1;
+    if (UNLIKELY(adjusted_seconds < INT64_MIN / parts_per_second)) {
+        return false;
+    }
+
+    if (UNLIKELY(!nanoseconds_to_parts_per_second(
+            INT64_C(1000000000) - (avm_int64_t) ts->tv_nsec, parts_per_second, true,
+            &fractional_part))) {
+        return false;
+    }
+
+    avm_int64_t second_part = adjusted_seconds * parts_per_second;
+    if (UNLIKELY(second_part < INT64_MIN + fractional_part)) {
+        return false;
+    }
+
+    *parts = second_part - fractional_part;
+    return true;
+}
+
+static term make_time_in_unit(Context *ctx, term unit, void (*time_fun)(struct timespec *))
+{
+    avm_int64_t parts_per_second;
+    if (UNLIKELY(!time_unit_to_parts_per_second(unit, &parts_per_second))) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    struct timespec ts;
+    time_fun(&ts);
+
+    avm_int64_t value;
+    if (UNLIKELY(!timespec_to_parts_per_second(&ts, parts_per_second, &value))) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    return make_maybe_boxed_int64(ctx, value);
+}
+
 term nif_erlang_monotonic_time_1(Context *ctx, int argc, term argv[])
 {
-    UNUSED(ctx);
-
     term unit;
     if (argc == 0) {
         unit = NATIVE_ATOM;
@@ -1852,54 +1964,11 @@ term nif_erlang_monotonic_time_1(Context *ctx, int argc, term argv[])
         unit = argv[0];
     }
 
-    struct timespec ts;
-    sys_monotonic_time(&ts);
-
-    if (unit == SECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ts.tv_sec);
-
-    } else if (unit == MILLISECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000UL + ts.tv_nsec / 1000000UL);
-
-    } else if (unit == MICROSECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000UL + ts.tv_nsec / 1000UL);
-
-    } else if (unit == NANOSECOND_ATOM || unit == NATIVE_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * INT64_C(1000000000) + ts.tv_nsec);
-
-    } else if (term_is_int64(unit)) {
-        avm_int64_t parts_per_second = term_maybe_unbox_int64(unit);
-        if (UNLIKELY(parts_per_second <= 0)) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-        if (UNLIKELY(
-                ((ts.tv_sec > 0) && ((avm_int64_t) ts.tv_sec > INT64_MAX / parts_per_second))
-                || ((ts.tv_sec < 0) && ((avm_int64_t) ts.tv_sec < INT64_MIN / parts_per_second)))) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-        avm_int64_t second_part = (avm_int64_t) ts.tv_sec * parts_per_second;
-        avm_int64_t quotient = parts_per_second / INT64_C(1000000000);
-        avm_int64_t remainder = parts_per_second % INT64_C(1000000000);
-        avm_int64_t fractional_high = (avm_int64_t) ts.tv_nsec * quotient;
-        avm_int64_t fractional_low = ((avm_int64_t) ts.tv_nsec * remainder) / INT64_C(1000000000);
-        if (UNLIKELY(fractional_high > INT64_MAX - fractional_low)) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-        avm_int64_t fractional_part = fractional_high + fractional_low;
-        if (UNLIKELY(second_part > INT64_MAX - fractional_part)) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-        return make_maybe_boxed_int64(ctx, second_part + fractional_part);
-
-    } else {
-        RAISE_ERROR(BADARG_ATOM);
-    }
+    return make_time_in_unit(ctx, unit, sys_monotonic_time);
 }
 
 term nif_erlang_system_time_1(Context *ctx, int argc, term argv[])
 {
-    UNUSED(ctx);
-
     term unit;
     if (argc == 0) {
         unit = NATIVE_ATOM;
@@ -1907,48 +1976,7 @@ term nif_erlang_system_time_1(Context *ctx, int argc, term argv[])
         unit = argv[0];
     }
 
-    struct timespec ts;
-    sys_time(&ts);
-
-    if (unit == SECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ts.tv_sec);
-
-    } else if (unit == MILLISECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000UL + ts.tv_nsec / 1000000UL);
-
-    } else if (unit == MICROSECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000UL + ts.tv_nsec / 1000UL);
-
-    } else if (unit == NANOSECOND_ATOM || unit == NATIVE_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * INT64_C(1000000000) + ts.tv_nsec);
-
-    } else if (term_is_int64(unit)) {
-        avm_int64_t parts_per_second = term_maybe_unbox_int64(unit);
-        if (UNLIKELY(parts_per_second <= 0)) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-        if (UNLIKELY(
-                ((ts.tv_sec > 0) && ((avm_int64_t) ts.tv_sec > INT64_MAX / parts_per_second))
-                || ((ts.tv_sec < 0) && ((avm_int64_t) ts.tv_sec < INT64_MIN / parts_per_second)))) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-        avm_int64_t second_part = (avm_int64_t) ts.tv_sec * parts_per_second;
-        avm_int64_t quotient = parts_per_second / INT64_C(1000000000);
-        avm_int64_t remainder = parts_per_second % INT64_C(1000000000);
-        avm_int64_t fractional_high = (avm_int64_t) ts.tv_nsec * quotient;
-        avm_int64_t fractional_low = ((avm_int64_t) ts.tv_nsec * remainder) / INT64_C(1000000000);
-        if (UNLIKELY(fractional_high > INT64_MAX - fractional_low)) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-        avm_int64_t fractional_part = fractional_high + fractional_low;
-        if (UNLIKELY(second_part > INT64_MAX - fractional_part)) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-        return make_maybe_boxed_int64(ctx, second_part + fractional_part);
-
-    } else {
-        RAISE_ERROR(BADARG_ATOM);
-    }
+    return make_time_in_unit(ctx, unit, sys_time);
 }
 
 static term build_datetime_from_tm(Context *ctx, struct tm *broken_down_time)
@@ -2062,27 +2090,14 @@ term nif_calendar_system_time_to_universal_time_2(Context *ctx, int argc, term a
     }
     avm_int64_t value = term_maybe_unbox_int64(argv[0]);
 
-    avm_int64_t divisor;
-    if (argv[1] == SECOND_ATOM) {
-        divisor = 1;
-    } else if (argv[1] == MILLISECOND_ATOM) {
-        divisor = 1000;
-    } else if (argv[1] == MICROSECOND_ATOM) {
-        divisor = INT64_C(1000000);
-    } else if (argv[1] == NANOSECOND_ATOM || argv[1] == NATIVE_ATOM) {
-        divisor = INT64_C(1000000000);
-    } else if (term_is_int64(argv[1])) {
-        divisor = term_maybe_unbox_int64(argv[1]);
-        if (UNLIKELY(divisor <= 0)) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-    } else {
+    avm_int64_t parts_per_second;
+    if (UNLIKELY(!time_unit_to_parts_per_second(argv[1], &parts_per_second))) {
         RAISE_ERROR(BADARG_ATOM);
     }
 
     // Floor division: round negative fractional seconds toward negative infinity
-    avm_int64_t quotient = value / divisor;
-    avm_int64_t remainder = value % divisor;
+    avm_int64_t quotient = value / parts_per_second;
+    avm_int64_t remainder = value % parts_per_second;
     struct timespec ts = {
         .tv_sec = (time_t) (quotient - (remainder < 0)),
         .tv_nsec = 0

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2025,19 +2025,18 @@ static bool int64_to_time_t_checked(avm_int64_t seconds, time_t *out)
 static term build_datetime_from_tm(Context *ctx, struct tm *broken_down_time)
 {
     avm_int64_t year = (avm_int64_t) broken_down_time->tm_year + 1900;
-    if (UNLIKELY(year < AVM_INT_MIN || year > AVM_INT_MAX)) {
-        RAISE_ERROR(BADARG_ATOM);
-    }
-
-    // 4 = size of date/time tuple, 3 size of date time tuple
-    if (UNLIKELY(memory_ensure_free_opt(ctx, 3 + 4 + 4, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    size_t heap_size
+        = TUPLE_SIZE(3) + TUPLE_SIZE(3) + TUPLE_SIZE(2) + term_boxed_integer_size(year);
+    if (UNLIKELY(memory_ensure_free_opt(ctx, heap_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
+
+    term year_term = term_make_maybe_boxed_int64(year, &ctx->heap);
     term date_tuple = term_alloc_tuple(3, &ctx->heap);
     term time_tuple = term_alloc_tuple(3, &ctx->heap);
     term date_time_tuple = term_alloc_tuple(2, &ctx->heap);
 
-    term_put_tuple_element(date_tuple, 0, term_from_int((avm_int_t) year));
+    term_put_tuple_element(date_tuple, 0, year_term);
     term_put_tuple_element(date_tuple, 1, term_from_int11(broken_down_time->tm_mon + 1));
     term_put_tuple_element(date_tuple, 2, term_from_int11(broken_down_time->tm_mday));
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1851,10 +1851,132 @@ term nif_erlang_make_ref_0(Context *ctx, int argc, term argv[])
     return term_from_ref_ticks(ref_ticks, &ctx->heap);
 }
 
+static bool time_unit_to_parts_per_second(term unit, avm_int64_t *parts_per_second)
+{
+    if (unit == SECOND_ATOM) {
+        *parts_per_second = 1;
+    } else if (unit == MILLISECOND_ATOM) {
+        *parts_per_second = 1000;
+    } else if (unit == MICROSECOND_ATOM) {
+        *parts_per_second = INT64_C(1000000);
+    } else if (unit == NANOSECOND_ATOM || unit == NATIVE_ATOM) {
+        // AtomVM exposes the Erlang `native` time unit as nanoseconds on all platforms.
+        *parts_per_second = INT64_C(1000000000);
+    } else if (term_is_int64(unit)) {
+        *parts_per_second = term_maybe_unbox_int64(unit);
+        if (UNLIKELY(*parts_per_second <= 0)) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    return true;
+}
+
+// Convert nanoseconds to parts using: parts = nanoseconds * pps / 1e9
+// Splits into high/low to avoid intermediate overflow.
+static bool nanoseconds_to_parts_per_second(
+    avm_int64_t nanoseconds, avm_int64_t parts_per_second, bool round_up, avm_int64_t *parts)
+{
+    if (UNLIKELY(
+            nanoseconds < 0 || nanoseconds >= INT64_C(1000000000) || parts_per_second <= 0)) {
+        return false;
+    }
+
+    avm_int64_t quotient = parts_per_second / INT64_C(1000000000);
+    avm_int64_t remainder = parts_per_second % INT64_C(1000000000);
+    avm_int64_t fractional_high = nanoseconds * quotient;
+    avm_int64_t remainder_product = nanoseconds * remainder;
+    avm_int64_t fractional_low = remainder_product / INT64_C(1000000000);
+
+    if (round_up && (remainder_product % INT64_C(1000000000)) != 0) {
+        fractional_low += 1;
+    }
+
+    if (UNLIKELY(fractional_high > INT64_MAX - fractional_low)) {
+        return false;
+    }
+
+    *parts = fractional_high + fractional_low;
+    return true;
+}
+
+// Convert a normalized timespec (0 <= tv_nsec < 1e9) to integer parts.
+// Uses floor semantics for negative timestamps with non-zero tv_nsec.
+static bool timespec_to_parts_per_second(
+    const struct timespec *ts, avm_int64_t parts_per_second, avm_int64_t *parts)
+{
+    if (UNLIKELY(
+            parts_per_second <= 0 || ts->tv_nsec < 0 || ts->tv_nsec >= INT64_C(1000000000))) {
+        return false;
+    }
+
+    avm_int64_t seconds = (avm_int64_t) ts->tv_sec;
+    avm_int64_t fractional_part;
+
+    if (ts->tv_nsec == 0 || seconds >= 0) {
+        if (UNLIKELY(
+                ((seconds > 0) && (seconds > INT64_MAX / parts_per_second))
+                || ((seconds < 0) && (seconds < INT64_MIN / parts_per_second)))) {
+            return false;
+        }
+
+        if (UNLIKELY(!nanoseconds_to_parts_per_second(
+                (avm_int64_t) ts->tv_nsec, parts_per_second, false, &fractional_part))) {
+            return false;
+        }
+
+        avm_int64_t second_part = seconds * parts_per_second;
+        if (UNLIKELY(second_part > INT64_MAX - fractional_part)) {
+            return false;
+        }
+
+        *parts = second_part + fractional_part;
+        return true;
+    }
+
+    // Preserve floor semantics for normalized negative timespecs such as {-2, 999999999}.
+    avm_int64_t adjusted_seconds = seconds + 1;
+    if (UNLIKELY(adjusted_seconds < INT64_MIN / parts_per_second)) {
+        return false;
+    }
+
+    if (UNLIKELY(!nanoseconds_to_parts_per_second(
+            INT64_C(1000000000) - (avm_int64_t) ts->tv_nsec, parts_per_second, true,
+            &fractional_part))) {
+        return false;
+    }
+
+    avm_int64_t second_part = adjusted_seconds * parts_per_second;
+    if (UNLIKELY(second_part < INT64_MIN + fractional_part)) {
+        return false;
+    }
+
+    *parts = second_part - fractional_part;
+    return true;
+}
+
+static term make_time_in_unit(Context *ctx, term unit, void (*time_fun)(struct timespec *))
+{
+    avm_int64_t parts_per_second;
+    if (UNLIKELY(!time_unit_to_parts_per_second(unit, &parts_per_second))) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    struct timespec ts;
+    time_fun(&ts);
+
+    avm_int64_t value;
+    if (UNLIKELY(!timespec_to_parts_per_second(&ts, parts_per_second, &value))) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    return make_maybe_boxed_int64(ctx, value);
+}
+
 term nif_erlang_monotonic_time_1(Context *ctx, int argc, term argv[])
 {
-    UNUSED(ctx);
-
     term unit;
     if (argc == 0) {
         unit = NATIVE_ATOM;
@@ -1862,30 +1984,11 @@ term nif_erlang_monotonic_time_1(Context *ctx, int argc, term argv[])
         unit = argv[0];
     }
 
-    struct timespec ts;
-    sys_monotonic_time(&ts);
-
-    if (unit == SECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ts.tv_sec);
-
-    } else if (unit == MILLISECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000UL + ts.tv_nsec / 1000000UL);
-
-    } else if (unit == MICROSECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000UL + ts.tv_nsec / 1000UL);
-
-    } else if (unit == NANOSECOND_ATOM || unit == NATIVE_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * INT64_C(1000000000) + ts.tv_nsec);
-
-    } else {
-        RAISE_ERROR(BADARG_ATOM);
-    }
+    return make_time_in_unit(ctx, unit, sys_monotonic_time);
 }
 
 term nif_erlang_system_time_1(Context *ctx, int argc, term argv[])
 {
-    UNUSED(ctx);
-
     term unit;
     if (argc == 0) {
         unit = NATIVE_ATOM;
@@ -1893,28 +1996,39 @@ term nif_erlang_system_time_1(Context *ctx, int argc, term argv[])
         unit = argv[0];
     }
 
-    struct timespec ts;
-    sys_time(&ts);
+    return make_time_in_unit(ctx, unit, sys_time);
+}
 
-    if (unit == SECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ts.tv_sec);
+static bool int64_to_time_t_checked(avm_int64_t seconds, time_t *out)
+{
+    if (((time_t) -1) > (time_t) 0) {
+        if (seconds < 0) {
+            return false;
+        }
 
-    } else if (unit == MILLISECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000UL + ts.tv_nsec / 1000000UL);
-
-    } else if (unit == MICROSECOND_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000UL + ts.tv_nsec / 1000UL);
-
-    } else if (unit == NANOSECOND_ATOM || unit == NATIVE_ATOM) {
-        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * INT64_C(1000000000) + ts.tv_nsec);
-
-    } else {
-        RAISE_ERROR(BADARG_ATOM);
+        time_t time_seconds = (time_t) (uint64_t) seconds;
+        if ((uint64_t) time_seconds != (uint64_t) seconds) {
+            return false;
+        }
+        *out = time_seconds;
+        return true;
     }
+
+    time_t time_seconds = (time_t) seconds;
+    if ((avm_int64_t) time_seconds != seconds) {
+        return false;
+    }
+    *out = time_seconds;
+    return true;
 }
 
 static term build_datetime_from_tm(Context *ctx, struct tm *broken_down_time)
 {
+    avm_int64_t year = (avm_int64_t) broken_down_time->tm_year + 1900;
+    if (UNLIKELY(year < AVM_INT_MIN || year > AVM_INT_MAX)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
     // 4 = size of date/time tuple, 3 size of date time tuple
     if (UNLIKELY(memory_ensure_free_opt(ctx, 3 + 4 + 4, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
@@ -1923,7 +2037,7 @@ static term build_datetime_from_tm(Context *ctx, struct tm *broken_down_time)
     term time_tuple = term_alloc_tuple(3, &ctx->heap);
     term date_time_tuple = term_alloc_tuple(2, &ctx->heap);
 
-    term_put_tuple_element(date_tuple, 0, term_from_int11(1900 + broken_down_time->tm_year));
+    term_put_tuple_element(date_tuple, 0, term_from_int((avm_int_t) year));
     term_put_tuple_element(date_tuple, 1, term_from_int11(broken_down_time->tm_mon + 1));
     term_put_tuple_element(date_tuple, 2, term_from_int11(broken_down_time->tm_mday));
 
@@ -1946,7 +2060,12 @@ term nif_erlang_universaltime_0(Context *ctx, int argc, term argv[])
     sys_time(&ts);
 
     struct tm broken_down_time;
-    return build_datetime_from_tm(ctx, gmtime_r(&ts.tv_sec, &broken_down_time));
+    struct tm *universal_time = gmtime_r(&ts.tv_sec, &broken_down_time);
+    if (UNLIKELY(universal_time == NULL)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    return build_datetime_from_tm(ctx, universal_time);
 }
 
 // setenv leaks the prior "TZ=value" string on overwrite (unbounded on
@@ -2095,35 +2214,35 @@ term nif_erlang_timestamp_0(Context *ctx, int argc, term argv[])
 
 term nif_calendar_system_time_to_universal_time_2(Context *ctx, int argc, term argv[])
 {
-    UNUSED(ctx);
     UNUSED(argc);
 
-    struct timespec ts;
-
+    if (UNLIKELY(!term_is_int64(argv[0]))) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
     avm_int64_t value = term_maybe_unbox_int64(argv[0]);
 
-    if (argv[1] == SECOND_ATOM) {
-        ts.tv_sec = (time_t) value;
-        ts.tv_nsec = 0;
+    avm_int64_t parts_per_second;
+    if (UNLIKELY(!time_unit_to_parts_per_second(argv[1], &parts_per_second))) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
 
-    } else if (argv[1] == MILLISECOND_ATOM) {
-        ts.tv_sec = (time_t) (value / 1000);
-        ts.tv_nsec = (value % 1000) * 1000000;
+    // Floor division: round negative fractional seconds toward negative infinity
+    avm_int64_t quotient = value / parts_per_second;
+    avm_int64_t remainder = value % parts_per_second;
+    avm_int64_t seconds = quotient - (remainder < 0);
 
-    } else if (argv[1] == MICROSECOND_ATOM) {
-        ts.tv_sec = (time_t) (value / 1000000);
-        ts.tv_nsec = (value % 1000000) * 1000;
-
-    } else if (argv[1] == NANOSECOND_ATOM || argv[1] == NATIVE_ATOM) {
-        ts.tv_sec = (time_t) (value / INT64_C(1000000000));
-        ts.tv_nsec = value % INT64_C(1000000000);
-
-    } else {
+    time_t time_seconds;
+    if (UNLIKELY(!int64_to_time_t_checked(seconds, &time_seconds))) {
         RAISE_ERROR(BADARG_ATOM);
     }
 
     struct tm broken_down_time;
-    return build_datetime_from_tm(ctx, gmtime_r(&ts.tv_sec, &broken_down_time));
+    struct tm *universal_time = gmtime_r(&time_seconds, &broken_down_time);
+    if (UNLIKELY(universal_time == NULL)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    return build_datetime_from_tm(ctx, universal_time);
 }
 
 static term nif_os_getenv_1(Context *ctx, int argc, term argv[])

--- a/tests/erlang_tests/test_monotonic_time.erl
+++ b/tests/erlang_tests/test_monotonic_time.erl
@@ -38,6 +38,8 @@ start() ->
     true = is_integer(N2 - N1) andalso (N2 - N1) >= 0,
 
     ok = test_native_monotonic_time(),
+    ok = test_integer_time_unit(),
+    ok = test_bad_integer_time_unit(),
 
     1.
 
@@ -46,6 +48,15 @@ test_diff(X) when is_integer(X) andalso X >= 0 ->
 test_diff(X) when X < 0 ->
     0.
 
+expect(F, Expect) ->
+    try
+        F(),
+        fail
+    catch
+        _:E when E == Expect ->
+            ok
+    end.
+
 test_native_monotonic_time() ->
     Na1 = erlang:monotonic_time(native),
     receive
@@ -53,4 +64,40 @@ test_native_monotonic_time() ->
     end,
     Na2 = erlang:monotonic_time(native),
     true = is_integer(Na2 - Na1) andalso (Na2 - Na1) >= 0,
+    ok.
+
+test_integer_time_unit() ->
+    %% integer 1 = parts per second, equivalent to second
+    S = erlang:monotonic_time(second),
+    S1 = erlang:monotonic_time(1),
+    true = abs(S1 - S) =< 1,
+
+    %% integer 1000 = parts per second, equivalent to millisecond
+    Ms = erlang:monotonic_time(millisecond),
+    Ms1 = erlang:monotonic_time(1000),
+    true = abs(Ms1 - Ms) =< 1,
+
+    %% integer 1000000 = parts per second, equivalent to microsecond
+    Us = erlang:monotonic_time(microsecond),
+    Us1 = erlang:monotonic_time(1000000),
+    true = abs(Us1 - Us) =< 1000,
+
+    %% integer 1000000000 = parts per second, equivalent to nanosecond
+    Ns = erlang:monotonic_time(nanosecond),
+    Ns1 = erlang:monotonic_time(1000000000),
+    true = abs(Ns1 - Ns) =< 1000000,
+
+    %% verify monotonicity with integer unit
+    T1 = erlang:monotonic_time(1000),
+    receive
+    after 1 -> ok
+    end,
+    T2 = erlang:monotonic_time(1000),
+    true = T2 >= T1,
+
+    ok.
+
+test_bad_integer_time_unit() ->
+    ok = expect(fun() -> erlang:monotonic_time(0) end, badarg),
+    ok = expect(fun() -> erlang:monotonic_time(-1) end, badarg),
     ok.

--- a/tests/erlang_tests/test_monotonic_time.erl
+++ b/tests/erlang_tests/test_monotonic_time.erl
@@ -39,6 +39,7 @@ start() ->
 
     ok = test_native_monotonic_time(),
     ok = test_integer_time_unit(),
+    ok = test_non_power_of_10_integer_time_unit(),
     ok = test_bad_integer_time_unit(),
 
     1.
@@ -97,7 +98,23 @@ test_integer_time_unit() ->
 
     ok.
 
+test_non_power_of_10_integer_time_unit() ->
+    ok = test_integer_time_unit_monotonicity(256),
+    ok = test_integer_time_unit_monotonicity(48000),
+    ok.
+
 test_bad_integer_time_unit() ->
     ok = expect(fun() -> erlang:monotonic_time(0) end, badarg),
     ok = expect(fun() -> erlang:monotonic_time(-1) end, badarg),
+    ok.
+
+test_integer_time_unit_monotonicity(PartsPerSecond) ->
+    T1 = erlang:monotonic_time(PartsPerSecond),
+    receive
+    after 1 -> ok
+    end,
+    T2 = erlang:monotonic_time(PartsPerSecond),
+    true = is_integer(T1),
+    true = is_integer(T2),
+    true = T2 >= T1,
     ok.

--- a/tests/erlang_tests/test_monotonic_time.erl
+++ b/tests/erlang_tests/test_monotonic_time.erl
@@ -38,6 +38,9 @@ start() ->
     true = is_integer(N2 - N1) andalso (N2 - N1) >= 0,
 
     ok = test_native_monotonic_time(),
+    ok = test_integer_time_unit(),
+    ok = test_non_power_of_10_integer_time_unit(),
+    ok = test_bad_integer_time_unit(),
 
     1.
 
@@ -46,6 +49,15 @@ test_diff(X) when is_integer(X) andalso X >= 0 ->
 test_diff(X) when X < 0 ->
     0.
 
+expect(F, Expect) ->
+    try
+        F(),
+        fail
+    catch
+        _:E when E == Expect ->
+            ok
+    end.
+
 test_native_monotonic_time() ->
     Na1 = erlang:monotonic_time(native),
     receive
@@ -53,4 +65,51 @@ test_native_monotonic_time() ->
     end,
     Na2 = erlang:monotonic_time(native),
     true = is_integer(Na2 - Na1) andalso (Na2 - Na1) >= 0,
+    ok.
+
+test_integer_time_unit() ->
+    S = erlang:monotonic_time(second),
+    S1 = erlang:monotonic_time(1),
+    true = abs(S1 - S) =< 1,
+
+    Ms = erlang:monotonic_time(millisecond),
+    Ms1 = erlang:monotonic_time(1000),
+    true = abs(Ms1 - Ms) =< 1,
+
+    Us = erlang:monotonic_time(microsecond),
+    Us1 = erlang:monotonic_time(1000000),
+    true = abs(Us1 - Us) =< 1000,
+
+    Ns = erlang:monotonic_time(nanosecond),
+    Ns1 = erlang:monotonic_time(1000000000),
+    true = abs(Ns1 - Ns) =< 1000000,
+
+    T1 = erlang:monotonic_time(1000),
+    receive
+    after 1 -> ok
+    end,
+    T2 = erlang:monotonic_time(1000),
+    true = T2 >= T1,
+
+    ok.
+
+test_non_power_of_10_integer_time_unit() ->
+    ok = test_integer_time_unit_monotonicity(256),
+    ok = test_integer_time_unit_monotonicity(48000),
+    ok.
+
+test_bad_integer_time_unit() ->
+    ok = expect(fun() -> erlang:monotonic_time(0) end, badarg),
+    ok = expect(fun() -> erlang:monotonic_time(-1) end, badarg),
+    ok.
+
+test_integer_time_unit_monotonicity(PartsPerSecond) ->
+    T1 = erlang:monotonic_time(PartsPerSecond),
+    receive
+    after 1 -> ok
+    end,
+    T2 = erlang:monotonic_time(PartsPerSecond),
+    true = is_integer(T1),
+    true = is_integer(T2),
+    true = T2 >= T1,
     ok.

--- a/tests/erlang_tests/test_system_time.erl
+++ b/tests/erlang_tests/test_system_time.erl
@@ -34,9 +34,14 @@ start() ->
     ok = test_os_system_time(),
     ok = test_time_unit_ratios(),
 
+    ok = test_integer_time_unit(),
+    ok = test_bad_integer_time_unit(),
+
     ok = expect(fun() -> erlang:system_time(not_a_time_unit) end, badarg),
 
     ok = test_system_time_to_universal_time(),
+    ok = test_integer_unit_universal_time(),
+    ok = test_bad_integer_unit_universal_time(),
 
     0.
 
@@ -164,4 +169,61 @@ test_nanosecond_universal_time() ->
 test_native_universal_time() ->
     {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(0, native),
     {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1000000000, native),
+    ok.
+
+test_integer_time_unit() ->
+    %% integer 1 = parts per second, equivalent to second
+    S = erlang:system_time(second),
+    S1 = erlang:system_time(1),
+    true = abs(S1 - S) =< 1,
+
+    %% integer 1000 = parts per second, equivalent to millisecond
+    Ms = erlang:system_time(millisecond),
+    Ms1 = erlang:system_time(1000),
+    true = abs(Ms1 - Ms) =< 1,
+
+    %% integer 1000000 = parts per second, equivalent to microsecond
+    Us = erlang:system_time(microsecond),
+    Us1 = erlang:system_time(1000000),
+    true = abs(Us1 - Us) =< 1000,
+
+    %% integer 1000000000 = parts per second, equivalent to nanosecond
+    Ns = erlang:system_time(nanosecond),
+    Ns1 = erlang:system_time(1000000000),
+    true = abs(Ns1 - Ns) =< 1000000,
+
+    %% verify values are positive
+    true = S1 > 0,
+    true = Ms1 > 0,
+    true = Us1 > 0,
+    true = Ns1 > 0,
+
+    ok.
+
+test_integer_unit_universal_time() ->
+    %% integer 1 = seconds
+    {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(0, 1),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1, 1),
+    {{2023, 7, 8}, {20, 19, 39}} = calendar:system_time_to_universal_time(1688847579, 1),
+
+    %% integer 1000 = milliseconds
+    {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(0, 1000),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1000, 1000),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1001, 1000),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, 1000),
+
+    %% integer 1000000 = microseconds
+    {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(0, 1000000),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1000000, 1000000),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, 1000000),
+
+    ok.
+
+test_bad_integer_time_unit() ->
+    ok = expect(fun() -> erlang:system_time(0) end, badarg),
+    ok = expect(fun() -> erlang:system_time(-1) end, badarg),
+    ok.
+
+test_bad_integer_unit_universal_time() ->
+    ok = expect(fun() -> calendar:system_time_to_universal_time(0, 0) end, badarg),
     ok.

--- a/tests/erlang_tests/test_system_time.erl
+++ b/tests/erlang_tests/test_system_time.erl
@@ -131,6 +131,13 @@ test_system_time_to_universal_time() ->
     {{2023, 7, 8}, {20, 19, 39}} = calendar:system_time_to_universal_time(1688847579, second),
 
     {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, second),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, millisecond),
+    {{1969, 12, 31}, {23, 59, 58}} = calendar:system_time_to_universal_time(-1001, millisecond),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, microsecond),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, nanosecond),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, native),
+
+    ok = expect(fun() -> calendar:system_time_to_universal_time(not_an_integer, second) end, badarg),
 
     ok = test_nanosecond_universal_time(),
     ok = test_native_universal_time(),

--- a/tests/erlang_tests/test_system_time.erl
+++ b/tests/erlang_tests/test_system_time.erl
@@ -35,6 +35,7 @@ start() ->
     ok = test_time_unit_ratios(),
 
     ok = test_integer_time_unit(),
+    ok = test_non_power_of_10_integer_time_unit(),
     ok = test_bad_integer_time_unit(),
 
     ok = expect(fun() -> erlang:system_time(not_a_time_unit) end, badarg),
@@ -137,7 +138,9 @@ test_system_time_to_universal_time() ->
     {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, nanosecond),
     {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, native),
 
-    ok = expect(fun() -> calendar:system_time_to_universal_time(not_an_integer, second) end, badarg),
+    ok = expect(
+        fun() -> calendar:system_time_to_universal_time(not_an_integer, second) end, badarg
+    ),
 
     ok = test_nanosecond_universal_time(),
     ok = test_native_universal_time(),
@@ -207,6 +210,11 @@ test_integer_time_unit() ->
 
     ok.
 
+test_non_power_of_10_integer_time_unit() ->
+    ok = test_integer_parts_per_second_ratio(256),
+    ok = test_integer_parts_per_second_ratio(48000),
+    ok.
+
 test_integer_unit_universal_time() ->
     %% integer 1 = seconds
     {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(0, 1),
@@ -218,11 +226,20 @@ test_integer_unit_universal_time() ->
     {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1000, 1000),
     {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1001, 1000),
     {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, 1000),
+    {{1969, 12, 31}, {23, 59, 58}} = calendar:system_time_to_universal_time(-1001, 1000),
 
     %% integer 1000000 = microseconds
     {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(0, 1000000),
     {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1000000, 1000000),
     {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, 1000000),
+
+    %% integer 256 and 48000 = arbitrary parts per second
+    {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(255, 256),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(256, 256),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, 256),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-255, 256),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(48000, 48000),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, 48000),
 
     ok.
 
@@ -232,5 +249,18 @@ test_bad_integer_time_unit() ->
     ok.
 
 test_bad_integer_unit_universal_time() ->
+    ok = expect(
+        fun() -> calendar:system_time_to_universal_time(not_an_integer, second) end, badarg
+    ),
+    ok = expect(fun() -> calendar:system_time_to_universal_time(not_an_integer, 1000) end, badarg),
     ok = expect(fun() -> calendar:system_time_to_universal_time(0, 0) end, badarg),
+    ok = expect(fun() -> calendar:system_time_to_universal_time(0, -1) end, badarg),
+    ok.
+
+test_integer_parts_per_second_ratio(PartsPerSecond) ->
+    Seconds = erlang:system_time(second),
+    Parts = erlang:system_time(PartsPerSecond),
+    true = is_integer(Parts) andalso Parts > 0,
+    true = Parts >= Seconds * PartsPerSecond,
+    true = Parts < Seconds * PartsPerSecond + (PartsPerSecond * 2),
     ok.

--- a/tests/erlang_tests/test_system_time.erl
+++ b/tests/erlang_tests/test_system_time.erl
@@ -34,9 +34,16 @@ start() ->
     ok = test_os_system_time(),
     ok = test_time_unit_ratios(),
 
+    ok = test_integer_time_unit(),
+    ok = test_non_power_of_10_integer_time_unit(),
+    ok = test_bad_integer_time_unit(),
+
     ok = expect(fun() -> erlang:system_time(not_a_time_unit) end, badarg),
 
     ok = test_system_time_to_universal_time(),
+    ok = test_negative_year_universal_time(),
+    ok = test_integer_unit_universal_time(),
+    ok = test_bad_integer_unit_universal_time(),
 
     0.
 
@@ -126,11 +133,75 @@ test_system_time_to_universal_time() ->
     {{2023, 7, 8}, {20, 19, 39}} = calendar:system_time_to_universal_time(1688847579, second),
 
     {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, second),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, millisecond),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(
+        -1000, millisecond
+    ),
+    {{1969, 12, 31}, {23, 59, 58}} = calendar:system_time_to_universal_time(-1001, millisecond),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, microsecond),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, nanosecond),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, native),
+
+    ok = expect(
+        fun() -> calendar:system_time_to_universal_time(not_an_integer, second) end, badarg
+    ),
 
     ok = test_nanosecond_universal_time(),
     ok = test_native_universal_time(),
 
     ok.
+
+test_negative_year_universal_time() ->
+    % Moderate negative: 20 years before epoch (fits in both 32-bit and 64-bit time_t)
+    {{1950, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(-631152000, second),
+
+    % Year 2100 probe (succeeds on 64-bit time_t, badarg on limited range)
+    ok = test_year_2100(),
+
+    % Extreme years: OTP <29 supports positive but not negative extremes.
+    % Separate probes so a failure on one does not skip the others.
+    ok = test_extreme_negative_year(),
+    ok = test_extreme_positive_year(),
+
+    ok.
+
+test_year_2100() ->
+    try
+        {{2100, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(4102444800, second),
+        ok
+    catch
+        error:badarg ->
+            % Platform with limited time_t range (e.g., 32-bit time_t)
+            ok
+    end.
+
+test_extreme_negative_year() ->
+    try
+        {{-998051, 6, 20}, {0, 0, 0}} = calendar:system_time_to_universal_time(
+            -31557600000000, second
+        ),
+        ok
+    catch
+        error:badarg ->
+            % AtomVM platform with limited time_t range or out-of-range
+            ok;
+        error:function_clause ->
+            % OTP <29 calendar limit on negative extremes (BEAM only)
+            true = is_beam(),
+            ok
+    end.
+
+test_extreme_positive_year() ->
+    try
+        {{1001990, 7, 15}, {0, 0, 0}} = calendar:system_time_to_universal_time(
+            31557600000000, second
+        ),
+        ok
+    catch
+        error:badarg ->
+            % Platform with limited time_t range (e.g., 32-bit time_t)
+            ok
+    end.
 
 test_nanosecond_system_time() ->
     ok = test_system_time(nanosecond, 1).
@@ -163,5 +234,111 @@ test_nanosecond_universal_time() ->
 
 test_native_universal_time() ->
     {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(0, native),
-    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1000000000, native),
+    ok =
+        case erlang:system_info(machine) of
+            "ATOM" ->
+                {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(
+                    1000000000, native
+                ),
+                ok;
+            _ ->
+                ok
+        end,
     ok.
+
+test_integer_time_unit() ->
+    S = erlang:system_time(second),
+    S1 = erlang:system_time(1),
+    true = abs(S1 - S) =< 1,
+
+    Ms = erlang:system_time(millisecond),
+    Ms1 = erlang:system_time(1000),
+    true = abs(Ms1 - Ms) =< 1,
+
+    Us = erlang:system_time(microsecond),
+    Us1 = erlang:system_time(1000000),
+    true = abs(Us1 - Us) =< 1000,
+
+    Ns = erlang:system_time(nanosecond),
+    Ns1 = erlang:system_time(1000000000),
+    true = abs(Ns1 - Ns) =< 1000000,
+
+    true = S1 > 0,
+    true = Ms1 > 0,
+    true = Us1 > 0,
+    true = Ns1 > 0,
+
+    ok.
+
+test_non_power_of_10_integer_time_unit() ->
+    ok = test_integer_parts_per_second_ratio(256),
+    ok = test_integer_parts_per_second_ratio(48000),
+    ok.
+
+test_integer_unit_universal_time() ->
+    {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(0, 1),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1, 1),
+    {{2023, 7, 8}, {20, 19, 39}} = calendar:system_time_to_universal_time(1688847579, 1),
+
+    {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(0, 1000),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1000, 1000),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1001, 1000),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, 1000),
+    {{1969, 12, 31}, {23, 59, 58}} = calendar:system_time_to_universal_time(-1001, 1000),
+
+    {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(0, 1000000),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(1000000, 1000000),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, 1000000),
+
+    {{1970, 1, 1}, {0, 0, 0}} = calendar:system_time_to_universal_time(255, 256),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(256, 256),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, 256),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-255, 256),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-256, 256),
+    {{1969, 12, 31}, {23, 59, 58}} = calendar:system_time_to_universal_time(-257, 256),
+    {{1970, 1, 1}, {0, 0, 1}} = calendar:system_time_to_universal_time(48000, 48000),
+    {{1969, 12, 31}, {23, 59, 59}} = calendar:system_time_to_universal_time(-1, 48000),
+
+    ok.
+
+test_bad_integer_time_unit() ->
+    ok = expect(fun() -> erlang:system_time(0) end, badarg),
+    ok = expect(fun() -> erlang:system_time(-1) end, badarg),
+    ok.
+
+test_bad_integer_unit_universal_time() ->
+    ok = expect(fun() -> calendar:system_time_to_universal_time(not_an_integer, 1000) end, badarg),
+    ok = expect(fun() -> calendar:system_time_to_universal_time(0, 0) end, badarg),
+    ok = expect(fun() -> calendar:system_time_to_universal_time(0, -1) end, badarg),
+    ok = expect(
+        fun() -> calendar:system_time_to_universal_time(0, not_a_time_unit) end, badarg
+    ),
+    ok = test_atomvm_integer_unit_bounds(),
+    ok.
+
+test_atomvm_integer_unit_bounds() ->
+    case is_beam() of
+        true ->
+            ok;
+        false ->
+            ok = expect(
+                fun() -> calendar:system_time_to_universal_time(9223372036854775807, 1) end,
+                badarg
+            ),
+            ok = expect(
+                fun() -> calendar:system_time_to_universal_time(-9223372036854775808, 1) end,
+                badarg
+            ),
+            ok
+    end.
+
+test_integer_parts_per_second_ratio(PartsPerSecond) ->
+    Seconds = erlang:system_time(second),
+    Parts = erlang:system_time(PartsPerSecond),
+    true = is_integer(Parts) andalso Parts > 0,
+    true = Parts >= Seconds * PartsPerSecond,
+    true = Parts < Seconds * PartsPerSecond + (PartsPerSecond * 2),
+    ok.
+
+is_beam() ->
+    erlang:system_info(machine) =:= "BEAM".

--- a/tests/erlang_tests/test_system_time.erl
+++ b/tests/erlang_tests/test_system_time.erl
@@ -162,6 +162,7 @@ test_negative_year_universal_time() ->
     % Separate probes so a failure on one does not skip the others.
     ok = test_extreme_negative_year(),
     ok = test_extreme_positive_year(),
+    ok = test_large_positive_year_beyond_32bit_smallint(),
 
     ok.
 
@@ -200,6 +201,30 @@ test_extreme_positive_year() ->
     catch
         error:badarg ->
             % Platform with limited time_t range (e.g., 32-bit time_t)
+            ok
+    end.
+
+test_large_positive_year_beyond_32bit_smallint() ->
+    % ~150 million years after the Unix epoch. If the platform time_t/gmtime_r
+    % supports this range, the returned year exceeds MAX_NOT_BOXED_INT on 32-bit
+    % AtomVM term builds and must be boxed, not encoded with term_from_int().
+    try
+        {{Year, Month, Day}, {Hour, Minute, Second}} =
+            calendar:system_time_to_universal_time(4730400000000000, second),
+        true = is_integer(Year),
+        true = Year > 134217727,
+        true = Month >= 1 andalso Month =< 12,
+        true = Day >= 1 andalso Day =< 31,
+        true = Hour >= 0 andalso Hour =< 23,
+        true = Minute >= 0 andalso Minute =< 59,
+        true = Second >= 0 andalso Second =< 60,
+        ok
+    catch
+        error:badarg ->
+            % Platform with limited time_t / gmtime_r range.
+            ok;
+        error:function_clause ->
+            true = is_beam(),
             ok
     end.
 


### PR DESCRIPTION
Add support for positive integer time units ("parts per second") in erlang:monotonic_time/1, erlang:system_time/1, and calendar:system_time_to_universal_time/2.

Used in elixir DynamicSupervisor - completes the timeunit support.

Restrict integer-unit handling to int64 inputs in the affected NIF paths. Use checked int64 decomposition for monotonic/system time conversion to avoid signed overflow in intermediate arithmetic. For calendar integer units, floor negative fractional values to whole seconds before converting to UTC.

Add focused Erlang tests for integer-unit parity, badarg on non-positive integer units, and negative fractional calendar conversion for integer units.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
