### PR TITLE
ESP32: sdmmc configurable pins and width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `"USB_SERIAL_JTAG"` peripheral to the ESP32 `uart` module on chips with a built-in
   USB-Serial-JTAG controller (C3/C5/C6/C61/H2/H21/H4/P4/S3)
 - Added support for the `safe` option in `erlang:binary_to_term/2`
+- Added support for configuring pins and width for sdmmc on ESP32
 
 ### Changed
 - Updated network type db() to dbm() to reflect the actual representation of the type

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -1300,6 +1300,33 @@ case esp:mount("sdmmc", "/sdcard", fat, []) of
 end.
 ```
 
+The SDMMC slot uses the default ESP-IDF pins unless pin options are supplied.  On SoCs whose SDMMC peripheral
+is routed through the GPIO matrix (for example ESP32-S3, and ESP32-P4 slot 1), boards that route the SD card to
+different GPIOs can configure the SDMMC lines in the mount options.  On the classic ESP32, the SDMMC pins are
+fixed by IOMUX; AtomVM rejects pin overrides on fixed-pin targets by raising `badarg`:
+
+```erlang
+SDMMCOpts = [
+    {clk, 39},
+    {cmd, 38},
+    {d0, 40},
+    {width, 1}
+],
+case esp:mount("sdmmc", "/sdcard", fat, SDMMCOpts) of
+    {ok, MountedRef} ->
+        io:format("SD card mounted successfully~n"),
+        {ok, MountedRef};
+    {error, Reason} ->
+        io:format("Failed to mount SD card: ~p~n", [Reason]),
+        {error, Reason}
+end.
+```
+
+The supported SDMMC options are `clk`, `cmd`, `d0`, `d1`, `d2`, `d3`, and `width`.  Use `{width, 1}` for
+1-bit mode or `{width, 4}` for 4-bit mode; omit `width` for the ESP-IDF default (the widest mode supported
+by the card).  The `d1`, `d2`, and `d3` pins are only required for 4-bit mode.  The `width` option is
+supported on fixed-pin and GPIO-matrix targets.
+
 #### Mounting SPI SD card
 
 To mount a SPI SD card, first create a SPI instance configured for your specific board, then use the `esp:mount/4` function:

--- a/libs/avm_esp32/src/esp.erl
+++ b/libs/avm_esp32/src/esp.erl
@@ -134,6 +134,19 @@
 -opaque task_wdt_user_handle() :: binary().
 
 -opaque mounted_fs() :: binary().
+-type sdmmc_mount_option() ::
+    {clk, non_neg_integer()}
+    | {cmd, non_neg_integer()}
+    | {d0, non_neg_integer()}
+    | {d1, non_neg_integer()}
+    | {d2, non_neg_integer()}
+    | {d3, non_neg_integer()}
+    | {width, 1 | 4}.
+-type sdspi_mount_option() ::
+    {spi_host, term()}
+    | {cs, non_neg_integer()}
+    | {cd, non_neg_integer()}.
+-type mount_options() :: [sdmmc_mount_option() | sdspi_mount_option()] | #{atom() => term()}.
 
 -export_type(
     [
@@ -146,6 +159,7 @@
         esp_partition_size/0,
         esp_partition_props/0,
         mounted_fs/0,
+        mount_options/0,
         task_wdt_config/0,
         task_wdt_user_handle/0
     ]
@@ -331,7 +345,14 @@ deep_sleep(_SleepMS) ->
 %% @param   Source the device that will be mounted
 %% @param   Target the path where the filesystem will be mounted
 %% @param   FS the filesystem, only fat is supported now
-%% @param   Opts
+%% @param   Opts mount options.  For `sdmmc', optional pin entries are `clk',
+%%          `cmd', `d0', `d1', `d2', and `d3' (only honored on SoCs whose SDMMC
+%%          peripheral is routed via the GPIO matrix, e.g. ESP32-S3 and
+%%          ESP32-P4 slot 1; on classic ESP32 the SDMMC pins are fixed by
+%%          IOMUX and any pin entries raise `badarg'); `width' may
+%%          be `1' or `4', omit for the ESP-IDF default (widest supported by
+%%          the card).  For `sdspi', required entries are `spi_host' and `cs',
+%%          with optional `cd'.
 %% @returns either a tuple having `ok' and the mounted fs resource, or an error tuple
 %% @doc     Mount a filesystem, and return a resource that can be used later for unmounting it
 %% @end
