### PR TITLE
Fix uart:open/1,2 and gpio:open/0, gpio:start/0 API

### DIFF
--- a/libs/avm_esp32/src/gpio.erl
+++ b/libs/avm_esp32/src/gpio.erl
@@ -72,7 +72,7 @@
 %% Event type that will trigger a `gpio_interrupt'.
 
 %%-----------------------------------------------------------------------------
-%% @returns Port | error | {error, Reason}
+%% @returns Port
 %% @doc     Start the GPIO driver port
 %%
 %%          Returns the port of the active GPIO port driver, otherwise the GPIO
@@ -81,7 +81,7 @@
 %%          that require a GPIO port as a parameter.
 %% @end
 %%-----------------------------------------------------------------------------
--spec start() -> gpio() | {error, Reason :: atom()} | error.
+-spec start() -> gpio().
 start() ->
     case whereis(gpio) of
         undefined ->
@@ -91,7 +91,7 @@ start() ->
     end.
 
 %%-----------------------------------------------------------------------------
-%% @returns Port | error | {error, Reason}
+%% @returns Port
 %% @doc     Start the GPIO driver port
 %%
 %%          The GPIO port driver will be stared and registered as `gpio'. If the
@@ -101,7 +101,7 @@ start() ->
 %%          GPIO port as a parameter.
 %% @end
 %%-----------------------------------------------------------------------------
--spec open() -> gpio() | {error, Reason :: atom()} | error.
+-spec open() -> gpio().
 open() ->
     open_port({spawn, "gpio"}, []).
 

--- a/libs/avm_esp32/src/uart.erl
+++ b/libs/avm_esp32/src/uart.erl
@@ -51,8 +51,7 @@
 %%          This function will open a connection to the UART driver.
 %% @end
 %%-----------------------------------------------------------------------------
--spec open(Name :: peripheral(), Opts :: uart_opts()) ->
-    Port :: port() | {error, _Reason :: term()}.
+-spec open(Name :: peripheral(), Opts :: uart_opts()) -> Port :: port().
 open(Name, Opts) ->
     open([{peripheral, Name} | Opts]).
 
@@ -64,7 +63,7 @@ open(Name, Opts) ->
 %%          This function will open a connection to the UART driver.
 %% @end
 %%-----------------------------------------------------------------------------
--spec open(Opts :: uart_opts()) -> Port :: port() | {error, _Reason :: term()}.
+-spec open(Opts :: uart_opts()) -> Port :: port().
 open(Opts) ->
     open_port({spawn, "uart"}, migrate_config(Opts)).
 

--- a/libs/avm_rp2/src/gpio.erl
+++ b/libs/avm_rp2/src/gpio.erl
@@ -76,7 +76,7 @@
 %% Event type that will trigger a `gpio_interrupt'.
 
 %%-----------------------------------------------------------------------------
-%% @returns Pid | error | {error, Reason}
+%% @returns Pid
 %% @doc     Start the GPIO driver
 %%
 %%          Returns the pid of the active GPIO driver process, otherwise the GPIO
@@ -85,7 +85,7 @@
 %%          that require a GPIO pid as a parameter.
 %% @end
 %%-----------------------------------------------------------------------------
--spec start() -> gpio() | {error, Reason :: atom()} | error.
+-spec start() -> gpio().
 start() ->
     case whereis(gpio) of
         undefined ->
@@ -95,7 +95,7 @@ start() ->
     end.
 
 %%-----------------------------------------------------------------------------
-%% @returns Pid | error | {error, Reason}
+%% @returns Pid
 %% @doc     Start the GPIO driver
 %%
 %%          The GPIO driver process will be started and registered as `gpio'. If the
@@ -103,7 +103,7 @@ start() ->
 %%          `gpio:start/0' the command will fail.
 %% @end
 %%-----------------------------------------------------------------------------
--spec open() -> gpio() | {error, Reason :: atom()} | error.
+-spec open() -> gpio().
 open() ->
     Pid = spawn(fun gpio_loop/0),
     register(gpio, Pid),

--- a/libs/avm_stm32/src/gpio.erl
+++ b/libs/avm_stm32/src/gpio.erl
@@ -75,7 +75,7 @@
 %% Event type that will trigger a `gpio_interrupt'.
 
 %%-----------------------------------------------------------------------------
-%% @returns Port | error | {error, Reason}
+%% @returns Port
 %% @doc     Start the GPIO driver port
 %%
 %%          Returns the port of the active GPIO port driver, otherwise the GPIO
@@ -84,7 +84,7 @@
 %%          that require a GPIO port as a parameter.
 %% @end
 %%-----------------------------------------------------------------------------
--spec start() -> gpio() | {error, Reason :: atom()} | error.
+-spec start() -> gpio().
 start() ->
     case whereis(gpio) of
         undefined ->
@@ -94,7 +94,7 @@ start() ->
     end.
 
 %%-----------------------------------------------------------------------------
