### PR TITLE
mailbox: drop inline from mailbox_enqueue_message

### DIFF
--- a/src/libAtomVM/mailbox.c
+++ b/src/libAtomVM/mailbox.c
@@ -213,7 +213,7 @@ size_t mailbox_size(Mailbox *mbox)
 // Messages are enqueued using atomics (or emulation) unless this is a no-smp
 // build with no support for driver tasks
 #if !defined(AVM_NO_SMP) || defined(AVM_TASK_DRIVER_ENABLED)
-inline void mailbox_enqueue_message(Context *c, MailboxMessage *m)
+void mailbox_enqueue_message(Context *c, MailboxMessage *m)
 {
     // Append message at the beginning of outer_first.
     MailboxMessage *current_first = NULL;


### PR DESCRIPTION
This created some issues with rp2 builds

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
