### PR TITLE
Remove workaround for OTP 29 TLS 1.3/fastly.com issue

### DIFF
--- a/.github/workflows/run-tests-with-beam.yaml
+++ b/.github/workflows/run-tests-with-beam.yaml
@@ -95,19 +95,6 @@ jobs:
           binutils-riscv64-linux-gnu \
           wabt
 
-    - name: "Workaround OTP 29 TLS 1.3 / picotls bug"
-      if: matrix.otp == '29'
-      run: |
-        # OTP 29's TLS 1.3 ClientHello advertises 34 signature algorithms, but
-        # picotls (used by Fastly, which fronts repo.hex.pm and builds.hex.pm)
-        # only inspects the first 16 and aborts the handshake when no match is
-        # found. Force httpc/ssl defaults to TLS 1.2 so rebar3 can fetch hex
-        # packages. See https://github.com/h2o/picotls/pull/600.
-        cat > /etc/erlang.config <<'CONF'
-        [{ssl, [{protocol_version, ['tlsv1.2']}]}].
-        CONF
-        echo "ERL_AFLAGS=-config /etc/erlang" >> "$GITHUB_ENV"
-
     - name: "Normalize ImageOS for setup-beam"
       if: matrix.os == 'macos-26'
       run: echo "ImageOS=macos15" >> "$GITHUB_ENV"


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
