### PR TITLE
MCUs: update deprecated use of term_from_int32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Stop using deprecated `term_from_int32` on STM32 platform
+- Stop using deprecated `term_from_int32` on RP2 platform
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added Erlang distribution over serial (uart)
 
+### Fixed
+- Stop using deprecated `term_from_int32` on STM32 platform
+
 ## [0.7.0-alpha.1] - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Stop using deprecated `term_from_int32` on STM32 platform
 - Stop using deprecated `term_from_int32` on RP2 platform
+- Stop using deprecated `term_from_int32` on ESP32 platform
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/src/platforms/esp32/components/avm_builtins/adc_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/adc_driver.c
@@ -595,7 +595,7 @@ static term nif_adc_sample(Context *ctx, int argc, term argv[])
 
     term read_options = argv[2];
     VALIDATE_VALUE(read_options, term_is_list);
-    term samples = interop_kv_get_value_default(read_options, ATOM_STR("\x7", "samples"), term_from_int32(DEFAULT_SAMPLES), ctx->global);
+    term samples = interop_kv_get_value_default(read_options, ATOM_STR("\x7", "samples"), term_from_int28(DEFAULT_SAMPLES), ctx->global);
     if (UNLIKELY(!term_is_integer(samples))) {
         ESP_LOGE(TAG, "samples value must be an integer from 1 to 1024.");
         RAISE_ERROR(BADARG_ATOM);
@@ -625,20 +625,20 @@ static term nif_adc_sample(Context *ctx, int argc, term argv[])
     adc_raw /= samples_val;
     ESP_LOGD(TAG, "read adc raw reading: %i", adc_raw);
 
-    raw = raw == TRUE_ATOM ? term_from_int32(adc_raw) : UNDEFINED_ATOM;
+    raw = raw == TRUE_ATOM ? term_from_int28(adc_raw) : UNDEFINED_ATOM;
     if (voltage == TRUE_ATOM) {
         int millivolts = 0;
         if (chan_rsrc->calibration > ESTIMATED) {
             err = adc_cali_raw_to_voltage(chan_rsrc->cali_handle, adc_raw, &millivolts);
             if (UNLIKELY(err != ESP_OK)) {
                 ESP_LOGW(TAG, "Failed to get calibrated voltage, returning estimated voltage");
-                voltage = term_from_int32(approximate_millivolts(adc_raw, chan_rsrc->attenuation, chan_rsrc->width));
+                voltage = term_from_int28(approximate_millivolts(adc_raw, chan_rsrc->attenuation, chan_rsrc->width));
             } else {
-                voltage = term_from_int32(millivolts);
+                voltage = term_from_int28(millivolts);
             }
         } else {
             ESP_LOGD(TAG, "ADC channel not calibrated, using estimated voltage");
-            voltage = term_from_int32(approximate_millivolts(adc_raw, chan_rsrc->attenuation, chan_rsrc->width));
+            voltage = term_from_int28(approximate_millivolts(adc_raw, chan_rsrc->attenuation, chan_rsrc->width));
         }
     } else {
         voltage = UNDEFINED_ATOM;

--- a/src/platforms/esp32/components/avm_builtins/gpio_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/gpio_driver.c
@@ -376,7 +376,7 @@ EventListener *gpio_interrupt_callback(GlobalContext *glb, EventListener *listen
 
     term int_msg = term_alloc_tuple(2, &heap);
     term_put_tuple_element(int_msg, 0, GPIO_INTERRUPT_ATOM);
-    term_put_tuple_element(int_msg, 1, term_from_int32(gpio_num));
+    term_put_tuple_element(int_msg, 1, term_from_int11(gpio_num));
 
     globalcontext_send_message(glb, listening_pid, int_msg);
 

--- a/src/platforms/esp32/components/avm_builtins/i2c_resource.c
+++ b/src/platforms/esp32/components/avm_builtins/i2c_resource.c
@@ -146,7 +146,7 @@ static term nif_i2c_open(Context *ctx, int argc, term argv[])
         }
     }
 
-    term send_timeout_ms = interop_kv_get_value_default(opts, ATOM_STR("\xF", "send_timeout_ms"), term_from_int32(DEFAULT_SEND_TIMEOUT_MS), global);
+    term send_timeout_ms = interop_kv_get_value_default(opts, ATOM_STR("\xF", "send_timeout_ms"), term_from_int(DEFAULT_SEND_TIMEOUT_MS), global);
     uint32_t send_timeout_ms_val = portMAX_DELAY;
     if (term_is_integer(send_timeout_ms)) {
         if (term_to_int32(send_timeout_ms) < 0) {

--- a/src/platforms/esp32/components/avm_builtins/socket_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/socket_driver.c
@@ -672,7 +672,9 @@ static NativeHandlerResult do_receive_data(Context *ctx)
         if (socket_data->type == TCPClientSocket) {
             // Close socket in case of errors or finish closing if it's closed
             // on the other end.
+            #ifndef AVM_NO_SMP
             struct ESP32PlatformData *platform = ctx->global->platform_data;
+            #endif
             synclist_remove(&platform->sockets, &socket_data->sockets_head);
             if (UNLIKELY(netconn_close(socket_data->conn) != ERR_OK)) {
                 TRACE("do_receive_data: netconn_close failed\n");
@@ -746,7 +748,7 @@ static NativeHandlerResult do_receive_data(Context *ctx)
             do_send_socket_error(ctx, ERR_BUF);
             return NativeContinue;
         }
-        term port = term_from_int32(netbuf_fromport(buf));
+        term port = term_from_int28(netbuf_fromport(buf));
         recv_term = term_alloc_tuple(3, &ctx->heap);
         term_put_tuple_element(recv_term, 0, addr_term);
         term_put_tuple_element(recv_term, 1, port);
@@ -1261,7 +1263,9 @@ static void do_close(Context *ctx, const GenMessage *gen_message)
     err_t delete_res = netconn_delete(socket_data->conn);
 
     socket_data->conn = NULL;
+    #ifndef AVM_NO_SMP
     struct ESP32PlatformData *platform = ctx->global->platform_data;
+    #endif
     synclist_remove(&platform->sockets, &socket_data->sockets_head);
 
     if (UNLIKELY(close_disconnect_res != ERR_OK)) {

--- a/src/platforms/esp32/components/avm_sys/sys.c
+++ b/src/platforms/esp32/components/avm_sys/sys.c
@@ -546,13 +546,13 @@ term sys_get_info(Context *ctx, term key)
 {
     GlobalContext *glb = ctx->global;
     if (key == globalcontext_make_atom(glb, esp_free_heap_size_atom)) {
-        return term_from_int32(esp_get_free_heap_size());
+        return term_from_int28(esp_get_free_heap_size());
     }
     if (key == globalcontext_make_atom(glb, esp_largest_free_block_atom)) {
-        return term_from_int32(heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT));
+        return term_from_int28(heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT));
     }
     if (key == globalcontext_make_atom(glb, esp_get_minimum_free_size_atom)) {
-        return term_from_int32(esp_get_minimum_free_heap_size());
+        return term_from_int28(esp_get_minimum_free_heap_size());
     }
     if (key == globalcontext_make_atom(glb, esp_chip_info_atom)) {
         esp_chip_info_t info;
@@ -560,11 +560,14 @@ term sys_get_info(Context *ctx, term key)
         if (memory_ensure_free(ctx, term_map_size_in_terms(4) + 4 * 2) != MEMORY_GC_OK) {
             return OUT_OF_MEMORY_ATOM;
         }
+
         term ret = term_alloc_map(4, &ctx->heap);
-        term_set_map_assoc(ret, 0, globalcontext_make_atom(glb, cores_atom), term_from_int32(info.cores));
+        _Static_assert(SOC_CPU_CORES_NUM <= 7, "core count may exceed term_from_int4 range");
+        term_set_map_assoc(ret, 0, globalcontext_make_atom(glb, cores_atom), term_from_int4(info.cores));
         term_set_map_assoc(ret, 1, globalcontext_make_atom(glb, features_atom), get_features(ctx, info.features));
         term_set_map_assoc(ret, 2, globalcontext_make_atom(glb, model_atom), get_model(ctx, info.model));
-        term_set_map_assoc(ret, 3, globalcontext_make_atom(glb, revision_atom), term_from_int32(info.revision));
+        _Static_assert(CONFIG_ESP_REV_MAX_FULL <= 1023, "chip revision may not fit in term_from_int11");
+        term_set_map_assoc(ret, 3, globalcontext_make_atom(glb, revision_atom), term_from_int11(info.revision));
         return ret;
     }
     if (key == globalcontext_make_atom(glb, esp_idf_version_atom)) {

--- a/src/platforms/rp2/src/lib/networkdriver.c
+++ b/src/platforms/rp2/src/lib/networkdriver.c
@@ -128,10 +128,10 @@ static void network_driver_do_cyw43_assoc(GlobalContext *glb);
 static term tuple_from_addr(Heap *heap, uint32_t addr)
 {
     term terms[4];
-    terms[0] = term_from_int32((addr >> 24) & 0xFF);
-    terms[1] = term_from_int32((addr >> 16) & 0xFF);
-    terms[2] = term_from_int32((addr >> 8) & 0xFF);
-    terms[3] = term_from_int32(addr & 0xFF);
+    terms[0] = term_from_int11((addr >> 24) & 0xFF);
+    terms[1] = term_from_int11((addr >> 16) & 0xFF);
+    terms[2] = term_from_int11((addr >> 8) & 0xFF);
+    terms[3] = term_from_int11(addr & 0xFF);
 
     return port_heap_create_tuple_n(heap, 4, terms);
 }
@@ -715,7 +715,7 @@ static void get_sta_rssi(Context *ctx, term pid, term ref)
         return;
     }
 
-    term rssi = term_from_int32(sta_rssi);
+    term rssi = term_from_int11(sta_rssi);
     // Reply: {Ref, {rssi, Value}}
     port_ensure_available(ctx, tuple_reply_size);
     term reply = port_create_tuple2(ctx, globalcontext_make_atom(ctx->global, ATOM_STR("\x4", "rssi")), rssi);

--- a/src/platforms/stm32/src/lib/gpio_driver.c
+++ b/src/platforms/stm32/src/lib/gpio_driver.c
@@ -672,7 +672,7 @@ void gpio_interrupt_callback(Context *ctx, uint32_t exti)
             term gpio_tuple = term_alloc_tuple(2, &heap);
             term_put_tuple_element(int_msg, 0, globalcontext_make_atom(ctx->global, gpio_interrupt_atom));
             term_put_tuple_element(gpio_tuple, 0, gpio_bank);
-            term_put_tuple_element(gpio_tuple, 1, term_from_int32((int32_t) gpio_pin));
+            term_put_tuple_element(gpio_tuple, 1, term_from_int11(gpio_pin));
             term_put_tuple_element(int_msg, 1, gpio_tuple);
 
             globalcontext_send_message(ctx->global, listening_pid, int_msg);


### PR DESCRIPTION
Update all MCU platforms useage of `term_from_int32` to safer variants of `term_from_int*`

See also: #1897

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
