### PR TITLE
globalcontext: dedup globalcontext_existing_term_from_atom_string code

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -665,13 +665,8 @@ bool globalcontext_is_atom_index_equal_to_atom_string(GlobalContext *glb, atom_i
 
 term globalcontext_existing_term_from_atom_string(GlobalContext *glb, AtomString atom_string)
 {
-    atom_index_t global_atom_index;
-    enum AtomTableEnsureAtomResult ensure_result = atom_table_ensure_atom(
-        glb->atom_table, atom_string_data(atom_string), atom_string_len(atom_string), AtomTableAlreadyExisting, &global_atom_index);
-    if (UNLIKELY(ensure_result != AtomTableEnsureAtomOk)) {
-        return term_invalid_term();
-    }
-    return term_from_atom_index(global_atom_index);
+    return globalcontext_existing_atom_from_buf(
+        glb, atom_string_data(atom_string), atom_string_len(atom_string));
 }
 
 int globalcontext_insert_module(GlobalContext *global, Module *module)


### PR DESCRIPTION
Implement globalcontext_existing_term_from_atom_string using newly introduced globalcontext_existing_atom_from_buf.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
