### PR TITLE
Fix incompatibility with elixir master

### DIFF
--- a/libs/exavmlib/lib/Enum.ex
+++ b/libs/exavmlib/lib/Enum.ex
@@ -595,6 +595,15 @@ defmodule Enum do
     end
   end
 
+  @doc false
+  def __in__(element, enumerable) when is_list(enumerable) do
+    :lists.member(element, enumerable)
+  end
+
+  def __in__(element, enumerable) do
+    member?(enumerable, element)
+  end
+
   ## all?
 
   defp all_list([h | t], fun) do


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
