### PR TITLE
jit_stream_mmap: toggle W^X around the mmap size-header write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed several underallocation issues that could trigger data corruption on `binary:replace`, `zlib:compress` and bsd socket recv code.
 - Fixed a bug where `catch` would raise on regular atom results
 - Fixed ESP32 socket driver holding the global socket-list lock across blocking TCP connects, leaking the port on connect failure, losing concurrent `accept` waiters, leaking `netbuf` on receive error paths, and a recycled-`netconn` race between socket close and the event handler
+- Fixed a JIT crash (`EXC_BAD_ACCESS`/SIGBUS) on Apple Silicon
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/src/platforms/generic_unix/lib/jit_stream_mmap.c
+++ b/src/platforms/generic_unix/lib/jit_stream_mmap.c
@@ -89,7 +89,13 @@ static term nif_jit_stream_mmap_new(Context *ctx, int argc, term argv[])
 
     // Write the total mmap size into the header so sys_release_native_code
     // can recover it (it reads *(size_t *)(entry_point - sizeof(size_t))).
+#if HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+    pthread_jit_write_protect_np(0);
+#endif
     *((size_t *) addr) = total;
+#if HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
+    pthread_jit_write_protect_np(1);
+#endif
 
     // Return a resource object
     struct JITStreamMMap *js = enif_alloc_resource(jit_stream_mmap_resource_type, sizeof(struct JITStreamMMap));


### PR DESCRIPTION
Fix EXC_BAD_ACCESS on Apple Silicon with JIT compilation.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
