### PR TITLE
Add missing fflush in nif_console_print

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2957,6 +2957,7 @@ static term nif_erlang_display_1(Context *ctx, int argc, term argv[])
 
     term_display(stdout, argv[0], ctx);
     printf("\n");
+    fflush(stdout);
 
     return TRUE_ATOM;
 }
@@ -5643,6 +5644,7 @@ static term nif_console_print(Context *ctx, int argc, term argv[])
         const char *data = term_binary_data(t);
         unsigned long n = term_binary_size(t);
         fprintf(stdout, "%.*s", (int) n, data);
+        fflush(stdout);
     } else {
         size_t size;
         switch (interop_iolist_size(t, &size)) {


### PR DESCRIPTION
This may have negatively affected some socat tests.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
