### PR TITLE
CI: pin esp32p4 to esp-idf v5.4.4 instead of release-v5.4 branch

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -54,7 +54,7 @@ jobs:
 
         include:
         - esp-idf-target: "esp32p4"
-          idf-version: 'release-v5.4'
+          idf-version: 'v5.4.4'
         - esp-idf-target: "esp32p4"
           idf-version: 'v5.5.3'
         - esp-idf-target: "esp32s3"


### PR DESCRIPTION
This additionally works around [a bug in release-v5.4 branch](https://github.com/espressif/esp-idf/issues/18619)

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
