### PR TITLE
esp32: register sleep_enable_ulp_wakeup under its documented name

### DIFF
--- a/src/platforms/esp32/components/avm_sys/platform_nifs.c
+++ b/src/platforms/esp32/components/avm_sys/platform_nifs.c
@@ -1226,7 +1226,13 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
         return &esp_sleep_enable_timer_wakeup_nif;
     }
 #if SOC_ULP_SUPPORTED
+    // Historical name kept for compatibility; esp.erl's documented API
+    // is sleep_enable_ulp_wakeup/0.
     if (strcmp("esp:sleep_ulp_wakeup/0", nifname) == 0) {
+        TRACE("Resolved platform nif %s ...\n", nifname);
+        return &esp_sleep_ulp_wakeup_nif;
+    }
+    if (strcmp("esp:sleep_enable_ulp_wakeup/0", nifname) == 0) {
         TRACE("Resolved platform nif %s ...\n", nifname);
         return &esp_sleep_ulp_wakeup_nif;
     }


### PR DESCRIPTION
The NIF was only registered as esp:sleep_ulp_wakeup/0 while esp.erl exports sleep_enable_ulp_wakeup/0, making the documented API undef at runtime. Register both names.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
