### PR TITLE
JIT compile-time optimizations

### DIFF
--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -99,17 +99,22 @@
     tail_cache :: tail_cache()
 }).
 
--type tail_cache() :: [{tuple(), non_neg_integer()}] | disabled.
+-type tail_cache() :: #{tuple() => non_neg_integer()} | disabled.
 -type stream() :: any().
 
 %%-define(TRACE(Fmt, Args), io:format(Fmt, Args)).
 -define(TRACE(Fmt, Args), ok).
 
-tail_cache_find(_Key, disabled) -> false;
-tail_cache_find(Key, TC) -> lists:keyfind(Key, 1, TC).
+tail_cache_find(_Key, disabled) ->
+    false;
+tail_cache_find(Key, TC) ->
+    case TC of
+        #{Key := Value} -> {Key, Value};
+        _ -> false
+    end.
 
 tail_cache_store(_Key, _Value, disabled) -> disabled;
-tail_cache_store(Key, Value, TC) -> [{Key, Value} | TC].
+tail_cache_store(Key, Value, TC) -> TC#{Key => Value}.
 
 %%-define(ASSERT_ALL_NATIVE_FREE(St), MMod:assert_all_native_free(St)).
 %%-define(ASSERT(Expr), true = Expr).
@@ -154,11 +159,11 @@ compile(
             case erlang:function_exported(MMod, supports_tail_cache, 0) of
                 true ->
                     case MMod:supports_tail_cache() of
-                        true -> [];
+                        true -> #{};
                         false -> disabled
                     end;
                 false ->
-                    []
+                    #{}
             end
     },
     MSt1 = MMod:jump_table(MSt0, LabelsCount),

--- a/libs/jit/src/jit_aarch64.erl
+++ b/libs/jit/src/jit_aarch64.erl
@@ -154,11 +154,11 @@
     stream_module :: module(),
     stream :: stream(),
     offset :: non_neg_integer(),
-    branches :: [{non_neg_integer(), non_neg_integer(), non_neg_integer()}],
+    branches :: #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]},
     jump_table_start :: non_neg_integer(),
     available_regs :: non_neg_integer(),
     used_regs :: non_neg_integer(),
-    labels :: [{integer() | reference(), integer()}],
+    labels :: #{integer() | reference() => integer()},
     variant :: non_neg_integer(),
     regs :: jit_regs:regs()
 }).
@@ -286,12 +286,12 @@ new(Variant, StreamModule, Stream) ->
     #state{
         stream_module = StreamModule,
         stream = Stream,
-        branches = [],
+        branches = #{},
         jump_table_start = 0,
         offset = StreamModule:offset(Stream),
         available_regs = ?AVAILABLE_REGS_MASK,
         used_regs = 0,
-        labels = [],
+        labels = #{},
         variant = Variant,
         regs = jit_regs:new()
     }.
@@ -465,27 +465,25 @@ patch_branch(StreamModule, Stream, Offset, Type, LabelOffset) ->
 -spec patch_branches_for_label(
     module(),
     stream(),
-    integer(),
+    integer() | reference(),
     non_neg_integer(),
-    [{integer(), non_neg_integer(), any()}]
-) -> {stream(), [{integer(), non_neg_integer(), any()}]}.
+    #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]}
+) ->
+    {stream(), #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]}}.
 patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches, []).
-
-patch_branches_for_label(_StreamModule, Stream, _TargetLabel, _LabelOffset, [], Acc) ->
-    {Stream, lists:reverse(Acc)};
-patch_branches_for_label(
-    StreamModule,
-    Stream0,
-    TargetLabel,
-    LabelOffset,
-    [{Label, Offset, Type} | Rest],
-    Acc
-) when Label =:= TargetLabel ->
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Type, LabelOffset),
-    patch_branches_for_label(StreamModule, Stream1, TargetLabel, LabelOffset, Rest, Acc);
-patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch | Rest], Acc) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Rest, [Branch | Acc]).
+    case Branches of
+        #{TargetLabel := BrList} ->
+            Stream1 = lists:foldl(
+                fun({Offset, Type}, AccStream) ->
+                    patch_branch(StreamModule, AccStream, Offset, Type, LabelOffset)
+                end,
+                Stream,
+                BrList
+            ),
+            {Stream1, maps:remove(TargetLabel, Branches)};
+        _ ->
+            {Stream, Branches}
+    end.
 
 %%-----------------------------------------------------------------------------
 %% @doc Rewrite stream to update all branches for labels.
@@ -494,19 +492,29 @@ patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
 -spec update_branches(state()) -> state().
-update_branches(#state{branches = []} = State) ->
-    State;
 update_branches(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
-        branches = [{Label, Offset, Type} | BranchesT],
+        branches = Branches,
         labels = Labels
     } = State
 ) ->
-    {Label, LabelOffset} = lists:keyfind(Label, 1, Labels),
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Type, LabelOffset),
-    update_branches(State#state{stream = Stream1, branches = BranchesT}).
+    Stream1 = maps:fold(
+        fun(Label, BrList, AccStream) ->
+            #{Label := LabelOffset} = Labels,
+            lists:foldl(
+                fun({Offset, Type}, AccStream2) ->
+                    patch_branch(StreamModule, AccStream2, Offset, Type, LabelOffset)
+                end,
+                AccStream,
+                BrList
+            )
+        end,
+        Stream0,
+        Branches
+    ),
+    State#state{stream = Stream1, branches = #{}}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit a call (call with return) to a primitive with arguments. This
@@ -650,21 +658,22 @@ jump_to_label(
     Label
 ) ->
     Offset = StreamModule:offset(Stream0),
-    case lists:keyfind(Label, 1, Labels) of
-        {Label, LabelOffset} ->
+    case Labels of
+        #{Label := LabelOffset} ->
             % Label is already known, emit direct branch without relocation
             Rel = LabelOffset - Offset,
             I1 = jit_aarch64_asm:b(Rel),
             Stream1 = StreamModule:append(Stream0, I1),
             State#state{stream = Stream1, regs = jit_regs:unreachable(State#state.regs)};
-        false ->
+        _ ->
             % Label not yet known, emit placeholder and add relocation
             I1 = jit_aarch64_asm:b(0),
-            Reloc = {Label, Offset, b},
+            BrEntry = {Offset, b},
+            ExistingBrs = maps:get(Label, AccBranches, []),
             Stream1 = StreamModule:append(Stream0, I1),
             State#state{
                 stream = Stream1,
-                branches = [Reloc | AccBranches],
+                branches = AccBranches#{Label => [BrEntry | ExistingBrs]},
                 regs = jit_regs:unreachable(State#state.regs)
             }
     end.
@@ -2354,21 +2363,26 @@ set_continuation_to_label(
     Temp = first_avail(Avail),
     Offset = StreamModule:offset(Stream0),
     Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
-    case lists:keyfind(Label, 1, Labels) of
-        {Label, LabelOffset} ->
+    case Labels of
+        #{Label := LabelOffset} ->
             Rel = LabelOffset - Offset,
             I1 = jit_aarch64_asm:adr(Temp, Rel),
             I2 = jit_aarch64_asm:str(Temp, ?JITSTATE_CONTINUATION),
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
             State#state{stream = Stream1, regs = Regs1};
-        false ->
+        _ ->
             I1 = jit_aarch64_asm:adr(Temp, 0),
-            Reloc = {Label, Offset, {adr, Temp}},
+            BrEntry = {Offset, {adr, Temp}},
             I2 = jit_aarch64_asm:str(Temp, ?JITSTATE_CONTINUATION),
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
-            State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}
+            ExistingBrs = maps:get(Label, Branches, []),
+            State#state{
+                stream = Stream1,
+                branches = Branches#{Label => [BrEntry | ExistingBrs]},
+                regs = Regs1
+            }
     end.
 
 %%-----------------------------------------------------------------------------
@@ -2393,12 +2407,19 @@ set_continuation_to_offset(
     OffsetRef = make_ref(),
     Offset = StreamModule:offset(Stream0),
     I1 = jit_aarch64_asm:adr(Temp, 0),
-    Reloc = {OffsetRef, Offset, {adr, Temp}},
+    BrEntry = {Offset, {adr, Temp}},
     I2 = jit_aarch64_asm:str(Temp, ?JITSTATE_CONTINUATION),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
     Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
-    {State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}, OffsetRef}.
+    {
+        State#state{
+            stream = Stream1,
+            branches = Branches#{OffsetRef => [BrEntry]},
+            regs = Regs1
+        },
+        OffsetRef
+    }.
 
 %%-----------------------------------------------------------------------------
 %% @doc Implement a continuation entry point. On AArch64 this is a nop
@@ -2783,20 +2804,24 @@ call_only_or_schedule_next(
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary>>),
     BNEOffset = StreamModule:offset(Stream1),
 
-    case lists:keyfind(Label, 1, Labels) of
-        {Label, LabelOffset} ->
+    case Labels of
+        #{Label := LabelOffset} ->
             % Label is already known, emit direct branch with calculated offset
             % Calculate relative offset (must be 4-byte aligned)
             Rel = LabelOffset - BNEOffset,
             I4 = jit_aarch64_asm:bcc(ne, Rel),
             Stream2 = StreamModule:append(Stream1, I4),
             State1 = State0#state{stream = Stream2};