@@ -340,7 +361,7 @@ deep_sleep(_SleepMS) ->
     Source :: unicode:chardata(),
     Target :: unicode:chardata(),
     FS :: fat,
-    Opts :: proplists:proplist() | #{atom() => term()}
+    Opts :: mount_options()
 ) -> {ok, mounted_fs()} | {error, term()}.
 mount(_Source, _Target, _FS, _Opts) ->
     erlang:nif_error(undefined).

--- a/src/platforms/esp32/components/avm_builtins/storage_nif.c
+++ b/src/platforms/esp32/components/avm_builtins/storage_nif.c
@@ -35,9 +35,11 @@
 
 #include <stdlib.h>
 
+#include <driver/gpio.h>
 #include <driver/sdmmc_host.h>
 #include <driver/sdspi_host.h>
 #include <esp_vfs_fat.h>
+#include <soc/soc_caps.h>
 
 #include <trace.h>
 
@@ -103,6 +105,116 @@ static void opts_to_fatfs_mount_config(term opts_term, esp_vfs_fat_mount_config_
     mount_config->allocation_unit_size = 512;
     // TODO: make it configurable: disk_status_check_enable = false
 }
+
+#ifdef SDMMC_SLOT_CONFIG_DEFAULT
+#if defined(SOC_SDMMC_USE_GPIO_MATRIX) && SOC_SDMMC_USE_GPIO_MATRIX
+static bool storage_nif_set_sdmmc_slot_pin_if_present(
+    term opts_term, AtomString key, gpio_num_t *pin, GlobalContext *glb)
+{
+    term value_term = interop_kv_get_value(opts_term, key, glb);
+    if (term_is_invalid_term(value_term)) {
+        // Omitted pin options keep the ESP-IDF slot default.
+        return true;
+    }
+    if (UNLIKELY(!term_is_integer(value_term))) {
+        return false;
+    }
+    avm_int_t pin_value = term_to_int(value_term);
+    if (UNLIKELY(pin_value < 0 || pin_value > GPIO_NUM_MAX)) {
+        return false;
+    }
+    *pin = (gpio_num_t) pin_value;
+    return true;
+}
+#else
+static bool storage_nif_has_no_sdmmc_slot_pin(
+    term opts_term, AtomString key, GlobalContext *glb)
+{
+    term value_term = interop_kv_get_value(opts_term, key, glb);
+    return term_is_invalid_term(value_term);
+}
+#endif
+
+static bool storage_nif_configure_sdmmc_slot(
+    term opts_term, sdmmc_slot_config_t *slot_config, GlobalContext *glb)
+{
+#if defined(SOC_SDMMC_USE_GPIO_MATRIX) && SOC_SDMMC_USE_GPIO_MATRIX
+    if (UNLIKELY(!storage_nif_set_sdmmc_slot_pin_if_present(
+            opts_term, ATOM_STR("\x3", "clk"), &slot_config->clk, glb))) {
+        return false;
+    }
+
+    if (UNLIKELY(!storage_nif_set_sdmmc_slot_pin_if_present(
+            opts_term, ATOM_STR("\x3", "cmd"), &slot_config->cmd, glb))) {
+        return false;
+    }
+
+    if (UNLIKELY(!storage_nif_set_sdmmc_slot_pin_if_present(
+            opts_term, ATOM_STR("\x2", "d0"), &slot_config->d0, glb))) {
+        return false;
+    }
+
+    if (UNLIKELY(!storage_nif_set_sdmmc_slot_pin_if_present(
+            opts_term, ATOM_STR("\x2", "d1"), &slot_config->d1, glb))) {
+        return false;
+    }
+
+    if (UNLIKELY(!storage_nif_set_sdmmc_slot_pin_if_present(
+            opts_term, ATOM_STR("\x2", "d2"), &slot_config->d2, glb))) {
+        return false;
+    }
+
+    if (UNLIKELY(!storage_nif_set_sdmmc_slot_pin_if_present(
+            opts_term, ATOM_STR("\x2", "d3"), &slot_config->d3, glb))) {
+        return false;
+    }
+#else
+    if (UNLIKELY(!storage_nif_has_no_sdmmc_slot_pin(
+            opts_term, ATOM_STR("\x3", "clk"), glb))) {
+        return false;
+    }
+
+    if (UNLIKELY(!storage_nif_has_no_sdmmc_slot_pin(
+            opts_term, ATOM_STR("\x3", "cmd"), glb))) {
+        return false;
+    }
+
+    if (UNLIKELY(!storage_nif_has_no_sdmmc_slot_pin(
+            opts_term, ATOM_STR("\x2", "d0"), glb))) {
+        return false;
+    }
+
+    if (UNLIKELY(!storage_nif_has_no_sdmmc_slot_pin(
+            opts_term, ATOM_STR("\x2", "d1"), glb))) {
+        return false;
+    }
+
+    if (UNLIKELY(!storage_nif_has_no_sdmmc_slot_pin(
+            opts_term, ATOM_STR("\x2", "d2"), glb))) {
+        return false;
+    }
+
+    if (UNLIKELY(!storage_nif_has_no_sdmmc_slot_pin(
+            opts_term, ATOM_STR("\x2", "d3"), glb))) {
+        return false;
+    }
+#endif
+
+    term width_term = interop_kv_get_value(opts_term, ATOM_STR("\x5", "width"), glb);
+    if (!term_is_invalid_term(width_term)) {
+        if (UNLIKELY(!term_is_integer(width_term))) {
+            return false;
+        }
+        avm_int_t width = term_to_int(width_term);
+        if (UNLIKELY(width != 1 && width != 4)) {
+            return false;
+        }
+        slot_config->width = (uint8_t) width;
+    }
+
+    return true;
+}
+#endif
 
 static term nif_esp_mount(Context *ctx, int argc, term argv[])
 {
@@ -183,8 +295,16 @@ static term nif_esp_mount(Context *ctx, int argc, term argv[])
         sdmmc_host_t host_config = SDMMC_HOST_DEFAULT();
         sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
 
+        if (UNLIKELY(!storage_nif_configure_sdmmc_slot(opts_term, &slot_config, ctx->global))) {
+            free(source);
+            free(target);
+            RAISE_ERROR(BADARG_ATOM);
+        }
+
         mount = enif_alloc_resource(platform->mounted_fs_resource_type, sizeof(struct MountedFS));
         if (IS_NULL_PTR(mount)) {
+            free(source);
+            free(target);
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         SMP_LOCK_INIT(mount);
@@ -202,8 +322,7 @@ static term nif_esp_mount(Context *ctx, int argc, term argv[])
         sdmmc_host_t host_config = SDSPI_HOST_DEFAULT();
         sdspi_device_config_t spi_slot_config = SDSPI_DEVICE_CONFIG_DEFAULT();
 
-        term spi_port = interop_kv_get_value_default(
-            opts_term, ATOM_STR("\x8", "spi_host"), term_invalid_term(), ctx->global);
+        term spi_port = interop_kv_get_value(opts_term, ATOM_STR("\x8", "spi_host"), ctx->global);
         spi_host_device_t host_dev;
         // spi_driver_get_peripheral already checks if spi_port is valid
         bool ok = spi_driver_get_peripheral(spi_port, &host_dev, ctx->global);
@@ -214,8 +333,7 @@ static term nif_esp_mount(Context *ctx, int argc, term argv[])
         }
         spi_slot_config.host_id = host_dev;
 
-        term cs_term = interop_kv_get_value_default(
-            opts_term, ATOM_STR("\x2", "cs"), term_invalid_term(), ctx->global);
+        term cs_term = interop_kv_get_value(opts_term, ATOM_STR("\x2", "cs"), ctx->global);
         if (UNLIKELY(!term_is_integer(cs_term))) {
             free(source);
             free(target);
@@ -255,22 +373,22 @@ static term nif_esp_mount(Context *ctx, int argc, term argv[])
 
     free(source);
 
-    term return_term = term_invalid_term();
     if (UNLIKELY(ret != ESP_OK)) {
         mount->mount_type = Unmounted;
-        return_term = make_esp_error_tuple(ret, ctx);
-    } else {
-        if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2) + TERM_BOXED_RESOURCE_SIZE)
-                != MEMORY_GC_OK)) {
-            enif_release_resource(mount);
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-        }
-        term mount_term = term_from_resource(mount, &ctx->heap);
-        return_term = term_alloc_tuple(2, &ctx->heap);
-        term_put_tuple_element(return_term, 0, OK_ATOM);
-        term_put_tuple_element(return_term, 1, mount_term);
+        enif_release_resource(mount); // release before raise-capable make_esp_error_tuple
+        return make_esp_error_tuple(ret, ctx);
     }
