### PR TITLE
Fix: redundant kernel:start calls

### DIFF
--- a/examples/erlang/rp2/picow_wifi_epmd_disterl.erl
+++ b/examples/erlang/rp2/picow_wifi_epmd_disterl.erl
@@ -49,7 +49,6 @@ got_ip(Parent, {IPv4, _Netmask, _Gateway}) ->
 
 distribution_start(Address) ->
     {ok, _EPMDPid} = epmd:start_link([]),
-    {ok, _KernelPid} = kernel:start(normal, []),
     {X, Y, Z, T} = Address,
     Node = list_to_atom(lists:flatten(io_lib:format("atomvm@~B.~B.~B.~B", [X, Y, Z, T]))),
     {ok, _NetKernelPid} = net_kernel:start(Node, #{name_domain => longnames}),

--- a/libs/esp32boot/esp32init.erl
+++ b/libs/esp32boot/esp32init.erl
@@ -24,7 +24,6 @@
 
 start() ->
     console:print(<<"AtomVM init.\n">>),
-    {ok, _} = kernel:start(normal, []),
     boot().
 
 is_dev_mode_enabled(SystemStatus) ->


### PR DESCRIPTION
Since init:boot/1 is the standard entry point and starts the kernel application automatically, manual calls to kernel:start/2 in esp32init:start/0 and picow_wifi_epmd_disterl:distribution_start/1 are redundant and crashes since they are already_started.

release-0.7 is currently broken - try flashing https://petermm.github.io/atomvm_flasher/all_versions

```
AtomVM init.
CRASH 
======
pid: <0.1.0>

Stacktrace:
[{esp32init,start,0,[{file,"/home/harmon/Dev/AtomVM/libs/esp32boot/esp32init.erl"},{line,27}]}]

cp: #CP<module: 0, label: 2, offset: 23>

x[0]: error
x[1]: {badmatch,{error,{already_started,<0.2.0>}}}
x[2]: {1,1,52,1,[{0,46}],error}
```

Seems like recent JIT work spilled over: https://github.com/atomvm/AtomVM/commits/release-0.7/libs/esp32boot/esp32init.erl

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
