### PR TITLE
Raise consistently on avm_unix uart:open/1,2 failure

### DIFF
--- a/libs/avm_unix/src/uart.erl
+++ b/libs/avm_unix/src/uart.erl
@@ -91,7 +91,7 @@ open(Opts) ->
                     {Pid, Fd};
                 {error, _} = CfgErr ->
                     atomvm:posix_close(Fd),
-                    CfgErr
+                    error(CfgErr)
             end;
         {error, Reason} ->
             error(Reason)


### PR DESCRIPTION
The configure-failure branch returned {error, _} while the other two failure paths raise; the open/1,2 spec only allows {pid(), fd()}.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
