### PR TITLE
Fix globalcontext_destroy leaks

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -108,7 +108,7 @@ GlobalContext *globalcontext_new(void)
 #ifndef AVM_NO_SMP
     glb->modules_lock = smp_rwlock_create();
     if (IS_NULL_PTR(glb->modules_lock)) {
-        free(glb->modules_table);
+        valueshashtable_destroy(glb->modules_table);
         atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
@@ -140,7 +140,7 @@ GlobalContext *globalcontext_new(void)
 #ifndef AVM_NO_SMP
         smp_rwlock_destroy(glb->modules_lock);
 #endif
-        free(glb->modules_table);
+        valueshashtable_destroy(glb->modules_table);
         atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
@@ -155,7 +155,7 @@ GlobalContext *globalcontext_new(void)
 #ifndef AVM_NO_SMP
         smp_rwlock_destroy(glb->modules_lock);
 #endif
-        free(glb->modules_table);
+        valueshashtable_destroy(glb->modules_table);
         atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
@@ -171,7 +171,7 @@ GlobalContext *globalcontext_new(void)
 #ifndef AVM_NO_SMP
         smp_rwlock_destroy(glb->modules_lock);
 #endif
-        free(glb->modules_table);
+        valueshashtable_destroy(glb->modules_table);
         atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
@@ -185,7 +185,7 @@ GlobalContext *globalcontext_new(void)
 #ifndef AVM_NO_SMP
         smp_rwlock_destroy(glb->modules_lock);
 #endif
-        free(glb->modules_table);
+        valueshashtable_destroy(glb->modules_table);
         atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
@@ -199,7 +199,7 @@ GlobalContext *globalcontext_new(void)
 #ifndef AVM_NO_SMP
         smp_rwlock_destroy(glb->modules_lock);
 #endif
-        free(glb->modules_table);
+        valueshashtable_destroy(glb->modules_table);
         atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
@@ -215,7 +215,7 @@ GlobalContext *globalcontext_new(void)
         resource_type_destroy(glb->posix_fd_resource_type);
 #endif
         smp_rwlock_destroy(glb->modules_lock);
-        free(glb->modules_table);
+        valueshashtable_destroy(glb->modules_table);
         atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
@@ -227,7 +227,7 @@ GlobalContext *globalcontext_new(void)
         resource_type_destroy(glb->posix_fd_resource_type);
 #endif
         smp_rwlock_destroy(glb->modules_lock);
-        free(glb->modules_table);
+        valueshashtable_destroy(glb->modules_table);
         atom_table_destroy(glb->atom_table);
         free(glb);
         return NULL;
@@ -310,6 +310,10 @@ COLD_FUNC void globalcontext_destroy(GlobalContext *glb)
     synclist_destroy(&glb->dist_connections);
     synclist_destroy(&glb->registered_processes);
     synclist_destroy(&glb->processes_table);
+
+    valueshashtable_destroy(glb->modules_table);
+    free(glb->modules_by_index);
+    atom_table_destroy(glb->atom_table);
 
     free(glb);
 }

--- a/src/libAtomVM/valueshashtable.c
+++ b/src/libAtomVM/valueshashtable.c
@@ -145,3 +145,26 @@ int valueshashtable_has_key(const struct ValuesHashTable *hash_table, uintptr_t 
     SMP_UNLOCK(hash_table);
     return 0;
 }
+
+void valueshashtable_destroy(struct ValuesHashTable *hash_table)
+{
+    if (IS_NULL_PTR(hash_table)) {
+        return;
+    }
+
+    for (size_t i = 0; i < hash_table->capacity; i++) {
+        struct HNode *node = hash_table->buckets[i];
+        while (node) {
+            struct HNode *tmp = node->next;
+            free(node);
+            node = tmp;
+        }
+    }
+    free(hash_table->buckets);
+
+#ifndef AVM_NO_SMP
+    smp_rwlock_destroy(hash_table->lock);
+#endif
+
+    free(hash_table);
+}

--- a/src/libAtomVM/valueshashtable.h
+++ b/src/libAtomVM/valueshashtable.h
@@ -48,6 +48,7 @@ struct ValuesHashTable
 };
 
 struct ValuesHashTable *valueshashtable_new(void);
+void valueshashtable_destroy(struct ValuesHashTable *hash_table);
 int valueshashtable_insert(struct ValuesHashTable *hash_table, uintptr_t key, uintptr_t value);
 uintptr_t valueshashtable_get_value(const struct ValuesHashTable *hash_table, uintptr_t key, uintptr_t default_value);
 int valueshashtable_has_key(const struct ValuesHashTable *hash_table, uintptr_t key);


### PR DESCRIPTION
Surfaced when doing test_main.c work for zephyr CI.

Knew they were there, should help the esp32 test_main.c harness, especially on the low memory boards and wifi tests.

Mostly (only?) relevant in those scenarios.

note that there is still a leak for: "atom_table_destroy still does not free atom strings allocated with AtomTableCopyAtom."
llm tells me:

> I’d estimate 30-60 minutes for a clean fix plus focused tests. The likely shape:
> Add an ownership bit to the internal atom-table node, e.g. bool owns_key.
> Set owns_key = true only when AtomTableCopyAtom allocates buf.
> Set owns_key = false for BEAM/default atoms that point into other owned storage.
> In atom_table_destroy, walk all node groups and free((void *) node->key) only for owned keys.
> Add/update test-structs coverage for copied atoms.
> Let CI/valgrind prove the leak is gone.
> Risk level: low to medium. The main thing is not accidentally freeing atom strings that belong to module binaries/default atom storage. But since HNode is private to atom_table.c, the API impact should be tiny.


but that is punted for a follow up.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
