### PR TITLE
[Updated] Add process_info/1 and process_info/2 with list argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed two bugs related to closing fds in `atomvm:subprocess/4`
 - Fixed `message_queue_len` (as reported by `erlang:process_info/2`): unprocessed signals,
   such as monitor or unlink requests, were counted as queued messages
+- Fixed a process hanging forever after catching an exception raised asynchronously by a
+  trapping BIF: the trap flag was left set, so the process parked at the next scheduling
+  point and never ran again
 - Fixed `erlang:localtime/1` memory leak, use-after-free, and TZ restore bugs on newlib/picolibc
 - Fixed ESP32 I2C driver resource leaks, half-closed state, and close-during-transmission errors
 - Fixed several underallocation issues that could trigger data corruption on `binary:replace`, `zlib:compress` and bsd socket recv code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `lists:mapfoldr/3`
 
 ### Changed
+- `erlang:process_info/2` now accepts only pids of local processes, as Erlang/OTP does:
+  calling it with a port now raises `badarg` (previous versions accepted any id-carrying
+  term, so it could be used to read port information; there is no `erlang:port_info/2`
+  in AtomVM yet to migrate such code to)
 - Updated network type db() to dbm() to reflect the actual representation of the type
 - Use ES6 modules for emscripten port, using .mjs suffix
 - `ahttp_client` now returns `{error, {parser, incomplete_response}}` when a socket closes mid-response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added USB CDC port drivers for ESP32, RP2, and STM32 platforms
 - Added a Linux `gpio` driver for the generic_unix port (in `avm_unix`) using sysfs
 - Added `console:print_err/1` to write to standard error
+- Added support for `process_info/1` and `process_info/2` with list argument
 - Added `erlang:term_to_binary/2`, `erlang:is_builtin/3` and `erlang:bitstring_to_list/1`
 - Added `lists:mapfoldr/3`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `ahttp_client` crash on headers with empty or all-whitespace values
 - Fixed a bug in `supervisor` handling of failing child
 - Fixed two bugs related to closing fds in `atomvm:subprocess/4`
+- Fixed `message_queue_len` (as reported by `erlang:process_info/2`): unprocessed signals,
+  such as monitor or unlink requests, were counted as queued messages
 - Fixed `erlang:localtime/1` memory leak, use-after-free, and TZ restore bugs on newlib/picolibc
 - Fixed ESP32 I2C driver resource leaks, half-closed state, and close-during-transmission errors
 - Fixed several underallocation issues that could trigger data corruption on `binary:replace`, `zlib:compress` and bsd socket recv code.

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -19,6 +19,10 @@ bitshifts: e.g. `(16#FFFF band 0xF) bsl 252`.
 - `binary_to_integer` and `list_to_integer` do not raise `overflow` error anymore, they instead
 raise `badarg` when trying to parse an integer that exceeds 256 bits. Update any relevant error
 handling code.
+- `erlang:process_info/2` now accepts only pids of local processes, as Erlang/OTP does: calling
+it with a port raises `badarg`. Previous versions accepted any id-carrying term, so it could be
+used to read port information; there is no `erlang:port_info/2` in AtomVM yet, so such calls
+must be removed or guarded when updating.
 - ESP32 builds with Elixir support may be configured without making changes to git-tracked files
 using `idf.py -DATOMVM_ELIXIR_SUPPORT=on set-target ${CHIP}` instead of copying
 partitions-elixir.csv to partitions.csv. This configures the build to use partitions-elixir.csv for

--- a/doc/src/apidocs/libatomvm/data_structures.rst
+++ b/doc/src/apidocs/libatomvm/data_structures.rst
@@ -23,7 +23,7 @@ Data Structures
    :allow-dot-graphs:
 .. doxygenstruct:: AVMPackData
    :allow-dot-graphs:
-.. doxygenstruct:: BuiltInAtomRequestSignal
+.. doxygenstruct:: ProcessInfoRequestSignal
    :allow-dot-graphs:
 .. doxygenstruct:: BuiltInAtomSignal
    :allow-dot-graphs:

--- a/doc/src/apidocs/libatomvm/data_structures.rst
+++ b/doc/src/apidocs/libatomvm/data_structures.rst
@@ -15,8 +15,6 @@ Data Structures
    :maxdepth: 4
    :caption: Structs
 
-.. doxygenstruct:: AtomsHashTable
-   :allow-dot-graphs:
 .. doxygenstruct:: AtomStringIntPair
    :allow-dot-graphs:
 .. doxygenstruct:: AtomTable

--- a/doc/src/apidocs/libatomvm/data_structures.rst
+++ b/doc/src/apidocs/libatomvm/data_structures.rst
@@ -23,10 +23,6 @@ Data Structures
    :allow-dot-graphs:
 .. doxygenstruct:: AVMPackData
    :allow-dot-graphs:
-.. doxygenstruct:: ProcessInfoRequestSignal
-   :allow-dot-graphs:
-.. doxygenstruct:: BuiltInAtomSignal
-   :allow-dot-graphs:
 .. doxygenstruct:: CharDataToBytesAcc
    :allow-dot-graphs:
 .. doxygenstruct:: CharDataToBytesSizeAcc
@@ -67,6 +63,8 @@ Data Structures
 .. doxygenstruct:: HNodeGroup
    :allow-dot-graphs:
 .. doxygenstruct:: IFFRecord
+   :allow-dot-graphs:
+.. doxygenstruct:: ImmediateSignal
    :allow-dot-graphs:
 .. doxygenstruct:: InMemoryAVMPack
    :allow-dot-graphs:
@@ -116,6 +114,8 @@ Data Structures
 .. doxygenstruct:: Nif
    :allow-dot-graphs:
 .. doxygenstruct:: PrinterFun
+.. doxygenstruct:: ProcessInfoRequestSignal
+   :allow-dot-graphs:
 .. doxygenstruct:: RefcBinary
    :allow-dot-graphs:
 .. doxygenstruct:: RefcBinaryAVMPack

--- a/doc/src/programmers-guide.md
+++ b/doc/src/programmers-guide.md
@@ -576,22 +576,27 @@ You can obtain a list of all processes in the system via [`erlang:processes/0`](
 Pids = erlang:processes().
 ```
 
-And for each process, you can get detailed process information via the [`erlang:process_info/2`](./apidocs/erlang/estdlib/erlang.md#process_info2) function:
+And for each process, you can get detailed process information via the [`erlang:process_info/1`](./apidocs/erlang/estdlib/erlang.md#process_info1) and [`erlang:process_info/2`](./apidocs/erlang/estdlib/erlang.md#process_info2) functions:
 
 ```erlang
 io:format("Heap size for Pid ~p: ~p~n", [Pid, erlang:process_info(Pid, heap_size)]).
 ```
 
-The return value is a tuple containing the key passed into the `erlang:process_info/2` function and its associated value.
+The return value is a tuple containing the key passed into the `erlang:process_info/2` function and its associated value, e.g. `{heap_size, 170}`. A list of keys may be passed instead of a single key, in which case the result is a list with one `{Key, Value}` tuple per requested key, in request order. `erlang:process_info/1` returns the default key set in one call. As in Erlang/OTP, these functions return `undefined` if the process is not alive, and querying the single key `registered_name` on a process without a registered name returns `[]`.
 
 The currently supported keys are enumerated in the following table:
 
 | Key | Value Type | Description |
 |-----|------------|-------------|
 | `heap_size` | `non_neg_integer()` | Number of terms (in machine words) used in the process heap |
+| `total_heap_size` | `non_neg_integer()` | Number of terms (in machine words) used in the process heap, including heap fragments |
 | `stack_size` | `non_neg_integer()` | Number of terms (in machine words) used in the process stack |
 | `message_queue_len` | `non_neg_integer()` | Number of unprocessed messages in the process mailbox |
 | `memory` | `non_neg_integer()` | Total number of bytes used by the process (estimate) |
+| `registered_name` | `atom()` | The registered name of the process |
+| `links` | `[pid()]` | The processes and ports the process is linked to |
+| `monitored_by` | `[pid() \| port() \| resource()]` | The processes, ports and NIF resources monitoring the process |
+| `trap_exit` | `boolean()` | Whether the process is trapping exits |
 
 See the `word_size` key in the [System APIs](#system-apis) section for information about how to find the number of bytes used in a machine word on the current platform.
 

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -322,26 +322,15 @@ send_after(Time, Dest, Msg) ->
 
 %%-----------------------------------------------------------------------------
 %% @param   Pid the process pid.
-%% @param   Key key used to find process information.
-%% @returns process information for the specified pid defined by the specified key.
-%% @doc     Return process information.
+%% @returns a list of `{Key, Value}' tuples, or `undefined' if the process
+%%          is not alive.
+%% @doc     Return information about the specified process.
 %%
-%% This function returns information about the specified process.
-%% The type of information returned is dependent on the specified key.
-%%
-%% The following keys are supported:
-%% <ul>
-%%      <li><b>heap_size</b> the number of words used in the heap (integer), including the stack but excluding fragments</li>
-%%      <li><b>total_heap_size</b> the number of words used in the heap (integer) including fragments</li>
-%%      <li><b>registered_name</b> - returns `{registered_name, RegisteredName}' where `RegisteredName' is the registered name of the port or process. If the port/process has no registered name, `[]' is returned</li>
-%%      <li><b>stack_size</b> the number of words used in the stack (integer)</li>
-%%      <li><b>message_queue_len</b> the number of messages enqueued for the process (integer)</li>
-%%      <li><b>memory</b> the estimated total number of bytes in use by the process (integer)</li>
-%%      <li><b>links</b> the list of linked processes</li>
-%%      <li><b>monitored_by</b> the list of processes, NIF resources or ports that monitor the process</li>
-%% </ul>
-%% Specifying an unsupported term or atom raises a bad_arg error.
-%%
+%% As in Erlang/OTP, the result covers a default set of keys; AtomVM returns
+%% the supported subset of OTP's default set, in the same relative order:
+%% `registered_name' (omitted when the process is not registered, first
+%% otherwise), `message_queue_len', `links', `trap_exit', `total_heap_size',
+%% `heap_size' and `stack_size'.
 %% @end
 %%-----------------------------------------------------------------------------
 -spec process_info(Pid :: pid()) -> [{atom(), term()}] | undefined.
@@ -364,15 +353,45 @@ process_info(Pid) when erlang:is_pid(Pid) ->
 process_info(Pid) ->
     erlang:error(badarg, [Pid]).
 
+%%-----------------------------------------------------------------------------
+%% @param   Pid the process pid.
+%% @param   Key key used to find process information.
+%% @returns process information for the specified pid defined by the specified key.
+%% @doc     Return process information.
+%%
+%% This function returns information about the specified process.
+%% The type of information returned is dependent on the specified key.
+%%
+%% The following keys are supported:
+%% <ul>
+%%      <li><b>heap_size</b> the number of words used in the heap (integer), including the stack but excluding fragments</li>
+%%      <li><b>total_heap_size</b> the number of words used in the heap (integer) including fragments</li>
+%%      <li><b>registered_name</b> - returns `{registered_name, RegisteredName}' where `RegisteredName' is the registered name of the port or process. If the port/process has no registered name, `[]' is returned</li>
+%%      <li><b>stack_size</b> the number of words used in the stack (integer)</li>
+%%      <li><b>message_queue_len</b> the number of messages enqueued for the process (integer)</li>
+%%      <li><b>memory</b> the estimated total number of bytes in use by the process (integer)</li>
+%%      <li><b>links</b> the list of linked processes</li>
+%%      <li><b>monitored_by</b> the list of processes, NIF resources or ports that monitor the process</li>
+%%      <li><b>trap_exit</b> whether the process is trapping exits (boolean)</li>
+%% </ul>
+%% A list of keys may also be specified, in which case the result is a list
+%% with one `{Key, Value}' tuple per requested key, in the same order and
+%% with duplicates preserved, or `undefined' if the process is not alive.
+%% Specifying an unsupported term or atom raises a badarg error.
+%%
+%% @end
+%%-----------------------------------------------------------------------------
 -spec process_info
-    (Pid :: pid(), heap_size) -> {heap_size, non_neg_integer()};
-    (Pid :: pid(), total_heap_size) -> {total_heap_size, non_neg_integer()};
-    (Pid :: pid(), registered_name) -> {registered_name, term()} | [];
-    (Pid :: pid(), stack_size) -> {stack_size, non_neg_integer()};
-    (Pid :: pid(), message_queue_len) -> {message_queue_len, non_neg_integer()};
-    (Pid :: pid(), memory) -> {memory, non_neg_integer()};
-    (Pid :: pid(), links) -> {links, [pid()]};
-    (Pid :: pid(), monitored_by) -> {monitored_by, [pid() | resource() | port()]}.
+    (Pid :: pid(), heap_size) -> {heap_size, non_neg_integer()} | undefined;
+    (Pid :: pid(), total_heap_size) -> {total_heap_size, non_neg_integer()} | undefined;
+    (Pid :: pid(), registered_name) -> {registered_name, term()} | [] | undefined;
+    (Pid :: pid(), stack_size) -> {stack_size, non_neg_integer()} | undefined;
+    (Pid :: pid(), message_queue_len) -> {message_queue_len, non_neg_integer()} | undefined;
+    (Pid :: pid(), memory) -> {memory, non_neg_integer()} | undefined;
+    (Pid :: pid(), links) -> {links, [pid()]} | undefined;
+    (Pid :: pid(), monitored_by) -> {monitored_by, [pid() | resource() | port()]} | undefined;
+    (Pid :: pid(), trap_exit) -> {trap_exit, boolean()} | undefined;
+    (Pid :: pid(), [atom()]) -> [{atom(), term()}] | undefined.
 process_info(_Pid, _Key) ->
     erlang:nif_error(undefined).
 

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -31,6 +31,7 @@
     start_timer/3, start_timer/4,
     cancel_timer/1,
     send_after/3,
+    process_info/1,
     process_info/2,
     system_info/1,
     system_flag/2,
@@ -343,6 +344,26 @@ send_after(Time, Dest, Msg) ->
 %%
 %% @end
 %%-----------------------------------------------------------------------------
+-spec process_info(Pid :: pid()) -> [{atom(), term()}] | undefined.
+process_info(Pid) when erlang:is_pid(Pid) ->
+    case
+        erlang:process_info(Pid, [
+            registered_name,
+            message_queue_len,
+            links,
+            trap_exit,
+            total_heap_size,
+            heap_size,
+            stack_size
+        ])
+    of
+        undefined -> undefined;
+        [{registered_name, []} | Info] -> Info;
+        Info -> Info
+    end;
+process_info(Pid) ->
+    erlang:error(badarg, [Pid]).
+
 -spec process_info
     (Pid :: pid(), heap_size) -> {heap_size, non_neg_integer()};
     (Pid :: pid(), total_heap_size) -> {total_heap_size, non_neg_integer()};

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -427,11 +427,10 @@ done:
     }
 }
 
