### PR TITLE
Backport ESP32-P4 fix

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -54,7 +54,7 @@ jobs:
 
         include:
         - esp-idf-target: "esp32p4"
-          idf-version: 'release-v5.4'
+          idf-version: 'v5.4.4'
         - esp-idf-target: "esp32p4"
           idf-version: 'v5.5.3'
         - esp-idf-target: "esp32s3"


### PR DESCRIPTION
The fix was already merged in main, merge it also in release-0.7.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