-    enif_release_resource(mount); // decrement refcount after either enif_alloc_resource
+
+    if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2) + TERM_BOXED_RESOURCE_SIZE)
+            != MEMORY_GC_OK)) {
+        enif_release_resource(mount);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    term mount_term = term_from_resource(mount, &ctx->heap);
+    term return_term = term_alloc_tuple(2, &ctx->heap);
+    term_put_tuple_element(return_term, 0, OK_ATOM);
+    term_put_tuple_element(return_term, 1, mount_term);
+    enif_release_resource(mount); // decrement refcount after enif_alloc_resource
 
     return return_term;
 }

--- a/src/platforms/esp32/test/main/test_erl_sources/test_mount.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_mount.erl
@@ -24,6 +24,10 @@
 start() ->
     {ok, Ref} = mount_working_sdmmc(),
     ok = umount_prev(Ref),
+    {ok, RefW1} = mount_working_sdmmc_width1(),
+    ok = umount_prev(RefW1),
+    ok = mount_invalid_sdmmc_opts(),
+    ok = mount_fixed_pin_sdmmc_rejects_pin_opts(),
     ok = mount_missing_fat_partition(),
     ok = umount_prev(Ref).
 
@@ -34,9 +38,53 @@ mount_working_sdmmc() ->
     ok = esp:umount(Ref),
     {ok, Ref}.
 
