### PR TITLE
Fix workflow template injection on GitHub refname

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -94,11 +94,14 @@ jobs:
 
       - name: Set docs target name
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-            if [[ ${{ github.ref_name }} == *"/merge" ]]; then
-              echo "AVM_DOCS_NAME=${{ github.event.pull_request.base.ref }}" | tr '/' '-' >> "$GITHUB_ENV";
+            if [[ ${REF_NAME} == *"/merge" ]]; then
+              echo "AVM_DOCS_NAME=${PR_BASE_REF}" | tr '/' '-' >> "$GITHUB_ENV";
             else
-              echo "AVM_DOCS_NAME=${{ github.ref_name }}" | tr '/' '-' >> "$GITHUB_ENV";
+              echo "AVM_DOCS_NAME=${REF_NAME}" | tr '/' '-' >> "$GITHUB_ENV";
             fi
 
       - uses: actions/checkout@v4
@@ -108,9 +111,11 @@ jobs:
 
       - name: Track all branches
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           git config --global --add safe.directory /__w/AtomVM/AtomVM
-          for branch in `git branch -a | grep "remotes/origin" | grep -v HEAD | grep -v  "${{ github.ref_name }}"`; do
+          for branch in `git branch -a | grep "remotes/origin" | grep -v HEAD | grep -v  "${REF_NAME}"`; do
             git branch --track ${branch#remotes/origin/} $branch
           done
 

--- a/.github/workflows/build-libraries.yaml
+++ b/.github/workflows/build-libraries.yaml
@@ -118,13 +118,15 @@ jobs:
 
     - name: "Rename and write sha256sum"
       working-directory: build
+      env:
+        REF_NAME: ${{ github.ref_name }}
       run: |
         for variant in atomvmlib atomvmlib-esp32 atomvmlib-rp2 atomvmlib-stm32 atomvmlib-emscripten; do
-          VARIANT_FILE="${variant}-${{ github.ref_name }}.avm"
+          VARIANT_FILE="${variant}-${REF_NAME}.avm"
           mv "libs/${variant}.avm" "libs/${VARIANT_FILE}" &&
           sha256sum "libs/${VARIANT_FILE}" > "libs/${VARIANT_FILE}.sha256"
         done
-        HELLO_WORLD_FILE=hello_world-${{ github.ref_name }}.avm
+        HELLO_WORLD_FILE=hello_world-${REF_NAME}.avm
         mv examples/erlang/hello_world.avm "examples/erlang/${HELLO_WORLD_FILE}"
         sha256sum "examples/erlang/${HELLO_WORLD_FILE}" > "examples/erlang/${HELLO_WORLD_FILE}.sha256"
 

--- a/.github/workflows/build-linux-artifacts.yaml
+++ b/.github/workflows/build-linux-artifacts.yaml
@@ -199,9 +199,12 @@ jobs:
 
     - name: Build AtomVM using docker
       timeout-minutes: 15
+      env:
+        REF_NAME: ${{ github.ref_name }}
       run: |
         docker run --platform linux/${{ matrix.platform }} --rm -v $PWD:/atomvm -w /atomvm \
         -e CFLAGS="${{ matrix.cflags }}" -e CXXFLAGS="${{ matrix.cflags }}" \
+        -e REF_NAME="${REF_NAME}" \
         ${{ matrix.docker_image }}:${{ matrix.tag }} /bin/bash -c '
         ([ -n "${{ matrix.sources }}" ] && echo "${{ matrix.sources }}" > /etc/apt/sources.list || true) &&
         cat /etc/apt/sources.list &&
@@ -251,8 +254,8 @@ jobs:
         ./src/AtomVM tests/libs/estdlib/test_estdlib.avm &&
         ./src/AtomVM tests/libs/eavmlib/test_eavmlib.avm &&
         ./src/AtomVM tests/libs/alisp/test_alisp.avm &&
-        cp ./src/AtomVM ./AtomVM-${{ matrix.build_name }}-${{ github.ref_name }} &&
-        sha256sum ./src/AtomVM > ./AtomVM-${{ matrix.build_name }}-${{ github.ref_name }}.sha256
+        cp ./src/AtomVM ./AtomVM-${{ matrix.build_name }}-${REF_NAME} &&
+        sha256sum ./src/AtomVM > ./AtomVM-${{ matrix.build_name }}-${REF_NAME}.sha256
         '
 
     - name: Release

--- a/.github/workflows/esp32-mkimage.yaml
+++ b/.github/workflows/esp32-mkimage.yaml
@@ -179,8 +179,10 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       shell: bash
       working-directory: src/platforms/esp32/build
+      env:
+        REF_NAME: ${{ github.ref_name }}
       run: |
-        ATOMVM_IMG="AtomVM-${{ matrix.soc }}${{ matrix.flavor }}-${{ github.ref_name }}.img"
+        ATOMVM_IMG="AtomVM-${{ matrix.soc }}${{ matrix.flavor }}-${REF_NAME}.img"
         mv atomvm-${{ matrix.soc }}${{ matrix.flavor }}.img "${ATOMVM_IMG}"
         sha256sum "${ATOMVM_IMG}" > "${ATOMVM_IMG}.sha256"
 

--- a/.github/workflows/pico-build.yaml
+++ b/.github/workflows/pico-build.yaml
@@ -121,8 +121,10 @@ jobs:
 
     - name: Set and escape ref name
       shell: bash
+      env:
+        REF_NAME: ${{ github.ref_name }}
       run: |
-          echo "AVM_REF_NAME=${{ github.ref_name }}" | tr '/' '-' >> "$GITHUB_ENV";
+          echo "AVM_REF_NAME=${REF_NAME}" | tr '/' '-' >> "$GITHUB_ENV";
 
     - name: Download atomvmlib artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -101,14 +101,18 @@ jobs:
 
       - name: Track all branches
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           git config --global --add safe.directory /__w/AtomVM/AtomVM
-          for branch in `git branch -a | grep "remotes/origin" | grep -v HEAD | grep -v "${{ github.ref_name }}" `; do
+          for branch in `git branch -a | grep "remotes/origin" | grep -v HEAD | grep -v "${REF_NAME}" `; do
             git branch --track ${branch#remotes/origin/} $branch
           done
 
       - name: Build Site
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           . /home/runner/python-env/sphinx/bin/activate
           mkdir build
@@ -116,20 +120,22 @@ jobs:
           cmake ..
           cd doc
           make GitHub_CI_Publish_Docs
-          rm -frv "/__w/AtomVM/AtomVM/www/${{ github.ref_name }}"
-          cp -av html "/__w/AtomVM/AtomVM/www/${{ github.ref_name }}"
+          rm -frv "/__w/AtomVM/AtomVM/www/${REF_NAME}"
+          cp -av html "/__w/AtomVM/AtomVM/www/${REF_NAME}"
       - name: Commit files
         id: commit_files
         if: github.repository == 'atomvm/AtomVM'
         working-directory: /home/runner/work/AtomVM/AtomVM/www
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           git config --local user.email "atomvm-doc-bot@users.noreply.github.com"
           git config --local user.name "AtomVM Doc Bot"
-          git status "${{ github.ref_name }}"
-          git add "${{ github.ref_name }}"
+          git status "${REF_NAME}"
+          git add "${REF_NAME}"
           git add .
           git diff --exit-code main || echo "Going to commit"
-          git diff --exit-code main || git commit -m "Update Documentation for ${{ github.ref_name }}"
+          git diff --exit-code main || git commit -m "Update Documentation for ${REF_NAME}"
           git log -1
       - name: Push changes
         if: github.repository == 'atomvm/AtomVM'

--- a/.github/workflows/wasm-build.yaml
+++ b/.github/workflows/wasm-build.yaml
@@ -213,11 +213,13 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/') && matrix.jit == ''
       shell: bash
       working-directory: src/platforms/emscripten/build/src
+      env:
+        REF_NAME: ${{ github.ref_name }}
       run: |
-        ATOMVM_JS=AtomVM-node-${{ github.ref_name }}.mjs
+        ATOMVM_JS=AtomVM-node-${REF_NAME}.mjs
         mv AtomVM.mjs "${ATOMVM_JS}"
         sha256sum "${ATOMVM_JS}" > "${ATOMVM_JS}.sha256"
-        ATOMVM_WASM=AtomVM-node-${{ github.ref_name }}.wasm
+        ATOMVM_WASM=AtomVM-node-${REF_NAME}.wasm
         mv AtomVM.wasm "${ATOMVM_WASM}"
         sha256sum "${ATOMVM_WASM}" > "${ATOMVM_WASM}.sha256"
 
@@ -340,11 +342,13 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       shell: bash
       working-directory: src/platforms/emscripten/build/src
+      env:
+        REF_NAME: ${{ github.ref_name }}
       run: |
-        ATOMVM_JS=AtomVM-web-${{ github.ref_name }}.mjs
+        ATOMVM_JS=AtomVM-web-${REF_NAME}.mjs
         mv AtomVM.mjs "${ATOMVM_JS}"
         sha256sum "${ATOMVM_JS}" > "${ATOMVM_JS}.sha256"
-        ATOMVM_WASM=AtomVM-web-${{ github.ref_name }}.wasm
+        ATOMVM_WASM=AtomVM-web-${REF_NAME}.wasm
         mv AtomVM.wasm "${ATOMVM_WASM}"
         sha256sum "${ATOMVM_WASM}" > "${ATOMVM_WASM}.sha256"
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