-%% @returns Port | error | {error, Reason}
+%% @returns Port
 %% @doc     Start the GPIO driver port
 %%
 %%          The GPIO port driver will be started and registered as `gpio'. If the
@@ -104,7 +104,7 @@ start() ->
 %%          GPIO port as a parameter.
 %% @end
 %%-----------------------------------------------------------------------------
--spec open() -> gpio() | {error, Reason :: atom()} | error.
+-spec open() -> gpio().
 open() ->
     open_port({spawn, "gpio"}, []).
 

--- a/libs/avm_unix/src/uart.erl
+++ b/libs/avm_unix/src/uart.erl
@@ -56,50 +56,45 @@
 %%-----------------------------------------------------------------------------
 %% @param Name device path, e.g. `"/dev/ttyUSB0"'
 %% @param Opts UART configuration options
-%% @returns UART handle or error
+%% @returns UART handle
 %% @doc Open a UART device with the given name and options.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec open(Name :: string() | binary(), Opts :: uart_opts()) ->
-    {pid(), atomvm:posix_fd()} | {error, term()}.
+    {pid(), atomvm:posix_fd()}.
 open(Name, Opts) ->
     open([{peripheral, Name} | Opts]).
 
 %%-----------------------------------------------------------------------------
 %% @param Opts UART configuration options including `{peripheral, Path}'
-%% @returns UART handle or error
+%% @returns UART handle
 %% @doc Open a UART device.
 %% @end
 %%-----------------------------------------------------------------------------
--spec open(Opts :: uart_opts()) -> {pid(), atomvm:posix_fd()} | {error, term()}.
+-spec open(Opts :: uart_opts()) -> {pid(), atomvm:posix_fd()}.
 open(Opts) ->
     Device =
         case proplists:get_value(peripheral, Opts) of
-            undefined -> {error, {missing, peripheral}};
+            undefined -> error({missing, peripheral});
             D when is_binary(D) -> D;
             D when is_list(D) -> D
         end,
-    case Device of
-        {error, _} = Err ->
-            Err;
-        _ ->
-            case atomvm:posix_open(Device, [o_rdwr, o_noctty]) of
-                {ok, Fd} ->
-                    case configure(Fd, Opts) of
-                        ok ->
-                            atomvm:posix_tcflush(Fd, tcioflush),
-                            Pid = spawn_link(fun() ->
-                                process_flag(trap_exit, true),
-                                loop(Fd)
-                            end),
-                            {Pid, Fd};
-                        {error, _} = CfgErr ->
-                            atomvm:posix_close(Fd),
-                            CfgErr
-                    end;
-                {error, _} = OpenErr ->
-                    OpenErr
-            end
+    case atomvm:posix_open(Device, [o_rdwr, o_noctty]) of
+        {ok, Fd} ->
+            case configure(Fd, Opts) of
+                ok ->
+                    atomvm:posix_tcflush(Fd, tcioflush),
+                    Pid = spawn_link(fun() ->
+                        process_flag(trap_exit, true),
+                        loop(Fd)
+                    end),
+                    {Pid, Fd};
+                {error, _} = CfgErr ->
+                    atomvm:posix_close(Fd),
+                    CfgErr
+            end;
+        {error, Reason} ->
+            error(Reason)
     end.
 
 %%-----------------------------------------------------------------------------

--- a/libs/eavmlib/src/gpio_hal.erl
+++ b/libs/eavmlib/src/gpio_hal.erl
@@ -200,14 +200,14 @@
 % Returns the handle of an existing GPIO driver if one is already
 % registered, or starts a new one. The returned handle is required
 % for all port-based API functions.
--callback start() -> gpio() | {error, Reason :: atom()} | error.
+-callback start() -> gpio().
 
 % Open a new GPIO driver instance.
 %
 % Always starts a new GPIO driver instance and registers it. Fails
 % if a driver is already registered. Use `start/0' to get an existing
 % instance or start a new one.
--callback open() -> gpio() | {error, Reason :: atom()} | error.
+-callback open() -> gpio().
 
 % Close a GPIO driver and release its resources.
 %

--- a/libs/eavmlib/src/uart_hal.erl
+++ b/libs/eavmlib/src/uart_hal.erl
@@ -95,13 +95,13 @@
 % Open a UART port with the given configuration parameters.
 %
 % Returns a handle for subsequent read/write operations.
--callback open(Params :: params()) -> uart() | {error, Reason :: term()}.
+-callback open(Params :: params()) -> uart().
 
 % Open a UART port on the specified peripheral.
 %
 % Convenience wrapper that adds `{peripheral, Name}' to the
 % parameters and calls `open/1'.
--callback open(Name :: peripheral(), Params :: params()) -> uart() | {error, Reason :: term()}.
+-callback open(Name :: peripheral(), Params :: params()) -> uart().
 
 % Close a UART port and release its resources.
 -callback close(UART :: uart()) -> ok | {error, Reason :: term()}.


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