-        false ->
+        _ ->
             % Label not yet known, emit placeholder and add relocation
             I4 = jit_aarch64_asm:bcc(ne, 0),
-            Reloc1 = {Label, BNEOffset, {bcc, ne}},
+            BrEntry = {BNEOffset, {bcc, ne}},
+            ExistingBrs = maps:get(Label, Branches, []),
             Stream2 = StreamModule:append(Stream1, I4),
-            State1 = State0#state{stream = Stream2, branches = [Reloc1 | Branches]}
+            State1 = State0#state{
+                stream = Stream2,
+                branches = Branches#{Label => [BrEntry | ExistingBrs]}
+            }
     end,
     State2 = set_continuation_to_label(State1, Label),
     call_primitive_last(State2, ?PRIM_SCHEDULE_NEXT_CP, [ctx, jit_state]).
@@ -2894,7 +2919,7 @@ return_labels_and_lines(
 ) ->
     SortedLabels = lists:keysort(2, [
         {Label, LabelOffset}
-     || {Label, LabelOffset} <- Labels, is_integer(Label)
+     || {Label, LabelOffset} <- maps:to_list(Labels), is_integer(Label)
     ]),
 
     I1 = jit_aarch64_asm:adr(r0, 8),
@@ -3049,10 +3074,10 @@ add_label(
     ),
 
     State#state{
-        stream = Stream2, branches = RemainingBranches, labels = [{Label, LabelOffset} | Labels]
+        stream = Stream2, branches = RemainingBranches, labels = Labels#{Label => LabelOffset}
     };
 add_label(#state{labels = Labels} = State, Label, Offset) ->
-    State#state{labels = [{Label, Offset} | Labels]}.
+    State#state{labels = Labels#{Label => Offset}}.
 
 -ifdef(JIT_DWARF).
 %%-----------------------------------------------------------------------------

--- a/libs/jit/src/jit_arm32.erl
+++ b/libs/jit/src/jit_arm32.erl
@@ -141,11 +141,11 @@
     stream_module :: module(),
     stream :: stream(),
     offset :: non_neg_integer(),
-    branches :: [{non_neg_integer(), non_neg_integer(), non_neg_integer()}],
+    branches :: #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]},
     jump_table_start :: non_neg_integer(),
     available_regs :: non_neg_integer(),
     used_regs :: non_neg_integer(),
-    labels :: [{integer() | reference(), integer()}],
+    labels :: #{integer() | reference() => integer()},
     variant :: non_neg_integer(),
     literal_pool :: [{non_neg_integer(), arm32_register(), non_neg_integer()}],
     %% Register value tracking for optimization
@@ -289,12 +289,12 @@ new(Variant, StreamModule, Stream) ->
     #state{
         stream_module = StreamModule,
         stream = Stream,
-        branches = [],
+        branches = #{},
         jump_table_start = 0,
         offset = StreamModule:offset(Stream),
         available_regs = ?AVAILABLE_REGS_MASK,
         used_regs = 0,
-        labels = [],
+        labels = #{},
         variant = Variant,
         literal_pool = [],
         regs = jit_regs:new()
@@ -484,27 +484,25 @@ patch_branch(StreamModule, Stream, Offset, Type, LabelOffset) ->
 -spec patch_branches_for_label(
     module(),
     stream(),
-    integer(),
+    integer() | reference(),
     non_neg_integer(),
-    [{integer(), non_neg_integer(), any()}]
-) -> {stream(), [{integer(), non_neg_integer(), any()}]}.
+    #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]}
+) ->
+    {stream(), #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]}}.
 patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches, []).
-
-patch_branches_for_label(_StreamModule, Stream, _TargetLabel, _LabelOffset, [], Acc) ->
-    {Stream, lists:reverse(Acc)};
-patch_branches_for_label(
-    StreamModule,
-    Stream0,
-    TargetLabel,
-    LabelOffset,
-    [{Label, Offset, Type} | Rest],
-    Acc
-) when Label =:= TargetLabel ->
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Type, LabelOffset),
-    patch_branches_for_label(StreamModule, Stream1, TargetLabel, LabelOffset, Rest, Acc);
-patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch | Rest], Acc) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Rest, [Branch | Acc]).
+    case Branches of
+        #{TargetLabel := BrList} ->
+            Stream1 = lists:foldl(
+                fun({Offset, Type}, AccStream) ->
+                    patch_branch(StreamModule, AccStream, Offset, Type, LabelOffset)
+                end,
+                Stream,
+                BrList
+            ),
+            {Stream1, maps:remove(TargetLabel, Branches)};
+        _ ->
+            {Stream, Branches}
+    end.
 
 %%-----------------------------------------------------------------------------
 %% @doc Rewrite stream to update all branches for labels.
@@ -513,19 +511,29 @@ patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
 -spec update_branches(state()) -> state().
-update_branches(#state{branches = []} = State) ->
-    State;
 update_branches(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
-        branches = [{Label, Offset, Type} | BranchesT],
+        branches = Branches,
         labels = Labels
     } = State
 ) ->
