### PR TITLE
ESP32: migrate init_usb_serial to esp_tinyusb v2.x API

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -59,6 +59,9 @@ jobs:
           idf-version: 'v5.5.3'
         - esp-idf-target: "esp32s3"
           idf-version: 'v5.5.3'
+        - esp-idf-target: "esp32s3"
+          idf-version: 'v5.5.3'
+          usb-serial: 'ON'
         - esp-idf-target: "esp32"
           idf-version: 'v5.4.3'
           libsodium: 'ON'
@@ -84,11 +87,23 @@ jobs:
         . $IDF_PATH/export.sh
         idf.py add-dependency "espressif/libsodium^1.0.20~4"
 
-    - name: Build with idf.py
-      shell: bash
+    - name: Add ESP TinyUSB dependency
+      if: matrix.usb-serial == 'ON'
       working-directory: ./src/platforms/esp32/
       run: |
         . $IDF_PATH/export.sh
+        idf.py add-dependency "espressif/esp_tinyusb^2.0.0"
+
+    - name: Build with idf.py
+      shell: bash
+      working-directory: ./src/platforms/esp32/
+      env:
+        USB_SERIAL: ${{ matrix.usb-serial || 'OFF' }}
+      run: |
+        . $IDF_PATH/export.sh
+        if [[ "${USB_SERIAL}" == "ON" ]]; then
+          echo 'CONFIG_USE_USB_SERIAL=y' >> sdkconfig.defaults.in
+        fi
         export IDF_TARGET=${{matrix.esp-idf-target}}
         idf.py set-target ${{matrix.esp-idf-target}}
         idf.py ${{ matrix.libsodium == 'ON' && '-DAVM_USE_LIBSODIUM=ON' || '' }} build

--- a/src/platforms/esp32/main/main.c
+++ b/src/platforms/esp32/main/main.c
@@ -38,11 +38,12 @@
 #include <utils.h>
 
 // before enabling this:
-// idf.py add-dependency esp_tinyusb
+// idf.py add-dependency "espressif/esp_tinyusb^2.0.0"
 // and enable USE_USB_SERIAL in menu config
 #ifdef CONFIG_USE_USB_SERIAL
 void init_usb_serial(void);
 #include "tinyusb.h"
+#include "tinyusb_default_config.h"
 #include "tusb_cdc_acm.h"
 #include "tusb_console.h"
 #endif
@@ -150,19 +151,7 @@ void init_usb_serial()
     /* Setting TinyUSB up */
     ESP_LOGI(TAG, "USB initialization");
 
-    const tinyusb_config_t tusb_cfg = {
-        .device_descriptor = NULL,
-        .string_descriptor = NULL,
-        .external_phy = false, // In the most cases you need to use a `false` value
-#if (TUD_OPT_HIGH_SPEED)
-        .fs_configuration_descriptor = NULL,
-        .hs_configuration_descriptor = NULL,
-        .qualifier_descriptor = NULL,
-#else
-        .configuration_descriptor = NULL,
-#endif // TUD_OPT_HIGH_SPEED
-    };
-
+    const tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG();
     ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
 
     tinyusb_config_cdcacm_t acm_cfg = { 0 }; // the configuration uses default values


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
