### PR TITLE
CI: bump rp2040js to 1.3.3 for the DMA register off-by-one fix

### DIFF
--- a/src/platforms/rp2/tests/package-lock.json
+++ b/src/platforms/rp2/tests/package-lock.json
@@ -7,7 +7,7 @@
       "name": "rp2040_tests",
       "dependencies": {
         "@tsconfig/node20": "^20.1.2",
-        "rp2040js": "^1.3.1",
+        "rp2040js": "^1.3.3",
         "sync-fetch": "^0.5.2",
         "tsx": "^3.12.8",
         "typescript": "^5.2.2",
@@ -471,9 +471,9 @@
       }
     },
     "node_modules/rp2040js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rp2040js/-/rp2040js-1.3.1.tgz",
-      "integrity": "sha512-yNpAr1VA6phNjTv5b8iZP+qePzHlGwJ9hQb9rYMKtcgxwdr6LV5g9k2YUNwt96hJ2/0wkRUsPajab+oO5hr5DQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rp2040js/-/rp2040js-1.3.3.tgz",
+      "integrity": "sha512-6uE6/Ht8L654aF3fB8HS6ICmywzEq1KN71XZq45RR0BUs9SUitPoy+mySoLEHPso6mu2695RCS1hKnchRlGhMA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/src/platforms/rp2/tests/package.json
+++ b/src/platforms/rp2/tests/package.json
@@ -3,7 +3,7 @@
   "description": "Tests using rp2040js emulator",
   "dependencies": {
     "@tsconfig/node20": "^20.1.2",
-    "rp2040js": "^1.3.1",
+    "rp2040js": "^1.3.3",
     "sync-fetch": "^0.5.2",
     "tsx": "^3.12.8",
     "typescript": "^5.2.2",


### PR DESCRIPTION
The bug affected some CI runs with pico_w.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
