### PR TITLE
Bump valgrind timeout as GitHub CI is slower than ever

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -781,7 +781,7 @@ jobs:
 
     - name: "Test: test_estdlib.avm with valgrind"
       if: matrix.library-arch == ''
-      timeout-minutes: 30
+      timeout-minutes: 45
       working-directory: build
       run: |
         ulimit -c unlimited


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
