### PR TITLE
Fix two close bugs in atomvm:subprocess/4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `ahttp_client` crash on non-numeric or negative `Content-Length` values
 - Fixed `ahttp_client` crash on headers with empty or all-whitespace values
 - Fixed a bug in `supervisor` handling of failing child
+- Fixed two bugs related to closing fds in `atomvm:subprocess/4`
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/src/libAtomVM/posix_nifs.c
+++ b/src/libAtomVM/posix_nifs.c
@@ -880,7 +880,7 @@ static term nif_atomvm_subprocess(Context *ctx, int argc, term argv[])
         if (UNLIKELY((r = posix_spawnattr_init(&spawn_attrs)) != 0)) {
             break;
         }
-        if (UNLIKELY((r = posix_spawnattr_setflags(&spawn_attrs, HAVE_POSIX_SPAWN_CLOEXEC_DEFAULT)) != 0)) {
+        if (UNLIKELY((r = posix_spawnattr_setflags(&spawn_attrs, POSIX_SPAWN_CLOEXEC_DEFAULT)) != 0)) {
             break;
         }
         if (UNLIKELY((r = posix_spawn(&pid, path, &file_actions, &spawn_attrs, args, envp)) != 0)) {
@@ -921,7 +921,7 @@ static term nif_atomvm_subprocess(Context *ctx, int argc, term argv[])
         closefrom(2);
 #else
         int maxfd = sysconf(_SC_OPEN_MAX);
-        for (int fd = 3; fd < maxfd; fd++) {
+        for (int fd = 2; fd < maxfd; fd++) {
             close(fd);
         }
 #endif


### PR DESCRIPTION
- Fix POSIX_SPAWN_CLOEXEC_DEFAULT usage (was wrongly HAVE_* macro)
- Fix close loop on platforms without closefrom (was starting from 3)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