-bool context_process_signal_trap_answer(Context *ctx, struct TermSignal *signal)
+void context_process_signal_trap_answer(Context *ctx, struct TermSignal *signal)
 {
     context_update_flags(ctx, ~Trap, NoFlags);
     ctx->x[0] = signal->signal_term;
-    return true;
 }
 
 bool context_process_signal_set_group_leader(Context *ctx, const struct TermSignal *signal)

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -638,7 +638,7 @@ void context_update_flags(Context *ctx, int mask, int value) CLANG_THREAD_SANITI
 
 size_t context_message_queue_len(Context *ctx)
 {
-    return mailbox_len(&ctx->mailbox);
+    return mailbox_normal_message_len(&ctx->mailbox);
 }
 
 size_t context_size(Context *ctx)

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -342,6 +342,13 @@ void context_process_process_info_request_signal(Context *ctx, struct ProcessInf
         return;
     }
 
+    if (process_table_locked) {
+        // Called from context_destroy: this process has already been removed
+        // from the process table
+        mailbox_send_term_signal(target, TrapAnswerSignal, UNDEFINED_ATOM);
+        return;
+    }
+
     if (signal->mode == PROCESS_INFO_SINGLE) {
         term atom = signal->atoms[0];
         size_t term_size;

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -327,7 +327,8 @@ void context_process_kill_signal(Context *ctx, struct TermSignal *signal)
     context_update_flags(ctx, ~NoFlags, Killed);
 }
 
