### PR TITLE
network: read the documented `host` key for the mdns config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ESP32 socket driver holding the global socket-list lock across blocking TCP connects, leaking the port on connect failure, losing concurrent `accept` waiters, leaking `netbuf` on receive error paths, and a recycled-`netconn` race between socket close and the event handler
 - Fixed generic_unix TCP server sockets performing an abortive close that could truncate replies awaiting ack
 - Fixed a JIT crash (`EXC_BAD_ACCESS`/SIGBUS) on Apple Silicon
+- Fixed the `network` mdns configuration to read the documented `host` key; the previously
+  required, undocumented `hostname` key is still accepted
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/libs/avm_network/src/network.erl
+++ b/libs/avm_network/src/network.erl
@@ -988,8 +988,15 @@ maybe_start_mdns(#state{config = Config, sta_ip_info = {InterfaceAddr, _, _}} = 
         undefined ->
             State;
         MDNSConfig ->
+            % The documented config key is `host` (see mdns_hostname_config());
+            % `hostname` is accepted too for compatibility with older code.
+            Hostname =
+                case proplists:get_value(host, MDNSConfig) of
+                    undefined -> proplists:get_value(hostname, MDNSConfig);
+                    Host -> Host
+                end,
             MDNSMap0 = #{
-                hostname => proplists:get_value(hostname, MDNSConfig), interface => InterfaceAddr
+                hostname => Hostname, interface => InterfaceAddr
             },
             MDNSMap1 =
                 case proplists:get_value(ttl, MDNSConfig) of


### PR DESCRIPTION
mdns_config() documents {host, ...} but maybe_start_mdns read the `hostname` key, so a spec-conforming config handed mdns:init an undefined hostname and it crashed on iolist_to_binary/1. Accept both, preferring the documented key.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
