### PR TITLE
generic_unix: use a graceful close for TCP server sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed several underallocation issues that could trigger data corruption on `binary:replace`, `zlib:compress` and bsd socket recv code.
 - Fixed a bug where `catch` would raise on regular atom results
 - Fixed ESP32 socket driver holding the global socket-list lock across blocking TCP connects, leaking the port on connect failure, losing concurrent `accept` waiters, leaking `netbuf` on receive error paths, and a recycled-`netconn` race between socket close and the event handler
+- Fixed generic_unix TCP server sockets performing an abortive close that could truncate replies awaiting ack
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/src/platforms/generic_unix/lib/socket_driver.c
+++ b/src/platforms/generic_unix/lib/socket_driver.c
@@ -367,17 +367,8 @@ static term init_server_tcp_socket(Context *ctx, SocketDriverData *socket_data, 
     }
     socket_data->sockfd = sockfd;
 
-    //
-    // set socket options:
-    //      reuse-address
-    //      disable linger
-    //
     int flag = 1;
     setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (char *) &flag, sizeof(int));
-    struct linger sl;
-    sl.l_onoff = 1;
-    sl.l_linger = 0;
-    setsockopt(sockfd, SOL_SOCKET, SO_LINGER, &sl, sizeof(sl));
 
     if (fcntl(socket_data->sockfd, F_SETFL, O_NONBLOCK) == -1) {
         close(sockfd);


### PR DESCRIPTION
Fix a behavior with init_server_tcp_socket that surfaced in FreeBSD CI failures.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
