### PR TITLE
Fix stability of `test_net_kernel` with three fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added more reset reasons and ensured `esp:reset_reason/0` doesn't return `undefined`
 - Added I2C and SPI APIs to stm32 platform
 - Added `Transfer-Encoding: chunked` response support to `ahttp_client`, including HTTP trailers
+- Added `proc_lib:init_fail/2,3`
 
 ### Changed
 - Updated network type db() to dbm() to reflect the actual representation of the type
@@ -48,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `erlang:system_info(system_architecture)` now reports normalized `arch-vendor-os` strings
 - Fixed `ahttp_client` crash on non-numeric or negative `Content-Length` values
 - Fixed `ahttp_client` crash on headers with empty or all-whitespace values
+- Fixed a bug in `supervisor` handling of failing child
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/libs/estdlib/src/erl_epmd.erl
+++ b/libs/estdlib/src/erl_epmd.erl
@@ -63,6 +63,12 @@
 -define(ERLANG_NODE_TYPE, 77).
 -define(VERSION, 6).
 
+%% There is a race in EPMD protocol, one can unregister and reregister
+%% faster than EPMD would process it.
+%% See: https://github.com/erlang/otp/issues/11083
+-define(REGISTER_RETRY_ATTEMPTS, 4).
+-define(REGISTER_RETRY_INITIAL_MS, 5).
+
 -record(receive_port2_resp, {
     port_no :: non_neg_integer(),
     highest_version :: non_neg_integer(),
@@ -201,6 +207,17 @@ handle_call({register_node, _Name, _Port}, _From, #state{socket = Socket} = Stat
 ->
     {reply, {error, already_registered}, State};
 handle_call({register_node, Name, Port}, _From, #state{} = State) ->
+    case do_register_node(Name, Port, ?REGISTER_RETRY_ATTEMPTS, ?REGISTER_RETRY_INITIAL_MS) of
+        {ok, Socket, Creation} ->
+            {reply, {ok, Creation}, State#state{socket = Socket}};
+        {error, _} = Error ->
+            {reply, Error, State}
+    end;
+handle_call(stop, _From, State) ->
+    {stop, shutdown, ok, State}.
+
+%% @private
+do_register_node(Name, Port, AttemptsLeft, BackoffMs) ->
     {ok, Socket} = socket:open(inet, stream, tcp),
     case socket:connect(Socket, #{addr => {127, 0, 0, 1}, port => ?EPMD_PORT, family => inet}) of
         ok ->
@@ -211,17 +228,21 @@ handle_call({register_node, Name, Port}, _From, #state{} = State) ->
                     ?VERSION:16, NameLen:16, NameBin/binary, 0:16>>,
             case send_request(Socket, Packet) of
                 {ok, #alive2_resp{creation = Creation}} ->
-                    {reply, {ok, Creation}, State#state{socket = Socket}};
+                    {ok, Socket, Creation};
+                {error, 1} when AttemptsLeft > 0 ->
+                    socket:close(Socket),
+                    receive
+                    after BackoffMs -> ok
+                    end,
+                    do_register_node(Name, Port, AttemptsLeft - 1, BackoffMs * 2);
                 {error, _} = RequestErr ->
                     socket:close(Socket),
-                    {reply, RequestErr, State}
+                    RequestErr
             end;
         {error, _} = ConnectErr ->
             socket:close(Socket),
-            {reply, ConnectErr, State}
-    end;
-handle_call(stop, _From, State) ->
-    {stop, shutdown, ok, State}.
+            ConnectErr
+    end.
 
 %% @hidden
 handle_cast(_Message, State) ->

--- a/libs/estdlib/src/gen_server.erl
+++ b/libs/estdlib/src/gen_server.erl
@@ -168,7 +168,7 @@ init_it(Starter, Module, Args, Options) ->
                     timeout = InitTimeout
                 }};
             {stop, Reason} ->
-                {fail, {error, {init_stopped, Reason}}, {exit, Reason}};
+                {fail, {error, Reason}, {exit, Reason}};
             Reply ->
                 {fail, {error, {unexpected_reply_from_init, Reply}},
                     {exit, {bad_return_value, Reply}}}

--- a/libs/estdlib/src/gen_server.erl
+++ b/libs/estdlib/src/gen_server.erl
@@ -144,54 +144,52 @@ init_it(Starter, Name, Module, Args, Options) ->
     end.
 
 init_it(Starter, Module, Args, Options) ->
-    StateT =
-        try
-            case Module:init(Args) of
-                {ok, ModState} ->
-                    proc_lib:init_ack(Starter, {ok, self()}),
-                    #state{
-                        name = proplists:get_value(name, Options),
-                        mod = Module,
-                        mod_state = ModState,
-                        timeout = infinity
-                    };
-                {ok, ModState, {continue, NewContinue}} ->
-                    proc_lib:init_ack(Starter, {ok, self()}),
-                    #state{
-                        name = proplists:get_value(name, Options),
-                        mod = Module,
-                        mod_state = ModState,
-                        timeout = {continue, NewContinue}
-                    };
-                {ok, ModState, InitTimeout} ->
-                    proc_lib:init_ack(Starter, {ok, self()}),
-                    #state{
-                        name = proplists:get_value(name, Options),
-                        mod = Module,
-                        mod_state = ModState,
-                        timeout = InitTimeout
-                    };
-                {stop, Reason} ->
-                    proc_lib:init_ack(Starter, {error, {init_stopped, Reason}}),
-                    undefined;
-                Reply ->
-                    proc_lib:init_ack(Starter, {error, {unexpected_reply_from_init, Reply}}),
-                    undefined
-            end
+    Outcome =
+        try Module:init(Args) of
+            {ok, ModState} ->
+                {ok, #state{
+                    name = proplists:get_value(name, Options),
+                    mod = Module,
+                    mod_state = ModState,
+                    timeout = infinity
+                }};
+            {ok, ModState, {continue, NewContinue}} ->
+                {ok, #state{
+                    name = proplists:get_value(name, Options),
+                    mod = Module,
+                    mod_state = ModState,
+                    timeout = {continue, NewContinue}
+                }};
+            {ok, ModState, InitTimeout} ->
+                {ok, #state{
+                    name = proplists:get_value(name, Options),
+                    mod = Module,
+                    mod_state = ModState,
+                    timeout = InitTimeout
+                }};
+            {stop, Reason} ->
+                {fail, {error, {init_stopped, Reason}}, {exit, Reason}};
+            Reply ->
+                {fail, {error, {unexpected_reply_from_init, Reply}},
+                    {exit, {bad_return_value, Reply}}}
         catch
-            _:E:S ->
+            Class:E:S ->
                 crash_report(
-                    io_lib:format("gen_server:init_it/4: Error initializing module ~p", [Module]),
+                    io_lib:format(
+                        "gen_server:init_it/4: Error initializing module ~p", [Module]
+                    ),
                     Starter,
                     E,
                     S
                 ),
-                proc_lib:init_ack(Starter, {error, {bad_return_value, E}}),
-                undefined
+                {fail, {error, {bad_return_value, E}}, {Class, E, S}}
         end,
-    case StateT of
-        undefined -> ok;
-        #state{} = State -> system_continue(Starter, [], State)
+    case Outcome of
+        {ok, State} ->
+            proc_lib:init_ack(Starter, {ok, self()}),
+            system_continue(Starter, [], State);
+        {fail, Return, Exception} ->
+            proc_lib:init_fail(Starter, Return, Exception)
     end.
 
 crash_report(ErrStr, Parent, E, S) ->

--- a/libs/estdlib/src/proc_lib.erl
+++ b/libs/estdlib/src/proc_lib.erl
@@ -50,6 +50,8 @@
     start_monitor/5,
     init_ack/1,
     init_ack/2,
+    init_fail/2,
+    init_fail/3,
 
     initial_call/1,
     translate_initial_call/1
@@ -60,7 +62,8 @@
 ]).
 
 -export_type([
-    start_spawn_option/0
+    start_spawn_option/0,
+    exception/0
 ]).
 
 -compile({no_auto_import, [spawn/3, spawn_link/3]}).