-    {Label, LabelOffset} = lists:keyfind(Label, 1, Labels),
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Type, LabelOffset),
-    update_branches(State#state{stream = Stream1, branches = BranchesT}).
+    Stream1 = maps:fold(
+        fun(Label, BrList, AccStream) ->
+            #{Label := LabelOffset} = Labels,
+            lists:foldl(
+                fun({Offset, Type}, AccStream2) ->
+                    patch_branch(StreamModule, AccStream2, Offset, Type, LabelOffset)
+                end,
+                AccStream,
+                BrList
+            )
+        end,
+        Stream0,
+        Branches
+    ),
+    State#state{stream = Stream1, branches = #{}}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Generate code to load a primitive function pointer into a register
@@ -778,7 +786,11 @@ return_if_not_equal_to_ctx(
 jump_to_label(
     #state{stream_module = StreamModule, stream = Stream0, labels = Labels} = State0, Label
 ) ->
-    LabelLookupResult = lists:keyfind(Label, 1, Labels),
+    LabelLookupResult =
+        case Labels of
+            #{Label := LabelOffset} -> {Label, LabelOffset};
+            _ -> false
+        end,
     Offset = StreamModule:offset(Stream0),
     {State1, CodeBlock} = branch_to_label_code(State0, Offset, Label, LabelLookupResult),
     Stream1 = StreamModule:append(Stream0, CodeBlock),
@@ -874,8 +886,8 @@ branch_to_label_code(
 ) ->
     % ARM32 b has +/-32MB range, emit a placeholder and add relocation
     CodeBlock = <<16#FFFFFFFF:32>>,
-    Reloc = {Label, Offset, branch},
-    State1 = State0#state{branches = [Reloc | Branches]},
+    ExistingBrs = maps:get(Label, Branches, []),
+    State1 = State0#state{branches = Branches#{Label => [{Offset, branch} | ExistingBrs]}},
     {State1, CodeBlock}.
 
 %%-----------------------------------------------------------------------------
@@ -2972,14 +2984,17 @@ set_continuation_to_offset(
     % We need to patch this to add(al, Temp, pc, TargetOffset - Offset - 8)
     ?ASSERT(byte_size(jit_arm32_asm:add(al, Temp, pc, 0)) =:= 4),
     I1 = <<16#FFFFFFFF:32>>,
-    Reloc = {OffsetRef, Offset, {add_pc, Temp}},
+    BrEntry = {Offset, {add_pc, Temp}},
     % Load jit_state pointer from stack, then store continuation
     I2 = jit_arm32_asm:ldr(al, TempJitState, {sp, ?STACK_OFFSET_JITSTATE}),
     I3 = jit_arm32_asm:str(al, Temp, ?JITSTATE_CONTINUATION(TempJitState)),
     Code = <<I1/binary, I2/binary, I3/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
     Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), TempJitState),
-    {State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}, OffsetRef}.
+    {
+        State#state{stream = Stream1, branches = Branches#{OffsetRef => [BrEntry]}, regs = Regs1},
+        OffsetRef
+    }.
 
 %% @doc Implement a continuation entry point.
 -spec continuation_entry_point(#state{}) -> #state{}.
@@ -3503,25 +3518,26 @@ call_only_or_schedule_next(
     % If not zero, we want to continue execution at Label
     % If zero, we want to fall through to scheduling code
 
-    % Look up label once to avoid duplicate lookup in helper
-    LabelLookupResult = lists:keyfind(Label, 1, State0#state.labels),
-
     BccOffset = StreamModule:offset(Stream1),
 
     State4 =
-        case LabelLookupResult of
-            {Label, LabelOffset} ->
+        case State0#state.labels of
+            #{Label := LabelOffset} ->
                 % Label is known, use direct conditional branch (ARM32 has +/-32MB range)
                 Rel = LabelOffset - BccOffset,
                 I4 = jit_arm32_asm:b(ne, Rel),
                 Stream2 = StreamModule:append(Stream1, I4),
                 State0#state{stream = Stream2};
-            false ->
+            _ ->
                 % Label not known, emit placeholder and add relocation
                 I4 = <<16#FFFFFFFF:32>>,
                 Stream2 = StreamModule:append(Stream1, I4),
-                Reloc = {Label, BccOffset, {cond_branch, ne}},
-                State0#state{stream = Stream2, branches = [Reloc | State0#state.branches]}
+                Branches = State0#state.branches,
+                ExistingBrs = maps:get(Label, Branches, []),
+                State0#state{
+                    stream = Stream2,
+                    branches = Branches#{Label => [{BccOffset, {cond_branch, ne}} | ExistingBrs]}
+                }
         end,
     State5 = set_continuation_to_label(State4, Label),
     call_primitive_last(State5, ?PRIM_SCHEDULE_NEXT_CP, [ctx, jit_state]).
@@ -3629,7 +3645,7 @@ return_labels_and_lines(
 ) ->
     SortedLabels = lists:keysort(2, [
         {Label, LabelOffset}
-     || {Label, LabelOffset} <- Labels, is_integer(Label)
+     || {Label, LabelOffset} <- maps:to_list(Labels), is_integer(Label)
     ]),
 
     % add r0, pc, #0 sets r0 to instruction_address + 8 = address of data after pop
@@ -3862,10 +3878,10 @@ add_label(
     ),
 
     State#state{
-        stream = Stream2, branches = RemainingBranches, labels = [{Label, LabelOffset} | Labels]
+        stream = Stream2, branches = RemainingBranches, labels = Labels#{Label => LabelOffset}
     };
 add_label(#state{labels = Labels} = State, Label, Offset) ->
-    State#state{labels = [{Label, Offset} | Labels]}.
+    State#state{labels = Labels#{Label => Offset}}.
 
 %% Convert a value to a contents descriptor for tracking.
 value_to_contents(Value) -> jit_regs:value_to_contents(Value, ?MAX_REG).

--- a/libs/jit/src/jit_armv6m.erl
+++ b/libs/jit/src/jit_armv6m.erl
@@ -154,11 +154,11 @@
     stream_module :: module(),
     stream :: stream(),
     offset :: non_neg_integer(),
-    branches :: [{non_neg_integer(), non_neg_integer(), branch_type()}],
+    branches :: #{integer() | reference() => [{non_neg_integer(), branch_type()}]},
     jump_table_start :: non_neg_integer(),
     available_regs :: non_neg_integer(),
     used_regs :: non_neg_integer(),
-    labels :: [{integer() | reference(), integer()}],
+    labels :: #{integer() | reference() => integer()},
     variant :: non_neg_integer(),
     literal_pool :: [{non_neg_integer(), armv6m_register(), non_neg_integer()}],
     regs :: jit_regs:regs(),
@@ -296,12 +296,12 @@ new(Variant, StreamModule, Stream) ->
     #state{
         stream_module = StreamModule,
         stream = Stream,
-        branches = [],
+        branches = #{},
         jump_table_start = 0,
         offset = StreamModule:offset(Stream),
         available_regs = ?AVAILABLE_REGS_MASK,
         used_regs = 0,
-        labels = [],
+        labels = #{},
         variant = Variant,
         literal_pool = [],
         regs = jit_regs:new(),
@@ -581,27 +581,25 @@ patch_branch(StreamModule, Stream, Offset, Type, LabelOffset) ->
 -spec patch_branches_for_label(
     module(),
     stream(),
-    integer(),
+    integer() | reference(),
     non_neg_integer(),
-    [{integer(), non_neg_integer(), any()}]
-) -> {stream(), [{integer(), non_neg_integer(), any()}]}.
+    #{integer() | reference() => [{non_neg_integer(), branch_type()}]}
+) ->
+    {stream(), #{integer() | reference() => [{non_neg_integer(), branch_type()}]}}.
 patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches, []).
-
-patch_branches_for_label(_StreamModule, Stream, _TargetLabel, _LabelOffset, [], Acc) ->
-    {Stream, lists:reverse(Acc)};
-patch_branches_for_label(
-    StreamModule,
-    Stream0,
-    TargetLabel,
-    LabelOffset,
-    [{Label, Offset, Type} | Rest],
-    Acc
-) when Label =:= TargetLabel ->
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Type, LabelOffset),
-    patch_branches_for_label(StreamModule, Stream1, TargetLabel, LabelOffset, Rest, Acc);
-patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch | Rest], Acc) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Rest, [Branch | Acc]).
+    case Branches of
+        #{TargetLabel := BrList} ->
+            Stream1 = lists:foldl(
+                fun({Offset, Type}, AccStream) ->
+                    patch_branch(StreamModule, AccStream, Offset, Type, LabelOffset)
+                end,
+                Stream,
+                BrList
+            ),
+            {Stream1, maps:remove(TargetLabel, Branches)};
+        _ ->
+            {Stream, Branches}
+    end.
 
 %%-----------------------------------------------------------------------------
 %% @doc Rewrite stream to update all branches for labels.
@@ -610,19 +608,29 @@ patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
 -spec update_branches(state()) -> state().
-update_branches(#state{branches = []} = State) ->
-    State;
 update_branches(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
-        branches = [{Label, Offset, Type} | BranchesT],
+        branches = Branches,
         labels = Labels
     } = State
 ) ->
