### PR TITLE
term_from_resource: fix C++ compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ESP32 socket driver holding the global socket-list lock across blocking TCP connects, leaking the port on connect failure, losing concurrent `accept` waiters, leaking `netbuf` on receive error paths, and a recycled-`netconn` race between socket close and the event handler
 - Fixed generic_unix TCP server sockets performing an abortive close that could truncate replies awaiting ack
 - Fixed a JIT crash (`EXC_BAD_ACCESS`/SIGBUS) on Apple Silicon
+- Fixed `term_from_resource` failing to compile from C++
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -3082,7 +3082,7 @@ static inline term term_from_resource(void *resource, Heap *heap)
     boxed_value[0] = TERM_BOXED_REFERENCE_RESOURCE_HEADER;
     boxed_value[1] = (term) refc;
     // Add the resource to the mso list
-    refc_binary_add_refcount(refc, 1);
+    refc_binary_increment_refcount(refc);
     term ret = ((term) boxed_value) | TERM_PRIMARY_BOXED;
     heap->root->mso_list = term_list_init_prepend(boxed_value + REFERENCE_RESOURCE_CONS_OFFSET, ret, heap->root->mso_list);
     return ret;


### PR DESCRIPTION
term_from_resource is a static inline in term.h and can be reached from C++ translation units, but refc_binary_add_refcount relies on C11 <stdatomic.h>, which C++ does not support. Use the extern "C" refc_binary_increment_refcount helper instead.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