@@ -73,6 +76,11 @@
     | {max_heap_size, pos_integer()}
     | {atomvm_heap_growth, erlang:atomvm_heap_growth_strategy()}
     | link.
+
+%% Exception specification accepted by `init_fail/2,3'.
+-type exception() ::
+    {error | exit | throw, Reason :: term()}
+    | {Class :: error | exit | throw, Reason :: term(), Stacktrace :: list()}.
 
 %% @equiv spawn(erlang, apply, [Fun, []])
 -spec spawn(fun(() -> any())) -> pid().
@@ -199,6 +207,21 @@ start0(Module, Function, Args, Timeout, SpawnOpts, Link, Monitor) ->
         {ack, Pid, Result} ->
             erlang:demonitor(MonitorRef, [flush]),
             Result;
+        %% Nack from init_fail: wait for the child to die before returning,
+        %% so its registered name is freed and linked children have got their
+        %% EXIT signal.
+        {nack, Pid, Result} when Monitor ->
+            receive
+                {'DOWN', MonitorRef, process, Pid, _} -> ok
+            end,
+            flush_exit(Pid, Link),
+            {Result, MonitorRef};
+        {nack, Pid, Result} ->
+            receive
+                {'DOWN', MonitorRef, process, Pid, _} -> ok
+            end,
+            flush_exit(Pid, Link),
+            Result;
         {'DOWN', MonitorRef, process, Pid, Reason} when Link ->
             receive
                 {'EXIT', Pid, _} -> ok
@@ -236,6 +259,15 @@ start0(Module, Function, Args, Timeout, SpawnOpts, Link, Monitor) ->
     end.
 
 %% @private
+flush_exit(_Pid, false) ->
+    ok;
+flush_exit(Pid, true) ->
+    receive
+        {'EXIT', Pid, _} -> ok
+    after 0 -> ok
+    end.
+
+%% @private
 get_ancestors() ->
     case get('$ancestors') of
         A when is_list(A) -> A;
@@ -262,6 +294,32 @@ init_ack(Result) ->
 init_ack(Parent, Result) ->
     Parent ! {ack, self(), Result},
     ok.
+
+%% @equiv init_fail(Parent, Return, Exception)
+-spec init_fail(Return :: term(), Exception :: exception()) -> no_return().
+init_fail(Return, Exception) ->
+    [Parent | _] = get('$ancestors'),
+    init_fail(Parent, Return, Exception).
+
+%%-----------------------------------------------------------------------------
+%% @doc     Signal init failure: nack the starter with Return and raise
+%%          Exception. Starter blocks until this process is dead, so any
+%%          registered name is released before the starter sees the failure.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec init_fail(Parent :: pid(), Return :: term(), Exception :: exception()) -> no_return().
+init_fail(Parent, Return, Exception) ->
+    _ = Parent ! {nack, self(), Return},
+    case Exception of
+        {error, Reason} ->
+            erlang:error(Reason);
+        {exit, Reason} ->
+            erlang:exit(Reason);
+        {throw, Reason} ->
+            erlang:throw(Reason);
+        {Class, Reason, Stacktrace} ->
+            erlang:raise(Class, Reason, Stacktrace)
+    end.
 
 %% @private
 -spec init_p(pid(), [pid()], atom(), atom(), [any()]) -> any().

--- a/libs/estdlib/src/socket_dist.erl
+++ b/libs/estdlib/src/socket_dist.erl
@@ -120,6 +120,8 @@ accept_loop(Kernel, LSock) ->
                     exit(unsupported_protocol)
             end,
             accept_loop(Kernel, LSock);
+        {error, closed} ->
+            exit(normal);
         {error, _} = Error ->
             exit(Error)
     end.

--- a/libs/estdlib/src/socket_dist_controller.erl
+++ b/libs/estdlib/src/socket_dist_controller.erl
@@ -148,8 +148,10 @@ handle_cast({handshake_complete, DHandle}, State0) ->
     ok = erlang:dist_ctrl_get_data_notification(DHandle),
     % We now need to get messages when data is coming.
     State1 = State0#state{dhandle = DHandle},
-    State2 = recv_data_loop(State1),
-    {noreply, State2}.
+    case recv_data_loop(State1) of
+        {ok, State2} -> {noreply, State2};
+        {stop, Reason, State2} -> {stop, Reason, State2}
+    end.
 
 handle_info(dist_data, State0) ->
     State1 = send_data_loop(State0),
@@ -158,8 +160,10 @@ handle_info(
     {'$socket', Socket, select, SelectHandle},
     #state{socket = Socket, select_handle = SelectHandle} = State0
 ) ->
-    State1 = recv_data_loop(State0),
-    {noreply, State1}.
+    case recv_data_loop(State0) of
+        {ok, State1} -> {noreply, State1};
+        {stop, Reason, State1} -> {stop, Reason, State1}
+    end.
 
 terminate(_Reason, _State) ->
     ok.
@@ -180,9 +184,15 @@ recv_data_loop(
             {NewBuffer, NewReceived} = process_recv_buffer(
                 DHandle, <<Buffer/binary, Data/binary>>, Received
             ),
-            State#state{buffer = NewBuffer, select_handle = SelectHandle, received = NewReceived};
+            {ok, State#state{
+                buffer = NewBuffer, select_handle = SelectHandle, received = NewReceived
+            }};
         {select, {select_info, recv, SelectHandle}} when is_reference(SelectHandle) ->
-            State#state{select_handle = SelectHandle}
+            {ok, State#state{select_handle = SelectHandle}};
+        {error, closed} ->
+            {stop, normal, State};
+        {error, Reason} ->
+            {stop, {recv_error, Reason}, State}
     end.
 
 process_recv_buffer(DHandle, <<Size:32, Rest/binary>>, Received) when byte_size(Rest) >= Size ->

--- a/libs/estdlib/src/supervisor.erl
+++ b/libs/estdlib/src/supervisor.erl
@@ -200,7 +200,9 @@ count_children(Supervisor) ->
 
 % @hidden
 -spec init({Mod :: module(), Args :: [any()]}) ->
-    {ok, State :: #state{}} | {stop, {bad_return, {Mod :: module(), init, Reason :: term()}}}.
+    {ok, State :: #state{}}
+    | {stop, {bad_return, {Mod :: module(), init, Reason :: term()}}}
+    | {stop, {shutdown, {failed_to_start_child, ChildId :: term(), Reason :: term()}}}.
 init({Mod, Args}) ->
     erlang:process_flag(trap_exit, true),
     case Mod:init(Args) of
@@ -210,8 +212,7 @@ init({Mod, Args}) ->
                 intensity = Intensity,
                 period = Period
             }),
-            NewChildren = start_children(State#state.children, []),
-            {ok, State#state{children = NewChildren}};
+            init_start_children(State);
         {ok, {#{} = SupSpec, StartSpec}} ->
             Strategy = maps:get(strategy, SupSpec, one_for_one),
             Intensity = maps:get(intensity, SupSpec, ?DEFAULT_INTENSITY),
@@ -221,11 +222,22 @@ init({Mod, Args}) ->
                 intensity = Intensity,
                 period = Period
             }),
-            NewChildren = start_children(State#state.children, []),
-            {ok, State#state{children = NewChildren}};
+            init_start_children(State);
         Error ->
             % TODO: log supervisor init failure
             {stop, {bad_return, {Mod, init, Error}}}
+    end.
+
+init_start_children(State) ->
+    case start_children(State#state.children, []) of
+        {ok, NewChildren} ->
+            {ok, State#state{children = NewChildren}};
+        {error, FailedId, Reason, StartedChildren} ->
+            %% Tear down siblings already started so their registered
+            %% names are released before we stop.
+            StartedPids = loop_terminate(StartedChildren, []),
+            ok = loop_wait_termination(StartedPids),
+            {stop, {shutdown, {failed_to_start_child, FailedId, Reason}}}
     end.
 
 -spec child_spec_to_record(child_spec()) -> #child{}.
@@ -276,14 +288,16 @@ init_state([], State) ->
     State#state{children = lists:reverse(State#state.children)}.
 
 -spec start_children(ChildSpecs :: [#child{}], [#child{}]) ->
-    Childs :: [#child{}].
-start_children([Child | T], StartedC) ->
+    {ok, [#child{}]} | {error, ChildId :: term(), Reason :: term(), Started :: [#child{}]}.
+start_children([#child{id = ID} = Child | T], StartedC) ->
     case try_start(Child) of
         {ok, Pid, _Result} ->
-            start_children(T, [Child#child{pid = Pid} | StartedC])
+            start_children(T, [Child#child{pid = Pid} | StartedC]);
+        {error, Reason} ->
+            {error, ID, Reason, StartedC}
     end;
 start_children([], StartedC) ->
-    StartedC.
+    {ok, StartedC}.
 
 % @hidden
 handle_call({start_child, ChildSpec}, _From, #state{children = Children} = State) ->

--- a/tests/libs/estdlib/test_supervisor.erl
+++ b/tests/libs/estdlib/test_supervisor.erl
@@ -40,6 +40,7 @@ test() ->
     ok = try_again_restart(),
     ok = try_again_restart_shutdown(),
     ok = try_again_one_for_all(),
+    ok = test_failed_child_cleanup_releases_names(),
     ok.
 
 test_basic_supervisor() ->
@@ -222,6 +223,14 @@ child_start(error) ->
     {error, child_error};
 child_start(fail) ->
     fail;
+child_start({register_then_idle, Name}) ->
+    Pid = spawn_link(fun() ->
+        true = register(Name, self()),
+        receive
+            ok -> ok
+        end
+    end),
+    {ok, Pid};
 child_start({trap_exit, Parent}) ->
     Pid = spawn_link(fun() ->
         process_flag(trap_exit, true),
@@ -403,6 +412,27 @@ init({test_try_again, Arbitrator, Parent, Ref}) ->
         }
     ],
     {ok, {#{strategy => one_for_one, intensity => 5, period => 10}, ChildSpec}};
+init({test_failed_child_cleanup, RegisterName}) ->
+    %% First child registers a name and idles. Second child returns {error,_}
+    %% so start_children fails. The supervisor must terminate the first child
+    %% before stopping, otherwise its registered name leaks past init failure.
+    ChildSpecs = [
+        #{
+            id => good_child,
+            start => {?MODULE, child_start, [{register_then_idle, RegisterName}]},
+            restart => permanent,
+            shutdown => brutal_kill,
+            type => worker
+        },
+        #{
+            id => bad_child,
+            start => {?MODULE, child_start, [error]},
+            restart => permanent,
+            shutdown => brutal_kill,
+            type => worker
+        }
+    ],
+    {ok, {#{strategy => one_for_one, intensity => 1, period => 5}, ChildSpecs}};
 init({test_retry_one_for_all, Arbitrator, Parent, Ref}) ->
     ChildSpec = [
         #{
@@ -540,6 +570,18 @@ test_one_for_all() ->
 
     unlink(SupPid),
     exit(SupPid, shutdown),
+    ok.
+
+test_failed_child_cleanup_releases_names() ->
+    process_flag(trap_exit, true),
+    Name = test_failed_child_cleanup_good,
+    undefined = whereis(Name),
+    %% Bad child returns {error, _}; good child registers Name. Supervisor
+    %% start must fail AND release the registered name before returning.
+    Result = supervisor:start_link(?MODULE, {test_failed_child_cleanup, Name}),
+    {error, {shutdown, {failed_to_start_child, bad_child, _}}} = Result,
+    undefined = whereis(Name),
+    process_flag(trap_exit, false),
     ok.
 
 test_crash_limits() ->


### PR DESCRIPTION
- Handle closed socket more gracefully in socket_dist
- Add a small retry with erl_epmd registration to work around a race in EPMD protocol (see https://github.com/erlang/otp/issues/11083)
- Fix a bug in supervisor and introduce `proc_lib:init_fail/2,3`

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
