### PR TITLE
CI: fix esp32c61 flappiness

### DIFF
--- a/src/platforms/esp32/test/main/test_erl_sources/test_wifi_scan.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_wifi_scan.erl
@@ -52,7 +52,7 @@ wifi_scan_test() ->
                         io:format("network:wifi_scan found ~p networks.\n", [Num]),
                         lists:foreach(
                             fun(
-                                _Network = #{
+                                #{
                                     authmode := Mode,
                                     bssid := BSSID,
                                     channel := Number,
@@ -61,10 +61,22 @@ wifi_scan_test() ->
                                     ssid := SSID
                                 }
                             ) ->
-                                io:format(
-                                    "Network: ~p, BSSID: ~p, signal ~p dBm, Security: ~p, channel ~p, hidden: ~p\n",
-                                    [SSID, BSSID, DBm, Mode, Number, Hidden]
-                                )
+                                io:put_chars([
+                                    "Network: ",
+                                    SSID,
+                                    ", BSSID: ",
+                                    bssid_hex(BSSID),
+                                    ", signal ",
+                                    integer_to_list(DBm),
+                                    " dBm",
+                                    ", Security: ",
+                                    atom_to_list(Mode),
+                                    ", channel ",
+                                    integer_to_list(Number),
+                                    ", hidden: ",
+                                    atom_to_list(Hidden),
+                                    "\n"
+                                ])
                             end,
                             Networks
                         ),
@@ -81,6 +93,29 @@ wifi_scan_test() ->
         {error, Reason} ->
             erlang:error({network_start_failed, Reason})
     end.
+
+%% Inline hex formatter — Important on
+%% tiny-RAM targets (esp32c61) where it can OOM.
+bssid_hex(<<A, B, C, D, E, F>>) ->
+    [
+        byte_hex(A),
+        $:,
+        byte_hex(B),
+        $:,
+        byte_hex(C),
+        $:,
+        byte_hex(D),
+        $:,
+        byte_hex(E),
+        $:,
+        byte_hex(F)
+    ].
+
+byte_hex(B) ->
+    [hex_char(B bsr 4), hex_char(B band 16#0F)].
+
+hex_char(N) when N < 10 -> $0 + N;
+hex_char(N) -> $a + N - 10.
 
 deny_concurrent_scan_test() ->
     case network:start([{sta, [managed, {scan_dwell_ms, 400}]}]) of

--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -619,11 +619,13 @@ TEST_CASE("test_wifi_example", "[test_run]")
 }
 #endif
 
+#if !CONFIG_IDF_TARGET_ESP32C61
 TEST_CASE("test_wifi_managed", "[test_run]")
 {
     term ret_value = avm_test_case("test_wifi_managed.beam");
     TEST_ASSERT(ret_value == OK_ATOM);
 }
+#endif
 
 TEST_CASE("test_wifi_scan", "[test_run]")
 {


### PR DESCRIPTION
In testing harness esp32c61 struggles with all the wifi tests, so we limit and optimise a bit.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
