### PR TITLE
esp32: disable WiFi modem power save on STA start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for this limit
 - Replaced the `exavmlib` `Protocol` module with a small runtime shim (only `Protocol.__concat__/2`),
   saving ~31 KB of flash. ExAtomVM uses precompiled, unconsolidated protocols and continue to function normally at runtime.
+- On ESP32 platform, when starting wifi as a station (client), disable wifi power save so TCP servers are reachable
 
 ### Removed
 - Removed `ahttp_client` support for obsolete line folding (RFC 9112 §5.2); folded header and

--- a/src/platforms/esp32/components/avm_builtins/network_driver.c
+++ b/src/platforms/esp32/components/avm_builtins/network_driver.c
@@ -757,6 +757,7 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
                 // TODO: expose an erlang callback so applications can choose how to respond to this
                 // event, i.e. start a periodic scan for known networks, or initiate a connection
                 ESP_LOGI(TAG, "WIFI_EVENT_STA_START received.");
+                esp_wifi_set_ps(WIFI_PS_NONE);
                 if (!data->managed) {
                     esp_wifi_connect();
                 }


### PR DESCRIPTION
The esp-idf default (WIFI_PS_MIN_MODEM) can make the station unreachable from the LAN on APs with imperfect DTIM buffering: outbound traffic flows but unsolicited inbound ARP/ICMP/TCP is lost. Applications that mostly deep-sleep spend little time with WiFi up, so trade standby current for reachability.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