-    {Label, LabelOffset} = lists:keyfind(Label, 1, Labels),
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Type, LabelOffset),
-    update_branches(State#state{stream = Stream1, branches = BranchesT}).
+    Stream1 = maps:fold(
+        fun(Label, BrList, AccStream) ->
+            #{Label := LabelOffset} = Labels,
+            lists:foldl(
+                fun({Offset, Type}, AccStream2) ->
+                    patch_branch(StreamModule, AccStream2, Offset, Type, LabelOffset)
+                end,
+                AccStream,
+                BrList
+            )
+        end,
+        Stream0,
+        Branches
+    ),
+    State#state{stream = Stream1, branches = #{}}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Generate code to load a primitive function pointer into a register
@@ -864,7 +872,11 @@ return_if_not_equal_to_ctx(
 jump_to_label(
     #state{stream_module = StreamModule, stream = Stream0, labels = Labels} = State0, Label
 ) ->
-    LabelLookupResult = lists:keyfind(Label, 1, Labels),
+    LabelLookupResult =
+        case Labels of
+            #{Label := LabelOffset} -> {Label, LabelOffset};
+            _ -> false
+        end,
     Offset = StreamModule:offset(Stream0),
     {State1, CodeBlock} = branch_to_label_code(State0, Offset, Label, LabelLookupResult),
     Stream1 = StreamModule:append(Stream0, CodeBlock),
@@ -992,8 +1004,8 @@ branch_to_label_code(
     #state{branches = Branches, thumb2 = true} = State0, Offset, Label, false
 ) ->
     CodeBlock = <<16#FFFF:16, 16#FFFF:16>>,
-    Reloc = {Label, Offset, b_w},
-    State1 = State0#state{branches = [Reloc | Branches]},
+    BrEntry = {Offset, b_w},
+    State1 = State0#state{branches = Branches#{Label => [BrEntry | maps:get(Label, Branches, [])]}},
     {State1, CodeBlock};
 branch_to_label_code(
     #state{available_regs = Available, branches = Branches} = State0, Offset, Label, false
@@ -1024,8 +1036,8 @@ branch_to_label_code(
         end,
     % Add relocation entry
     CodeBlock = binary:copy(<<16#FF>>, SequenceSize),
-    Reloc = {Label, Offset, {far_branch, SequenceSize, TempReg}},
-    State1 = State0#state{branches = [Reloc | Branches]},
+    BrEntry = {Offset, {far_branch, SequenceSize, TempReg}},
+    State1 = State0#state{branches = Branches#{Label => [BrEntry | maps:get(Label, Branches, [])]}},
     {State1, CodeBlock};
 branch_to_label_code(
     #state{available_regs = 0, branches = Branches} = State0, Offset, Label, false
@@ -1066,8 +1078,8 @@ branch_to_label_code(
         end,
     % Add relocation entry
     CodeBlock = binary:copy(<<16#FF>>, SequenceSize),
-    Reloc = {Label, Offset, {far_branch, SequenceSize, ?IP_REG}},
-    State1 = State0#state{branches = [Reloc | Branches]},
+    BrEntry = {Offset, {far_branch, SequenceSize, ?IP_REG}},
+    State1 = State0#state{branches = Branches#{Label => [BrEntry | maps:get(Label, Branches, [])]}},
     {State1, CodeBlock};
 branch_to_label_code(#state{available_regs = 0}, _Offset, _Label, _LabelLookup) ->
     error({no_available_registers, _LabelLookup}).
@@ -3229,7 +3241,7 @@ set_continuation_to_offset(
     Offset = StreamModule:offset(Stream0),
     ?ASSERT(byte_size(jit_armv6m_asm:adr(Temp, 4)) =:= 2),
     I1 = <<16#FFFF:16>>,
-    Reloc = {OffsetRef, Offset, {adr, Temp}},
+    BrEntry = {Offset, {adr, Temp}},
     % Set thumb bit (LSB = 1) by adding 1 to the 4-byte aligned address
     I2 = jit_armv6m_asm:adds(Temp, Temp, 1),
     % Load jit_state pointer from stack, then store continuation
@@ -3238,7 +3250,10 @@ set_continuation_to_offset(
     Code = <<I1/binary, I2/binary, I3/binary, I4/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
     Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, Temp), TempJitState),
-    {State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}, OffsetRef}.
+    {
+        State#state{stream = Stream1, branches = Branches#{OffsetRef => [BrEntry]}, regs = Regs1},
+        OffsetRef
+    }.
 
 %% @doc Implement a continuation entry point.
 %% TODO: push r4-r7 and lr
@@ -3876,7 +3891,11 @@ call_only_or_schedule_next(
     % If zero, we want to fall through to scheduling code
 
     % Look up label once to avoid duplicate lookup in helper
-    LabelLookupResult = lists:keyfind(Label, 1, State0#state.labels),
+    LabelLookupResult =
+        case State0#state.labels of
+            #{Label := LabelOffset0} -> {Label, LabelOffset0};
+            _ -> false
+        end,
 
     BccOffset = StreamModule:offset(Stream1),
 
@@ -4033,7 +4052,7 @@ return_labels_and_lines(
 ) ->
     SortedLabels = lists:keysort(2, [
         {Label, LabelOffset}
-     || {Label, LabelOffset} <- Labels, is_integer(Label)
+     || {Label, LabelOffset} <- maps:to_list(Labels), is_integer(Label)
     ]),
 
     % Check if current offset is 4-byte aligned
@@ -4303,10 +4322,10 @@ add_label(
     ),
 
     State#state{
-        stream = Stream2, branches = RemainingBranches, labels = [{Label, LabelOffset} | Labels]
+        stream = Stream2, branches = RemainingBranches, labels = Labels#{Label => LabelOffset}
     };
 add_label(#state{labels = Labels} = State, Label, Offset) ->
-    State#state{labels = [{Label, Offset} | Labels]}.
+    State#state{labels = Labels#{Label => Offset}}.
 
 -ifdef(JIT_DWARF).
 %%-----------------------------------------------------------------------------

--- a/libs/jit/src/jit_riscv32.erl
+++ b/libs/jit/src/jit_riscv32.erl
@@ -171,11 +171,11 @@
     stream_module :: module(),
     stream :: stream(),
     offset :: non_neg_integer(),
-    branches :: [{non_neg_integer(), non_neg_integer(), non_neg_integer()}],
+    branches :: #{integer() | reference() => [{non_neg_integer(), tuple()}]},
     jump_table_start :: non_neg_integer(),
     available_regs :: non_neg_integer(),
     used_regs :: non_neg_integer(),
-    labels :: [{integer() | reference(), integer()}],
+    labels :: #{integer() | reference() => integer()},
     variant :: non_neg_integer(),
     regs :: jit_regs:regs()
 }).

--- a/libs/jit/src/jit_riscv64.erl
+++ b/libs/jit/src/jit_riscv64.erl
@@ -174,11 +174,11 @@
     stream_module :: module(),
     stream :: stream(),
     offset :: non_neg_integer(),
-    branches :: [{non_neg_integer(), non_neg_integer(), non_neg_integer()}],
+    branches :: #{integer() | reference() => [{non_neg_integer(), tuple()}]},
     jump_table_start :: non_neg_integer(),
     available_regs :: non_neg_integer(),
     used_regs :: non_neg_integer(),
-    labels :: [{integer() | reference(), integer()}],
+    labels :: #{integer() | reference() => integer()},
     variant :: non_neg_integer(),
     %% Register value tracking for optimization
     regs :: jit_regs:regs()

--- a/libs/jit/src/jit_riscv_impl.hrl
+++ b/libs/jit/src/jit_riscv_impl.hrl
@@ -43,12 +43,12 @@ new(Variant, StreamModule, Stream) ->
     #state{
         stream_module = StreamModule,
         stream = Stream,
-        branches = [],
+        branches = #{},
         jump_table_start = 0,
         offset = StreamModule:offset(Stream),
         available_regs = ?AVAILABLE_REGS_MASK,
         used_regs = 0,
-        labels = [],
+        labels = #{},
         variant = Variant,
         regs = jit_regs:new()
     }.
@@ -252,22 +252,19 @@ patch_branch(StreamModule, Stream, Offset, Type, LabelOffset) ->
 %% @return {UpdatedStream, RemainingBranches}
 %%-----------------------------------------------------------------------------
 patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches, []).
-
-patch_branches_for_label(_StreamModule, Stream, _TargetLabel, _LabelOffset, [], Acc) ->
-    {Stream, lists:reverse(Acc)};
-patch_branches_for_label(
-    StreamModule,
-    Stream0,
-    TargetLabel,
-    LabelOffset,
-    [{Label, Offset, Type} | Rest],
-    Acc
-) when Label =:= TargetLabel ->
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Type, LabelOffset),
-    patch_branches_for_label(StreamModule, Stream1, TargetLabel, LabelOffset, Rest, Acc);
-patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch | Rest], Acc) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Rest, [Branch | Acc]).
+    case Branches of
+        #{TargetLabel := BrList} ->
+            Stream1 = lists:foldl(
+                fun({Offset, Type}, AccStream) ->
+                    patch_branch(StreamModule, AccStream, Offset, Type, LabelOffset)
+                end,
+                Stream,
+                BrList
+            ),
+            {Stream1, maps:remove(TargetLabel, Branches)};
+        _ ->
+            {Stream, Branches}
+    end.
 
 %%-----------------------------------------------------------------------------
 %% @doc Rewrite stream to update all branches for labels.
@@ -275,19 +272,29 @@ patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch
 %% @param State current backend state
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
-update_branches(#state{branches = []} = State) ->
-    State;
 update_branches(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
-        branches = [{Label, Offset, Type} | BranchesT],
+        branches = Branches,
         labels = Labels
     } = State
 ) ->
-    {Label, LabelOffset} = lists:keyfind(Label, 1, Labels),
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Type, LabelOffset),
-    update_branches(State#state{stream = Stream1, branches = BranchesT}).
+    Stream1 = maps:fold(
+        fun(Label, BrList, AccStream) ->
+            #{Label := LabelOffset} = Labels,
+            lists:foldl(
+                fun({Offset, Type}, AccStream2) ->
+                    patch_branch(StreamModule, AccStream2, Offset, Type, LabelOffset)
+                end,
+                AccStream,
+                BrList
+            )
+        end,
+        Stream0,
+        Branches
+    ),
+    State#state{stream = Stream1, branches = #{}}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Generate code to load a primitive function pointer into a register
@@ -493,7 +500,11 @@ return_if_not_equal_to_ctx(
 jump_to_label(
     #state{stream_module = StreamModule, stream = Stream0, labels = Labels} = State0, Label
 ) ->
-    LabelLookupResult = lists:keyfind(Label, 1, Labels),
+    LabelLookupResult =
+        case Labels of
+            #{Label := LabelOffset} -> {Label, LabelOffset};
+            _ -> false
+        end,
     Offset = StreamModule:offset(Stream0),
     {State1, CodeBlock} = branch_to_label_code(State0, Offset, Label, LabelLookupResult),
     Stream1 = StreamModule:append(Stream0, CodeBlock),
@@ -592,8 +603,8 @@ branch_to_label_code(
     % Placeholder: jalr zero, TempReg, 0
     CodeBlock = <<16#FFFFFFFF:32, 16#FFFFFFFF:32>>,
     % Add relocation entry
-    Reloc = {Label, Offset, {far_branch, TempReg}},
-    State1 = State0#state{branches = [Reloc | Branches]},
+    BrEntry = {Offset, {far_branch, TempReg}},
+    State1 = State0#state{branches = Branches#{Label => [BrEntry | maps:get(Label, Branches, [])]}},
     {State1, CodeBlock};
 branch_to_label_code(
     #state{available_regs = 0, branches = Branches} = State0, Offset, Label, false
@@ -605,8 +616,8 @@ branch_to_label_code(
     % Placeholder: jalr zero, t6, 0
     CodeBlock = <<16#FFFFFFFF:32, 16#FFFFFFFF:32>>,
     % Add relocation entry
-    Reloc = {Label, Offset, {far_branch, t6}},
-    State1 = State0#state{branches = [Reloc | Branches]},
+    BrEntry = {Offset, {far_branch, t6}},
+    State1 = State0#state{branches = Branches#{Label => [BrEntry | maps:get(Label, Branches, [])]}},
     {State1, CodeBlock};
 branch_to_label_code(#state{available_regs = 0}, _Offset, _Label, LabelLookup) ->
     error({no_available_registers, LabelLookup}).
@@ -2570,8 +2581,8 @@ set_continuation_to_label(
     Temp = first_avail(Avail),
     Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
     Offset = StreamModule:offset(Stream0),
-    case lists:keyfind(Label, 1, Labels) of
-        {Label, LabelOffset} ->
+    case Labels of
+        #{Label := LabelOffset} ->
             % Label is already known, emit direct pc-relative address without relocation
             Rel = LabelOffset - Offset,
             I1 = pc_relative_address(Temp, Rel),
@@ -2579,16 +2590,20 @@ set_continuation_to_label(
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
             State#state{stream = Stream1, regs = Regs1};
-        false ->
+        _ ->
             % Label not yet known, emit placeholder and add relocation
             % Reserve 8 bytes (2 x 32-bit instructions) with all-1s placeholder for flash programming
             % The relocation will replace these with the correct offset
             I1 = <<16#FFFFFFFF:32/little, 16#FFFFFFFF:32/little>>,
-            Reloc = {Label, Offset, {adr, Temp}},
+            BrEntry = {Offset, {adr, Temp}},
             I2 = ?STORE_WORD(?JITSTATE_REG, Temp, ?JITSTATE_CONTINUATION_OFFSET),
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
-            State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}
+            State#state{
+                stream = Stream1,
+                branches = Branches#{Label => [BrEntry | maps:get(Label, Branches, [])]},
+                regs = Regs1
+            }
     end.
 
 %% @doc Set the continuation to a given offset.
@@ -2609,13 +2624,14 @@ set_continuation_to_offset(
     Offset = StreamModule:offset(Stream0),
     % Reserve 8 bytes with all-1s placeholder for flash programming
     I1 = <<16#FFFFFFFF:32/little, 16#FFFFFFFF:32/little>>,
-    Reloc = {OffsetRef, Offset, {adr, Temp}},
+    BrEntry = {Offset, {adr, Temp}},
     % Store continuation (jit_state is in a1)
     I2 = ?STORE_WORD(?JITSTATE_REG, Temp, ?JITSTATE_CONTINUATION_OFFSET),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
     Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
-    {State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}, OffsetRef}.
+    {State#state{stream = Stream1, branches = Branches#{OffsetRef => [BrEntry]}, regs = Regs1},
+        OffsetRef}.
 
 %% @doc Implement a continuation entry point.
 continuation_entry_point(State) ->
@@ -3021,7 +3037,11 @@ call_only_or_schedule_next(
     % If zero, we want to fall through to scheduling code
 
     % Look up label once to avoid duplicate lookup in helper
-    LabelLookupResult = lists:keyfind(Label, 1, State0#state.labels),
+    LabelLookupResult =
+        case State0#state.labels of
+            #{Label := KnownLabelOffset} -> {Label, KnownLabelOffset};
+            _ -> false
+        end,
 
     BccOffset = StreamModule:offset(Stream1),
 
@@ -3175,7 +3195,7 @@ return_labels_and_lines(
 ) ->
     SortedLabels = lists:keysort(2, [
         {Label, LabelOffset}
-     || {Label, LabelOffset} <- Labels, is_integer(Label)
+     || {Label, LabelOffset} <- maps:to_list(Labels), is_integer(Label)
     ]),
 
     I2 = ?ASM:ret(),
@@ -3460,7 +3480,7 @@ add_label(
     ),
 
     State#state{
-        stream = Stream2, branches = RemainingBranches, labels = [{Label, LabelOffset} | Labels]
+        stream = Stream2, branches = RemainingBranches, labels = Labels#{Label => LabelOffset}
     };
 add_label(#state{labels = Labels} = State, Label, Offset) ->
-    State#state{labels = [{Label, Offset} | Labels]}.
+    State#state{labels = Labels#{Label => Offset}}.

--- a/libs/jit/src/jit_wasm32.erl
+++ b/libs/jit/src/jit_wasm32.erl
@@ -158,12 +158,12 @@
     stream_module :: module(),
     stream :: stream(),
     offset :: non_neg_integer(),
-    branches :: [{non_neg_integer(), non_neg_integer(), non_neg_integer()}],
+    branches :: #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]},
     jump_table_start :: non_neg_integer(),
     available_regs :: non_neg_integer(),
     used_regs :: non_neg_integer(),
     max_scratch :: non_neg_integer(),
-    labels :: [{integer() | reference(), integer()}],
+    labels :: #{integer() | reference() => integer()},
     variant :: non_neg_integer(),
     regs :: jit_regs:regs(),
     func_bodies :: [{integer(), binary()}],
@@ -217,13 +217,13 @@ new(Variant, StreamModule, Stream) ->
     #state{
         stream_module = StreamModule,
         stream = Stream,
-        branches = [],
+        branches = #{},
         jump_table_start = 0,
         offset = StreamModule:offset(Stream),
         available_regs = ?AVAILABLE_REGS_MASK,
         used_regs = 0,
         max_scratch = ?NUM_SCRATCH_LOCALS,
-        labels = [],
+        labels = #{},
         variant = Variant,
         regs = jit_regs:new(),
         func_bodies = [],
@@ -250,9 +250,9 @@ offset(#state{current_label = Label, labels = Labels, jump_table_start = _JTStar
         _ when is_integer(Label) -> Label * ?JUMP_TABLE_ENTRY_SIZE;
         _ ->
             %% Reference labels - find if already registered
-            case lists:keyfind(Label, 1, Labels) of
-                {Label, Offset} -> Offset;
-                false -> 0
+            case Labels of
+                #{Label := Offset} -> Offset;
+                _ -> 0
             end
     end.
 
@@ -338,11 +338,11 @@ emit_n_times(StreamModule, Stream, Binary, N) when N > 0 ->
 %%=============================================================================
 
 -spec update_branches(state()) -> state().
-update_branches(#state{branches = []} = State) ->
+update_branches(#state{branches = Branches} = State) when map_size(Branches) =:= 0 ->
     State;
 update_branches(State) ->
     %% Branches are resolved at label-add time in WASM.
-    State#state{branches = []}.
+    State#state{branches = #{}}.
 
 %%=============================================================================
 %% Primitive calls
@@ -394,7 +394,7 @@ call_primitive_with_cp(State0, Primitive, Args) ->
         func_bodies = NewFuncBodies,
         current_body = <<>>,
         current_label = ContLabel,
-        labels = [{ContLabel, ContLabelOff} | Labels],
+        labels = Labels#{ContLabel => ContLabelOff},
         available_regs = AllFree,
         used_regs = 0,
         regs = jit_regs:invalidate_all(State3#state.regs)
@@ -1081,7 +1081,7 @@ decrement_reductions_and_maybe_schedule_next(State0) ->
         func_bodies = NewFuncBodies,
         current_body = <<>>,
         current_label = ContLabel,
-        labels = [{ContLabel, ContLabelOff} | Labels],
+        labels = Labels#{ContLabel => ContLabelOff},
         available_regs = AllFree,
         used_regs = 0,
         regs = jit_regs:invalidate_all(State9#state.regs)
@@ -1119,7 +1119,7 @@ call_or_schedule_next(State0, Label) ->
         func_bodies = NewFuncBodies,
         current_body = <<>>,
         current_label = ContLabel,
-        labels = [{ContLabel, ContLabelOff} | Labels],
+        labels = Labels#{ContLabel => ContLabelOff},
         available_regs = AllFree,
         used_regs = 0,
         regs = jit_regs:invalidate_all(State3#state.regs)
@@ -1288,7 +1288,7 @@ add_label(
         func_bodies = NewFuncBodies,
         current_body = <<>>,
         current_label = Label,
-        labels = [{Label, LabelOff} | Labels],
+        labels = Labels#{Label => LabelOff},
         regs = Regs1,
         beam_label = Label
     };
@@ -1321,7 +1321,7 @@ add_label(
         func_bodies = NewFuncBodies,
         current_body = <<>>,
         current_label = ContLabel,
-        labels = [{ContLabel, ContLabelOff} | Labels],
+        labels = Labels#{ContLabel => ContLabelOff},
         available_regs = AllFree,
         used_regs = 0,
         regs = Regs1
@@ -1345,7 +1345,7 @@ add_label(
             _ ->
                 JumpTableStart
         end,
-    State#state{labels = [{Label, LabelOff} | Labels]}.
+    State#state{labels = Labels#{Label => LabelOff}}.
 
 get_regs_tracking(#state{regs = Regs}) -> Regs.
 

--- a/libs/jit/src/jit_x86_64.erl
+++ b/libs/jit/src/jit_x86_64.erl
@@ -135,11 +135,11 @@
     stream_module :: module(),
     stream :: stream(),
     offset :: non_neg_integer(),
-    branches :: [{non_neg_integer(), non_neg_integer(), non_neg_integer()}],
+    branches :: #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]},
     jump_table_start :: non_neg_integer(),
     available_regs :: non_neg_integer(),
     used_regs :: non_neg_integer(),
-    labels :: [{integer() | reference(), integer()}],
+    labels :: #{integer() | reference() => integer()},
     variant :: non_neg_integer(),
     regs :: jit_regs:regs()
 }).
@@ -260,12 +260,12 @@ new(Variant, StreamModule, Stream) ->
     #state{
         stream_module = StreamModule,
         stream = Stream,
-        branches = [],
+        branches = #{},
         jump_table_start = 0,
         offset = StreamModule:offset(Stream),
         available_regs = ?AVAILABLE_REGS_MASK,
         used_regs = 0,
-        labels = [],
+        labels = #{},
         variant = Variant,
         regs = jit_regs:new()
     }.
@@ -434,27 +434,25 @@ patch_branch(StreamModule, Stream, Offset, Size, LabelOffset) ->
 -spec patch_branches_for_label(
     module(),
     stream(),
-    integer(),
+    integer() | reference(),
     non_neg_integer(),
-    [{integer(), non_neg_integer(), non_neg_integer()}]
-) -> {stream(), [{integer(), non_neg_integer(), non_neg_integer()}]}.
+    #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]}
+) ->
+    {stream(), #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]}}.
 patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches, []).
-
-patch_branches_for_label(_StreamModule, Stream, _TargetLabel, _LabelOffset, [], Acc) ->
-    {Stream, lists:reverse(Acc)};
-patch_branches_for_label(
-    StreamModule,
-    Stream0,
-    TargetLabel,
-    LabelOffset,
-    [{Label, Offset, Size} | Rest],
-    Acc
-) when Label =:= TargetLabel ->
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Size, LabelOffset),
-    patch_branches_for_label(StreamModule, Stream1, TargetLabel, LabelOffset, Rest, Acc);
-patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch | Rest], Acc) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Rest, [Branch | Acc]).
+    case Branches of
+        #{TargetLabel := BrList} ->
+            Stream1 = lists:foldl(
+                fun({Offset, Size}, AccStream) ->
+                    patch_branch(StreamModule, AccStream, Offset, Size, LabelOffset)
+                end,
+                Stream,
+                BrList
+            ),
+            {Stream1, maps:remove(TargetLabel, Branches)};
+        _ ->
+            {Stream, Branches}
+    end.
 
 %%-----------------------------------------------------------------------------
 %% @doc Rewrite stream to update all branches for labels.
@@ -463,19 +461,29 @@ patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
 -spec update_branches(state()) -> state().
-update_branches(#state{branches = []} = State) ->
-    State;
 update_branches(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
-        branches = [{Label, Offset, Size} | BranchesT],
+        branches = Branches,
         labels = Labels
     } = State
 ) ->
-    {Label, LabelOffset} = lists:keyfind(Label, 1, Labels),
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Size, LabelOffset),
-    update_branches(State#state{stream = Stream1, branches = BranchesT}).
+    Stream1 = maps:fold(
+        fun(Label, BrList, AccStream) ->
+            #{Label := LabelOffset} = Labels,
+            lists:foldl(
+                fun({Offset, Size}, AccStream2) ->
+                    patch_branch(StreamModule, AccStream2, Offset, Size, LabelOffset)
+                end,
+                AccStream,
+                BrList
+            )
+        end,
+        Stream0,
+        Branches
+    ),
+    State#state{stream = Stream1, branches = #{}}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Emit a call (call with return) to a primitive with arguments. This
@@ -663,8 +671,8 @@ jump_to_label(
     Label
 ) ->
     Offset = StreamModule:offset(Stream0),
-    case lists:keyfind(Label, 1, Labels) of
-        {Label, LabelOffset} ->
+    case Labels of
+        #{Label := LabelOffset} ->
             % Label is already known, emit direct branch without relocation
 
             % Calculate relative offset (assembler will adjust for instruction size)
@@ -673,14 +681,15 @@ jump_to_label(
             Stream1 = StreamModule:append(Stream0, I1),
             %% After unconditional jump, register tracking is dead until next label
             State#state{stream = Stream1, regs = jit_regs:unreachable(State#state.regs)};
-        false ->
+        _ ->
             % Label not yet known, emit placeholder and add relocation
             {RelocOffset, I1} = jit_x86_64_asm:jmp_rel32(1),
-            Reloc = {Label, Offset + RelocOffset, 32},
             Stream1 = StreamModule:append(Stream0, I1),
+            BrEntry = {Offset + RelocOffset, 32},
+            ExistingBrs = maps:get(Label, AccBranches, []),
             State#state{
                 stream = Stream1,
-                branches = [Reloc | AccBranches],
+                branches = AccBranches#{Label => [BrEntry | ExistingBrs]},
                 regs = jit_regs:unreachable(State#state.regs)
             }
     end.
@@ -1256,18 +1265,25 @@ call_func_ptr(
     ),
     UsedRegs1 = UsedRegs0 band (bnot FreeMask),
     SavedRegs = [?CTX_REG, ?JITSTATE_REG, ?NATIVE_INTERFACE_REG | mask_to_list(UsedRegs1)],
-    Stream1 = lists:foldl(
-        fun(Reg, AccStream) ->
-            StreamModule:append(AccStream, jit_x86_64_asm:pushq(Reg))
-        end,
-        Stream0,
-        SavedRegs
-    ),
+    PushBin = iolist_to_binary([jit_x86_64_asm:pushq(R) || R <- SavedRegs]),
+    Stream1 = StreamModule:append(Stream0, PushBin),
     PushOdds = length(SavedRegs) rem 2,
-    Stream3 =
+    % x86 64 stack should be aligned to 16 bytes when running callq instruction
+    % It is therefore unaligned and we need to always push an odd number of
+    % registers.
+    % Align stack by pushing ?NATIVE_INTERFACE_REG
+    % ?NATIVE_INTERFACE_REG may have been pushed as the function pointer
+    AlignBin =
+        case PushOdds of
+            1 -> <<>>;
+            0 -> jit_x86_64_asm:pushq(?NATIVE_INTERFACE_REG)
+        end,
+    Stream4 =
         case FuncPtrTuple of
-            {free, _} ->
+            {free, _} when PushOdds =:= 1 ->
                 Stream1;
+            {free, _} ->
+                StreamModule:append(Stream1, AlignBin);
             {primitive, Primitive} ->
                 PrepCall0 =
                     case Primitive of
@@ -1277,20 +1293,9 @@ call_func_ptr(
                             jit_x86_64_asm:movq(?PRIMITIVE(N), ?NATIVE_INTERFACE_REG)
                     end,
                 PrepCall1 = jit_x86_64_asm:pushq(?NATIVE_INTERFACE_REG),
-                StreamModule:append(Stream1, <<PrepCall0/binary, PrepCall1/binary>>)
-        end,
-    % x86 64 stack should be aligned to 16 bytes when running callq instruction
-    % It is therefore unaligned and we need to always push an odd number of
-    % registers.
-    % Align stack by pushing ?NATIVE_INTERFACE_REG
-    % ?NATIVE_INTERFACE_REG may have been pushed as the function pointer
-    Stream4 =
-        case PushOdds of
-            1 ->
-                Stream3;
-            0 ->
-                PrepCall2 = jit_x86_64_asm:pushq(?NATIVE_INTERFACE_REG),
-                StreamModule:append(Stream3, PrepCall2)
+                StreamModule:append(
+                    Stream1, <<PrepCall0/binary, PrepCall1/binary, AlignBin/binary>>
+                )
         end,
     State1 = set_args(State0#state{stream = Stream4}, Args),
     #state{stream = Stream5} = State1,
@@ -1303,16 +1308,13 @@ call_func_ptr(
                 Call1 = jit_x86_64_asm:callq({rax}),
                 <<Call0/binary, Call1/binary>>
         end,
-    Stream6 = StreamModule:append(Stream5, Call),
-    % Unalign stack
-    Stream7 =
+    % Unalign stack: combine call + unalign-pop into one append when needed
+    CallAndUnalign =
         case PushOdds of
-            1 ->
-                Stream6;
-            0 ->
-                PostCall1 = jit_x86_64_asm:popq(?NATIVE_INTERFACE_REG),
-                StreamModule:append(Stream6, PostCall1)
+            1 -> Call;
+            0 -> <<Call/binary, (jit_x86_64_asm:popq(?NATIVE_INTERFACE_REG))/binary>>
         end,
+    Stream7 = StreamModule:append(Stream5, CallAndUnalign),
     % If rax is in used regs, save it to another temporary register
     AvailableRegs1 = AvailableRegs0 bor FreeMask,
     {Stream8, ResultReg} =
@@ -1323,13 +1325,8 @@ call_func_ptr(
                 Temp = first_avail(AvailableRegs1),
                 {StreamModule:append(Stream7, jit_x86_64_asm:movq(rax, Temp)), Temp}
         end,
-    Stream9 = lists:foldl(
-        fun(Reg, AccStream) ->
-            StreamModule:append(AccStream, jit_x86_64_asm:popq(Reg))
-        end,
-        Stream8,
-        lists:reverse(SavedRegs)
-    ),
+    PopBin = iolist_to_binary([jit_x86_64_asm:popq(R) || R <- lists:reverse(SavedRegs)]),
+    Stream9 = StreamModule:append(Stream8, PopBin),
     ResultBit = reg_bit(ResultReg),
     AvailableRegs2 = (AvailableRegs1 band (bnot ResultBit)) band ?AVAILABLE_REGS_MASK,
     UsedRegs2 = UsedRegs1 bor ResultBit,
@@ -2394,8 +2391,8 @@ set_continuation_to_label(
     Temp = first_avail(Avail),
     Offset = StreamModule:offset(Stream0),
     Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
-    case lists:keyfind(Label, 1, Labels) of
-        {Label, LabelOffset} ->
+    case Labels of
+        #{Label := LabelOffset} ->
             % Label is already known, emit direct leaq without relocation
             % leaq instruction is 7 bytes, RIP points to next instruction
             RelOffset = LabelOffset - (Offset + 7),
@@ -2404,14 +2401,19 @@ set_continuation_to_label(
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
             State#state{stream = Stream1, regs = Regs1};
-        false ->
+        _ ->
             % Label not yet known, emit placeholder and add relocation
             {RewriteLEAOffset, I1} = jit_x86_64_asm:leaq_rel32({-4, rip}, Temp),
-            Reloc = {Label, Offset + RewriteLEAOffset, 32},
+            BrEntry = {Offset + RewriteLEAOffset, 32},
             I2 = jit_x86_64_asm:movq(Temp, ?JITSTATE_CONTINUATION),
             Code = <<I1/binary, I2/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
-            State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}
+            ExistingBrs = maps:get(Label, Branches, []),
+            State#state{
+                stream = Stream1,
+                branches = Branches#{Label => [BrEntry | ExistingBrs]},
+                regs = Regs1
+            }
     end.
 
 set_continuation_to_offset(
@@ -2427,12 +2429,19 @@ set_continuation_to_offset(
     OffsetRef = make_ref(),
     Offset = StreamModule:offset(Stream0),
     {RewriteLEAOffset, I1} = jit_x86_64_asm:leaq_rel32({-4, rip}, Temp),
-    Reloc = {OffsetRef, Offset + RewriteLEAOffset, 32},
+    BrEntry = {Offset + RewriteLEAOffset, 32},
     I2 = jit_x86_64_asm:movq(Temp, ?JITSTATE_CONTINUATION),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
     Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
-    {State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}, OffsetRef}.
+    {
+        State#state{
+            stream = Stream1,
+            branches = Branches#{OffsetRef => [BrEntry]},
+            regs = Regs1
+        },
+        OffsetRef
+    }.
 
 %% @doc Implement a continuation entry point. On x86-64 this is a nop
 %% as we don't need to save any register.
@@ -2488,10 +2497,9 @@ and_(
     TempReg = first_avail(Avail),
     I1 = jit_x86_64_asm:movabsq(Val, TempReg),
     I2 = jit_x86_64_asm:andq(TempReg, Reg),
-    Stream1 = StreamModule:append(Stream0, I1),
-    Stream2 = StreamModule:append(Stream1, I2),
+    Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
     Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, TempReg), Reg),
-    {State#state{stream = Stream2, regs = Regs1}, Reg};
+    {State#state{stream = Stream1, regs = Regs1}, Reg};
 and_(
     #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, {free, Reg}, Val
 ) when
@@ -2524,12 +2532,11 @@ and_(
     Bit = reg_bit(ResultReg),
     I1 = jit_x86_64_asm:movabsq(Val, ResultReg),
     I2 = jit_x86_64_asm:andq(Reg, ResultReg),
-    Stream1 = StreamModule:append(Stream0, I1),
-    Stream2 = StreamModule:append(Stream1, I2),
+    Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
     Regs1 = jit_regs:invalidate_reg(Regs0, ResultReg),
     {
         State#state{
-            stream = Stream2,
+            stream = Stream1,
             available_regs = Avail band (bnot Bit),
             used_regs = UR bor Bit,
             regs = Regs1
@@ -2557,12 +2564,11 @@ and_(
             Val >= 0, Val =< 16#FFFFFFFF -> jit_x86_64_asm:andl(Val, ResultReg);
             true -> jit_x86_64_asm:andq(Val, ResultReg)
         end,
-    Stream1 = StreamModule:append(Stream0, I1),
-    Stream2 = StreamModule:append(Stream1, I2),
+    Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
     Regs1 = jit_regs:invalidate_reg(Regs0, ResultReg),
     {
         State#state{
-            stream = Stream2,
+            stream = Stream1,
             available_regs = Avail band (bnot Bit),
             used_regs = UR bor Bit,
             regs = Regs1
@@ -2586,10 +2592,9 @@ or_(
     TempReg = first_avail(Avail),
     I1 = jit_x86_64_asm:movabsq(Val, TempReg),
     I2 = jit_x86_64_asm:orq(TempReg, Reg),
-    Stream1 = StreamModule:append(Stream0, I1),
-    Stream2 = StreamModule:append(Stream1, I2),
+    Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
     Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, TempReg), Reg),
-    State#state{stream = Stream2, regs = Regs1};
+    State#state{stream = Stream1, regs = Regs1};
 or_(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) ->
     I1 = jit_x86_64_asm:orq(Val, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
@@ -2612,10 +2617,9 @@ xor_(
     TempReg = first_avail(Avail),
     I1 = jit_x86_64_asm:movabsq(Val, TempReg),
     I2 = jit_x86_64_asm:xorq(TempReg, Reg),
-    Stream1 = StreamModule:append(Stream0, I1),
-    Stream2 = StreamModule:append(Stream1, I2),
+    Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
     Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, TempReg), Reg),
-    State#state{stream = Stream2, regs = Regs1};
+    State#state{stream = Stream1, regs = Regs1};
 xor_(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) ->
     I1 = jit_x86_64_asm:xorq(Val, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
@@ -2635,10 +2639,9 @@ add(
     TempReg = first_avail(Avail),
     I1 = jit_x86_64_asm:movabsq(Val, TempReg),
     I2 = jit_x86_64_asm:addq(TempReg, Reg),
-    Stream1 = StreamModule:append(Stream0, I1),
-    Stream2 = StreamModule:append(Stream1, I2),
+    Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
     Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, TempReg), Reg),
-    State#state{stream = Stream2, regs = Regs1};
+    State#state{stream = Stream1, regs = Regs1};
 add(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) ->
     I1 = jit_x86_64_asm:addq(Val, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
@@ -2658,10 +2661,9 @@ sub(
     TempReg = first_avail(Avail),
     I1 = jit_x86_64_asm:movabsq(Val, TempReg),
     I2 = jit_x86_64_asm:subq(TempReg, Reg),
-    Stream1 = StreamModule:append(Stream0, I1),
-    Stream2 = StreamModule:append(Stream1, I2),
+    Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary>>),
     Regs1 = jit_regs:invalidate_reg(jit_regs:invalidate_reg(Regs0, TempReg), Reg),
-    State#state{stream = Stream2, regs = Regs1};
+    State#state{stream = Stream1, regs = Regs1};
 sub(#state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, Reg, Val) ->
     I1 = jit_x86_64_asm:subq(Val, Reg),
     Stream1 = StreamModule:append(Stream0, I1),
@@ -2854,8 +2856,8 @@ call_only_or_schedule_next(
     I1 = jit_x86_64_asm:decl(?JITSTATE_REMAINING_REDUCTIONS),
     I1Size = byte_size(I1),
 
-    case lists:keyfind(Label, 1, Labels) of
-        {Label, LabelOffset} ->
+    case Labels of
+        #{Label := LabelOffset} ->
             % Label is already known, emit direct jmp with calculated offset
             % jz is 2 bytes, jmp_rel32 is 5 bytes
             JmpSize = 5,
@@ -2867,15 +2869,19 @@ call_only_or_schedule_next(
             Code = <<I1/binary, I2/binary, I3/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
             State1 = State0#state{stream = Stream1};
-        false ->
+        _ ->
             % Label not yet known, emit placeholder and add relocation
             {RewriteJMPOffset, I3} = jit_x86_64_asm:jmp_rel32(1),
             I2 = jit_x86_64_asm:jz(byte_size(I3) + 2),
             Sz = I1Size + byte_size(I2),
-            Reloc1 = {Label, Offset + Sz + RewriteJMPOffset, 32},
+            BrEntry = {Offset + Sz + RewriteJMPOffset, 32},
             Code = <<I1/binary, I2/binary, I3/binary>>,
             Stream1 = StreamModule:append(Stream0, Code),
-            State1 = State0#state{stream = Stream1, branches = [Reloc1 | Branches]}
+            ExistingBrs = maps:get(Label, Branches, []),
+            State1 = State0#state{
+                stream = Stream1,
+                branches = Branches#{Label => [BrEntry | ExistingBrs]}
+            }
     end,
     State2 = set_continuation_to_label(State1, Label),
     call_primitive_last(State2, ?PRIM_SCHEDULE_NEXT_CP, [ctx, jit_state]).
@@ -2939,7 +2945,7 @@ return_labels_and_lines(
 ) ->
     SortedLabels = lists:keysort(2, [
         {Label, LabelOffset}
-     || {Label, LabelOffset} <- Labels, is_integer(Label), Label /= 0
+     || {Label, LabelOffset} <- maps:to_list(Labels), is_integer(Label), Label /= 0
     ]),
 
     I2 = jit_x86_64_asm:retq(),
@@ -3060,11 +3066,11 @@ add_label(
     State#state{
         stream = Stream2,
         branches = RemainingBranches,
-        labels = [{Label, LabelOffset} | Labels],
+        labels = Labels#{Label => LabelOffset},
         regs = jit_regs:invalidate_all(State#state.regs)
     };
 add_label(#state{labels = Labels, regs = Regs0} = State, Label, Offset) ->
-    State#state{labels = [{Label, Offset} | Labels], regs = jit_regs:invalidate_all(Regs0)}.
+    State#state{labels = Labels#{Label => Offset}, regs = jit_regs:invalidate_all(Regs0)}.
 
 -ifdef(JIT_DWARF).
 %%-----------------------------------------------------------------------------

--- a/libs/jit/src/jit_xtensa.erl
+++ b/libs/jit/src/jit_xtensa.erl
@@ -164,11 +164,11 @@
     stream_module :: module(),
     stream :: stream(),
     offset :: non_neg_integer(),
-    branches :: [{non_neg_integer(), non_neg_integer(), non_neg_integer()}],
+    branches :: #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]},
     jump_table_start :: non_neg_integer(),
     available_regs :: non_neg_integer(),
     used_regs :: non_neg_integer(),
-    labels :: [{integer() | reference(), integer()}],
+    labels :: #{integer() | reference() => integer()},
     variant :: non_neg_integer(),
     regs :: jit_regs:regs()
 }).
@@ -310,12 +310,12 @@ new(Variant, StreamModule, Stream) ->
     #state{
         stream_module = StreamModule,
         stream = Stream,
-        branches = [],
+        branches = #{},
         jump_table_start = 0,
         offset = StreamModule:offset(Stream),
         available_regs = ?AVAILABLE_REGS_MASK,
         used_regs = 0,
-        labels = [],
+        labels = #{},
         variant = Variant,
         regs = jit_regs:new()
     }.
@@ -536,27 +536,25 @@ patch_branch(StreamModule, Stream, Offset, Type, LabelOffset) ->
 -spec patch_branches_for_label(
     module(),
     stream(),
-    integer(),
+    integer() | reference(),
     non_neg_integer(),
-    [{integer(), non_neg_integer(), any()}]
-) -> {stream(), [{integer(), non_neg_integer(), any()}]}.
+    #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]}
+) ->
+    {stream(), #{integer() | reference() => [{non_neg_integer(), non_neg_integer()}]}}.
 patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Branches, []).
-
-patch_branches_for_label(_StreamModule, Stream, _TargetLabel, _LabelOffset, [], Acc) ->
-    {Stream, lists:reverse(Acc)};
-patch_branches_for_label(
-    StreamModule,
-    Stream0,
-    TargetLabel,
-    LabelOffset,
-    [{Label, Offset, Type} | Rest],
-    Acc
-) when Label =:= TargetLabel ->
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Type, LabelOffset),
-    patch_branches_for_label(StreamModule, Stream1, TargetLabel, LabelOffset, Rest, Acc);
-patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch | Rest], Acc) ->
-    patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, Rest, [Branch | Acc]).
+    case Branches of
+        #{TargetLabel := BrList} ->
+            Stream1 = lists:foldl(
+                fun({Offset, Type}, AccStream) ->
+                    patch_branch(StreamModule, AccStream, Offset, Type, LabelOffset)
+                end,
+                Stream,
+                BrList
+            ),
+            {Stream1, maps:remove(TargetLabel, Branches)};
+        _ ->
+            {Stream, Branches}
+    end.
 
 %%-----------------------------------------------------------------------------
 %% @doc Rewrite stream to update all branches for labels.
@@ -565,20 +563,30 @@ patch_branches_for_label(StreamModule, Stream, TargetLabel, LabelOffset, [Branch
 %% @return Updated backend state
 %%-----------------------------------------------------------------------------
 -spec update_branches(state()) -> state().
-update_branches(#state{branches = []} = State) ->
-    State;
 update_branches(
     #state{
         stream_module = StreamModule,
         stream = Stream0,
-        branches = [{Label, Offset, Type} | BranchesT],
+        branches = Branches,
         labels = Labels
     } = State
 ) ->
     % all branches Labels are in Labels
-    {Label, LabelOffset} = lists:keyfind(Label, 1, Labels),
-    Stream1 = patch_branch(StreamModule, Stream0, Offset, Type, LabelOffset),
-    update_branches(State#state{stream = Stream1, branches = BranchesT}).
+    Stream1 = maps:fold(
+        fun(Label, BrList, AccStream) ->
+            #{Label := LabelOffset} = Labels,
+            lists:foldl(
+                fun({Offset, Type}, AccStream2) ->
+                    patch_branch(StreamModule, AccStream2, Offset, Type, LabelOffset)
+                end,
+                AccStream,
+                BrList
+            )
+        end,
+        Stream0,
+        Branches
+    ),
+    State#state{stream = Stream1, branches = #{}}.
 
 %%-----------------------------------------------------------------------------
 %% @doc Generate code to load a primitive function pointer into a register
@@ -761,7 +769,11 @@ return_if_not_equal_to_ctx(
 jump_to_label(
     #state{stream_module = StreamModule, stream = Stream0, labels = Labels} = State0, Label
 ) ->
-    LabelLookupResult = lists:keyfind(Label, 1, Labels),
+    LabelLookupResult =
+        case Labels of
+            #{Label := LabelOffset} -> {Label, LabelOffset};
+            _ -> false
+        end,
     Offset = StreamModule:offset(Stream0),
     {State1, CodeBlock} = branch_to_label_code(State0, Offset, Label, LabelLookupResult),
     Stream1 = StreamModule:append(Stream0, CodeBlock),
@@ -852,8 +864,8 @@ branch_to_label_code(
     %% Pick a temp register now and encode it in the relocation.
     Temp = first_avail(Avail),
     CodeBlock = list_to_binary(lists:duplicate(24, 16#FF)),
-    Reloc = {Label, Offset, {far_branch, Temp, JTS}},
-    State1 = State0#state{branches = [Reloc | Branches]},
+    BrEntry = {Offset, {far_branch, Temp, JTS}},
+    State1 = State0#state{branches = Branches#{Label => [BrEntry | maps:get(Label, Branches, [])]}},
     {State1, CodeBlock}.
 
 %%-----------------------------------------------------------------------------
@@ -3122,13 +3134,16 @@ set_continuation_to_offset(
     Offset = StreamModule:offset(Stream0),
     %% Reserve 21 bytes placeholder for code_relative_address_padded
     I1 = list_to_binary(lists:duplicate(?CODE_RELATIVE_ADDRESS_PADDED_SIZE, 16#FF)),
-    Reloc = {OffsetRef, Offset, {adr, Temp, JumpTableStart}},
+    BrEntry = {Offset, {adr, Temp, JumpTableStart}},
     %% Store continuation
     I2 = jit_xtensa_asm:s32i(Temp, ?JITSTATE_REG, ?JITSTATE_CONTINUATION_OFFSET),
     Code = <<I1/binary, I2/binary>>,
     Stream1 = StreamModule:append(Stream0, Code),
     Regs1 = jit_regs:invalidate_reg(Regs0, Temp),
-    {State#state{stream = Stream1, branches = [Reloc | Branches], regs = Regs1}, OffsetRef}.
+    {
+        State#state{stream = Stream1, branches = Branches#{OffsetRef => [BrEntry]}, regs = Regs1},
+        OffsetRef
+    }.
 
 %% @doc Implement a continuation entry point.
 %% In windowed ABI, C calls the continuation via CALL8, so we need ENTRY
@@ -3871,7 +3886,11 @@ call_only_or_schedule_next(
     I2 = jit_xtensa_asm:addi(Temp, Temp, -1),
     I3 = jit_xtensa_asm:s32i(Temp, ?JITSTATE_REG, ?JITSTATE_REDUCTIONCOUNT_OFFSET),
     Stream1 = StreamModule:append(Stream0, <<I1/binary, I2/binary, I3/binary>>),
-    LabelLookupResult = lists:keyfind(Label, 1, State0#state.labels),
+    LabelLookupResult =
+        case State0#state.labels of
+            #{Label := LabelOffset0} -> {Label, LabelOffset0};
+            _ -> false
+        end,
 
     BccOffset = StreamModule:offset(Stream1),
 
@@ -4001,7 +4020,7 @@ return_labels_and_lines(
 ) ->
     SortedLabels = lists:keysort(2, [
         {Label, LabelOffset}
-     || {Label, LabelOffset} <- Labels, is_integer(Label)
+     || {Label, LabelOffset} <- maps:to_list(Labels), is_integer(Label)
     ]),
 
     I2 = jit_xtensa_asm:retw(),
@@ -4315,11 +4334,11 @@ add_label(
     State#state{
         stream = Stream2,
         branches = RemainingBranches,
-        labels = [{Label, LabelOffset} | Labels],
+        labels = Labels#{Label => LabelOffset},
         regs = jit_regs:invalidate_all(State#state.regs)
     };
 add_label(#state{labels = Labels, regs = Regs0} = State, Label, Offset) ->
-    State#state{labels = [{Label, Offset} | Labels], regs = jit_regs:invalidate_all(Regs0)}.
+    State#state{labels = Labels#{Label => Offset}, regs = jit_regs:invalidate_all(Regs0)}.
 
 %% @doc Get the register tracking state.
 get_regs_tracking(#state{regs = Regs}) -> Regs.


### PR DESCRIPTION
Replace O(n) list lookups with O(log n) maps for hot data structures in the JIT compiler, and batch consecutive small instruction emits into single stream appends to reduce NIF dispatch overhead.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
