### PR TITLE
CI: bump esp-idf + fixup 5.2.7

### DIFF
--- a/.github/workflows/esp32-build.yaml
+++ b/.github/workflows/esp32-build.yaml
@@ -47,10 +47,10 @@ jobs:
       matrix:
         esp-idf-target: ["esp32", "esp32c3"]
         idf-version:
-         - 'v5.2.6'
-         - 'v5.3.4'
-         - 'v5.4.3'
-         - 'v5.5.3'
+         - 'v5.2.7'
+         - 'v5.3.5'
+         - 'v5.4.4'
+         - 'v5.5.4'
         jit: [false]
 
         include:
@@ -58,32 +58,32 @@ jobs:
           idf-version: 'v5.4.4'
           jit: false
         - esp-idf-target: "esp32p4"
-          idf-version: 'v5.5.3'
+          idf-version: 'v5.5.4'
           jit: false
         - esp-idf-target: "esp32s3"
-          idf-version: 'v5.5.3'
+          idf-version: 'v5.5.4'
           jit: false
         - esp-idf-target: "esp32s3"
-          idf-version: 'v5.5.3'
+          idf-version: 'v5.5.4'
           usb-serial: 'ON'
           jit: false
         - esp-idf-target: "esp32s3"
-          idf-version: 'v5.5.3'
+          idf-version: 'v5.5.4'
           usb-cdc: 'ON'
           jit: false
         - esp-idf-target: "esp32"
-          idf-version: 'v5.4.3'
+          idf-version: 'v5.4.4'
           libsodium: 'ON'
           jit: false
-        # JIT builds (v5.5.3 only)
+        # JIT builds (v5.5.4 only)
         - esp-idf-target: "esp32c3"
-          idf-version: 'v5.5.3'
+          idf-version: 'v5.5.4'
           jit: true
         - esp-idf-target: "esp32"
-          idf-version: 'v5.5.3'
+          idf-version: 'v5.5.4'
           jit: true
         - esp-idf-target: "esp32s3"
-          idf-version: 'v5.5.3'
+          idf-version: 'v5.5.4'
           jit: true
 
     steps:
@@ -139,13 +139,14 @@ jobs:
           idf.py set-target ${{matrix.esp-idf-target}}
           idf.py ${{ matrix.libsodium == 'ON' && '-DAVM_USE_LIBSODIUM=ON' || '' }} build
         fi
-        idf.py size
 
-    - name: Print component size info with idf.py
+    - name: Print size info with idf.py
+      if: matrix.idf-version != 'v5.2.7'
       shell: bash
       working-directory: ./src/platforms/esp32/
       run: |
         . $IDF_PATH/export.sh
+        idf.py size
         idf.py size-components
 
     - name: "Perform CodeQL Analysis"

--- a/.github/workflows/esp32-simtest.yaml
+++ b/.github/workflows/esp32-simtest.yaml
@@ -80,24 +80,24 @@ jobs:
             "esp32c6",
             "esp32h2"
           ]
-        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.2.6", "v5.3.4", "v5.4.3", "v5.5.3"]')) || fromJSON('["v5.5.3"]') }}
+        idf-version: ${{ ((contains(github.event.head_commit.message, 'full_sim_test')||contains(github.event.pull_request.title, 'full_sim_test')) &&  fromJSON('["v5.2.7", "v5.3.5", "v5.4.4", "v5.5.4"]')) || fromJSON('["v5.5.4"]') }}
         exclude:
           - esp-idf-target: "esp32p4"
-            idf-version: "v5.2.6"
+            idf-version: "v5.2.7"
           - esp-idf-target: "esp32h2"
-            idf-version: "v5.2.6"
+            idf-version: "v5.2.7"
           - esp-idf-target: "esp32c5"
-            idf-version: "v5.2.6"
+            idf-version: "v5.2.7"
           - esp-idf-target: "esp32c5"
-            idf-version: "v5.3.4"
+            idf-version: "v5.3.5"
           - esp-idf-target: "esp32c5"
-            idf-version: "v5.4.3"
+            idf-version: "v5.4.4"
         # CI now uses chip revision 3 that is currently only available since 5.5.2
         include:
           - esp-idf-target: "esp32p4"
-            idf-version: "v5.5.3"
+            idf-version: "v5.5.4"
           - esp-idf-target: "esp32c61"
-            idf-version: "v5.5.3"
+            idf-version: "v5.5.4"
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Minor snag with 5.2.7 crashing on the idf.py size command for some reason unrelated to atomvm, so minor cleanup there.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