-void context_process_process_info_request_signal(Context *ctx, struct ProcessInfoRequestSignal *signal, bool process_table_locked)
+void context_process_process_info_request_signal(
+    Context *ctx, struct ProcessInfoRequestSignal *signal, bool process_table_locked)
 {
     // TODO: guarantee completion to the trapped requester even under allocation
     // failure, e.g. by reserving a fallback answer signal with the request
@@ -349,7 +350,7 @@ void context_process_process_info_request_signal(Context *ctx, struct ProcessInf
         return;
     }
 
-    if (signal->mode == PROCESS_INFO_SINGLE) {
+    if (signal->mode == ProcessInfoSingle) {
         term atom = signal->atoms[0];
         size_t term_size;
         if (!context_get_process_info(ctx, NULL, &term_size, atom, NULL)) {
@@ -365,8 +366,8 @@ void context_process_process_info_request_signal(Context *ctx, struct ProcessInf
 
         term ret;
         if (context_get_process_info(ctx, &ret, NULL, atom, &heap)) {
-            // return [] when unregistered (BEAM backward compatibility)
-            if (atom == REGISTERED_NAME_ATOM && term_is_tuple(ret) && term_is_nil(term_get_tuple_element(ret, 1))) {
+            // return [] when unregistered (BEAM compatibility)
+            if (atom == REGISTERED_NAME_ATOM && term_is_nil(term_get_tuple_element(ret, 1))) {
                 ret = term_nil();
             }
             mailbox_send_term_signal(target, TrapAnswerSignal, ret);
@@ -375,10 +376,14 @@ void context_process_process_info_request_signal(Context *ctx, struct ProcessInf
         }
         memory_destroy_heap(&heap, ctx->global);
     } else {
+        assert(signal->mode == ProcessInfoList);
+        assert(signal->atoms_len > 0);
+
         size_t total_size = 0;
-        for (size_t i = 0; i < signal->len; i++) {
+        for (size_t i = 0; i < signal->atoms_len; i++) {
             size_t item_size;
-            if (UNLIKELY(!context_get_process_info(ctx, NULL, &item_size, signal->atoms[i], NULL))) {
+            if (UNLIKELY(
+                    !context_get_process_info(ctx, NULL, &item_size, signal->atoms[i], NULL))) {
                 mailbox_send_immediate_signal(target, TrapExceptionSignal, BADARG_ATOM);
                 goto done;
             }
@@ -390,11 +395,6 @@ void context_process_process_info_request_signal(Context *ctx, struct ProcessInf
             total_size += item_size + CONS_SIZE;
         }
 
-        if (signal->len == 0) {
-            mailbox_send_term_signal(target, TrapAnswerSignal, term_nil());
-            goto done;
-        }
-
         Heap heap;
         if (UNLIKELY(memory_init_heap(&heap, total_size) != MEMORY_GC_OK)) {
             mailbox_send_immediate_signal(target, TrapExceptionSignal, OUT_OF_MEMORY_ATOM);
@@ -404,9 +404,10 @@ void context_process_process_info_request_signal(Context *ctx, struct ProcessInf
         // Build list backwards to preserve input order
         term result = term_nil();
         bool build_ok = true;
-        for (ssize_t i = (ssize_t) signal->len - 1; i >= 0; i--) {
+        for (size_t i = signal->atoms_len; i-- > 0;) {
             term item_result;
-            if (UNLIKELY(!context_get_process_info(ctx, &item_result, NULL, signal->atoms[i], &heap))) {
+            if (UNLIKELY(
+                    !context_get_process_info(ctx, &item_result, NULL, signal->atoms[i], &heap))) {
                 mailbox_send_immediate_signal(target, TrapExceptionSignal, item_result);
                 build_ok = false;
                 break;
@@ -764,7 +765,6 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
             break;
         }
 
-        // true if a process traps exits, otherwise false
         case TRAP_EXIT_ATOM: {
             term_put_tuple_element(ret, 0, TRAP_EXIT_ATOM);
             term_put_tuple_element(ret, 1, ctx->trap_exit ? TRUE_ATOM : FALSE_ATOM);

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -652,6 +652,26 @@ size_t context_size(Context *ctx)
         + memory_heap_memory_size(&ctx->heap) * BYTES_PER_TERM;
 }
 
+bool context_is_valid_process_info_key(term key)
+{
+    // must accept exactly the keys context_get_process_info handles
+    switch (key) {
+        case HEAP_SIZE_ATOM:
+        case TOTAL_HEAP_SIZE_ATOM:
+        case STACK_SIZE_ATOM:
+        case MESSAGE_QUEUE_LEN_ATOM:
+        case REGISTERED_NAME_ATOM:
+        case MEMORY_ATOM:
+        case TRAP_EXIT_ATOM:
+        case LINKS_ATOM:
+        case MONITORED_BY_ATOM:
+        case CURRENT_STACKTRACE_ATOM:
+            return true;
+        default:
+            return false;
+    }
+}
+
 bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term atom_key, Heap *heap)
 {
     size_t ret_size;

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -398,10 +398,6 @@ void context_process_process_info_request_signal(Context *ctx, struct ProcessInf
                 break;
             }
 
-            if (signal->mode == PROCESS_INFO_LIST_OMIT_UNREGISTERED && signal->atoms[i] == REGISTERED_NAME_ATOM && term_is_nil(term_get_tuple_element(item_result, 1))) {
-                continue;
-            }
-
             result = term_list_prepend(item_result, result, &heap);
         }
         if (LIKELY(build_ok)) {

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -172,8 +172,8 @@ void context_destroy(Context *ctx)
     while (signal_message) {
         switch (signal_message->type) {
             case ProcessInfoRequestSignal: {
-                struct BuiltInAtomRequestSignal *request_signal
-                    = CONTAINER_OF(signal_message, struct BuiltInAtomRequestSignal, base);
+                struct ProcessInfoRequestSignal *request_signal
+                    = CONTAINER_OF(signal_message, struct ProcessInfoRequestSignal, base);
                 context_process_process_info_request_signal(ctx, request_signal, true);
                 break;
             }
@@ -327,7 +327,7 @@ void context_process_kill_signal(Context *ctx, struct TermSignal *signal)
     context_update_flags(ctx, ~NoFlags, Killed);
 }
 
-void context_process_process_info_request_signal(Context *ctx, struct BuiltInAtomRequestSignal *signal, bool process_table_locked)
+void context_process_process_info_request_signal(Context *ctx, struct ProcessInfoRequestSignal *signal, bool process_table_locked)
 {
     Context *target;
     if (process_table_locked) {
@@ -335,28 +335,85 @@ void context_process_process_info_request_signal(Context *ctx, struct BuiltInAto
     } else {
         target = globalcontext_get_process_lock(ctx->global, signal->sender_pid);
     }
-    if (LIKELY(target)) {
+
+    if (UNLIKELY(!target)) {
+        return;
+    }
+
+    if (signal->mode == PROCESS_INFO_SINGLE) {
+        term atom = signal->atoms[0];
         size_t term_size;
-        if (context_get_process_info(ctx, NULL, &term_size, signal->atom, NULL)) {
-            Heap heap;
-            if (UNLIKELY(memory_init_heap(&heap, term_size) != MEMORY_GC_OK)) {
-                mailbox_send_immediate_signal(target, TrapExceptionSignal, OUT_OF_MEMORY_ATOM);
-            } else {
-                term ret;
-                if (context_get_process_info(ctx, &ret, NULL, signal->atom, &heap)) {
-                    mailbox_send_term_signal(target, TrapAnswerSignal, ret);
-                } else {
-                    mailbox_send_immediate_signal(target, TrapExceptionSignal, ret);
-                }
-                memory_destroy_heap(&heap, ctx->global);
-            }
-        } else {
+        if (!context_get_process_info(ctx, NULL, &term_size, atom, NULL)) {
             mailbox_send_immediate_signal(target, TrapExceptionSignal, BADARG_ATOM);
+            goto done;
         }
-        if (!process_table_locked) {
-            globalcontext_get_process_unlock(ctx->global, target);
+
+        Heap heap;
+        if (UNLIKELY(memory_init_heap(&heap, term_size) != MEMORY_GC_OK)) {
+            mailbox_send_immediate_signal(target, TrapExceptionSignal, OUT_OF_MEMORY_ATOM);
+            goto done;
         }
-    } // else: sender died
+
+        term ret;
+        if (context_get_process_info(ctx, &ret, NULL, atom, &heap)) {
+            // return [] when unregistered (BEAM backward compatibility)
+            if (atom == REGISTERED_NAME_ATOM && term_is_tuple(ret) && term_is_nil(term_get_tuple_element(ret, 1))) {
+                ret = term_nil();
+            }
+            mailbox_send_term_signal(target, TrapAnswerSignal, ret);
+        } else {
+            mailbox_send_immediate_signal(target, TrapExceptionSignal, ret);
+        }
+        memory_destroy_heap(&heap, ctx->global);
+    } else {
+        size_t total_size = 0;
+        for (size_t i = 0; i < signal->len; i++) {
+            size_t item_size;
+            if (UNLIKELY(!context_get_process_info(ctx, NULL, &item_size, signal->atoms[i], NULL))) {
+                mailbox_send_immediate_signal(target, TrapExceptionSignal, BADARG_ATOM);
+                goto done;
+            }
+            total_size += item_size + CONS_SIZE;
+        }
+
+        if (signal->len == 0) {
+            mailbox_send_term_signal(target, TrapAnswerSignal, term_nil());
+            goto done;
+        }
+
+        Heap heap;
+        if (UNLIKELY(memory_init_heap(&heap, total_size) != MEMORY_GC_OK)) {
+            mailbox_send_immediate_signal(target, TrapExceptionSignal, OUT_OF_MEMORY_ATOM);
+            goto done;
+        }
+
+        // Build list backwards to preserve input order
+        term result = term_nil();
+        bool build_ok = true;
+        for (ssize_t i = (ssize_t) signal->len - 1; i >= 0; i--) {
+            term item_result;
+            if (UNLIKELY(!context_get_process_info(ctx, &item_result, NULL, signal->atoms[i], &heap))) {
+                mailbox_send_immediate_signal(target, TrapExceptionSignal, item_result);
+                build_ok = false;
+                break;
+            }
+
+            if (signal->mode == PROCESS_INFO_LIST_OMIT_UNREGISTERED && signal->atoms[i] == REGISTERED_NAME_ATOM && term_is_nil(term_get_tuple_element(item_result, 1))) {
+                continue;
+            }
+
+            result = term_list_prepend(item_result, result, &heap);
+        }
+        if (LIKELY(build_ok)) {
+            mailbox_send_term_signal(target, TrapAnswerSignal, result);
+        }
+        memory_destroy_heap(&heap, ctx->global);
+    }
+
+done:
+    if (!process_table_locked) {
+        globalcontext_get_process_unlock(ctx->global, target);
+    }
 }
 
 bool context_process_signal_trap_answer(Context *ctx, struct TermSignal *signal)
@@ -594,6 +651,7 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
         case MESSAGE_QUEUE_LEN_ATOM:
         case REGISTERED_NAME_ATOM:
         case MEMORY_ATOM:
+        case TRAP_EXIT_ATOM:
             ret_size = TUPLE_SIZE(2);
             break;
         case LINKS_ATOM: {
@@ -659,12 +717,8 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
         // registered_name for process or port..
         case REGISTERED_NAME_ATOM: {
             term name = globalcontext_get_registered_name_process(ctx->global, ctx->process_id);
-            if (term_is_invalid_term((name))) {
-                ret = term_nil(); // Set ret to an empty list to match erlang behaviour
-            } else {
-                term_put_tuple_element(ret, 0, REGISTERED_NAME_ATOM);
-                term_put_tuple_element(ret, 1, name);
-            }
+            term_put_tuple_element(ret, 0, REGISTERED_NAME_ATOM);
+            term_put_tuple_element(ret, 1, term_is_invalid_term(name) ? term_nil() : name);
             break;
         }
 
@@ -697,6 +751,13 @@ bool context_get_process_info(Context *ctx, term *out, size_t *term_size, term a
             term_put_tuple_element(ret, 0, MEMORY_ATOM);
             unsigned long value = context_size(ctx);
             term_put_tuple_element(ret, 1, term_from_int(value));
+            break;
+        }
+
+        // true if a process traps exits, otherwise false
+        case TRAP_EXIT_ATOM: {
+            term_put_tuple_element(ret, 0, TRAP_EXIT_ATOM);
+            term_put_tuple_element(ret, 1, ctx->trap_exit ? TRUE_ATOM : FALSE_ATOM);
             break;
         }
 

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -329,6 +329,8 @@ void context_process_kill_signal(Context *ctx, struct TermSignal *signal)
 
 void context_process_process_info_request_signal(Context *ctx, struct ProcessInfoRequestSignal *signal, bool process_table_locked)
 {
+    // TODO: guarantee completion to the trapped requester even under allocation
+    // failure, e.g. by reserving a fallback answer signal with the request
     Context *target;
     if (process_table_locked) {
         target = globalcontext_get_process_nolock(ctx->global, signal->sender_pid);
@@ -371,6 +373,11 @@ void context_process_process_info_request_signal(Context *ctx, struct ProcessInf
             size_t item_size;
             if (UNLIKELY(!context_get_process_info(ctx, NULL, &item_size, signal->atoms[i], NULL))) {
                 mailbox_send_immediate_signal(target, TrapExceptionSignal, BADARG_ATOM);
+                goto done;
+            }
+            if (UNLIKELY(item_size > MEMORY_HEAP_MAX_TERMS - CONS_SIZE
+                    || item_size + CONS_SIZE > MEMORY_HEAP_MAX_TERMS - total_size)) {
+                mailbox_send_immediate_signal(target, TrapExceptionSignal, OUT_OF_MEMORY_ATOM);
                 goto done;
             }
             total_size += item_size + CONS_SIZE;

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -520,6 +520,14 @@ term context_process_alias_message_signal(Context *ctx, struct TermSignal *signa
 void context_process_code_server_resume_signal(Context *ctx);
 
 /**
+ * @brief Check a process information key.
+ *
+ * @param key the item key to check
+ * @return \c true if the key is one context_get_process_info can answer
+ */
+bool context_is_valid_process_info_key(term key);
+
+/**
  * @brief Get process information.
  *
  * @param ctx the context being executed

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -447,10 +447,10 @@ void context_process_kill_signal(Context *ctx, struct TermSignal *signal);
  * @brief Process a process info request signal.
  *
  * @param ctx the context being executed
- * @param signal the process info signal
+ * @param signal the process info request signal
  * @param process_table_locked whether process table is already locked
  */
-void context_process_process_info_request_signal(Context *ctx, struct BuiltInAtomRequestSignal *signal, bool process_table_locked);
+void context_process_process_info_request_signal(Context *ctx, struct ProcessInfoRequestSignal *signal, bool process_table_locked);
 
 /**
  * @brief Process a trap answer signal.

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -458,9 +458,8 @@ void context_process_process_info_request_signal(
  *
  * @param ctx the context being executed
  * @param signal the answer message
- * @return \c true if successful, \c false in case of memory error
  */
-bool context_process_signal_trap_answer(Context *ctx, struct TermSignal *signal);
+void context_process_signal_trap_answer(Context *ctx, struct TermSignal *signal);
 
 /**
  * @brief Process a flush monitor signal.

--- a/src/libAtomVM/context.h
+++ b/src/libAtomVM/context.h
@@ -450,7 +450,8 @@ void context_process_kill_signal(Context *ctx, struct TermSignal *signal);
  * @param signal the process info request signal
  * @param process_table_locked whether process table is already locked
  */
-void context_process_process_info_request_signal(Context *ctx, struct ProcessInfoRequestSignal *signal, bool process_table_locked);
+void context_process_process_info_request_signal(
+    Context *ctx, struct ProcessInfoRequestSignal *signal, bool process_table_locked);
 
 /**
  * @brief Process a trap answer signal.

--- a/src/libAtomVM/jit.c
+++ b/src/libAtomVM/jit.c
@@ -917,10 +917,7 @@ static Context *jit_process_signal_messages(Context *ctx, JITState *jit_state)
             case TrapAnswerSignal: {
                 struct TermSignal *trap_answer
                     = CONTAINER_OF(signal_message, struct TermSignal, base);
-                if (UNLIKELY(!context_process_signal_trap_answer(ctx, trap_answer))) {
-                    set_error(ctx, jit_state, 0, OUT_OF_MEMORY_ATOM);
-                    handle_error = true;
-                }
+                context_process_signal_trap_answer(ctx, trap_answer);
                 break;
             }
             case TrapExceptionSignal: {

--- a/src/libAtomVM/jit.c
+++ b/src/libAtomVM/jit.c
@@ -926,6 +926,7 @@ static Context *jit_process_signal_messages(Context *ctx, JITState *jit_state)
             case TrapExceptionSignal: {
                 struct ImmediateSignal *trap_exception
                     = CONTAINER_OF(signal_message, struct ImmediateSignal, base);
+                context_update_flags(ctx, ~Trap, NoFlags);
                 set_error(ctx, jit_state, 0, trap_exception->immediate);
                 handle_error = true;
                 break;

--- a/src/libAtomVM/jit.c
+++ b/src/libAtomVM/jit.c
@@ -909,8 +909,8 @@ static Context *jit_process_signal_messages(Context *ctx, JITState *jit_state)
                 break;
             }
             case ProcessInfoRequestSignal: {
-                struct BuiltInAtomRequestSignal *request_signal
-                    = CONTAINER_OF(signal_message, struct BuiltInAtomRequestSignal, base);
+                struct ProcessInfoRequestSignal *request_signal
+                    = CONTAINER_OF(signal_message, struct ProcessInfoRequestSignal, base);
                 context_process_process_info_request_signal(ctx, request_signal, false);
                 break;
             }

--- a/src/libAtomVM/mailbox.c
+++ b/src/libAtomVM/mailbox.c
@@ -189,6 +189,24 @@ size_t mailbox_len(Mailbox *mbox)
     return result;
 }
 
+size_t mailbox_normal_message_len(Mailbox *mbox)
+{
+    size_t result = 0;
+    MailboxMessage *msg = mbox->outer_first;
+    while (msg) {
+        if (msg->type == NormalMessage || msg->type == AliasMessageSignal) {
+            result++;
+        }
+        msg = msg->next;
+    }
+    msg = mbox->inner_first;
+    while (msg) {
+        result++;
+        msg = msg->next;
+    }
+    return result;
+}
+
 size_t mailbox_size(Mailbox *mbox)
 {
     size_t result = 0;

--- a/src/libAtomVM/mailbox.c
+++ b/src/libAtomVM/mailbox.c
@@ -112,8 +112,8 @@ void mailbox_message_dispose(MailboxMessage *m, Heap *heap)
             break;
         }
         case ProcessInfoRequestSignal: {
-            struct BuiltInAtomRequestSignal *request_signal
-                = CONTAINER_OF(m, struct BuiltInAtomRequestSignal, base);
+            struct ProcessInfoRequestSignal *request_signal
+                = CONTAINER_OF(m, struct ProcessInfoRequestSignal, base);
             free(request_signal);
             break;
         }
@@ -293,19 +293,24 @@ void mailbox_send_immediate_signal(Context *c, enum MessageType type, term immed
     mailbox_post_message(c, &immediate_signal->base);
 }
 
-void mailbox_send_built_in_atom_request_signal(
-    Context *c, enum MessageType type, int32_t pid, term atom)
+void mailbox_send_process_info_request_signal(
+    Context *c, int32_t sender_pid, process_info_mode_t mode, const term *atoms, size_t len)
 {
-    struct BuiltInAtomRequestSignal *atom_request = malloc(sizeof(struct BuiltInAtomRequestSignal));
-    if (IS_NULL_PTR(atom_request)) {
+    struct ProcessInfoRequestSignal *signal = malloc(
+        sizeof(struct ProcessInfoRequestSignal) + len * sizeof(term));
+    if (IS_NULL_PTR(signal)) {
         fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
         return;
     }
-    atom_request->base.type = type;
-    atom_request->sender_pid = pid;
-    atom_request->atom = atom;
+    signal->base.type = ProcessInfoRequestSignal;
+    signal->sender_pid = sender_pid;
+    signal->mode = mode;
+    signal->len = len;
+    for (size_t i = 0; i < len; i++) {
+        signal->atoms[i] = atoms[i];
+    }
 
-    mailbox_post_message(c, &atom_request->base);
+    mailbox_post_message(c, &signal->base);
 }
 
 void mailbox_send_ref_signal(Context *c, enum MessageType type, uint64_t ref_ticks)

--- a/src/libAtomVM/mailbox.c
+++ b/src/libAtomVM/mailbox.c
@@ -293,14 +293,13 @@ void mailbox_send_immediate_signal(Context *c, enum MessageType type, term immed
     mailbox_post_message(c, &immediate_signal->base);
 }
 
-void mailbox_send_process_info_request_signal(
+bool mailbox_send_process_info_request_signal(
     Context *c, int32_t sender_pid, process_info_mode_t mode, const term *atoms, size_t len)
 {
     struct ProcessInfoRequestSignal *signal = malloc(
         sizeof(struct ProcessInfoRequestSignal) + len * sizeof(term));
     if (IS_NULL_PTR(signal)) {
-        fprintf(stderr, "Failed to allocate memory: %s:%i.\n", __FILE__, __LINE__);
-        return;
+        return false;
     }
     signal->base.type = ProcessInfoRequestSignal;
     signal->sender_pid = sender_pid;
@@ -311,6 +310,7 @@ void mailbox_send_process_info_request_signal(
     }
 
     mailbox_post_message(c, &signal->base);
+    return true;
 }
 
 void mailbox_send_ref_signal(Context *c, enum MessageType type, uint64_t ref_ticks)

--- a/src/libAtomVM/mailbox.c
+++ b/src/libAtomVM/mailbox.c
@@ -312,18 +312,18 @@ void mailbox_send_immediate_signal(Context *c, enum MessageType type, term immed
 }
 
 bool mailbox_send_process_info_request_signal(
-    Context *c, int32_t sender_pid, process_info_mode_t mode, const term *atoms, size_t len)
+    Context *c, int32_t sender_pid, process_info_mode_t mode, const term atoms[], size_t atoms_len)
 {
-    struct ProcessInfoRequestSignal *signal = malloc(
-        sizeof(struct ProcessInfoRequestSignal) + len * sizeof(term));
+    struct ProcessInfoRequestSignal *signal
+        = malloc(sizeof(struct ProcessInfoRequestSignal) + atoms_len * sizeof(term));
     if (IS_NULL_PTR(signal)) {
         return false;
     }
     signal->base.type = ProcessInfoRequestSignal;
     signal->sender_pid = sender_pid;
     signal->mode = mode;
-    signal->len = len;
-    for (size_t i = 0; i < len; i++) {
+    signal->atoms_len = atoms_len;
+    for (size_t i = 0; i < atoms_len; i++) {
         signal->atoms[i] = atoms[i];
     }
 

--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -140,8 +140,8 @@ struct ImmediateSignal
 
 typedef enum
 {
-    PROCESS_INFO_SINGLE,
-    PROCESS_INFO_LIST,
+    ProcessInfoSingle,
+    ProcessInfoList,
 } process_info_mode_t;
 
 struct ProcessInfoRequestSignal
@@ -150,7 +150,7 @@ struct ProcessInfoRequestSignal
 
     int32_t sender_pid;
     process_info_mode_t mode;
-    size_t len;
+    size_t atoms_len;
     term atoms[];
 };
 
@@ -289,12 +289,12 @@ void mailbox_send_immediate_signal(Context *c, enum MessageType type, term immed
  * @param sender_pid the sender of the signal (to get the answer)
  * @param mode whether the answer is a single item tuple or a list of them
  * @param atoms array of atom terms to query
- * @param len number of atoms in the array
+ * @param atoms_len number of atoms in the array
  * @return true if the signal was sent, false on allocation failure, in
  * which case no answer will ever be sent back
  */
 bool mailbox_send_process_info_request_signal(
-    Context *c, int32_t sender_pid, process_info_mode_t mode, const term *atoms, size_t len);
+    Context *c, int32_t sender_pid, process_info_mode_t mode, const term atoms[], size_t atoms_len);
 
 /**
  * @brief Sends a ref signal to a certain mailbox.

--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -275,11 +275,13 @@ void mailbox_send_immediate_signal(Context *c, enum MessageType type, term immed
  *
  * @param c the process context.
  * @param sender_pid the sender of the signal (to get the answer)
- * @param mode controls result shape and registered_name handling
+ * @param mode whether the answer is a single item tuple or a list of them
  * @param atoms array of atom terms to query
  * @param len number of atoms in the array
+ * @return true if the signal was sent, false on allocation failure, in
+ * which case no answer will ever be sent back
  */
-void mailbox_send_process_info_request_signal(
+bool mailbox_send_process_info_request_signal(
     Context *c, int32_t sender_pid, process_info_mode_t mode, const term *atoms, size_t len);
 
 /**

--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -138,12 +138,21 @@ struct ImmediateSignal
     term immediate;
 };
 
-struct BuiltInAtomRequestSignal
+typedef enum
+{
+    PROCESS_INFO_SINGLE,
+    PROCESS_INFO_LIST,
+    PROCESS_INFO_LIST_OMIT_UNREGISTERED,
+} process_info_mode_t;
+
+struct ProcessInfoRequestSignal
 {
     MailboxMessage base;
 
     int32_t sender_pid;
-    term atom;
+    process_info_mode_t mode;
+    size_t len;
+    term atoms[];
 };
 
 struct RefSignal
@@ -263,15 +272,16 @@ void mailbox_send_term_signal(Context *c, enum MessageType type, term t);
 void mailbox_send_immediate_signal(Context *c, enum MessageType type, term immediate);
 
 /**
- * @brief Sends a built-in atom-based request signal to a certain mailbox.
+ * @brief Sends a process info request signal to a certain mailbox.
  *
  * @param c the process context.
- * @param type the type of the signal
  * @param sender_pid the sender of the signal (to get the answer)
- * @param atom the built-in atom
+ * @param mode controls result shape and registered_name handling
+ * @param atoms array of atom terms to query
+ * @param len number of atoms in the array
  */
-void mailbox_send_built_in_atom_request_signal(
-    Context *c, enum MessageType type, int32_t sender_pid, term atom);
+void mailbox_send_process_info_request_signal(
+    Context *c, int32_t sender_pid, process_info_mode_t mode, const term *atoms, size_t len);
 
 /**
  * @brief Sends a ref signal to a certain mailbox.

--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -212,6 +212,18 @@ void mailbox_init(Mailbox *mbox);
 size_t mailbox_len(Mailbox *mbox);
 
 /**
+ * @brief Compute the number of queued messages in the mailbox, not counting
+ * signals.
+ *
+ * @details This is what message_queue_len reports: normal messages plus
+ * accepted alias messages not yet converted, which OTP counts as queued even
+ * if the alias is deactivated before reception. To be called from the process
+ * only.
+ * @param mbox the mailbox to get the number of messages of.
+ */
+size_t mailbox_normal_message_len(Mailbox *mbox);
+
+/**
  * @brief Compute the mailbox size, in bytes.
  *
  * @details To be called from the process only.

--- a/src/libAtomVM/mailbox.h
+++ b/src/libAtomVM/mailbox.h
@@ -142,7 +142,6 @@ typedef enum
 {
     PROCESS_INFO_SINGLE,
     PROCESS_INFO_LIST,
-    PROCESS_INFO_LIST_OMIT_UNREGISTERED,
 } process_info_mode_t;
 
 struct ProcessInfoRequestSignal

--- a/src/libAtomVM/memory.h
+++ b/src/libAtomVM/memory.h
@@ -129,6 +129,15 @@ typedef struct Heap Heap;
 void memory_init_heap_root_fragment(Heap *heap, HeapFragment *root, size_t size);
 
 /**
+ * @brief Largest heap capacity, in terms, that can be allocated.
+ *
+ * @details Allocating a heap multiplies the capacity by `sizeof(term)` and adds
+ * the fragment header, so a capacity computed from a size that callers can
+ * influence must be kept within this bound.
+ */
+#define MEMORY_HEAP_MAX_TERMS ((SIZE_MAX - sizeof(HeapFragment)) / sizeof(term))
+
+/**
  * @brief Initialize a root heap.
  *
  * @details This function should be balanced with `memory_destroy_heap` or

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3398,7 +3398,11 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
         } else {
             // Currently, all items require a signal. We could nevertheless filter
             // items that do not exist.
-            mailbox_send_process_info_request_signal(target, ctx->process_id, PROCESS_INFO_SINGLE, &item, 1);
+            if (UNLIKELY(!mailbox_send_process_info_request_signal(
+                    target, ctx->process_id, PROCESS_INFO_SINGLE, &item, 1))) {
+                globalcontext_get_process_unlock(ctx->global, target);
+                RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            }
             context_update_flags(ctx, ~NoFlags, Trap);
         }
         globalcontext_get_process_unlock(ctx->global, target);
@@ -3427,8 +3431,12 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
     size_t items_len = list_len;
 
     if (ctx != target) {
-        mailbox_send_process_info_request_signal(
-            target, ctx->process_id, PROCESS_INFO_LIST, items, items_len);
+        if (UNLIKELY(!mailbox_send_process_info_request_signal(
+                target, ctx->process_id, PROCESS_INFO_LIST, items, items_len))) {
+            free(items_alloc);
+            globalcontext_get_process_unlock(ctx->global, target);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
         context_update_flags(ctx, ~NoFlags, Trap);
         free(items_alloc);
         globalcontext_get_process_unlock(ctx->global, target);
@@ -3443,6 +3451,12 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
             free(items_alloc);
             globalcontext_get_process_unlock(ctx->global, target);
             RAISE_ERROR(BADARG_ATOM);
+        }
+        if (UNLIKELY(item_size > MEMORY_HEAP_MAX_TERMS - CONS_SIZE
+                || item_size + CONS_SIZE > MEMORY_HEAP_MAX_TERMS - total_size)) {
+            free(items_alloc);
+            globalcontext_get_process_unlock(ctx->global, target);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         total_size += item_size + CONS_SIZE;
     }

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3340,9 +3340,31 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
     UNUSED(argc);
 
     term pid = argv[0];
+    VALIDATE_VALUE(pid, term_is_local_pid);
 
-    if (!term_is_pid(pid)) {
-        RAISE_ERROR(BADARG_ATOM);
+    // OTP compatibility: the second argument is validated before the target
+    // aliveness is considered, so a dead pid with an invalid argument is a
+    // badarg, not undefined.
+    size_t list_len = 0;
+    if (!term_is_list(argv[1])) {
+        // NOLINT(allocations-without-ensure-free) called with NULL heap, only checks item validity
+        if (UNLIKELY(!term_is_atom(argv[1])
+                || !context_get_process_info(ctx, NULL, NULL, argv[1], NULL))) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
+    } else {
+        term l = argv[1];
+        for (; term_is_nonempty_list(l); l = term_get_list_tail(l), list_len++) {
+            term item = term_get_list_head(l);
+            // NOLINT(allocations-without-ensure-free) called with NULL heap, only checks item validity
+            if (UNLIKELY(!term_is_atom(item)
+                    || !context_get_process_info(ctx, NULL, NULL, item, NULL))) {
+                RAISE_ERROR(BADARG_ATOM);
+            }
+        }
+        if (UNLIKELY(!term_is_nil(l))) {
+            RAISE_ERROR(BADARG_ATOM);
+        }
     }
 
     int local_process_id = term_to_local_process_id(pid);
@@ -3352,14 +3374,11 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
     }
 
     if (!term_is_list(argv[1])) {
-        if (!term_is_atom(argv[1])) {
-            globalcontext_get_process_unlock(ctx->global, target);
-            RAISE_ERROR(BADARG_ATOM);
-        }
         term item = argv[1];
         term ret = term_invalid_term();
         if (ctx == target) {
             size_t term_size;
+            // NOLINT(allocations-without-ensure-free) called with NULL heap, only computes size
             if (UNLIKELY(!context_get_process_info(ctx, NULL, &term_size, item, NULL))) {
                 globalcontext_get_process_unlock(ctx->global, target);
                 RAISE_ERROR(BADARG_ATOM);
@@ -3387,20 +3406,6 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
     }
 
     term item_list = argv[1];
-    size_t list_len = 0;
-    term l = item_list;
-
-    for (; term_is_nonempty_list(l); l = term_get_list_tail(l), list_len++) {
-        if (UNLIKELY(!term_is_atom(term_get_list_head(l)))) {
-            globalcontext_get_process_unlock(ctx->global, target);
-            RAISE_ERROR(BADARG_ATOM);
-        }
-    }
-
-    if (UNLIKELY(!term_is_nil(l))) {
-        globalcontext_get_process_unlock(ctx->global, target);
-        RAISE_ERROR(BADARG_ATOM);
-    }
 
     if (list_len == 0) {
         globalcontext_get_process_unlock(ctx->global, target);
@@ -3412,7 +3417,7 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
         globalcontext_get_process_unlock(ctx->global, target);
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
-    l = item_list;
+    term l = item_list;
     for (size_t i = 0; i < list_len; i++) {
         items_alloc[i] = term_get_list_head(l);
         l = term_get_list_tail(l);
@@ -3433,6 +3438,7 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
     size_t total_size = 0;
     for (size_t i = 0; i < items_len; i++) {
         size_t item_size;
+        // NOLINT(allocations-without-ensure-free) called with NULL heap, only computes size
         if (UNLIKELY(!context_get_process_info(ctx, NULL, &item_size, items[i], NULL))) {
             free(items_alloc);
             globalcontext_get_process_unlock(ctx->global, target);

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3347,18 +3347,13 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
     // badarg, not undefined.
     size_t list_len = 0;
     if (!term_is_list(argv[1])) {
-        // NOLINT(allocations-without-ensure-free) NULL heap call, only checks item validity
-        if (UNLIKELY(!term_is_atom(argv[1])
-                || !context_get_process_info(ctx, NULL, NULL, argv[1], NULL))) {
+        if (UNLIKELY(!context_is_valid_process_info_key(argv[1]))) {
             RAISE_ERROR(BADARG_ATOM);
         }
     } else {
         term l = argv[1];
         for (; term_is_nonempty_list(l); l = term_get_list_tail(l), list_len++) {
-            term item = term_get_list_head(l);
-            // NOLINT(allocations-without-ensure-free) NULL heap call, only checks item validity
-            if (UNLIKELY(!term_is_atom(item)
-                    || !context_get_process_info(ctx, NULL, NULL, item, NULL))) {
+            if (UNLIKELY(!context_is_valid_process_info_key(term_get_list_head(l)))) {
                 RAISE_ERROR(BADARG_ATOM);
             }
         }

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3347,7 +3347,7 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
     // badarg, not undefined.
     size_t list_len = 0;
     if (!term_is_list(argv[1])) {
-        // NOLINT(allocations-without-ensure-free) called with NULL heap, only checks item validity
+        // NOLINT(allocations-without-ensure-free) NULL heap call, only checks item validity
         if (UNLIKELY(!term_is_atom(argv[1])
                 || !context_get_process_info(ctx, NULL, NULL, argv[1], NULL))) {
             RAISE_ERROR(BADARG_ATOM);
@@ -3356,7 +3356,7 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
         term l = argv[1];
         for (; term_is_nonempty_list(l); l = term_get_list_tail(l), list_len++) {
             term item = term_get_list_head(l);
-            // NOLINT(allocations-without-ensure-free) called with NULL heap, only checks item validity
+            // NOLINT(allocations-without-ensure-free) NULL heap call, only checks item validity
             if (UNLIKELY(!term_is_atom(item)
                     || !context_get_process_info(ctx, NULL, NULL, item, NULL))) {
                 RAISE_ERROR(BADARG_ATOM);
@@ -3378,12 +3378,13 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
         term ret = term_invalid_term();
         if (ctx == target) {
             size_t term_size;
-            // NOLINT(allocations-without-ensure-free) called with NULL heap, only computes size
+            // NOLINT(allocations-without-ensure-free) NULL heap call, only computes size
             if (UNLIKELY(!context_get_process_info(ctx, NULL, &term_size, item, NULL))) {
                 globalcontext_get_process_unlock(ctx->global, target);
                 RAISE_ERROR(BADARG_ATOM);
             }
-            if (UNLIKELY(memory_ensure_free_opt(ctx, term_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            if (UNLIKELY(
+                    memory_ensure_free_opt(ctx, term_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
                 globalcontext_get_process_unlock(ctx->global, target);
                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
             }
@@ -3391,15 +3392,13 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
                 globalcontext_get_process_unlock(ctx->global, target);
                 RAISE_ERROR(ret);
             }
-            // return [] when unregistered (BEAM backward compatibility)
+            // return [] when unregistered (BEAM compatibility)
             if (item == REGISTERED_NAME_ATOM && term_is_nil(term_get_tuple_element(ret, 1))) {
                 ret = term_nil();
             }
         } else {
-            // Currently, all items require a signal. We could nevertheless filter
-            // items that do not exist.
             if (UNLIKELY(!mailbox_send_process_info_request_signal(
-                    target, ctx->process_id, PROCESS_INFO_SINGLE, &item, 1))) {
+                    target, ctx->process_id, ProcessInfoSingle, &item, 1))) {
                 globalcontext_get_process_unlock(ctx->global, target);
                 RAISE_ERROR(OUT_OF_MEMORY_ATOM);
             }
@@ -3432,7 +3431,7 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
 
     if (ctx != target) {
         if (UNLIKELY(!mailbox_send_process_info_request_signal(
-                target, ctx->process_id, PROCESS_INFO_LIST, items, items_len))) {
+                target, ctx->process_id, ProcessInfoList, items, items_len))) {
             free(items_alloc);
             globalcontext_get_process_unlock(ctx->global, target);
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
@@ -3446,7 +3445,7 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
     size_t total_size = 0;
     for (size_t i = 0; i < items_len; i++) {
         size_t item_size;
-        // NOLINT(allocations-without-ensure-free) called with NULL heap, only computes size
+        // NOLINT(allocations-without-ensure-free) NULL heap call, only computes size
         if (UNLIKELY(!context_get_process_info(ctx, NULL, &item_size, items[i], NULL))) {
             free(items_alloc);
             globalcontext_get_process_unlock(ctx->global, target);
@@ -3469,7 +3468,7 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
 
     // Atoms in `items` are immediate, safe after GC
     term ret = term_nil();
-    for (ssize_t i = (ssize_t) items_len - 1; i >= 0; i--) {
+    for (size_t i = items_len; i-- > 0;) {
         term item_result;
         if (UNLIKELY(!context_get_process_info(ctx, &item_result, NULL, items[i], &ctx->heap))) {
             free(items_alloc);

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3337,17 +3337,11 @@ static term nif_erlang_processes(Context *ctx, int argc, term argv[])
 
 static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
 {
-    UNUSED(argc);
-
     term pid = argv[0];
-    term item_or_item_info = argv[1];
 
-    if (!term_is_atom(item_or_item_info)) {
+    if (!term_is_pid(pid)) {
         RAISE_ERROR(BADARG_ATOM);
     }
-    // TODO add support for process_info/1
-    // and process_info/2 when second argument is a list
-    term item = item_or_item_info;
 
     int local_process_id = term_to_local_process_id(pid);
     Context *target = globalcontext_get_process_lock(ctx->global, local_process_id);
@@ -3355,30 +3349,145 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
         return UNDEFINED_ATOM;
     }
 
-    term ret = term_invalid_term();
-    if (ctx == target) {
-        size_t term_size;
-        // NOLINT(allocations-without-ensure-free) called with NULL heap, only computes size
-        if (UNLIKELY(!context_get_process_info(ctx, NULL, &term_size, item, NULL))) {
+    if (argc == 2 && !term_is_list(argv[1])) {
+        if (!term_is_atom(argv[1])) {
             globalcontext_get_process_unlock(ctx->global, target);
             RAISE_ERROR(BADARG_ATOM);
         }
-        if (UNLIKELY(memory_ensure_free_opt(ctx, term_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        term item = argv[1];
+        term ret = term_invalid_term();
+        if (ctx == target) {
+            size_t term_size;
+            if (UNLIKELY(!context_get_process_info(ctx, NULL, &term_size, item, NULL))) {
+                globalcontext_get_process_unlock(ctx->global, target);
+                RAISE_ERROR(BADARG_ATOM);
+            }
+            if (UNLIKELY(memory_ensure_free_opt(ctx, term_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+                globalcontext_get_process_unlock(ctx->global, target);
+                RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+            }
+            if (UNLIKELY(!context_get_process_info(ctx, &ret, NULL, item, &ctx->heap))) {
+                globalcontext_get_process_unlock(ctx->global, target);
+                RAISE_ERROR(ret);
+            }
+            // return [] when unregistered (BEAM backward compatibility)
+            if (item == REGISTERED_NAME_ATOM && term_is_nil(term_get_tuple_element(ret, 1))) {
+                ret = term_nil();
+            }
+        } else {
+            // Currently, all items require a signal. We could nevertheless filter
+            // items that do not exist.
+            mailbox_send_process_info_request_signal(target, ctx->process_id, PROCESS_INFO_SINGLE, &item, 1);
+            context_update_flags(ctx, ~NoFlags, Trap);
+        }
+        globalcontext_get_process_unlock(ctx->global, target);
+        return ret;
+    }
+
+    static const term default_items[] = {
+        REGISTERED_NAME_ATOM,
+        MESSAGE_QUEUE_LEN_ATOM,
+        LINKS_ATOM,
+        TRAP_EXIT_ATOM,
+        TOTAL_HEAP_SIZE_ATOM,
+        HEAP_SIZE_ATOM,
+        STACK_SIZE_ATOM,
+    };
+
+    const term *items;
+    size_t items_len;
+    term *items_alloc = NULL;
+    bool omit_unregistered;
+    process_info_mode_t signal_mode;
+
+    if (argc == 1) {
+        items = default_items;
+        items_len = sizeof(default_items) / sizeof(default_items[0]);
+        omit_unregistered = true;
+        signal_mode = PROCESS_INFO_LIST_OMIT_UNREGISTERED;
+    } else {
+        term item_list = argv[1];
+        size_t list_len = 0;
+        term l = item_list;
+
+        for (; term_is_nonempty_list(l); l = term_get_list_tail(l), list_len++) {
+            if (UNLIKELY(!term_is_atom(term_get_list_head(l)))) {
+                globalcontext_get_process_unlock(ctx->global, target);
+                RAISE_ERROR(BADARG_ATOM);
+            }
+        }
+
+        if (UNLIKELY(!term_is_nil(l))) {
+            globalcontext_get_process_unlock(ctx->global, target);
+            RAISE_ERROR(BADARG_ATOM);
+        }
+
+        if (list_len == 0) {
+            globalcontext_get_process_unlock(ctx->global, target);
+            return term_nil();
+        }
+
+        items_alloc = malloc(list_len * sizeof(term));
+        if (IS_NULL_PTR(items_alloc)) {
             globalcontext_get_process_unlock(ctx->global, target);
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
-        if (UNLIKELY(!context_get_process_info(ctx, &ret, NULL, item, &ctx->heap))) {
-            globalcontext_get_process_unlock(ctx->global, target);
-            RAISE_ERROR(ret);
+        l = item_list;
+        for (size_t i = 0; i < list_len; i++) {
+            items_alloc[i] = term_get_list_head(l);
+            l = term_get_list_tail(l);
         }
-    } else {
-        // Currently, all items require a signal. We could nevertheless filter
-        // items that do not exist.
-        mailbox_send_built_in_atom_request_signal(target, ProcessInfoRequestSignal, ctx->process_id, item);
-        context_update_flags(ctx, ~NoFlags, Trap);
-    }
-    globalcontext_get_process_unlock(ctx->global, target);
 
+        items = items_alloc;
+        items_len = list_len;
+        omit_unregistered = false;
+        signal_mode = PROCESS_INFO_LIST;
+    }
+
+    if (ctx != target) {
+        mailbox_send_process_info_request_signal(target, ctx->process_id, signal_mode, items, items_len);
+        context_update_flags(ctx, ~NoFlags, Trap);
+        free(items_alloc);
+        globalcontext_get_process_unlock(ctx->global, target);
+        return term_invalid_term();
+    }
+
+    size_t total_size = 0;
+    for (size_t i = 0; i < items_len; i++) {
+        size_t item_size;
+        if (UNLIKELY(!context_get_process_info(ctx, NULL, &item_size, items[i], NULL))) {
+            free(items_alloc);
+            globalcontext_get_process_unlock(ctx->global, target);
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        total_size += item_size + CONS_SIZE;
+    }
+
+    if (UNLIKELY(memory_ensure_free_opt(ctx, total_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        free(items_alloc);
+        globalcontext_get_process_unlock(ctx->global, target);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    // Atoms in `items` are immediate, safe after GC
+    term ret = term_nil();
+    for (ssize_t i = (ssize_t) items_len - 1; i >= 0; i--) {
+        term item_result;
+        if (UNLIKELY(!context_get_process_info(ctx, &item_result, NULL, items[i], &ctx->heap))) {
+            free(items_alloc);
+            globalcontext_get_process_unlock(ctx->global, target);
+            RAISE_ERROR(item_result);
+        }
+
+        if (omit_unregistered && items[i] == REGISTERED_NAME_ATOM && term_is_nil(term_get_tuple_element(item_result, 1))) {
+            continue;
+        }
+
+        ret = term_list_prepend(item_result, ret, &ctx->heap);
+    }
+
+    free(items_alloc);
+    globalcontext_get_process_unlock(ctx->global, target);
     return ret;
 }
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3337,6 +3337,8 @@ static term nif_erlang_processes(Context *ctx, int argc, term argv[])
 
 static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
 {
+    UNUSED(argc);
+
     term pid = argv[0];
 
     if (!term_is_pid(pid)) {
@@ -3349,7 +3351,7 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
         return UNDEFINED_ATOM;
     }
 
-    if (argc == 2 && !term_is_list(argv[1])) {
+    if (!term_is_list(argv[1])) {
         if (!term_is_atom(argv[1])) {
             globalcontext_get_process_unlock(ctx->global, target);
             RAISE_ERROR(BADARG_ATOM);
@@ -3384,68 +3386,44 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
         return ret;
     }
 
-    static const term default_items[] = {
-        REGISTERED_NAME_ATOM,
-        MESSAGE_QUEUE_LEN_ATOM,
-        LINKS_ATOM,
-        TRAP_EXIT_ATOM,
-        TOTAL_HEAP_SIZE_ATOM,
-        HEAP_SIZE_ATOM,
-        STACK_SIZE_ATOM,
-    };
+    term item_list = argv[1];
+    size_t list_len = 0;
+    term l = item_list;
 
-    const term *items;
-    size_t items_len;
-    term *items_alloc = NULL;
-    bool omit_unregistered;
-    process_info_mode_t signal_mode;
-
-    if (argc == 1) {
-        items = default_items;
-        items_len = sizeof(default_items) / sizeof(default_items[0]);
-        omit_unregistered = true;
-        signal_mode = PROCESS_INFO_LIST_OMIT_UNREGISTERED;
-    } else {
-        term item_list = argv[1];
-        size_t list_len = 0;
-        term l = item_list;
-
-        for (; term_is_nonempty_list(l); l = term_get_list_tail(l), list_len++) {
-            if (UNLIKELY(!term_is_atom(term_get_list_head(l)))) {
-                globalcontext_get_process_unlock(ctx->global, target);
-                RAISE_ERROR(BADARG_ATOM);
-            }
-        }
-
-        if (UNLIKELY(!term_is_nil(l))) {
+    for (; term_is_nonempty_list(l); l = term_get_list_tail(l), list_len++) {
+        if (UNLIKELY(!term_is_atom(term_get_list_head(l)))) {
             globalcontext_get_process_unlock(ctx->global, target);
             RAISE_ERROR(BADARG_ATOM);
         }
-
-        if (list_len == 0) {
-            globalcontext_get_process_unlock(ctx->global, target);
-            return term_nil();
-        }
-
-        items_alloc = malloc(list_len * sizeof(term));
-        if (IS_NULL_PTR(items_alloc)) {
-            globalcontext_get_process_unlock(ctx->global, target);
-            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-        }
-        l = item_list;
-        for (size_t i = 0; i < list_len; i++) {
-            items_alloc[i] = term_get_list_head(l);
-            l = term_get_list_tail(l);
-        }
-
-        items = items_alloc;
-        items_len = list_len;
-        omit_unregistered = false;
-        signal_mode = PROCESS_INFO_LIST;
     }
 
+    if (UNLIKELY(!term_is_nil(l))) {
+        globalcontext_get_process_unlock(ctx->global, target);
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    if (list_len == 0) {
+        globalcontext_get_process_unlock(ctx->global, target);
+        return term_nil();
+    }
+
+    term *items_alloc = malloc(list_len * sizeof(term));
+    if (IS_NULL_PTR(items_alloc)) {
+        globalcontext_get_process_unlock(ctx->global, target);
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    l = item_list;
+    for (size_t i = 0; i < list_len; i++) {
+        items_alloc[i] = term_get_list_head(l);
+        l = term_get_list_tail(l);
+    }
+
+    const term *items = items_alloc;
+    size_t items_len = list_len;
+
     if (ctx != target) {
-        mailbox_send_process_info_request_signal(target, ctx->process_id, signal_mode, items, items_len);
+        mailbox_send_process_info_request_signal(
+            target, ctx->process_id, PROCESS_INFO_LIST, items, items_len);
         context_update_flags(ctx, ~NoFlags, Trap);
         free(items_alloc);
         globalcontext_get_process_unlock(ctx->global, target);
@@ -3477,10 +3455,6 @@ static term nif_erlang_process_info(Context *ctx, int argc, term argv[])
             free(items_alloc);
             globalcontext_get_process_unlock(ctx->global, target);
             RAISE_ERROR(item_result);
-        }
-
-        if (omit_unregistered && items[i] == REGISTERED_NAME_ATOM && term_is_nil(term_get_tuple_element(item_result, 1))) {
-            continue;
         }
 
         ret = term_list_prepend(item_result, ret, &ctx->heap);

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -129,7 +129,6 @@ erlang:timestamp/0, &timestamp_nif
 erlang:process_flag/2, &process_flag_nif
 erlang:process_flag/3, &process_flag_nif
 erlang:processes/0, &processes_nif
-erlang:process_info/1, &process_info_nif
 erlang:process_info/2, &process_info_nif
 erlang:get/0, &get_0_nif
 erlang:put/2, &put_nif

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -129,6 +129,7 @@ erlang:timestamp/0, &timestamp_nif
 erlang:process_flag/2, &process_flag_nif
 erlang:process_flag/3, &process_flag_nif
 erlang:processes/0, &processes_nif
+erlang:process_info/1, &process_info_nif
 erlang:process_info/2, &process_info_nif
 erlang:get/0, &get_0_nif
 erlang:put/2, &put_nif

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -807,8 +807,8 @@ static void destroy_extended_registers(Context *ctx, unsigned int live)
                     break;                                                                      \
                 }                                                                               \
                 case ProcessInfoRequestSignal: {                                                \
-                    struct BuiltInAtomRequestSignal *request_signal                             \
-                        = CONTAINER_OF(signal_message, struct BuiltInAtomRequestSignal, base);  \
+                    struct ProcessInfoRequestSignal *request_signal                             \
+                        = CONTAINER_OF(signal_message, struct ProcessInfoRequestSignal, base);  \
                     context_process_process_info_request_signal(ctx, request_signal, false);    \
                     break;                                                                      \
                 }                                                                               \

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -824,6 +824,7 @@ static void destroy_extended_registers(Context *ctx, unsigned int live)
                 case TrapExceptionSignal: {                                                     \
                     struct ImmediateSignal *trap_exception                                      \
                         = CONTAINER_OF(signal_message, struct ImmediateSignal, base);           \
+                    context_update_flags(ctx, ~Trap, NoFlags);                                  \
                     SET_ERROR(trap_exception->immediate);                                       \
                     handle_error = true;                                                        \
                     break;                                                                      \

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -815,10 +815,7 @@ static void destroy_extended_registers(Context *ctx, unsigned int live)
                 case TrapAnswerSignal: {                                                        \
                     struct TermSignal *trap_answer                                              \
                         = CONTAINER_OF(signal_message, struct TermSignal, base);                \
-                    if (UNLIKELY(!context_process_signal_trap_answer(ctx, trap_answer))) {      \
-                        SET_ERROR(OUT_OF_MEMORY_ATOM);                                          \
-                        handle_error = true;                                                    \
-                    }                                                                           \
+                    context_process_signal_trap_answer(ctx, trap_answer);                       \
                     break;                                                                      \
                 }                                                                               \
                 case TrapExceptionSignal: {                                                     \

--- a/src/libAtomVM/scheduler.c
+++ b/src/libAtomVM/scheduler.c
@@ -90,8 +90,8 @@ static void scheduler_process_native_signal_messages(Context *ctx)
                 break;
             }
             case ProcessInfoRequestSignal: {
-                struct BuiltInAtomRequestSignal *request_signal
-                    = CONTAINER_OF(signal_message, struct BuiltInAtomRequestSignal, base);
+                struct ProcessInfoRequestSignal *request_signal
+                    = CONTAINER_OF(signal_message, struct ProcessInfoRequestSignal, base);
                 context_process_process_info_request_signal(ctx, request_signal, false);
                 break;
             }

--- a/tests/erlang_tests/test_process_info.erl
+++ b/tests/erlang_tests/test_process_info.erl
@@ -23,74 +23,22 @@
 -export([start/0, loop/2]).
 
 start() ->
-    Self = self(),
-    {Pid, Ref} = spawn_opt(?MODULE, loop, [Self, []], [monitor]),
-    receive
-        ok -> ok
-    end,
-    [] = erlang:process_info(Self, registered_name),
-    erlang:register(has_name, Self),
-    {registered_name, Name} = erlang:process_info(Self, registered_name),
-    assert(Name =:= has_name),
-    erlang:unregister(has_name),
-    [] = erlang:process_info(Self, registered_name),
-    test_message_queue_len(Pid, Self),
-    {links, []} = process_info(Pid, links),
-    link(Pid),
-    {links, [Self]} = process_info(Pid, links),
-    unlink(Pid),
-    {links, []} = process_info(Pid, links),
-    Monitor = monitor(process, Pid),
-    % Twice because of spawn_opt above
-    {monitored_by, [Self, Self]} = process_info(Pid, monitored_by),
-    demonitor(Monitor),
-    {monitored_by, [Self]} = process_info(Pid, monitored_by),
-    Pid ! {Self, stop},
-    _Accum =
-        receive
-            {Pid, result, X} -> X
-        end,
-    normal =
-        receive
-            {'DOWN', Ref, process, Pid, Reason} -> Reason
-        end,
-    MessageQueueLen = process_info(Pid, message_queue_len),
-    MessageQueueLen = undefined,
-    ok = test_process_info_memory_other(),
+    ok = test_process_info_1(),
+
+    ok = test_registered_name(),
+    ok = test_heap_size(),
+    ok = test_memory(),
+    ok = test_total_heap_size(),
+    ok = test_message_queue_len(),
+    ok = test_links(),
+    ok = test_monitored_by(),
+
+    ok = test_list_semantics(),
+    ok = test_badargs(),
+
     0.
 
-test_message_queue_len(Pid, Self) ->
-    {message_queue_len, MessageQueueLen} = process_info(Pid, message_queue_len),
-    {memory, Memory} = process_info(Pid, memory),
-    {heap_size, HeapSize} = process_info(Pid, heap_size),
-    {total_heap_size, TotalHeapSize} = process_info(Pid, total_heap_size),
-    Pid ! incr,
-    Pid ! incr,
-    Pid ! incr,
-    {message_queue_len, MessageQueueLen2} = process_info(Pid, message_queue_len),
-    {memory, Memory2} = process_info(Pid, memory),
-    Pid ! unlock,
-    Pid ! {Self, ping},
-    receive
-        pong -> ok
-    end,
-    {total_heap_size, TotalHeapSize2} = process_info(Pid, total_heap_size),
-    {heap_size, HeapSize2} = process_info(Pid, heap_size),
-    true = MessageQueueLen < MessageQueueLen2,
-    case erlang:system_info(machine) of
-        "BEAM" ->
-            true = Memory =< Memory2,
-            true = HeapSize =< TotalHeapSize,
-            true = HeapSize2 =< TotalHeapSize2,
-            true = TotalHeapSize =< TotalHeapSize2;
-        _ ->
-            true = Memory < Memory2,
-            true = HeapSize =< TotalHeapSize,
-            true = HeapSize2 =< TotalHeapSize2,
-            true = TotalHeapSize =< TotalHeapSize2
-    end.
-
-test_process_info_memory_other() ->
+with_other_pid(Fun) ->
     {Pid, Ref} = spawn_opt(
         fun() ->
             receive
@@ -99,20 +47,259 @@ test_process_info_memory_other() ->
         end,
         [monitor]
     ),
-    {total_heap_size, THS0} = process_info(Pid, total_heap_size),
-    test_process_info_memory_other_loop(Pid, THS0, 50),
+    Fun(Pid),
+    Pid ! quit,
+    normal =
+        receive
+            {'DOWN', Ref, process, Pid, Reason} -> Reason
+        end.
+
+with_dead_pid(Fun) ->
+    {DeadPid, Ref} = spawn_opt(fun() -> ok end, [monitor]),
+    normal =
+        receive
+            {'DOWN', Ref, process, DeadPid, Reason} -> Reason
+        end,
+    Fun(DeadPid).
+
+get_item(Pid, Item) ->
+    {Item, Val} = process_info(Pid, Item),
+    [{Item, Val}] = process_info(Pid, [Item]),
+    Val.
+
+test_process_info_1() ->
+    Check = fun(Pid) ->
+        Info = process_info(Pid),
+        true = is_list(Info),
+
+        {heap_size, HS} = lists:keyfind(heap_size, 1, Info),
+        true = is_integer(HS) andalso HS > 0,
+
+        {total_heap_size, THS} = lists:keyfind(total_heap_size, 1, Info),
+        true = THS >= HS,
+
+        {stack_size, SS} = lists:keyfind(stack_size, 1, Info),
+        true = is_integer(SS) andalso SS >= 0,
+
+        {message_queue_len, MQL} = lists:keyfind(message_queue_len, 1, Info),
+        true = is_integer(MQL) andalso MQL >= 0,
+
+        {links, Links} = lists:keyfind(links, 1, Info),
+        true = is_list(Links),
+
+        {trap_exit, TE} = lists:keyfind(trap_exit, 1, Info),
+        true = is_boolean(TE),
+
+        false = lists:keyfind(registered_name, 1, Info)
+    end,
+
+    Check(self()),
+    % with_other_pid(Check),
+
+    with_dead_pid(fun(DeadPid) ->
+        undefined = process_info(DeadPid)
+    end),
+
+    ok.
+
+test_registered_name() ->
+    Check = fun(Pid) ->
+        [] = process_info(Pid, registered_name),
+        [{registered_name, []}] = process_info(Pid, [registered_name]),
+
+        erlang:register(has_name, Pid),
+        has_name = get_item(Pid, registered_name),
+
+        erlang:unregister(has_name),
+        [] = process_info(Pid, registered_name),
+        [{registered_name, []}] = process_info(Pid, [registered_name])
+    end,
+
+    Check(self()),
+    with_other_pid(Check),
+
+    ok.
+
+test_heap_size() ->
+    Self = self(),
+    HS = get_item(Self, heap_size),
+    true = is_integer(HS) andalso HS > 0,
+
+    with_other_pid(fun(Pid) ->
+        HS2 = get_item(Pid, heap_size),
+        true = is_integer(HS2) andalso HS2 > 0
+    end),
+
+    with_dead_pid(fun(DeadPid) ->
+        undefined = process_info(DeadPid, heap_size)
+    end),
+
+    ok.
+
+test_memory() ->
+    Self = self(),
+    M = get_item(Self, memory),
+    true = is_integer(M) andalso M > 0,
+
+    with_other_pid(fun(Pid) ->
+        M2 = get_item(Pid, memory),
+        true = is_integer(M2) andalso M2 > 0
+    end),
+
+    with_dead_pid(fun(DeadPid) ->
+        undefined = process_info(DeadPid, memory)
+    end),
+
+    ok.
+
+test_total_heap_size() ->
+    Self = self(),
+    HS = get_item(Self, heap_size),
+    THS = get_item(Self, total_heap_size),
+    true = HS =< THS,
+
+    with_other_pid(fun(Pid) ->
+        HS2 = get_item(Pid, heap_size),
+        THS2 = get_item(Pid, total_heap_size),
+        true = HS2 =< THS2,
+        verify_stable_total_heap_size(Pid, THS2, 50)
+    end),
+
+    with_dead_pid(fun(DeadPid) ->
+        undefined = process_info(DeadPid, total_heap_size)
+    end),
+
+    ok.
+
+verify_stable_total_heap_size(_Pid, _THS, 0) ->
+    ok;
+verify_stable_total_heap_size(Pid, THS, N) ->
+    {total_heap_size, THS} = process_info(Pid, total_heap_size),
+    verify_stable_total_heap_size(Pid, THS, N - 1).
+
+test_message_queue_len() ->
+    Self = self(),
+    {Pid, Ref} = spawn_opt(?MODULE, loop, [Self, []], [monitor]),
+    receive
+        ok -> ok
+    end,
+
+    Q0 = get_item(Pid, message_queue_len),
+
+    Pid ! incr,
+    Pid ! incr,
+    Pid ! incr,
+
+    Q1 = get_item(Pid, message_queue_len),
+    true = Q0 < Q1,
+
+    Pid ! unlock,
+    Pid ! {Self, ping},
+    receive
+        pong -> ok
+    end,
+    Q2 = get_item(Pid, message_queue_len),
+    true = Q2 < Q1,
+
+    Pid ! {Self, stop},
+    receive
+        {Pid, result, _} -> ok
+    end,
+    normal =
+        receive
+            {'DOWN', Ref, process, Pid, Reason} -> Reason
+        end,
+
+    undefined = process_info(Pid, message_queue_len),
+
+    ok.
+
+test_links() ->
+    Self = self(),
+
+    with_other_pid(fun(Pid) ->
+        [] = get_item(Pid, links),
+
+        link(Pid),
+        [Self] = get_item(Pid, links),
+
+        unlink(Pid),
+        [] = get_item(Pid, links)
+    end),
+
+    ok.
+
+test_monitored_by() ->
+    Self = self(),
+    [] = get_item(Self, monitored_by),
+
+    {Pid, Ref} = spawn_opt(
+        fun() ->
+            receive
+                quit -> ok
+            end
+        end,
+        [monitor]
+    ),
+
+    % spawn_opt with [monitor] counts as one monitor from Self
+    [Self] = get_item(Pid, monitored_by),
+
+    Mon = monitor(process, Pid),
+    [Self, Self] = get_item(Pid, monitored_by),
+
+    demonitor(Mon),
+    [Self] = get_item(Pid, monitored_by),
+
     Pid ! quit,
     normal =
         receive
             {'DOWN', Ref, process, Pid, Reason} -> Reason
         end,
+
     ok.
 
-test_process_info_memory_other_loop(_Pid, _THS0, 0) ->
-    ok;
-test_process_info_memory_other_loop(Pid, THS0, N) ->
-    {total_heap_size, THS0} = process_info(Pid, total_heap_size),
-    test_process_info_memory_other_loop(Pid, THS0, N - 1).
+test_list_semantics() ->
+    Self = self(),
+
+    [] = process_info(Self, []),
+
+    [{heap_size, _}, {memory, _}] = process_info(Self, [heap_size, memory]),
+    [{memory, _}, {heap_size, _}] = process_info(Self, [memory, heap_size]),
+
+    [{total_heap_size, THS}, {total_heap_size, THS}] =
+        process_info(Self, [total_heap_size, total_heap_size]),
+
+    with_other_pid(fun(Pid) ->
+        [] = process_info(Pid, []),
+        [{message_queue_len, _}, {heap_size, _}, {memory, _}] =
+            process_info(Pid, [message_queue_len, heap_size, memory])
+    end),
+
+    with_dead_pid(fun(DeadPid) ->
+        undefined = process_info(DeadPid, []),
+        undefined = process_info(DeadPid, [heap_size]),
+        undefined = process_info(DeadPid, [heap_size, memory])
+    end),
+
+    ok.
+
+test_badargs() ->
+    Self = self(),
+
+    assert_badarg(fun() -> process_info(bad_pid) end),
+    assert_badarg(fun() -> process_info(bad_pid, heap_size) end),
+    assert_badarg(fun() -> process_info(Self, bad_item) end),
+
+    assert_badarg(fun() -> process_info(Self, 42) end),
+    assert_badarg(fun() -> process_info(Self, {heap_size}) end),
+
+    assert_badarg(fun() -> process_info(bad_pid, [heap_size]) end),
+    assert_badarg(fun() -> process_info(Self, [heap_size, 42]) end),
+    assert_badarg(fun() -> process_info(Self, [heap_size, invalid_key]) end),
+    assert_badarg(fun() -> process_info(Self, [heap_size | not_a_list]) end),
+
+    ok.
 
 loop(undefined, Accum) ->
     receive
@@ -132,4 +319,13 @@ loop(Pid, Accum) ->
     Pid ! ok,
     loop(locked, Accum).
 
-assert(true) -> ok.
+assert_badarg(Fun) ->
+    try
+        Fun(),
+        erlang:error(no_throw)
+    catch
+        error:badarg ->
+            ok;
+        OtherClass:OtherError ->
+            erlang:error({OtherClass, OtherError})
+    end.

--- a/tests/erlang_tests/test_process_info.erl
+++ b/tests/erlang_tests/test_process_info.erl
@@ -22,9 +22,10 @@
 
 -export([start/0, loop/2]).
 
+% process_info/1 is implemented in estdlib's erlang module, so it is
+% covered by tests/libs/estdlib/test_process_info.erl; only the native
+% process_info/2 paths are tested here.
 start() ->
-    ok = test_process_info_1(),
-
     ok = test_registered_name(),
     ok = test_heap_size(),
     ok = test_memory(),
@@ -66,41 +67,6 @@ get_item(Pid, Item) ->
     {Item, Val} = process_info(Pid, Item),
     [{Item, Val}] = process_info(Pid, [Item]),
     Val.
-
-test_process_info_1() ->
-    Check = fun(Pid) ->
-        Info = process_info(Pid),
-        true = is_list(Info),
-
-        {heap_size, HS} = lists:keyfind(heap_size, 1, Info),
-        true = is_integer(HS) andalso HS > 0,
-
-        {total_heap_size, THS} = lists:keyfind(total_heap_size, 1, Info),
-        true = THS >= HS,
-
-        {stack_size, SS} = lists:keyfind(stack_size, 1, Info),
-        true = is_integer(SS) andalso SS >= 0,
-
-        {message_queue_len, MQL} = lists:keyfind(message_queue_len, 1, Info),
-        true = is_integer(MQL) andalso MQL >= 0,
-
-        {links, Links} = lists:keyfind(links, 1, Info),
-        true = is_list(Links),
-
-        {trap_exit, TE} = lists:keyfind(trap_exit, 1, Info),
-        true = is_boolean(TE),
-
-        false = lists:keyfind(registered_name, 1, Info)
-    end,
-
-    Check(self()),
-    % with_other_pid(Check),
-
-    with_dead_pid(fun(DeadPid) ->
-        undefined = process_info(DeadPid)
-    end),
-
-    ok.
 
 test_registered_name() ->
     Check = fun(Pid) ->
@@ -287,7 +253,6 @@ test_list_semantics() ->
 test_badargs() ->
     Self = self(),
 
-    assert_badarg(fun() -> process_info(bad_pid) end),
     assert_badarg(fun() -> process_info(bad_pid, heap_size) end),
     assert_badarg(fun() -> process_info(Self, bad_item) end),
 

--- a/tests/erlang_tests/test_process_info.erl
+++ b/tests/erlang_tests/test_process_info.erl
@@ -36,6 +36,7 @@ start() ->
 
     ok = test_list_semantics(),
     ok = test_badargs(),
+    ok = test_external_pid(),
 
     0.
 
@@ -264,6 +265,22 @@ test_badargs() ->
     assert_badarg(fun() -> process_info(Self, [heap_size, invalid_key]) end),
     assert_badarg(fun() -> process_info(Self, [heap_size | not_a_list]) end),
 
+    % An invalid argument is a badarg even when the process is dead
+    with_dead_pid(fun(DeadPid) ->
+        assert_badarg(fun() -> process_info(DeadPid, bad_item) end),
+        assert_badarg(fun() -> process_info(DeadPid, 42) end),
+        assert_badarg(fun() -> process_info(DeadPid, [bad_item]) end),
+        assert_badarg(fun() -> process_info(DeadPid, [heap_size, bad_item]) end),
+        assert_badarg(fun() -> process_info(DeadPid, [heap_size | not_a_list]) end)
+    end),
+
+    ok.
+
+test_external_pid() ->
+    ExternalPid = binary_to_term(<<131, 88, 119, 10, "other@node", 1:32, 0:32, 42:32>>),
+    true = is_pid(ExternalPid),
+    assert_badarg(fun() -> process_info(ExternalPid, heap_size) end),
+    assert_badarg(fun() -> process_info(ExternalPid, [heap_size]) end),
     ok.
 
 loop(undefined, Accum) ->

--- a/tests/erlang_tests/test_process_info.erl
+++ b/tests/erlang_tests/test_process_info.erl
@@ -35,10 +35,12 @@ start() ->
     ok = test_message_queue_len_alias(),
     ok = test_links(),
     ok = test_monitored_by(),
+    ok = test_trap_exit(),
 
     ok = test_list_semantics(),
     ok = test_badargs(),
     ok = test_external_pid(),
+    ok = test_port_badarg(),
 
     0.
 
@@ -76,6 +78,13 @@ get_item(Pid, Item) ->
     [{Item, Val}] = process_info(Pid, [Item]),
     Val.
 
+get_volatile_item(Pid, Item) ->
+    {Item, Val1} = process_info(Pid, Item),
+    [{Item, Val2}] = process_info(Pid, [Item]),
+    true = is_integer(Val1) andalso Val1 >= 0,
+    true = is_integer(Val2) andalso Val2 >= 0,
+    Val2.
+
 test_registered_name() ->
     Check = fun(Pid) ->
         [] = process_info(Pid, registered_name),
@@ -96,12 +105,12 @@ test_registered_name() ->
 
 test_heap_size() ->
     Self = self(),
-    HS = get_item(Self, heap_size),
-    true = is_integer(HS) andalso HS > 0,
+    HS = get_volatile_item(Self, heap_size),
+    true = HS > 0,
 
     with_other_pid(fun(Pid) ->
-        HS2 = get_item(Pid, heap_size),
-        true = is_integer(HS2) andalso HS2 > 0
+        HS2 = get_volatile_item(Pid, heap_size),
+        true = HS2 > 0
     end),
 
     with_dead_pid(fun(DeadPid) ->
@@ -112,12 +121,12 @@ test_heap_size() ->
 
 test_memory() ->
     Self = self(),
-    M = get_item(Self, memory),
-    true = is_integer(M) andalso M > 0,
+    M = get_volatile_item(Self, memory),
+    true = M > 0,
 
     with_other_pid(fun(Pid) ->
-        M2 = get_item(Pid, memory),
-        true = is_integer(M2) andalso M2 > 0
+        M2 = get_volatile_item(Pid, memory),
+        true = M2 > 0
     end),
 
     with_dead_pid(fun(DeadPid) ->
@@ -128,13 +137,15 @@ test_memory() ->
 
 test_total_heap_size() ->
     Self = self(),
-    HS = get_item(Self, heap_size),
-    THS = get_item(Self, total_heap_size),
+    % Take both values from one call: a single list request is an atomic
+    % snapshot, so the invariant cannot be broken by a GC in between
+    [{heap_size, HS}, {total_heap_size, THS}] =
+        process_info(Self, [heap_size, total_heap_size]),
     true = HS =< THS,
 
     with_other_pid(fun(Pid) ->
-        HS2 = get_item(Pid, heap_size),
-        THS2 = get_item(Pid, total_heap_size),
+        [{heap_size, HS2}, {total_heap_size, THS2}] =
+            process_info(Pid, [heap_size, total_heap_size]),
         true = HS2 =< THS2,
         verify_stable_total_heap_size(Pid, THS2, 50)
     end),
@@ -159,13 +170,19 @@ test_message_queue_len() ->
     end,
 
     Q0 = get_item(Pid, message_queue_len),
+    {memory, Memory0} = process_info(Pid, memory),
 
     Pid ! incr,
     Pid ! incr,
     Pid ! incr,
 
     Q1 = get_item(Pid, message_queue_len),
+    {memory, Memory1} = process_info(Pid, memory),
     true = Q0 < Q1,
+    case erlang:system_info(machine) of
+        "BEAM" -> true = Memory0 =< Memory1;
+        _ -> true = Memory0 < Memory1
+    end,
 
     Pid ! unlock,
     Pid ! {Self, ping},
@@ -318,6 +335,22 @@ test_monitored_by() ->
 
     ok.
 
+test_trap_exit() ->
+    Self = self(),
+    false = get_item(Self, trap_exit),
+
+    false = process_flag(trap_exit, true),
+    true = get_item(Self, trap_exit),
+
+    true = process_flag(trap_exit, false),
+    false = get_item(Self, trap_exit),
+
+    with_other_pid(fun(Pid) ->
+        false = get_item(Pid, trap_exit)
+    end),
+
+    ok.
+
 test_list_semantics() ->
     Self = self(),
 
@@ -365,8 +398,14 @@ test_badargs() ->
     assert_badarg(fun() -> process_info(Self, [heap_size, 42]) end),
     assert_badarg(fun() -> process_info(Self, [heap_size, invalid_key]) end),
     assert_badarg(fun() -> process_info(Self, [heap_size | not_a_list]) end),
+    assert_badarg(fun() -> process_info(Self, [[heap_size]]) end),
 
-    % An invalid argument is a badarg even when the process is dead
+    with_other_pid(fun(Pid) ->
+        assert_badarg(fun() -> process_info(Pid, bad_item) end),
+        assert_badarg(fun() -> process_info(Pid, 42) end),
+        assert_badarg(fun() -> process_info(Pid, [heap_size, bad_item]) end)
+    end),
+
     with_dead_pid(fun(DeadPid) ->
         assert_badarg(fun() -> process_info(DeadPid, bad_item) end),
         assert_badarg(fun() -> process_info(DeadPid, 42) end),
@@ -382,6 +421,20 @@ test_external_pid() ->
     true = is_pid(ExternalPid),
     assert_badarg(fun() -> process_info(ExternalPid, heap_size) end),
     assert_badarg(fun() -> process_info(ExternalPid, [heap_size]) end),
+    ok.
+
+test_port_badarg() ->
+    % on AtomVM "echo" is the echo driver; on BEAM it would spawn /bin/echo,
+    % whose output nobody reads, so use a silent command there
+    PortName =
+        case erlang:system_info(machine) of
+            "BEAM" -> "true";
+            _ -> "echo"
+        end,
+    Port = open_port({spawn, PortName}, []),
+    true = is_port(Port),
+    assert_badarg(fun() -> process_info(Port, heap_size) end),
+    assert_badarg(fun() -> process_info(Port, [heap_size]) end),
     ok.
 
 loop(undefined, Accum) ->

--- a/tests/erlang_tests/test_process_info.erl
+++ b/tests/erlang_tests/test_process_info.erl
@@ -56,6 +56,11 @@ with_other_pid(Fun) ->
             {'DOWN', Ref, process, Pid, Reason} -> Reason
         end.
 
+repeat(0, _Item) ->
+    [];
+repeat(N, Item) ->
+    [Item | repeat(N - 1, Item)].
+
 with_dead_pid(Fun) ->
     {DeadPid, Ref} = spawn_opt(fun() -> ok end, [monitor]),
     normal =
@@ -237,10 +242,19 @@ test_list_semantics() ->
     [{total_heap_size, THS}, {total_heap_size, THS}] =
         process_info(Self, [total_heap_size, total_heap_size]),
 
+    LongRequest = repeat(100, total_heap_size),
+    [{total_heap_size, SelfTHS} | SelfRest] = process_info(Self, LongRequest),
+    99 = length(SelfRest),
+    [] = [Item || Item <- SelfRest, Item =/= {total_heap_size, SelfTHS}],
+
     with_other_pid(fun(Pid) ->
         [] = process_info(Pid, []),
         [{message_queue_len, _}, {heap_size, _}, {memory, _}] =
-            process_info(Pid, [message_queue_len, heap_size, memory])
+            process_info(Pid, [message_queue_len, heap_size, memory]),
+
+        [{total_heap_size, OtherTHS} | OtherRest] = process_info(Pid, LongRequest),
+        99 = length(OtherRest),
+        [] = [Item || Item <- OtherRest, Item =/= {total_heap_size, OtherTHS}]
     end),
 
     with_dead_pid(fun(DeadPid) ->

--- a/tests/erlang_tests/test_process_info.erl
+++ b/tests/erlang_tests/test_process_info.erl
@@ -31,6 +31,8 @@ start() ->
     ok = test_memory(),
     ok = test_total_heap_size(),
     ok = test_message_queue_len(),
+    ok = test_message_queue_len_signals(),
+    ok = test_message_queue_len_alias(),
     ok = test_links(),
     ok = test_monitored_by(),
 
@@ -185,6 +187,91 @@ test_message_queue_len() ->
     undefined = process_info(Pid, message_queue_len),
 
     ok.
+
+test_message_queue_len_signals() ->
+    Self = self(),
+    {Flooder, Ref} = spawn_opt(fun() -> monitor_flood(Self) end, [monitor]),
+    % queue-neutral proof that the flooder completed at least one cycle
+    ok = wait_registered(monitor_flood_started, 1000000),
+    ok = sample_empty_message_queue(Self, 200),
+    Flooder ! stop,
+    normal =
+        receive
+            {'DOWN', Ref, process, Flooder, Reason} -> Reason
+        end,
+    {message_queue_len, 0} = process_info(Self, message_queue_len),
+    ok.
+
+monitor_flood(Target) ->
+    Mon = monitor(process, Target),
+    demonitor(Mon),
+    register(monitor_flood_started, self()),
+    monitor_flood_loop(Target).
+
+monitor_flood_loop(Target) ->
+    Mon = monitor(process, Target),
+    demonitor(Mon),
+    receive
+        stop -> ok
+    after 0 -> monitor_flood_loop(Target)
+    end.
+
+sample_empty_message_queue(_Self, 0) ->
+    ok;
+sample_empty_message_queue(Self, N) ->
+    {message_queue_len, 0} = process_info(Self, message_queue_len),
+    sample_empty_message_queue(Self, N - 1).
+
+test_message_queue_len_alias() ->
+    {Receiver, Ref} = spawn_opt(fun() -> alias_queue_receiver() end, [monitor]),
+    normal =
+        receive
+            {'DOWN', Ref, process, Receiver, Reason} -> Reason
+        end,
+    ok.
+
+alias_queue_receiver() ->
+    Self = self(),
+    Alias = alias(),
+    % the arrival flag must not touch the receiver's queue: receiving would
+    % convert the pending alias messages before the count under test is taken
+    Sender = spawn_opt(
+        fun() ->
+            Alias ! m1,
+            Alias ! m2,
+            Self ! direct,
+            register(alias_queue_sender_done, self()),
+            receive
+                quit -> ok
+            end
+        end,
+        []
+    ),
+    ok = wait_registered(alias_queue_sender_done, 1000000),
+    {message_queue_len, 3} = process_info(Self, message_queue_len),
+    [{message_queue_len, 3}] = process_info(Self, [message_queue_len]),
+    Sender ! quit,
+    m1 =
+        receive
+            First -> First
+        end,
+    m2 =
+        receive
+            Second -> Second
+        end,
+    direct =
+        receive
+            Third -> Third
+        end,
+    {message_queue_len, 0} = process_info(Self, message_queue_len).
+
+wait_registered(_Name, 0) ->
+    timeout;
+wait_registered(Name, N) ->
+    case whereis(Name) of
+        undefined -> wait_registered(Name, N - 1);
+        _Pid -> ok
+    end.
 
 test_links() ->
     Self = self(),

--- a/tests/libs/estdlib/CMakeLists.txt
+++ b/tests/libs/estdlib/CMakeLists.txt
@@ -50,6 +50,7 @@ set(ERLANG_MODULES
     mock_uart_hal
     file_uart_hal
     test_proc_lib
+    test_process_info
     test_sets
     test_spawn
     test_ssl

--- a/tests/libs/estdlib/test_process_info.erl
+++ b/tests/libs/estdlib/test_process_info.erl
@@ -75,6 +75,11 @@ test_registered_name_first() ->
 
 test_badargs() ->
     assert_badarg(fun() -> process_info(bad_pid) end),
+
+    ExternalPid = binary_to_term(<<131, 88, 119, 10, "other@node", 1:32, 0:32, 42:32>>),
+    true = is_pid(ExternalPid),
+    assert_badarg(fun() -> process_info(ExternalPid) end),
+
     ok.
 
 with_other_pid(Fun) ->

--- a/tests/libs/estdlib/test_process_info.erl
+++ b/tests/libs/estdlib/test_process_info.erl
@@ -1,0 +1,113 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Davide Bettio <davide@uninstall.it>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_process_info).
+
+-export([test/0]).
+
+%% process_info/1 is not a nif but implemented in the erlang module on top
+%% of process_info/2 with a list argument.
+
+test() ->
+    ok = test_process_info_1(),
+    ok = test_registered_name_first(),
+    ok = test_badargs(),
+    ok.
+
+test_process_info_1() ->
+    Check = fun(Pid) ->
+        Info = process_info(Pid),
+        true = is_list(Info),
+
+        {heap_size, HS} = lists:keyfind(heap_size, 1, Info),
+        true = is_integer(HS) andalso HS > 0,
+
+        {total_heap_size, THS} = lists:keyfind(total_heap_size, 1, Info),
+        true = THS >= HS,
+
+        {stack_size, SS} = lists:keyfind(stack_size, 1, Info),
+        true = is_integer(SS) andalso SS >= 0,
+
+        {message_queue_len, MQL} = lists:keyfind(message_queue_len, 1, Info),
+        true = is_integer(MQL) andalso MQL >= 0,
+
+        {links, Links} = lists:keyfind(links, 1, Info),
+        true = is_list(Links),
+
+        {trap_exit, TE} = lists:keyfind(trap_exit, 1, Info),
+        true = is_boolean(TE),
+
+        false = lists:keyfind(registered_name, 1, Info)
+    end,
+
+    Check(self()),
+    with_other_pid(Check),
+
+    with_dead_pid(fun(DeadPid) ->
+        undefined = process_info(DeadPid)
+    end),
+
+    ok.
+
+test_registered_name_first() ->
+    erlang:register(process_info_1_test, self()),
+    [{registered_name, process_info_1_test} | _] = process_info(self()),
+    erlang:unregister(process_info_1_test),
+    false = lists:keyfind(registered_name, 1, process_info(self())),
+    ok.
+
+test_badargs() ->
+    assert_badarg(fun() -> process_info(bad_pid) end),
+    ok.
+
+with_other_pid(Fun) ->
+    {Pid, Ref} = spawn_opt(
+        fun() ->
+            receive
+                quit -> ok
+            end
+        end,
+        [monitor]
+    ),
+    Fun(Pid),
+    Pid ! quit,
+    normal =
+        receive
+            {'DOWN', Ref, process, Pid, Reason} -> Reason
+        end.
+
+with_dead_pid(Fun) ->
+    {DeadPid, Ref} = spawn_opt(fun() -> ok end, [monitor]),
+    normal =
+        receive
+            {'DOWN', Ref, process, DeadPid, Reason} -> Reason
+        end,
+    Fun(DeadPid).
+
+assert_badarg(Fun) ->
+    try
+        Fun(),
+        erlang:error(no_throw)
+    catch
+        error:badarg ->
+            ok;
+        OtherClass:OtherError ->
+            erlang:error({OtherClass, OtherError})
+    end.

--- a/tests/libs/estdlib/test_process_info.erl
+++ b/tests/libs/estdlib/test_process_info.erl
@@ -68,10 +68,29 @@ test_process_info_1() ->
 
 test_registered_name_first() ->
     erlang:register(process_info_1_test, self()),
-    [{registered_name, process_info_1_test} | _] = process_info(self()),
+    Info = process_info(self()),
+    {registered_name, process_info_1_test} = lists:keyfind(registered_name, 1, Info),
+    assert_registered_name_first(process_info_1_test, Info),
     erlang:unregister(process_info_1_test),
     false = lists:keyfind(registered_name, 1, process_info(self())),
+
+    with_other_pid(fun(Pid) ->
+        erlang:register(process_info_1_other, Pid),
+        OtherInfo = process_info(Pid),
+        {registered_name, process_info_1_other} = lists:keyfind(registered_name, 1, OtherInfo),
+        assert_registered_name_first(process_info_1_other, OtherInfo),
+        erlang:unregister(process_info_1_other)
+    end),
+
     ok.
+
+%% OTP documents no order for the process_info/1 result, so the
+%% first-position check runs on AtomVM only
+assert_registered_name_first(Name, Info) ->
+    case erlang:system_info(machine) of
+        "BEAM" -> ok;
+        _ -> [{registered_name, Name} | _] = Info
+    end.
 
 test_badargs() ->
     assert_badarg(fun() -> process_info(bad_pid) end),

--- a/tests/libs/estdlib/tests.erl
+++ b/tests/libs/estdlib/tests.erl
@@ -71,6 +71,7 @@ get_non_networking_tests(_OTPVersion) ->
         test_logger,
         test_maps,
         test_proc_lib,
+        test_process_info,
         test_proplists,
         test_queue,
         test_timer,

--- a/tests/test-mailbox.c
+++ b/tests/test-mailbox.c
@@ -124,6 +124,55 @@ void test_mailbox_next(void)
     assert(!mailbox_has_next(&ctx->mailbox));
     assert(mailbox_len(&ctx->mailbox) == 0);
 
+    // 4. mailbox_len counts signals, mailbox_normal_message_len does not
+    mailbox_send(ctx, term_from_int(1));
+    mailbox_send_empty_body_signal(ctx, GCSignal);
+    mailbox_send(ctx, term_from_int(2));
+    assert(mailbox_len(&ctx->mailbox) == 3);
+    assert(mailbox_normal_message_len(&ctx->mailbox) == 2);
+
+    MailboxMessage *signal = mailbox_process_outer_list_native(&ctx->mailbox);
+    assert(signal != NULL);
+    assert(signal->type == GCSignal);
+    assert(signal->next == NULL);
+    mailbox_message_dispose(signal, &ctx->heap);
+
+    assert(mailbox_len(&ctx->mailbox) == 2);
+    assert(mailbox_normal_message_len(&ctx->mailbox) == 2);
+
+    assert(mailbox_peek(ctx, &t));
+    assert(1 == term_to_int(t));
+    mailbox_remove_message(&ctx->mailbox, &ctx->heap);
+
+    assert(mailbox_peek(ctx, &t));
+    assert(2 == term_to_int(t));
+    mailbox_remove_message(&ctx->mailbox, &ctx->heap);
+
+    assert(mailbox_len(&ctx->mailbox) == 0);
+    assert(mailbox_normal_message_len(&ctx->mailbox) == 0);
+
+    // 5. mailbox_normal_message_len counts unconverted alias messages
+    mailbox_send(ctx, term_from_int(3));
+    mailbox_send_term_signal(ctx, AliasMessageSignal, term_from_int(4));
+    assert(mailbox_len(&ctx->mailbox) == 2);
+    assert(mailbox_normal_message_len(&ctx->mailbox) == 2);
+
+    signal = mailbox_process_outer_list_native(&ctx->mailbox);
+    assert(signal != NULL);
+    assert(signal->type == AliasMessageSignal);
+    assert(signal->next == NULL);
+    mailbox_message_dispose(signal, &ctx->heap);
+
+    assert(mailbox_len(&ctx->mailbox) == 1);
+    assert(mailbox_normal_message_len(&ctx->mailbox) == 1);
+
+    assert(mailbox_peek(ctx, &t));
+    assert(3 == term_to_int(t));
+    mailbox_remove_message(&ctx->mailbox, &ctx->heap);
+
+    assert(mailbox_len(&ctx->mailbox) == 0);
+    assert(mailbox_normal_message_len(&ctx->mailbox) == 0);
+
     context_destroy(ctx);
     globalcontext_destroy(glb);
 }


### PR DESCRIPTION
Implement erlang:process_info/1 and the list-of-keys form of
erlang:process_info/2, matching Erlang/OTP behaviour. Both are needed
by Popcorn.

This revamps the original, stalled effort by Mateusz Furga (Software
Mansion) in #2219.

Main differences from that approach:

- process_info/1 is implemented in Erlang (estdlib) rather than C,
simplifying the native code and making the default key set easier
to maintain.
- Pid and argument validation match OTP: badarg for external pids, and
badarg for an invalid argument even when the target process is dead.
- Fixes for pre-existing defects that process_info now exposes:
message_queue_len no longer counts queued signals, a request racing
process teardown answers undefined, and a caught trap exception no
longer leaves the process wedged.
- Allocation failures raise out_of_memory instead of trapping forever,
and the result heap size is bounded.

Closes: #2190, #2191
See also: #2219



These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