+mount_working_sdmmc_width1() ->
+    {ok, Ref} = esp:mount("sdmmc", "/test", fat, [{width, 1}]),
+    ok = esp:umount(Ref),
+    {ok, Ref}.
+
 mount_missing_fat_partition() ->
     {error, esp_err_not_found} = esp:mount("/dev/partition/by-name/missingpart", "/test", fat, []),
     ok.
+
+mount_invalid_sdmmc_opts() ->
+    ok = expect_badarg(fun() -> esp:mount("sdmmc", "/test", fat, [{width, 2}]) end),
+    ok = expect_badarg(fun() -> esp:mount("sdmmc", "/test", fat, [{clk, invalid}]) end),
+    ok = expect_badarg(fun() -> esp:mount("sdmmc", "/test", fat, [{width, undefined}]) end),
+    ok = expect_badarg(fun() -> esp:mount("sdmmc", "/test", fat, [{clk, undefined}]) end),
+    ok = expect_badarg(fun() -> esp:mount("sdmmc", "/test", fat, [{clk, -1}]) end),
+    ok = expect_badarg(fun() -> esp:mount("sdmmc", "/test", fat, #{width => 2}) end),
+    ok = expect_badarg(fun() -> esp:mount("sdmmc", "/test", fat, #{clk => invalid}) end),
+    ok.
+
+mount_fixed_pin_sdmmc_rejects_pin_opts() ->
+    Sysinfo = erlang:system_info(esp32_chip_info),
+    Model =
+        if
+            is_map(Sysinfo) -> maps:get(model, Sysinfo);
+            true -> undefined
+        end,
+    case Model of
+        esp32 ->
+            PinOpts = [{clk, 14}, {cmd, 15}, {d0, 2}, {d1, 4}, {d2, 12}, {d3, 13}],
+            ok = lists:foreach(
+                fun(Opt) ->
+                    ok = expect_badarg(fun() -> esp:mount("sdmmc", "/test", fat, [Opt]) end)
+                end,
+                PinOpts
+            ),
+            ok = expect_badarg(fun() -> esp:mount("sdmmc", "/test", fat, #{clk => 14}) end);
+        _ ->
+            ok
+    end.
+
+expect_badarg(Fun) ->
+    try Fun() of
+        _ -> error
+    catch
+        error:badarg -> ok;
+        _:_ -> not_badarg
+    end.
 
 umount_prev(Ref) ->
     try esp:umount(Ref) of


### PR DESCRIPTION
Fixes https://github.com/atomvm/atomvm_examples/issues/31

tl;dr: the newer boards (afaik s3/p4 and that family) can drive sdmmc through their gpio matrix, meaning pins are configurable, and to save pins, one can even use 1bit width.

Based on work by @etnt

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
