### PR TITLE
CI: Fix ESP32 test partition layout simtest

### DIFF
--- a/src/platforms/esp32/test/main/test_erl_sources/test_esp_partition.erl
+++ b/src/platforms/esp32/test/main/test_erl_sources/test_esp_partition.erl
@@ -22,14 +22,7 @@
 -export([start/0]).
 
 start() ->
-    [
-        {<<"nvs">>, 1, 2, 16#9000, 16#6000, []},
-        {<<"phy_init">>, 1, 1, 16#f000, 16#1000, []},
-        {<<"factory">>, 0, 0, 16#10000, 16#500000, []},
-        {<<"lib.avm">>, 1, 1, 16#510000, 16#80000, []},
-        {<<"main.avm">>, 1, 1, 16#590000, 16#40000, []},
-        {<<"data">>, 1, 1, 16#5D0000, 16#10000, []}
-    ] = esp:partition_list(),
+    ok = assert_partition_layout(esp:partition_list()),
     ok = esp:partition_erase_range(<<"data">>, 0),
     ok = esp:partition_write(<<"data">>, 0, <<"hello">>),
     {ok, <<"hello">>} = esp:partition_read(<<"data">>, 0, 5),
@@ -39,3 +32,24 @@ start() ->
     {ok, <<"world">>} = esp:partition_read(<<"data">>, 0, 5),
     {ok, <<"world">>} = esp:partition_mmap(<<"data">>, 0, 5),
     0.
+
+%% Wokwi uses the 4MB test/partitions.csv layout; QEMU/JIT tests use
+%% the larger 8MB partitions-test.csv layout.
+assert_partition_layout([
+    {<<"nvs">>, 1, 2, 16#9000, 16#6000, []},
+    {<<"phy_init">>, 1, 1, 16#f000, 16#1000, []},
+    {<<"factory">>, 0, 0, 16#10000, 16#2C0000, []},
+    {<<"lib.avm">>, 1, 1, 16#2D0000, 16#40000, []},
+    {<<"main.avm">>, 1, 1, 16#310000, 16#40000, []},
+    {<<"data">>, 1, 1, 16#350000, 16#10000, []}
+]) ->
+    ok;
+assert_partition_layout([
+    {<<"nvs">>, 1, 2, 16#9000, 16#6000, []},
+    {<<"phy_init">>, 1, 1, 16#f000, 16#1000, []},
+    {<<"factory">>, 0, 0, 16#10000, 16#500000, []},
+    {<<"lib.avm">>, 1, 1, 16#510000, 16#80000, []},
+    {<<"main.avm">>, 1, 1, 16#590000, 16#40000, []},
+    {<<"data">>, 1, 1, 16#5D0000, 16#10000, []}
+]) ->
+    ok.


### PR DESCRIPTION
JIT/xtensa made it an 8mb partition for the qemu tests, but simtest is still 4mb.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
