### PR TITLE
Work around `bs_test_unit` test crash with OTP29

### DIFF
--- a/tests/erlang_tests/test_op_bs_test_unit.erl
+++ b/tests/erlang_tests/test_op_bs_test_unit.erl
@@ -20,15 +20,10 @@
 
 %% Force the compiler to use bs_test_unit opcode instead of the
 %% newer bs_match opcode (OTP 25+). On older OTP this is ignored.
-%% On OTP 29+, no_bs_match was removed but no_ssa_opt_bs_ensure
-%% prevents the SSA pass from converting bs_test_unit to bs_match
-%% with ensure_at_least.
+%% On OTP 29+, bs_test_unit is now gone.
 -ifdef(OTP_RELEASE).
 -if(?OTP_RELEASE =< 28).
 -compile([no_bs_match]).
--endif.
--if(?OTP_RELEASE >= 29).
--compile([no_ssa_opt_bs_ensure]).
 -endif.
 -endif.
 


### PR DESCRIPTION
Work around a crash with current OTP master when `no_ssa_opt_bs_ensure` is used. OTP29 no longer emits bs_test_unit anyway, so we don't pass the option.

See https://github.com/erlang/otp/issues/11086

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
