### PR TITLE
Add timezone support to SNTP network config

### DIFF
--- a/libs/avm_network/src/network.erl
+++ b/libs/avm_network/src/network.erl
@@ -186,10 +186,12 @@
 -type ap_config() :: {ap, [ap_config_property()]}.
 
 -type sntp_host_config() :: {host, string() | binary()}.
+-type sntp_timezone_config() :: {timezone, string() | binary()}.
 -type sntp_synchronized_config() ::
     {synchronized, fun(({non_neg_integer(), non_neg_integer()}) -> term())}.
 -type sntp_config_property() ::
     sntp_host_config()
+    | sntp_timezone_config()
     | sntp_synchronized_config().
 -type sntp_config() :: {sntp, [sntp_config_property()]}.
 

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -98,6 +98,7 @@ static const char *const sta_connected_atom = ATOM_STR("\xD", "sta_connected");
 static const char *const sta_beacon_timeout_atom = ATOM_STR("\x12", "sta_beacon_timeout");
 static const char *const sta_disconnected_atom = ATOM_STR("\x10", "sta_disconnected");
 static const char *const sta_got_ip_atom = ATOM_STR("\xA", "sta_got_ip");
+static const char *const timezone_atom = ATOM_STR("\x8", "timezone");
 static const char *const network_down_atom = ATOM_STR("\x0C", "network_down");
 
 ESP_EVENT_DECLARE_BASE(sntp_event_base);
@@ -1147,6 +1148,20 @@ static void maybe_set_sntp(term sntp_config, GlobalContext *global)
             ESP_LOGI(TAG, "SNTP initialized with host set to %s", host);
         } else {
             ESP_LOGE(TAG, "Unable to locate sntp host in configuration");
+        }
+
+        term timezone_term = interop_kv_get_value(sntp_config, timezone_atom, global);
+        if (!term_is_invalid_term(timezone_term)) {
+            int tz_ok;
+            char *tz = interop_term_to_string(timezone_term, &tz_ok);
+            if (LIKELY(tz_ok)) {
+                setenv("TZ", tz, 1);
+                tzset();
+                ESP_LOGI(TAG, "Timezone set to %s", tz);
+                free(tz);
+            } else {
+                ESP_LOGE(TAG, "Unable to parse timezone string in configuration");
+            }
         }
     }
 }


### PR DESCRIPTION
Allow setting the system timezone via the SNTP configuration proplist by adding a {timezone, PosixTzString} option. When present, the driver calls setenv("TZ", ...) and tzset() after SNTP initialization, making erlang:localtime() return correctly adjusted local time including automatic DST transitions.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later

NOTE: An example usage can be found here: https://github.com/atomvm/atomvm_examples/compare/master...etnt:atomvm_examples:etnt/wifi-sntp-timezone-config

NOTE 2: I'm new to the AtomVM so be extra careful reviewing this...  :-)