### PR TITLE
Fix spec of string:trim/2

### DIFF
--- a/libs/estdlib/src/string.erl
+++ b/libs/estdlib/src/string.erl
@@ -187,7 +187,7 @@ trim(String) ->
 %% <<".Hello">>'''
 %% @end
 %%-----------------------------------------------------------------------------
--spec trim(String :: string, Direction :: atom()) -> string() | char().
+-spec trim(String :: string(), Direction :: atom()) -> string() | char().
 trim(String, leading) ->
     triml(String);
 trim(String, trailing) ->


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
