### PR TITLE
stm32: allow excluding mbedTLS to fit flash-constrained stm32g474ret6

### DIFF
--- a/.github/workflows/stm32-build.yaml
+++ b/.github/workflows/stm32-build.yaml
@@ -98,6 +98,9 @@ jobs:
             tests: "boot gpio i2c spi crypto uart"
           - device: stm32g474ret6
             max_size: 393216
+            # 384 KB flash: exclude mbedTLS/crypto (~38 KB) to fit the whole
+            # firmware. G474 has an RNG, so crypto is opt-out via the flag.
+            disable-crypto: "ON"
           - device: stm32l476rgt6
             max_size: 524288
           - device: stm32l562qei6
@@ -166,7 +169,7 @@ jobs:
         set -euo pipefail
         mkdir build
         cd build
-        cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/arm-toolchain.cmake -DDEVICE=${{ matrix.device }} ${{ matrix.usb-cdc == 'ON' && '-DAVM_USB_CDC_PORT_DRIVER_ENABLED=ON' || '' }}
+        cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/arm-toolchain.cmake -DDEVICE=${{ matrix.device }} ${{ matrix.usb-cdc == 'ON' && '-DAVM_USB_CDC_PORT_DRIVER_ENABLED=ON' || '' }} ${{ matrix.disable-crypto == 'ON' && '-DAVM_DISABLE_MBEDTLS=ON' || '' }}
         cmake --build .
 
     - name: "Perform CodeQL Analysis"

--- a/src/platforms/stm32/CMakeLists.txt
+++ b/src/platforms/stm32/CMakeLists.txt
@@ -35,6 +35,7 @@ option(AVM_ENABLE_LOG_LINES "Include source and line info for all enabled levels
 option(AVM_CONFIG_REBOOT_ON_NOT_OK "Reboot when application exits with non 'ok' return" OFF)
 option(AVM_DISABLE_GPIO_NIFS "Disable GPIO nifs (input and output)" OFF)
 option(AVM_DISABLE_GPIO_PORT_DRIVER "Disable GPIO 'port' driver (input, output, and interrupts)" OFF)
+option(AVM_DISABLE_MBEDTLS "Exclude mbedTLS/crypto NIFs even on devices with an RNG (saves ~38 KB flash)" OFF)
 option(AVM_PRINT_PROCESS_CRASH_DUMPS "Print crash reports when processes die with non-standard reasons" ON)
 
 set(AVM_HSE_VALUE "" CACHE STRING "HSE crystal frequency in Hz (e.g. 25000000). Overrides family default.")

--- a/src/platforms/stm32/cmake/stm32_device.cmake
+++ b/src/platforms/stm32/cmake/stm32_device.cmake
@@ -155,6 +155,15 @@ else()
     set(STM32_HAS_RNG FALSE)
 endif()
 
+# Flash-constrained devices that do have an RNG (e.g. stm32g474ret6, 384 KB
+# flash) can opt out of mbedTLS/crypto to save ~38 KB. STM32_HAS_RNG is the
+# sole gate for crypto (mbedTLS fetch/link + otp_crypto.c), so forcing it FALSE
+# takes the same no-crypto path already exercised by RNG-less devices (g0b1).
+if (STM32_HAS_RNG AND AVM_DISABLE_MBEDTLS)
+    set(STM32_HAS_RNG FALSE)
+    set(STM32_CRYPTO_DISABLED_BY_OPTION TRUE)
+endif()
+
 message("-----------Device Info-----------")
 message(STATUS "Device      : ${DEVICE}")
 message(STATUS "Family      : ${STM32_FAMILY}")
@@ -162,3 +171,6 @@ message(STATUS "CPU         : ${STM32_CPU}")
 message(STATUS "FPU         : ${STM32_FPU}")
 message(STATUS "Arch Flags  : ${_arch_flags_str}")
 message(STATUS "Has RNG     : ${STM32_HAS_RNG}")
+if (STM32_CRYPTO_DISABLED_BY_OPTION)
+    message(STATUS "Crypto      : disabled via AVM_DISABLE_MBEDTLS (RNG present)")
+endif()


### PR DESCRIPTION
The stm32g474ret6 has only 384 KB of flash. Cumulative firmware growth pushed the build past that limit, and mbedTLS/crypto accounts for ~38 KB. The G474 has an RNG, so crypto was pulled in unconditionally via STM32_HAS_RNG.

Add an AVM_DISABLE_MBEDTLS option that forces the existing no-crypto build path (already used by RNG-less devices such as the G0B1) even on devices that have an RNG, and enable it for stm32g474ret6 in CI.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
