### PR TITLE
doc fix: i2c:open property list table format

### DIFF
--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -1721,7 +1721,7 @@ The AtomVM I2C implementation uses the AtomVM Port mechanism and must be initial
 | `scl` | `integer()` | yes | I2C clock pin (SCL) |
 | `sda` | `integer()` | yes | I2C data pin (SDA) |
 | `clock_speed_hz` | `integer()` | yes | I2C clock frequency (in hertz) |
-| `peripheral` | `string() | binary()` | no (platform dependent default) | I2C peripheral, such as `"i2c0"` |
+| `peripheral` | `string() \| binary()` | no (platform dependent default) | I2C peripheral, such as `"i2c0"` |
 
 For example,
 


### PR DESCRIPTION
There was an unescaped `|` character in the properties list table in the Programmers Guide under I2C. This simply adds the escape character so that the table formats correctly.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
