### PR TITLE
Add safe to `binary_to_term/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added UART API to rp2 platform
 - Added `"USB_SERIAL_JTAG"` peripheral to the ESP32 `uart` module on chips with a built-in
   USB-Serial-JTAG controller (C3/C5/C6/C61/H2/H21/H4/P4/S3)
+- Added support for the `safe` option in `erlang:binary_to_term/2`
 
 ### Changed
 - Updated network type db() to dbm() to reflect the actual representation of the type

--- a/src/libAtomVM/defaultatoms.def
+++ b/src/libAtomVM/defaultatoms.def
@@ -71,6 +71,7 @@ X(SHORT_ATOM, "\x5", "short")
 
 X(LOW_ENTROPY_ATOM, "\xB", "low_entropy")
 X(USED_ATOM, "\x4", "used")
+X(SAFE_ATOM, "\x4", "safe")
 X(START_ATOM, "\x5", "start")
 
 X(UNDEF_ATOM, "\x5", "undef")

--- a/src/libAtomVM/external_term.c
+++ b/src/libAtomVM/external_term.c
@@ -28,10 +28,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "bif.h"
 #include "bitstring.h"
 #include "defaultatoms.h"
+#include "globalcontext.h"
 #include "memory.h"
 #include "module.h"
+#include "nifs.h"
 #include "resources.h"
 #include "term.h"
 #include "unicode.h"
@@ -76,8 +79,8 @@
 // buffer).  The parse_external_terms function does NOT perform range checking, and MUST
 // therefore always be preceeded by a call to calculate_heap_usage.
 
-static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm_size, bool copy, Heap *heap, GlobalContext *glb);
-static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaining, size_t *eterm_size, bool copy);
+static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm_size, bool copy, Heap *heap, GlobalContext *glb, external_term_read_opts_t opts);
+static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaining, size_t *eterm_size, bool copy, external_term_read_opts_t opts, GlobalContext *glb);
 static size_t compute_external_size(term t, GlobalContext *glb);
 static int external_term_from_term(uint8_t **buf, size_t *len, term t, GlobalContext *glb);
 static int serialize_term(uint8_t *buf, term t, GlobalContext *glb);
@@ -85,11 +88,8 @@ static int serialize_term(uint8_t *buf, term t, GlobalContext *glb);
 external_term_read_result_t external_term_validate_buf_raw(const void *buf, size_t buf_size,
     external_term_read_opts_t opts, size_t *required_heap, size_t *bytes_read, GlobalContext *glb)
 {
-    UNUSED(opts);
-    UNUSED(glb);
-
     size_t eterm_size = 0;
-    int heap_usage = calculate_heap_usage(buf, buf_size, &eterm_size, true);
+    int heap_usage = calculate_heap_usage(buf, buf_size, &eterm_size, true, opts, glb);
     if (UNLIKELY(heap_usage < 0)) {
         return ExternalTermReadInvalid;
     }
@@ -104,10 +104,9 @@ external_term_read_result_t external_term_deserialize_buf_raw(const void *buf, s
     external_term_read_opts_t opts, Heap *heap, term *out_term, GlobalContext *glb)
 {
     UNUSED(buf_size);
-    UNUSED(opts);
 
     size_t eterm_size = 0;
-    term result = parse_external_terms(buf, &eterm_size, true, heap, glb);
+    term result = parse_external_terms(buf, &eterm_size, true, heap, glb, opts);
     if (UNLIKELY(term_is_invalid_term(result))) {
         return ExternalTermReadInvalid;
     }
@@ -133,7 +132,7 @@ term external_term_from_binary_with_roots(Context *ctx, size_t binary_ix, size_t
     size_t size = binary_len - offset;
 
     size_t eterm_size;
-    int heap_usage = calculate_heap_usage(external_term_buf + 1, size - 1, &eterm_size, true);
+    int heap_usage = calculate_heap_usage(external_term_buf + 1, size - 1, &eterm_size, true, ExternalTermReadNoOpts, ctx->global);
     if (heap_usage == INVALID_TERM_SIZE) {
         return term_invalid_term();
     }
@@ -144,7 +143,7 @@ term external_term_from_binary_with_roots(Context *ctx, size_t binary_ix, size_t
     }
     // Recompute external_term_buf
     external_term_buf = (const uint8_t *) term_binary_data(roots[binary_ix]) + offset;
-    term result = parse_external_terms(external_term_buf + 1, &eterm_size, true, &ctx->heap, ctx->global);
+    term result = parse_external_terms(external_term_buf + 1, &eterm_size, true, &ctx->heap, ctx->global, ExternalTermReadNoOpts);
     *bytes_read = eterm_size + 1;
     return result;
 }
@@ -156,7 +155,7 @@ term external_term_from_const_literal(const void *external_term, size_t size, Co
         return term_invalid_term();
     }
     size_t eterm_size;
-    int heap_usage = calculate_heap_usage(external_term_buf + 1, size - 1, &eterm_size, false);
+    int heap_usage = calculate_heap_usage(external_term_buf + 1, size - 1, &eterm_size, false, ExternalTermReadNoOpts, ctx->global);
     if (heap_usage == INVALID_TERM_SIZE) {
         return term_invalid_term();
     }
@@ -166,7 +165,7 @@ term external_term_from_const_literal(const void *external_term, size_t size, Co
     if (UNLIKELY(memory_init_heap(&heap, heap_usage) != MEMORY_GC_OK)) {
         return term_invalid_term();
     }
-    term result = parse_external_terms(external_term_buf + 1, &eterm_size, false, &heap, ctx->global);
+    term result = parse_external_terms(external_term_buf + 1, &eterm_size, false, &heap, ctx->global, ExternalTermReadNoOpts);
     memory_heap_append_heap(&ctx->heap, &heap);
     return result;
 }
@@ -589,8 +588,70 @@ static avm_uint64_t read_bytes(const uint8_t *buf, uint8_t num_bytes)
     return value;
 }
 
-static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm_size, bool copy, Heap *heap, GlobalContext *glb)
+// Validate that M:F/A names an existing BIF/NIF or exported function in a
+// loaded module. Factored out of parse_external_terms so its 260-byte mfa
+// buffer doesn't inflate the recursive function's stack frame.
+static bool safe_export_is_resolvable(
+    GlobalContext *glb, atom_index_t m_idx, atom_index_t f_idx, int arity)
 {
+    char mfa[MAX_MFA_NAME_LEN];
+    atom_table_write_mfa(glb->atom_table, mfa, sizeof(mfa), m_idx, f_idx, arity);
+    if (bif_registry_get_handler(mfa) != NULL || nifs_get(mfa) != NULL) {
+        return true;
+    }
+    Module *mod = globalcontext_get_module(glb, m_idx);
+    return mod != NULL && module_search_exported_function(mod, f_idx, arity) != 0;
+}
+
+// Look up an external-term atom in the atom table without inserting it.
+// Latin1 input (ATOM_EXT with non-ASCII bytes) is re-encoded to UTF-8.
+static bool atom_exists_in_table(
+    const uint8_t *atom_chars, uint16_t atom_len, bool is_utf8, GlobalContext *glb)
+{
+    if (is_utf8 || unicode_buf_is_ascii(atom_chars, atom_len)) {
+        return !term_is_invalid_term(
+            globalcontext_existing_atom_from_buf(glb, atom_chars, atom_len));
+    }
+    size_t required_buf_size = unicode_latin1_buf_size_as_utf8(atom_chars, atom_len);
+    if (UNLIKELY(required_buf_size > 255)) {
+        return false;
+    }
+    uint8_t utf8_buf[255];
+    uint8_t *curr = utf8_buf;
+    for (uint16_t i = 0; i < atom_len; i++) {
+        size_t codepoint_size;
+        bitstring_utf8_encode(atom_chars[i], curr, &codepoint_size);
+        curr += codepoint_size;
+    }
+    return !term_is_invalid_term(
+        globalcontext_existing_atom_from_buf(glb, utf8_buf, required_buf_size));
+}
+
+// Re-encode a latin1 ATOM_EXT to UTF-8 and insert into the atom table.
+// Extracted into a non-recursive helper so the 255-byte stack buffer is not
+// charged to every parse_external_terms recursion frame.
+static term insert_latin1_atom_ext(
+    const uint8_t *atom_chars, uint16_t atom_len, GlobalContext *glb)
+{
+    size_t required_buf_size = unicode_latin1_buf_size_as_utf8(atom_chars, atom_len);
+    if (UNLIKELY(required_buf_size > 255)) {
+        return term_invalid_term();
+    }
+    uint8_t utf8_buf[255];
+    uint8_t *curr = utf8_buf;
+    for (uint16_t i = 0; i < atom_len; i++) {
+        size_t codepoint_size;
+        // latin1 encoding is always successful
+        bitstring_utf8_encode(atom_chars[i], curr, &codepoint_size);
+        curr += codepoint_size;
+    }
+    return globalcontext_insert_atom_maybe_copy(glb, utf8_buf, required_buf_size, true);
+}
+
+static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm_size, bool copy, Heap *heap, GlobalContext *glb, external_term_read_opts_t opts)
+{
+    // The safe flag is enforced in calculate_heap_usage (which must run first);
+    // this function only forwards opts through recursion.
     switch (external_term_buf[0]) {
         case NEW_FLOAT_EXT: {
             union
@@ -666,21 +727,10 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
                     glb, atom_chars, atom_len, copy);
             } else {
                 // need to re-encode latin1 to UTF-8
-                size_t required_buf_size = unicode_latin1_buf_size_as_utf8(atom_chars, atom_len);
-                if (UNLIKELY(required_buf_size > 255)) {
-                    return term_invalid_term();
+                atom_term = insert_latin1_atom_ext(atom_chars, atom_len, glb);
+                if (UNLIKELY(term_is_invalid_term(atom_term))) {
+                    return atom_term;
                 }
-                uint8_t *atom_buf = malloc(required_buf_size);
-                uint8_t *curr_codepoint = atom_buf;
-                for (int i = 0; i < atom_len; i++) {
-                    size_t codepoint_size;
-                    // latin1 encoding is always successful
-                    bitstring_utf8_encode(atom_chars[i], curr_codepoint, &codepoint_size);
-                    curr_codepoint += codepoint_size;
-                }
-                atom_term
-                    = globalcontext_insert_atom_maybe_copy(glb, atom_buf, required_buf_size, true);
-                free(atom_buf);
             }
 
             *eterm_size = ATOM_EXT_BASE_SIZE + atom_len;
@@ -702,7 +752,7 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
 
             for (size_t i = 0; i < arity; i++) {
                 size_t element_size;
-                term put_value = parse_external_terms(external_term_buf + buf_pos, &element_size, copy, heap, glb);
+                term put_value = parse_external_terms(external_term_buf + buf_pos, &element_size, copy, heap, glb, opts);
                 if (UNLIKELY(term_is_invalid_term(put_value))) {
                     return put_value;
                 }
@@ -736,7 +786,7 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
 
             for (unsigned int i = 0; i < list_len; i++) {
                 size_t item_size;
-                term head = parse_external_terms(external_term_buf + buf_pos, &item_size, copy, heap, glb);
+                term head = parse_external_terms(external_term_buf + buf_pos, &item_size, copy, heap, glb, opts);
                 if (UNLIKELY(term_is_invalid_term(head))) {
                     return head;
                 }
@@ -756,7 +806,7 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
 
             if (prev_term) {
                 size_t tail_size;
-                term tail = parse_external_terms(external_term_buf + buf_pos, &tail_size, copy, heap, glb);
+                term tail = parse_external_terms(external_term_buf + buf_pos, &tail_size, copy, heap, glb, opts);
                 if (UNLIKELY(term_is_invalid_term(tail))) {
                     return tail;
                 }
@@ -782,23 +832,41 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
             size_t buf_pos = 1;
             size_t element_size;
 
-            term m = parse_external_terms(external_term_buf + buf_pos, &element_size, copy, heap, glb);
+            term m = parse_external_terms(external_term_buf + buf_pos, &element_size, copy, heap, glb, opts);
             if (UNLIKELY(term_is_invalid_term(m))) {
                 return m;
             }
             buf_pos += element_size;
 
-            term f = parse_external_terms(external_term_buf + buf_pos, &element_size, copy, heap, glb);
+            term f = parse_external_terms(external_term_buf + buf_pos, &element_size, copy, heap, glb, opts);
             if (UNLIKELY(term_is_invalid_term(f))) {
                 return f;
             }
             buf_pos += element_size;
 
-            term a = parse_external_terms(external_term_buf + buf_pos, &element_size, copy, heap, glb);
+            term a = parse_external_terms(external_term_buf + buf_pos, &element_size, copy, heap, glb, opts);
             if (UNLIKELY(term_is_invalid_term(a))) {
                 return a;
             }
             buf_pos += element_size;
+
+            if (UNLIKELY((opts & ExternalTermReadSafe) != 0)) {
+                // Slightly stricter than OTP: a module that exists in OTP
+                // only as an export-entry stub (never actually loaded)
+                // would be rejected here, while OTP would accept it.
+                if (UNLIKELY(!term_is_integer(a))) {
+                    return term_invalid_term();
+                }
+                avm_int_t arity = term_to_int(a);
+                if (UNLIKELY(arity < 0 || arity > 255)) {
+                    return term_invalid_term();
+                }
+                atom_index_t m_idx = term_to_atom_index(m);
+                atom_index_t f_idx = term_to_atom_index(f);
+                if (!safe_export_is_resolvable(glb, m_idx, f_idx, arity)) {
+                    return term_invalid_term();
+                }
+            }
 
             *eterm_size = buf_pos;
             return term_make_function_reference(m, f, a, heap);
@@ -810,14 +878,14 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
             size_t buf_pos = 5;
             for (uint32_t i = 0; i < size; ++i) {
                 size_t key_size;
-                term key = parse_external_terms(external_term_buf + buf_pos, &key_size, copy, heap, glb);
+                term key = parse_external_terms(external_term_buf + buf_pos, &key_size, copy, heap, glb, opts);
                 if (UNLIKELY(term_is_invalid_term(key))) {
                     return key;
                 }
                 buf_pos += key_size;
 
                 size_t value_size;
-                term value = parse_external_terms(external_term_buf + buf_pos, &value_size, copy, heap, glb);
+                term value = parse_external_terms(external_term_buf + buf_pos, &value_size, copy, heap, glb, opts);
                 if (UNLIKELY(term_is_invalid_term(value))) {
                     return value;
                 }
@@ -857,7 +925,7 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
 
         case NEW_PID_EXT: {
             size_t node_size;
-            term node = parse_external_terms(external_term_buf + 1, &node_size, copy, heap, glb);
+            term node = parse_external_terms(external_term_buf + 1, &node_size, copy, heap, glb, opts);
             if (UNLIKELY(!term_is_atom(node))) {
                 return term_invalid_term();
             }
@@ -883,7 +951,7 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
 
         case V4_PORT_EXT: {
             size_t node_size;
-            term node = parse_external_terms(external_term_buf + 1, &node_size, copy, heap, glb);
+            term node = parse_external_terms(external_term_buf + 1, &node_size, copy, heap, glb, opts);
             if (UNLIKELY(!term_is_atom(node))) {
                 return term_invalid_term();
             }
@@ -915,7 +983,7 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
                 return term_invalid_term();
             }
             size_t node_size;
-            term node = parse_external_terms(external_term_buf + 3, &node_size, copy, heap, glb);
+            term node = parse_external_terms(external_term_buf + 3, &node_size, copy, heap, glb, opts);
             if (UNLIKELY(!term_is_atom(node))) {
                 return term_invalid_term();
             }
@@ -952,15 +1020,15 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
             uint32_t num_free = READ_32_UNALIGNED(external_term_buf + 26);
             size_t term_size;
             size_t offset = 30;
-            term module = parse_external_terms(external_term_buf + offset, &term_size, copy, heap, glb);
+            term module = parse_external_terms(external_term_buf + offset, &term_size, copy, heap, glb, opts);
             offset += term_size;
-            term old_index = parse_external_terms(external_term_buf + offset, &term_size, copy, heap, glb);
+            term old_index = parse_external_terms(external_term_buf + offset, &term_size, copy, heap, glb, opts);
             offset += term_size;
             // TODO: old_uniq is marked deprecated in OTP source likely to be removed in OTP29
-            term old_uniq = parse_external_terms(external_term_buf + offset, &term_size, copy, heap, glb);
+            term old_uniq = parse_external_terms(external_term_buf + offset, &term_size, copy, heap, glb, opts);
             offset += term_size;
             // skip pid
-            if (UNLIKELY(calculate_heap_usage(external_term_buf + offset, len - offset + 1, &term_size, copy) == INVALID_TERM_SIZE)) {
+            if (UNLIKELY(calculate_heap_usage(external_term_buf + offset, len - offset + 1, &term_size, copy, opts, glb) == INVALID_TERM_SIZE)) {
                 return term_invalid_term();
             }
             offset += term_size;
@@ -992,7 +1060,7 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
 
             boxed_func[2] = term_from_int(index);
             for (uint32_t i = 0; i < num_free; i++) {
-                boxed_func[i + free_index] = parse_external_terms(external_term_buf + offset, &term_size, copy, heap, glb);
+                boxed_func[i + free_index] = parse_external_terms(external_term_buf + offset, &term_size, copy, heap, glb, opts);
                 offset += term_size;
             }
             *eterm_size = len + 1;
@@ -1004,8 +1072,9 @@ static term parse_external_terms(const uint8_t *external_term_buf, size_t *eterm
     }
 }
 
-static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaining, size_t *eterm_size, bool copy)
+static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaining, size_t *eterm_size, bool copy, external_term_read_opts_t opts, GlobalContext *glb)
 {
+    bool safe = (opts & ExternalTermReadSafe) != 0;
     if (UNLIKELY(remaining < 1)) {
         return INVALID_TERM_SIZE;
     }
@@ -1080,6 +1149,12 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
             if (UNLIKELY(remaining < atom_len)) {
                 return INVALID_TERM_SIZE;
             }
+            if (UNLIKELY(safe)) {
+                if (!atom_exists_in_table(external_term_buf + ATOM_EXT_BASE_SIZE,
+                        atom_len, external_term_buf[0] == ATOM_UTF8_EXT, glb)) {
+                    return INVALID_TERM_SIZE;
+                }
+            }
             *eterm_size = ATOM_EXT_BASE_SIZE + atom_len;
             return 0;
         }
@@ -1112,7 +1187,7 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
 
             for (size_t i = 0; i < arity; i++) {
                 size_t element_size = 0;
-                int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &element_size, copy);
+                int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &element_size, copy, opts, glb);
                 if (UNLIKELY(u == INVALID_TERM_SIZE)) {
                     return INVALID_TERM_SIZE;
                 }
@@ -1166,7 +1241,7 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
 
             for (unsigned int i = 0; i < list_len; i++) {
                 size_t item_size = 0;
-                int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &item_size, copy);
+                int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &item_size, copy, opts, glb);
                 if (UNLIKELY(u == INVALID_TERM_SIZE)) {
                     return INVALID_TERM_SIZE;
                 }
@@ -1180,7 +1255,7 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
             }
 
             size_t tail_size = 0;
-            int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &tail_size, copy);
+            int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &tail_size, copy, opts, glb);
             if (UNLIKELY(u == INVALID_TERM_SIZE)) {
                 return INVALID_TERM_SIZE;
             }
@@ -1229,8 +1304,18 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
             int buf_pos = 1;
             remaining -= 1;
             for (int i = 0; i < 3; i++) {
+                if (UNLIKELY(remaining < 1)) {
+                    return INVALID_TERM_SIZE;
+                }
+                uint8_t tag = external_term_buf[buf_pos];
+                bool ok_tag = (i < 2)
+                    ? (tag == ATOM_EXT || tag == ATOM_UTF8_EXT || tag == SMALL_ATOM_UTF8_EXT)
+                    : (tag == SMALL_INTEGER_EXT || tag == INTEGER_EXT);
+                if (UNLIKELY(!ok_tag)) {
+                    return INVALID_TERM_SIZE;
+                }
                 size_t element_size = 0;
-                int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &element_size, copy);
+                int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &element_size, copy, opts, glb);
                 if (UNLIKELY(u == INVALID_TERM_SIZE)) {
                     return INVALID_TERM_SIZE;
                 }
@@ -1260,7 +1345,7 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
             size_t buf_pos = MAP_EXT_BASE_SIZE;
             for (uint32_t i = 0; i < size; ++i) {
                 size_t key_size = 0;
-                int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &key_size, copy);
+                int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &key_size, copy, opts, glb);
                 if (UNLIKELY(u == INVALID_TERM_SIZE)) {
                     return INVALID_TERM_SIZE;
                 }
@@ -1272,7 +1357,7 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
                 }
                 remaining -= key_size;
                 size_t value_size = 0;
-                u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &value_size, copy);
+                u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &value_size, copy, opts, glb);
                 if (UNLIKELY(u == INVALID_TERM_SIZE)) {
                     return INVALID_TERM_SIZE;
                 }
@@ -1297,6 +1382,12 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
             if (UNLIKELY(remaining < atom_len)) {
                 return INVALID_TERM_SIZE;
             }
+            if (UNLIKELY(safe)) {
+                if (!atom_exists_in_table(external_term_buf + SMALL_ATOM_EXT_BASE_SIZE,
+                        atom_len, true, glb)) {
+                    return INVALID_TERM_SIZE;
+                }
+            }
             *eterm_size = SMALL_ATOM_EXT_BASE_SIZE + atom_len;
             return 0;
         }
@@ -1310,7 +1401,7 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
             int buf_pos = 1;
             size_t heap_size = EXTERNAL_PID_SIZE;
             size_t node_size = 0;
-            int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &node_size, copy);
+            int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &node_size, copy, opts, glb);
             if (UNLIKELY(u == INVALID_TERM_SIZE)) {
                 return INVALID_TERM_SIZE;
             }
@@ -1321,7 +1412,8 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
                 }
                 // If this is our node, but we're distributed, we'll allocate more memory and may not use it.
                 // This way we're sure to not go out of bounds if distribution changes between now and when we deserialize
-            } else if (UNLIKELY(external_term_buf[1] != ATOM_EXT)) {
+            } else if (UNLIKELY(external_term_buf[1] != ATOM_EXT
+                           && external_term_buf[1] != ATOM_UTF8_EXT)) {
                 return INVALID_TERM_SIZE;
             }
             buf_pos += node_size;
@@ -1342,7 +1434,7 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
             uint16_t len = READ_16_UNALIGNED(external_term_buf + 1);
             size_t heap_size = EXTERNAL_REF_SIZE(len);
             size_t node_size = 0;
-            int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &node_size, copy);
+            int u = calculate_heap_usage(external_term_buf + buf_pos, remaining, &node_size, copy, opts, glb);
             if (UNLIKELY(u == INVALID_TERM_SIZE)) {
                 return INVALID_TERM_SIZE;
             }
@@ -1356,7 +1448,8 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
                     }
                 }
                 // See above for pids
-            } else if (UNLIKELY(external_term_buf[3] != ATOM_EXT)) {
+            } else if (UNLIKELY(external_term_buf[3] != ATOM_EXT
+                           && external_term_buf[3] != ATOM_UTF8_EXT)) {
                 return INVALID_TERM_SIZE;
             }
             buf_pos += node_size;
@@ -1381,29 +1474,53 @@ static int calculate_heap_usage(const uint8_t *external_term_buf, size_t remaini
             // If module doesn't match or exist, we'll need 3 more for arity, old_index and old_uniq
             size_t heap_size = BOXED_FUN_SIZE + num_free + 3;
             int u;
-            if (num_free > 0) {
-                remaining -= 29;
-                size_t offset = 30;
-                size_t term_size;
-                // skip module atom, old index, old uniq, pid
-                for (int i = 0; i < 4; i++) {
-                    u = calculate_heap_usage(external_term_buf + offset, remaining, &term_size, copy);
-                    if (UNLIKELY(u == INVALID_TERM_SIZE)) {
-                        return INVALID_TERM_SIZE;
-                    }
-                    remaining -= term_size;
-                    offset += term_size;
+            remaining -= 29;
+            size_t offset = 30;
+            size_t term_size;
+            // validate module atom, old index, old uniq, pid (even when there are
+            // no free variables, so that the `safe` flag check on the module atom
+            // is enforced)
+            for (int i = 0; i < 4; i++) {
+                if (UNLIKELY(remaining < 1)) {
+                    return INVALID_TERM_SIZE;
                 }
-                // add free values
-                for (size_t i = 0; i < num_free; i++) {
-                    u = calculate_heap_usage(external_term_buf + offset, remaining, &term_size, copy);
-                    if (UNLIKELY(u == INVALID_TERM_SIZE)) {
-                        return INVALID_TERM_SIZE;
-                    }
-                    heap_size += u;
-                    remaining -= term_size;
-                    offset += term_size;
+                uint8_t tag = external_term_buf[offset];
+                bool ok_tag;
+                switch (i) {
+                    case 0:
+                        // module: atom
+                        ok_tag = (tag == ATOM_EXT || tag == ATOM_UTF8_EXT
+                            || tag == SMALL_ATOM_UTF8_EXT);
+                        break;
+                    case 1:
+                    case 2:
+                        // old_index, old_uniq: integer
+                        ok_tag = (tag == SMALL_INTEGER_EXT || tag == INTEGER_EXT);
+                        break;
+                    default:
+                        // pid: only NEW_PID_EXT is decoded by parse_external_terms
+                        ok_tag = (tag == NEW_PID_EXT);
+                        break;
                 }
+                if (UNLIKELY(!ok_tag)) {
+                    return INVALID_TERM_SIZE;
+                }
+                u = calculate_heap_usage(external_term_buf + offset, remaining, &term_size, copy, opts, glb);
+                if (UNLIKELY(u == INVALID_TERM_SIZE)) {
+                    return INVALID_TERM_SIZE;
+                }
+                remaining -= term_size;
+                offset += term_size;
+            }
+            // add free values
+            for (size_t i = 0; i < num_free; i++) {
+                u = calculate_heap_usage(external_term_buf + offset, remaining, &term_size, copy, opts, glb);
+                if (UNLIKELY(u == INVALID_TERM_SIZE)) {
+                    return INVALID_TERM_SIZE;
+                }
+                heap_size += u;
+                remaining -= term_size;
+                offset += term_size;
             }
             *eterm_size = 1 + len;
             return heap_size;

--- a/src/libAtomVM/external_term.h
+++ b/src/libAtomVM/external_term.h
@@ -64,11 +64,16 @@ typedef enum
  * @brief Options for external term read operations.
  *
  * Passed to validate and deserialize functions to control their behavior.
- * Reserved for future use; pass \c ExternalTermReadNoOpts for now.
+ * Values are bit flags and can be combined with bitwise OR.
+ *
+ * \c ExternalTermReadSafe matches the OTP \c safe option of
+ * \c binary_to_term/2: it forbids creation of new atoms (directly or
+ * embedded in pids/ports/refs/funs).
  */
 typedef enum
 {
-    ExternalTermReadNoOpts
+    ExternalTermReadNoOpts = 0,
+    ExternalTermReadSafe = 1
 } external_term_read_opts_t;
 
 /**

--- a/src/libAtomVM/globalcontext.h
+++ b/src/libAtomVM/globalcontext.h
@@ -427,6 +427,27 @@ static inline term globalcontext_insert_atom_maybe_copy(GlobalContext *glb, cons
 }
 
 /**
+ * @brief Look up an existing atom by data and length, without creating a new one.
+ *
+ * @details Like \c globalcontext_insert_atom_maybe_copy, but returns an invalid
+ * term if the atom is not already in the table.
+ * @param glb the global context.
+ * @param atom_data the atom data
+ * @param atom_len the atom data length
+ * @returns the atom term if already present, otherwise \c term_invalid_term().
+ */
+static inline term globalcontext_existing_atom_from_buf(GlobalContext *glb, const uint8_t *atom_data, size_t atom_len)
+{
+    atom_index_t global_atom_index;
+    enum AtomTableEnsureAtomResult ensure_result = atom_table_ensure_atom(
+        glb->atom_table, atom_data, atom_len, AtomTableAlreadyExisting, &global_atom_index);
+    if (ensure_result != AtomTableEnsureAtomOk) {
+        return term_invalid_term();
+    }
+    return term_from_atom_index(global_atom_index);
+}
+
+/**
  * @brief Compares an atom table index with an AtomString.
  *
  * @details Checks if the given atom table index and the given AtomString refers to the same atom.

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3393,9 +3393,14 @@ static term nif_erlang_binary_to_term(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
     uint8_t return_used = 0;
-    if (argc == 2
-        && interop_proplist_get_value_default(argv[1], USED_ATOM, FALSE_ATOM) == TRUE_ATOM) {
-        return_used = 1;
+    external_term_read_opts_t read_opts = ExternalTermReadNoOpts;
+    if (argc == 2) {
+        if (interop_proplist_get_value_default(argv[1], USED_ATOM, FALSE_ATOM) == TRUE_ATOM) {
+            return_used = 1;
+        }
+        if (interop_proplist_get_value_default(argv[1], SAFE_ATOM, FALSE_ATOM) == TRUE_ATOM) {
+            read_opts |= ExternalTermReadSafe;
+        }
     }
 
     GlobalContext *glb = ctx->global;
@@ -3403,7 +3408,7 @@ static term nif_erlang_binary_to_term(Context *ctx, int argc, term argv[])
     size_t required_heap;
     size_t bytes_read;
     external_term_read_result_t res = external_term_validate_buf(term_binary_data(binary),
-        term_binary_size(binary), ExternalTermReadNoOpts, &required_heap, &bytes_read, glb);
+        term_binary_size(binary), read_opts, &required_heap, &bytes_read, glb);
     if (UNLIKELY(res != ExternalTermReadOk)) {
         RAISE_ERROR(BADARG_ATOM);
     }
@@ -3418,7 +3423,7 @@ static term nif_erlang_binary_to_term(Context *ctx, int argc, term argv[])
 
     term dst;
     res = external_term_deserialize_buf(term_binary_data(binary), term_binary_size(binary),
-        ExternalTermReadNoOpts, &ctx->heap, &dst, glb);
+        read_opts, &ctx->heap, &dst, glb);
     if (UNLIKELY(res != ExternalTermReadOk)) {
         RAISE_ERROR(BADARG_ATOM);
     }

--- a/tests/erlang_tests/test_binary_to_term.erl
+++ b/tests/erlang_tests/test_binary_to_term.erl
@@ -154,6 +154,9 @@ start() ->
     ok = test_encode_port(),
     ok = test_atom_encoding(),
     ok = test_encode_resource(),
+    ok = test_safe_option(),
+    ok = test_invalid_export_fun_encoding(),
+    ok = test_atom_utf8_ext_node(),
     0.
 
 test_reverse(T, Interop) ->
@@ -1003,6 +1006,302 @@ test_atom_encoding() ->
     true = compare_pair_encoding(latin1_as_utf8_2),
     true = compare_pair_encoding(latin1_as_utf8_3),
     true = compare_pair_encoding(long_with_two_bytes_length),
+    ok.
+
+% Build the SMALL_ATOM_UTF8_EXT (tag 119) encoding for a fresh atom name,
+% without writing the atom as a literal anywhere (which would add it to the
+% atom table at module load).
+make_fresh_small_atom_bin(Name) when is_list(Name) ->
+    Bytes = list_to_binary(Name),
+    Len = byte_size(Bytes),
+    true = Len =< 255,
+    <<131, 119, Len, Bytes/binary>>.
+
+make_fresh_atom_utf8_bin(Name) when is_list(Name) ->
+    Bytes = list_to_binary(Name),
+    Len = byte_size(Bytes),
+    <<131, 118, Len:16, Bytes/binary>>.
+
+% ATOM_EXT (tag 100): latin1-encoded
+make_fresh_atom_ext_bin(Bytes) when is_binary(Bytes) ->
+    Len = byte_size(Bytes),
+    <<131, 100, Len:16, Bytes/binary>>.
+
+unique_atom_name(Suffix) ->
+    PidStr = pid_to_list(self()),
+    Now = integer_to_list(erlang:system_time(microsecond)),
+    "atomvm_safe_" ++ Suffix ++ "_" ++ Now ++ "_" ++ PidStr.
+
+test_safe_option() ->
+    foo = binary_to_term(<<131, 119, 3, "foo">>, [safe]),
+    {foo, bar} = binary_to_term(
+        <<131, 104, 2, 119, 3, "foo", 119, 3, "bar">>, [safe]
+    ),
+    true = binary_to_term(<<131, 119, 4, "true">>, [safe]),
+
+    42 = binary_to_term(<<131, 97, 42>>, [safe]),
+    [] = binary_to_term(<<131, 106>>, [safe]),
+    <<"hi">> = binary_to_term(<<131, 109, 0, 0, 0, 2, "hi">>, [safe]),
+
+    {32768, 6} = binary_to_term(<<131, 98, 0, 0, 128, 0, 127>>, [safe, used]),
+
+    FreshName1 = unique_atom_name("one"),
+    FreshBin1 = make_fresh_small_atom_bin(FreshName1),
+    ok = expect_badarg(fun() -> binary_to_term(FreshBin1, [safe]) end),
+    FreshAtom1 = binary_to_term(FreshBin1),
+    true = is_atom(FreshAtom1),
+    FreshAtom1 = binary_to_term(FreshBin1, [safe]),
+
+    % ATOM_UTF8_EXT
+    FreshName2 = unique_atom_name("two"),
+    FreshBin2 = make_fresh_atom_utf8_bin(FreshName2),
+    ok = expect_badarg(fun() -> binary_to_term(FreshBin2, [safe]) end),
+    FreshAtom2 = binary_to_term(FreshBin2),
+    true = is_atom(FreshAtom2),
+    FreshAtom2 = binary_to_term(FreshBin2, [safe]),
+
+    % ATOM_EXT (tag 100), pure ASCII payload
+    FreshName2a = unique_atom_name("twoa"),
+    FreshBin2a = make_fresh_atom_ext_bin(list_to_binary(FreshName2a)),
+    ok = expect_badarg(fun() -> binary_to_term(FreshBin2a, [safe]) end),
+    FreshAtom2a = binary_to_term(FreshBin2a),
+    true = is_atom(FreshAtom2a),
+    FreshAtom2a = binary_to_term(FreshBin2a, [safe]),
+
+    % ATOM_EXT (tag 100), latin1 with non-ASCII bytes
+    FreshName2bAscii = unique_atom_name("twob"),
+    Latin1Tail = <<16#E9, 16#FF, 16#C0>>,
+    FreshBytes2b = <<(list_to_binary(FreshName2bAscii))/binary, Latin1Tail/binary>>,
+    FreshBin2b = make_fresh_atom_ext_bin(FreshBytes2b),
+    ok = expect_badarg(fun() -> binary_to_term(FreshBin2b, [safe]) end),
+    FreshAtom2b = binary_to_term(FreshBin2b),
+    true = is_atom(FreshAtom2b),
+    FreshAtom2b = binary_to_term(FreshBin2b, [safe]),
+
+    ExpectedUtf8Tail = unicode:characters_to_binary(Latin1Tail, latin1, utf8),
+    ExpectedUtf8 = <<(list_to_binary(FreshName2bAscii))/binary, ExpectedUtf8Tail/binary>>,
+    ExpectedUtf8 = atom_to_binary(FreshAtom2b, utf8),
+
+    FreshName3 = unique_atom_name("three"),
+    NameBin3 = list_to_binary(FreshName3),
+    NameLen3 = byte_size(NameBin3),
+    TupleWithFresh =
+        <<131, 104, 2, 97, 1, 119, NameLen3, NameBin3/binary>>,
+    ok = expect_badarg(fun() -> binary_to_term(TupleWithFresh, [safe]) end),
+    {1, _} = binary_to_term(TupleWithFresh),
+    ok = expect_badarg(
+        fun() ->
+            FreshName4 = unique_atom_name("four"),
+            NameBin4 = list_to_binary(FreshName4),
+            NameLen4 = byte_size(NameBin4),
+            ListWithFresh =
+                <<131, 108, 0, 0, 0, 1, 119, NameLen4, NameBin4/binary, 106>>,
+            binary_to_term(ListWithFresh, [safe])
+        end
+    ),
+    % MAP_EXT
+    ok = expect_badarg(
+        fun() ->
+            FreshName5 = unique_atom_name("five"),
+            NameBin5 = list_to_binary(FreshName5),
+            NameLen5 = byte_size(NameBin5),
+            MapWithFresh =
+                <<131, 116, 0, 0, 0, 1, 97, 1, 119, NameLen5, NameBin5/binary>>,
+            binary_to_term(MapWithFresh, [safe])
+        end
+    ),
+
+    % EXPORT_EXT — M:F/A must resolve to an existing export under [safe]
+    ModuleBin = atom_to_binary(?MODULE, utf8),
+    ModuleLen = byte_size(ModuleBin),
+    ExportBinExisting =
+        <<131, 113, 119, ModuleLen, ModuleBin/binary, 119, 2, "id", 97, 1>>,
+    ExportFun = binary_to_term(ExportBinExisting, [safe]),
+    true = is_function(ExportFun),
+
+    FreshModName = unique_atom_name("modname"),
+    FreshModBin = list_to_binary(FreshModName),
+    FreshModLen = byte_size(FreshModBin),
+    ExportBinFreshMod =
+        <<131, 113, 119, FreshModLen, FreshModBin/binary, 119, 2, "id", 97, 1>>,
+    ok = expect_badarg(fun() -> binary_to_term(ExportBinFreshMod, [safe]) end),
+    ExportFun2 = binary_to_term(ExportBinFreshMod),
+    true = is_function(ExportFun2),
+
+    % EXPORT_EXT with existing atoms but the function does not exist in the
+    % loaded module — [safe] must reject, plain decode must build the fun.
+    ExportBinNonexistentFun =
+        <<131, 113, 119, ModuleLen, ModuleBin/binary, 119, 2, "id", 97, 99>>,
+    ok = expect_badarg(fun() -> binary_to_term(ExportBinNonexistentFun, [safe]) end),
+    NonexistentFun = binary_to_term(ExportBinNonexistentFun),
+    true = is_function(NonexistentFun),
+
+    % EXPORT_EXT for a BIF — [safe] must accept.
+    BifBin = <<131, 113, 119, 6, "erlang", 119, 1, "+", 97, 2>>,
+    BifFun = binary_to_term(BifBin, [safe]),
+    true = is_function(BifFun),
+
+    % EXPORT_EXT with arity 256 — outside the valid 0..255 range.
+    %% encoded as INTEGER_EXT (98), 32-bit signed
+    InvalidArityBin =
+        <<131, 113, 119, ModuleLen, ModuleBin/binary, 119, 2, "id", 98, 0, 0, 1, 0>>,
+    ok = expect_badarg(fun() -> binary_to_term(InvalidArityBin, [safe]) end),
+
+    % NEW_FUN_EXT
+    LocalFun = fun(X) -> X * 2 end,
+    NewFunBin = term_to_binary(LocalFun),
+    DecodedFun = binary_to_term(NewFunBin, [safe]),
+    true = is_function(DecodedFun),
+
+    % NEW_FUN_EXT with num_free = 0 referencing a fresh module atom.
+    % The whole fresh-atom check would otherwise be skipped when no free
+    % variables are captured, letting [safe] accept a binary that creates
+    % a brand-new module atom.
+    FreshFunMod = unique_atom_name("newfunmod"),
+    FreshFunModBin = list_to_binary(FreshFunMod),
+    FreshFunModLen = byte_size(FreshFunModBin),
+    ModuleSelfBin = atom_to_binary(?MODULE, utf8),
+    ModuleSelfLen = byte_size(ModuleSelfBin),
+    NewFunBody =
+        <<119, FreshFunModLen, FreshFunModBin/binary, 97, 0, 97, 0, 88, 119, ModuleSelfLen,
+            ModuleSelfBin/binary, 0:32, 0:32, 0:32>>,
+    NewFunRest =
+        <<1, 0:128, 0:32, 0:32, NewFunBody/binary>>,
+    NewFunSize = byte_size(NewFunRest) + 4,
+    NewFunFreshBin = <<131, 112, NewFunSize:32, NewFunRest/binary>>,
+    ok = expect_badarg(fun() -> binary_to_term(NewFunFreshBin, [safe]) end),
+    DecodedFreshFun = binary_to_term(NewFunFreshBin),
+    true = is_function(DecodedFreshFun),
+
+    % NEW_FUN_EXT with num_free = 0 whose embedded pid carries a fresh node
+    % atom — [safe] must reject the entire fun.
+    FreshFunPidNode = unique_atom_name("funpidnode"),
+    FreshFunPidNodeBin = list_to_binary(FreshFunPidNode),
+    FreshFunPidNodeLen = byte_size(FreshFunPidNodeBin),
+    NewFunFreshPidBody =
+        <<119, ModuleSelfLen, ModuleSelfBin/binary, 97, 0, 97, 0, 88, 119, FreshFunPidNodeLen,
+            FreshFunPidNodeBin/binary, 0:32, 0:32, 0:32>>,
+    NewFunFreshPidRest = <<1, 0:128, 0:32, 0:32, NewFunFreshPidBody/binary>>,
+    NewFunFreshPidSize = byte_size(NewFunFreshPidRest) + 4,
+    NewFunFreshPidBin = <<131, 112, NewFunFreshPidSize:32, NewFunFreshPidRest/binary>>,
+    ok = expect_badarg(fun() -> binary_to_term(NewFunFreshPidBin, [safe]) end),
+    DecodedFreshPidFun = binary_to_term(NewFunFreshPidBin),
+    true = is_function(DecodedFreshPidFun),
+
+    % NEW_FUN_EXT with num_free = 1 whose captured free var is a fresh atom
+    % — [safe] must reject.
+    FreshFreeVar = unique_atom_name("freevar"),
+    FreshFreeVarBin = list_to_binary(FreshFreeVar),
+    FreshFreeVarLen = byte_size(FreshFreeVarBin),
+    NewFunFreshFreeBody =
+        <<119, ModuleSelfLen, ModuleSelfBin/binary, 97, 0, 97, 0, 88, 119, ModuleSelfLen,
+            ModuleSelfBin/binary, 0:32, 0:32, 0:32, 119, FreshFreeVarLen, FreshFreeVarBin/binary>>,
+    NewFunFreshFreeRest = <<1, 0:128, 0:32, 1:32, NewFunFreshFreeBody/binary>>,
+    NewFunFreshFreeSize = byte_size(NewFunFreshFreeRest) + 4,
+    NewFunFreshFreeBin =
+        <<131, 112, NewFunFreshFreeSize:32, NewFunFreshFreeRest/binary>>,
+    ok = expect_badarg(fun() -> binary_to_term(NewFunFreshFreeBin, [safe]) end),
+    DecodedFreshFreeFun = binary_to_term(NewFunFreshFreeBin),
+    true = is_function(DecodedFreshFreeFun),
+
+    FreshNodeName = unique_atom_name("nodename"),
+    NodeBin = list_to_binary(FreshNodeName),
+    NodeLen = byte_size(NodeBin),
+    PidWithFreshNode =
+        <<131, 88, 119, NodeLen, NodeBin/binary, 1:32, 0:32, 0:32>>,
+    ok = expect_badarg(fun() -> binary_to_term(PidWithFreshNode, [safe]) end),
+    DecodedPid = binary_to_term(PidWithFreshNode),
+    true = is_pid(DecodedPid),
+
+    PidWithFreshNode2 =
+        <<131, 88, 119, NodeLen, NodeBin/binary, 2:32, 0:32, 0:32>>,
+    DecodedPid2 = binary_to_term(PidWithFreshNode2, [safe]),
+    true = is_pid(DecodedPid2),
+
+    ok.
+
+test_invalid_export_fun_encoding() ->
+    ModuleSelfBin = atom_to_binary(?MODULE, utf8),
+    ModuleSelfLen = byte_size(ModuleSelfBin),
+    PidBin = <<88, 119, ModuleSelfLen, ModuleSelfBin/binary, 0:32, 0:32, 0:32>>,
+
+    %% EXPORT_EXT with non-atom module
+    ok = expect_badarg(
+        fun() ->
+            binary_to_term(<<131, 113, 97, 42, 119, 3, "foo", 97, 0>>)
+        end
+    ),
+    %% EXPORT_EXT with non-atom function
+    ok = expect_badarg(
+        fun() ->
+            binary_to_term(<<131, 113, 119, 3, "foo", 97, 42, 97, 0>>)
+        end
+    ),
+    %% EXPORT_EXT with non-integer arity (atom in place of arity)
+    ok = expect_badarg(
+        fun() ->
+            binary_to_term(<<131, 113, 119, 3, "foo", 119, 3, "bar", 119, 3, "baz">>)
+        end
+    ),
+
+    %% NEW_FUN_EXT with non-atom module
+    Body1 = <<97, 42, 97, 0, 97, 0, PidBin/binary>>,
+    Rest1 = <<1, 0:128, 0:32, 0:32, Body1/binary>>,
+    Size1 = byte_size(Rest1) + 4,
+    Bin1 = <<131, 112, Size1:32, Rest1/binary>>,
+    ok = expect_badarg(fun() -> binary_to_term(Bin1) end),
+
+    %% NEW_FUN_EXT with non-integer old_index (atom in place)
+    Body2 =
+        <<119, ModuleSelfLen, ModuleSelfBin/binary, 119, 3, "abc", 97, 0, PidBin/binary>>,
+    Rest2 = <<1, 0:128, 0:32, 0:32, Body2/binary>>,
+    Size2 = byte_size(Rest2) + 4,
+    Bin2 = <<131, 112, Size2:32, Rest2/binary>>,
+    ok = expect_badarg(fun() -> binary_to_term(Bin2) end),
+
+    %% NEW_FUN_EXT with non-integer old_uniq (atom in place)
+    Body3 =
+        <<119, ModuleSelfLen, ModuleSelfBin/binary, 97, 0, 119, 3, "abc", PidBin/binary>>,
+    Rest3 = <<1, 0:128, 0:32, 0:32, Body3/binary>>,
+    Size3 = byte_size(Rest3) + 4,
+    Bin3 = <<131, 112, Size3:32, Rest3/binary>>,
+    ok = expect_badarg(fun() -> binary_to_term(Bin3) end),
+
+    %% NEW_FUN_EXT with non-pid in pid slot (integer in place).
+    %% OTP < 27 accepts this; OTP 27+ and AtomVM reject it.
+    case get_otp_version() of
+        OTPVersion when is_integer(OTPVersion), OTPVersion < 27 ->
+            ok;
+        _ ->
+            Body4 =
+                <<119, ModuleSelfLen, ModuleSelfBin/binary, 97, 0, 97, 0, 97, 42>>,
+            Rest4 = <<1, 0:128, 0:32, 0:32, Body4/binary>>,
+            Size4 = byte_size(Rest4) + 4,
+            Bin4 = <<131, 112, Size4:32, Rest4/binary>>,
+            ok = expect_badarg(fun() -> binary_to_term(Bin4) end)
+    end,
+    ok.
+
+test_atom_utf8_ext_node() ->
+    %% OTP accepts ATOM_UTF8_EXT (tag 118) for the embedded node atom in
+    %% NEW_PID_EXT, V4_PORT_EXT, and NEWER_REFERENCE_EXT, even though OTP29
+    %% encoder always emits SMALL_ATOM_UTF8_EXT for short node names.
+    NodeUtf8 = <<118, 0, 13, "nonode@nohost">>,
+
+    %% NEW_PID_EXT
+    PidBin = <<131, 88, NodeUtf8/binary, 1:32, 0:32, 0:32>>,
+    Pid = binary_to_term(PidBin),
+    true = is_pid(Pid),
+
+    %% V4_PORT_EXT
+    PortBin = <<131, 120, NodeUtf8/binary, 1:64, 0:32>>,
+    Port = binary_to_term(PortBin),
+    true = is_port(Port),
+
+    %% NEWER_REFERENCE_EXT
+    RefBin = <<131, 90, 0, 2, NodeUtf8/binary, 0:32, 1:32, 2:32>>,
+    Ref = binary_to_term(RefBin),
+    true = is_reference(Ref),
     ok.
 
 make_binterm_fun(Id) ->


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
