### PR TITLE
Fix localtime/1 memory leak, use-after-free, and TZ restore bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `ahttp_client` crash on headers with empty or all-whitespace values
 - Fixed a bug in `supervisor` handling of failing child
 - Fixed two bugs related to closing fds in `atomvm:subprocess/4`
+- Fixed `erlang:localtime/1` memory leak, use-after-free, and TZ restore bugs on newlib/picolibc
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1949,6 +1949,23 @@ term nif_erlang_universaltime_0(Context *ctx, int argc, term argv[])
     return build_datetime_from_tm(ctx, gmtime_r(&ts.tv_sec, &broken_down_time));
 }
 
+// On newlib/picolibc, setenv leaks the old "NAME=value" string on every
+// overwrite. Some affected putenv implementations also funnel through setenv
+// instead of installing the caller-provided string, so they leak too.
+// See: https://github.com/espressif/esp-idf/issues/3046
+//
+// Workaround: temporarily swap the environ pointer to a minimal array
+// containing only our TZ entry. This avoids all setenv/putenv calls
+// on the affected platforms. The swap is protected by env_spinlock. This
+// assumes AtomVM is the sole user of TZ -- no external threads should
+// read/write environ or call time functions during the temporary override.
+#if defined(__NEWLIB__) || defined(__PICOLIBC__)
+#define AVM_TZ_SETENV_LEAKS 1
+extern char **environ;
+#else
+#define AVM_TZ_SETENV_LEAKS 0
+#endif
+
 term nif_erlang_localtime(Context *ctx, int argc, term argv[])
 {
     char *tz;
@@ -1968,29 +1985,57 @@ term nif_erlang_localtime(Context *ctx, int argc, term argv[])
     struct tm storage;
     struct tm *localtime;
 
-#ifndef AVM_NO_SMP
-    smp_spinlock_lock(&ctx->global->env_spinlock);
-#endif
+    SMP_SPINLOCK_LOCK(&ctx->global->env_spinlock);
     if (tz) {
-        char *oldtz = getenv("TZ");
+#if AVM_TZ_SETENV_LEAKS
+        char tz_env_entry[64];
+        int n = snprintf(tz_env_entry, sizeof(tz_env_entry), "TZ=%s", tz);
+        if (UNLIKELY(n < 0 || n >= (int) sizeof(tz_env_entry))) {
+            SMP_SPINLOCK_UNLOCK(&ctx->global->env_spinlock);
+            free(tz);
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        char *tz_environ[] = { tz_env_entry, NULL };
+        char **saved_environ = environ;
+        environ = tz_environ;
+        tzset();
+        localtime = localtime_r(&ts.tv_sec, &storage);
+        environ = saved_environ;
+        tzset();
+#else
+        char *oldtz_env = getenv("TZ");
+        char *oldtz = NULL;
+        if (oldtz_env) {
+            oldtz = strdup(oldtz_env);
+            if (UNLIKELY(oldtz == NULL)) {
+                SMP_SPINLOCK_UNLOCK(&ctx->global->env_spinlock);
+                free(tz);
+                RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            }
+        }
         setenv("TZ", tz, 1);
         tzset();
         localtime = localtime_r(&ts.tv_sec, &storage);
         if (oldtz) {
             setenv("TZ", oldtz, 1);
+            free(oldtz);
         } else {
             unsetenv("TZ");
         }
+        tzset();
+#endif
     } else {
-        // Call tzset to handle DST changes
         tzset();
         localtime = localtime_r(&ts.tv_sec, &storage);
     }
-#ifndef AVM_NO_SMP
-    smp_spinlock_unlock(&ctx->global->env_spinlock);
-#endif
+    SMP_SPINLOCK_UNLOCK(&ctx->global->env_spinlock);
 
     free(tz);
+
+    if (UNLIKELY(localtime == NULL)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
     return build_datetime_from_tm(ctx, localtime);
 }
 
@@ -2065,25 +2110,19 @@ static term nif_os_getenv_1(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-#ifndef AVM_NO_SMP
-    smp_spinlock_lock(&ctx->global->env_spinlock);
-#endif
+    SMP_SPINLOCK_LOCK(&ctx->global->env_spinlock);
 
     const char *env_var_value_tmp = getenv(env_var);
     free(env_var);
 
     if (IS_NULL_PTR(env_var_value_tmp)) {
-#ifndef AVM_NO_SMP
-        smp_spinlock_unlock(&ctx->global->env_spinlock);
-#endif
+        SMP_SPINLOCK_UNLOCK(&ctx->global->env_spinlock);
         return FALSE_ATOM;
     }
 
     char *env_var_value = strdup(env_var_value_tmp);
 
-#ifndef AVM_NO_SMP
-    smp_spinlock_unlock(&ctx->global->env_spinlock);
-#endif
+    SMP_SPINLOCK_UNLOCK(&ctx->global->env_spinlock);
 
     if (IS_NULL_PTR(env_var_value)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1949,21 +1949,23 @@ term nif_erlang_universaltime_0(Context *ctx, int argc, term argv[])
     return build_datetime_from_tm(ctx, gmtime_r(&ts.tv_sec, &broken_down_time));
 }
 
-// On newlib/picolibc, setenv leaks the old "NAME=value" string on every
-// overwrite. Some affected putenv implementations also funnel through setenv
-// instead of installing the caller-provided string, so they leak too.
+// setenv leaks the prior "TZ=value" string on overwrite (unbounded on
+// newlib/picolibc, bounded on glibc; some putenv impls leak similarly).
 // See: https://github.com/espressif/esp-idf/issues/3046
 //
-// Workaround: temporarily swap the environ pointer to a minimal array
-// containing only our TZ entry. This avoids all setenv/putenv calls
-// on the affected platforms. The swap is protected by env_spinlock. This
-// assumes AtomVM is the sole user of TZ -- no external threads should
-// read/write environ or call time functions during the temporary override.
-#if defined(__NEWLIB__) || defined(__PICOLIBC__)
-#define AVM_TZ_SETENV_LEAKS 1
+// Workaround: under env_spinlock, briefly swap environ to a minimal
+// {"TZ=...", NULL} array around tzset()/localtime_r(), then restore.
+// During the swap, any code reading environ without env_spinlock (e.g.
+// a concurrent posix_spawn) will see only the TZ entry.
+//
+// Define AVM_TZ_USE_SETENV_FALLBACK=1 to opt into the (leaky) setenv
+// path on platforms that don't expose a writable environ.
+#ifndef AVM_TZ_USE_SETENV_FALLBACK
+#define AVM_TZ_USE_SETENV_FALLBACK 0
+#endif
+
+#if !AVM_TZ_USE_SETENV_FALLBACK
 extern char **environ;
-#else
-#define AVM_TZ_SETENV_LEAKS 0
 #endif
 
 term nif_erlang_localtime(Context *ctx, int argc, term argv[])
@@ -1985,16 +1987,21 @@ term nif_erlang_localtime(Context *ctx, int argc, term argv[])
     struct tm storage;
     struct tm *localtime;
 
+#if !AVM_TZ_USE_SETENV_FALLBACK
+    char *tz_env_entry = NULL;
+    if (tz) {
+        size_t tz_len = strlen(tz);
+        tz_env_entry = malloc(tz_len + 4); // "TZ=" + tz + '\0'
+        if (UNLIKELY(tz_env_entry == NULL)) {
+            free(tz);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
+        memcpy(tz_env_entry, "TZ=", 3);
+        memcpy(tz_env_entry + 3, tz, tz_len + 1);
+    }
+
     SMP_SPINLOCK_LOCK(&ctx->global->env_spinlock);
     if (tz) {
-#if AVM_TZ_SETENV_LEAKS
-        char tz_env_entry[64];
-        int n = snprintf(tz_env_entry, sizeof(tz_env_entry), "TZ=%s", tz);
-        if (UNLIKELY(n < 0 || n >= (int) sizeof(tz_env_entry))) {
-            SMP_SPINLOCK_UNLOCK(&ctx->global->env_spinlock);
-            free(tz);
-            RAISE_ERROR(BADARG_ATOM);
-        }
         char *tz_environ[] = { tz_env_entry, NULL };
         char **saved_environ = environ;
         environ = tz_environ;
@@ -2002,7 +2009,16 @@ term nif_erlang_localtime(Context *ctx, int argc, term argv[])
         localtime = localtime_r(&ts.tv_sec, &storage);
         environ = saved_environ;
         tzset();
+    } else {
+        tzset();
+        localtime = localtime_r(&ts.tv_sec, &storage);
+    }
+    SMP_SPINLOCK_UNLOCK(&ctx->global->env_spinlock);
+
+    free(tz_env_entry);
 #else
+    SMP_SPINLOCK_LOCK(&ctx->global->env_spinlock);
+    if (tz) {
         char *oldtz_env = getenv("TZ");
         char *oldtz = NULL;
         if (oldtz_env) {
@@ -2023,12 +2039,12 @@ term nif_erlang_localtime(Context *ctx, int argc, term argv[])
             unsetenv("TZ");
         }
         tzset();
-#endif
     } else {
         tzset();
         localtime = localtime_r(&ts.tv_sec, &storage);
     }
     SMP_SPINLOCK_UNLOCK(&ctx->global->env_spinlock);
+#endif
 
     free(tz);
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1968,6 +1968,78 @@ term nif_erlang_universaltime_0(Context *ctx, int argc, term argv[])
 extern char **environ;
 #endif
 
+static struct tm *tzstr_localtime_r(
+    const time_t *timer, struct tm *result, const char *tzstr, GlobalContext *global)
+{
+#ifdef AVM_NO_SMP
+    UNUSED(global);
+#endif
+    errno = 0;
+
+    struct tm *localtime;
+
+#if !AVM_TZ_USE_SETENV_FALLBACK
+    char *tz_env_entry = NULL;
+    if (tzstr) {
+        size_t tz_len = strlen(tzstr);
+        tz_env_entry = malloc(tz_len + 4); // "TZ=" + tzstr + '\0'
+        if (UNLIKELY(tz_env_entry == NULL)) {
+            errno = ENOMEM;
+            return NULL;
+        }
+        memcpy(tz_env_entry, "TZ=", 3);
+        memcpy(tz_env_entry + 3, tzstr, tz_len + 1);
+    }
+
+    SMP_SPINLOCK_LOCK(&global->env_spinlock);
+    if (tzstr) {
+        char *tz_environ[] = { tz_env_entry, NULL };
+        char **saved_environ = environ;
+        environ = tz_environ;
+        tzset();
+        localtime = localtime_r(timer, result);
+        environ = saved_environ;
+        tzset();
+    } else {
+        tzset();
+        localtime = localtime_r(timer, result);
+    }
+    SMP_SPINLOCK_UNLOCK(&global->env_spinlock);
+
+    free(tz_env_entry);
+#else
+    SMP_SPINLOCK_LOCK(&global->env_spinlock);
+    if (tzstr) {
+        char *oldtz_env = getenv("TZ");
+        char *oldtz = NULL;
+        if (oldtz_env) {
+            oldtz = strdup(oldtz_env);
+            if (UNLIKELY(oldtz == NULL)) {
+                SMP_SPINLOCK_UNLOCK(&global->env_spinlock);
+                errno = ENOMEM;
+                return NULL;
+            }
+        }
+        setenv("TZ", tzstr, 1);
+        tzset();
+        localtime = localtime_r(timer, result);
+        if (oldtz) {
+            setenv("TZ", oldtz, 1);
+            free(oldtz);
+        } else {
+            unsetenv("TZ");
+        }
+        tzset();
+    } else {
+        tzset();
+        localtime = localtime_r(timer, result);
+    }
+    SMP_SPINLOCK_UNLOCK(&global->env_spinlock);
+#endif
+
+    return localtime;
+}
+
 term nif_erlang_localtime(Context *ctx, int argc, term argv[])
 {
     char *tz;
@@ -1985,70 +2057,15 @@ term nif_erlang_localtime(Context *ctx, int argc, term argv[])
     sys_time(&ts);
 
     struct tm storage;
-    struct tm *localtime;
-
-#if !AVM_TZ_USE_SETENV_FALLBACK
-    char *tz_env_entry = NULL;
-    if (tz) {
-        size_t tz_len = strlen(tz);
-        tz_env_entry = malloc(tz_len + 4); // "TZ=" + tz + '\0'
-        if (UNLIKELY(tz_env_entry == NULL)) {
-            free(tz);
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-        }
-        memcpy(tz_env_entry, "TZ=", 3);
-        memcpy(tz_env_entry + 3, tz, tz_len + 1);
-    }
-
-    SMP_SPINLOCK_LOCK(&ctx->global->env_spinlock);
-    if (tz) {
-        char *tz_environ[] = { tz_env_entry, NULL };
-        char **saved_environ = environ;
-        environ = tz_environ;
-        tzset();
-        localtime = localtime_r(&ts.tv_sec, &storage);
-        environ = saved_environ;
-        tzset();
-    } else {
-        tzset();
-        localtime = localtime_r(&ts.tv_sec, &storage);
-    }
-    SMP_SPINLOCK_UNLOCK(&ctx->global->env_spinlock);
-
-    free(tz_env_entry);
-#else
-    SMP_SPINLOCK_LOCK(&ctx->global->env_spinlock);
-    if (tz) {
-        char *oldtz_env = getenv("TZ");
-        char *oldtz = NULL;
-        if (oldtz_env) {
-            oldtz = strdup(oldtz_env);
-            if (UNLIKELY(oldtz == NULL)) {
-                SMP_SPINLOCK_UNLOCK(&ctx->global->env_spinlock);
-                free(tz);
-                RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-            }
-        }
-        setenv("TZ", tz, 1);
-        tzset();
-        localtime = localtime_r(&ts.tv_sec, &storage);
-        if (oldtz) {
-            setenv("TZ", oldtz, 1);
-            free(oldtz);
-        } else {
-            unsetenv("TZ");
-        }
-        tzset();
-    } else {
-        tzset();
-        localtime = localtime_r(&ts.tv_sec, &storage);
-    }
-    SMP_SPINLOCK_UNLOCK(&ctx->global->env_spinlock);
-#endif
+    struct tm *localtime = tzstr_localtime_r(&ts.tv_sec, &storage, tz, ctx->global);
+    int localtime_errno = errno;
 
     free(tz);
 
     if (UNLIKELY(localtime == NULL)) {
+        if (localtime_errno == ENOMEM) {
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
         RAISE_ERROR(BADARG_ATOM);
     }
 

--- a/src/platforms/esp32/test/main/test_erl_sources/test_tz.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_tz.erl
@@ -21,7 +21,24 @@
 -module(test_tz).
 -export([start/0]).
 
+%% Slack to absorb unrelated allocator noise / atom table growth between
+%% Before/After snapshots. The setenv leak on newlib was ~strlen("TZ=" ++ Rule)
+%% bytes per call, so 500 iterations would add up to tens of KB if the leak
+%% were still present. 1024 bytes of slack is well below that.
+-define(LEAK_SLACK_BYTES, 1024).
+-define(LEAK_ITERATIONS, 500).
+
 start() ->
+    ok = test_basic(),
+    ok = test_offsets(),
+    ok = test_localtime0_after_localtime1(),
+    ok = test_badarg(),
+    ok = test_no_leak(),
+    ok.
+
+%% Original sanity check: localtime("UTC") should fall between two
+%% surrounding universaltime() snapshots.
+test_basic() ->
     UTCTime1 = erlang:universaltime(),
     LocalTimeUTC = erlang:localtime("UTC"),
     UTCTime2 = erlang:universaltime(),
@@ -30,3 +47,103 @@ start() ->
     UTCTime3 = erlang:universaltime(),
     true = UTCTime2 =/= ParisTime andalso UTCTime3 =/= ParisTime,
     ok.
+
+%% Verify that several POSIX TZ strings produce the expected offsets
+%% relative to UTC. We capture three localtime/1 calls back-to-back and
+%% allow a small drift for the wall clock advancing between calls.
+test_offsets() ->
+    UTC = erlang:localtime("UTC0"),
+    %% UTC-5, no DST
+    EST = erlang:localtime("EST5"),
+    %% UTC+9, no DST
+    JST = erlang:localtime("JST-9"),
+
+    UTCSecs = calendar:datetime_to_gregorian_seconds(UTC),
+    ESTSecs = calendar:datetime_to_gregorian_seconds(EST),
+    JSTSecs = calendar:datetime_to_gregorian_seconds(JST),
+
+    %% EST should read ~5h earlier than UTC; JST ~9h later than UTC.
+    %% Allow 5s drift for clock advance between the three calls.
+    DiffEST = UTCSecs - ESTSecs,
+    DiffJST = JSTSecs - UTCSecs,
+    true = abs(DiffEST - 5 * 3600) =< 5,
+    true = abs(DiffJST - 9 * 3600) =< 5,
+
+    %% Strict ordering: EST < UTC < JST (allowing equality due to drift).
+    true = ESTSecs =< UTCSecs,
+    true = UTCSecs =< JSTSecs,
+    ok.
+
+%% After many TZ overrides the global libc state must be back to its
+%% original timezone -- localtime/0 should still match universaltime/0
+%% (assuming the device boots with TZ unset / UTC).
+test_localtime0_after_localtime1() ->
+    _ = erlang:localtime("EST5EDT,M3.2.0/2,M11.1.0/2"),
+    _ = erlang:localtime("CET-1CEST,M3.5.0,M10.5.0/3"),
+    _ = erlang:localtime("JST-9"),
+    UTC1 = erlang:universaltime(),
+    Local = erlang:localtime(),
+    UTC2 = erlang:universaltime(),
+    %% Default TZ on ESP32 is UTC, so localtime/0 should equal universaltime/0
+    %% modulo the second tick.
+    true = UTC1 =< Local andalso Local =< UTC2,
+    ok.
+
+%% A non-string / non-list / non-binary TZ argument must raise badarg, not
+%% crash or leak. Binaries are accepted by interop_term_to_string and are
+%% therefore valid TZ inputs (verified below).
+test_badarg() ->
+    ok = expect_badarg(fun() -> erlang:localtime(42) end),
+    ok = expect_badarg(fun() -> erlang:localtime({tuple, ok}) end),
+    %% Binary TZ should be accepted (and decoded).
+    UTCTime1 = erlang:universaltime(),
+    BinUTC = erlang:localtime(<<"UTC0">>),
+    UTCTime2 = erlang:universaltime(),
+    true = UTCTime1 =< BinUTC andalso BinUTC =< UTCTime2,
+    ok.
+
+expect_badarg(F) ->
+    try F() of
+        R -> {unexpected_result, R}
+    catch
+        error:badarg -> ok
+    end.
+
+%% Memory-leak regression test for the newlib/picolibc setenv leak fix.
+%% Calls localtime/1 ?LEAK_ITERATIONS times rotating through 4 distinct
+%% TZ rules and asserts the free heap does not shrink by more than
+%% ?LEAK_SLACK_BYTES.
+test_no_leak() ->
+    %% Warm-up: trigger any one-time allocations (atom table growth,
+    %% libc internal state, etc.) before snapshotting the heap.
+    leak_loop(16),
+    erlang:garbage_collect(),
+
+    Before = erlang:system_info(esp32_free_heap_size),
+    leak_loop(?LEAK_ITERATIONS),
+    erlang:garbage_collect(),
+    After = erlang:system_info(esp32_free_heap_size),
+
+    Delta = Before - After,
+    erlang:display({tz_leak_check, before, Before, after_, After, delta, Delta}),
+
+    case Delta =< ?LEAK_SLACK_BYTES of
+        true ->
+            ok;
+        false ->
+            erlang:display({tz_leak_detected, Delta, slack, ?LEAK_SLACK_BYTES}),
+            {error, {tz_leak_detected, Delta}}
+    end.
+
+leak_loop(0) ->
+    ok;
+leak_loop(N) ->
+    TZ =
+        case N rem 4 of
+            0 -> "UTC0";
+            1 -> "EST5EDT,M3.2.0/2,M11.1.0/2";
+            2 -> "CET-1CEST,M3.5.0,M10.5.0/3";
+            3 -> "JST-9"
+        end,
+    _ = erlang:localtime(TZ),
+    leak_loop(N - 1).


### PR DESCRIPTION
Added test for the leak - and the original attempt in https://github.com/atomvm/AtomVM/pull/2083 didn't work.

Fixes https://github.com/atomvm/AtomVM/issues/2062 - test passes - no leaks.

This uses Pauls suggestion for swapping environ, dirty but works.

---
The original localtime/1 implementation had several correctness issues:

- Memory leak on newlib/picolibc (ESP32): setenv leaks the old "NAME=value" string on every overwrite (espressif/esp-idf#3046). Both newlib and picolibc putenv implementations also funnel through setenv (copy-based, not direct-pointer), so they leak too. Fix: temporarily swap the environ pointer to a minimal array containing only our TZ entry. This avoids all setenv/putenv calls and produces zero allocations and zero leaks.

- Use-after-free: the getenv("TZ") pointer was used after setenv overwrites it, reading freed or stale memory. Fix: strdup the old TZ value before modifying the environment.

- Missing tzset after restore: the original code called tzset only when setting the new TZ, not after restoring the old one, leaving libc in an inconsistent state for subsequent calls.

- Missing localtime_r NULL check: a failing localtime_r would pass
  NULL to build_datetime_from_tm. Fix: raise badarg on NULL.

The environ swap is protected by env_spinlock and assumes AtomVM is the sole user of TZ -- no external threads should read/write environ or call time functions during the temporary override.

See: https://github.com/espressif/esp-idf/issues/3046

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
