### PR TITLE
Reject negative dynamic segment sizes in bit syntax matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a JIT crash (`EXC_BAD_ACCESS`/SIGBUS) on Apple Silicon
 - Fixed the ESP32 event poller re-blocking after running a listener, which could delay a process
   readied by a driver (e.g. an active-mode socket message) until the next event or timer tick
+- Fixed a bug where negative or oversized segment sizes were not rejected in binary matching
 
 ## [0.7.0-alpha.1] - 2026-04-06
 

--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -1307,7 +1307,7 @@ first_pass(<<?OP_BS_GET_INTEGER2, Rest0/binary>>, MMod, MSt0, State0) ->
             is_integer(SizeReg) ->
                 {MSt4, SizeReg * Unit};
             true ->
-                MSt5 = MMod:mul(MSt4, SizeReg, Unit),
+                MSt5 = scale_size_by_unit(SizeReg, Unit, Fail, MMod, MSt4),
                 {MSt5, SizeReg}
         end,
     {MSt7, BSBinaryReg} = MMod:get_array_element(MSt6, MatchStateRegPtr, 1),
@@ -1345,7 +1345,7 @@ first_pass(<<?OP_BS_GET_FLOAT2, Rest0/binary>>, MMod, MSt0, State0) ->
             is_integer(SizeReg) ->
                 {MSt4, SizeReg * Unit};
             true ->
-                MSt5 = MMod:mul(MSt4, SizeReg, Unit),
+                MSt5 = scale_size_by_unit(SizeReg, Unit, Fail, MMod, MSt4),
                 {MSt5, SizeReg}
         end,
     {MSt7, Result} = MMod:call_primitive(MSt6, ?PRIM_BITSTRING_EXTRACT_FLOAT, [
@@ -1415,11 +1415,12 @@ first_pass(<<?OP_BS_GET_BINARY2, Rest0/binary>>, MMod, MSt0, State0) ->
                         MMod:free_native_registers(BSt1, [SizeValReg])
                     end,
                     fun(BSt0) ->
-                        {BSt1, SizeValReg} = term_to_int(SizeValReg, 0, MMod, BSt0),
-                        BSt2 = MMod:sub(BSt1, SizeReg, SizeValReg),
-                        BSt3 = cond_jump_to_label({SizeReg, '<', BSOffsetReg1}, Fail, MMod, BSt2),
-                        BSt4 = MMod:move_to_native_register(BSt3, SizeValReg, SizeReg),
-                        MMod:free_native_registers(BSt4, [SizeValReg])
+                        {BSt1, SizeValReg} = term_to_int(SizeValReg, Fail, MMod, BSt0),
+                        BSt2 = cond_jump_to_label({SizeValReg, '<', 0}, Fail, MMod, BSt1),
+                        BSt3 = MMod:sub(BSt2, SizeReg, SizeValReg),
+                        BSt4 = cond_jump_to_label({SizeReg, '<', BSOffsetReg1}, Fail, MMod, BSt3),
+                        BSt5 = MMod:move_to_native_register(BSt4, SizeValReg, SizeReg),
+                        MMod:free_native_registers(BSt5, [SizeValReg])
                     end
                 ),
                 {MSt12, SizeReg}
@@ -1467,7 +1468,7 @@ first_pass(<<?OP_BS_SKIP_BITS2, Rest0/binary>>, MMod, MSt0, State0) ->
             is_integer(SizeReg) ->
                 {MSt4, SizeReg * Unit};
             true ->
-                MSt5 = MMod:mul(MSt4, SizeReg, Unit),
+                MSt5 = scale_size_by_unit(SizeReg, Unit, Fail, MMod, MSt4),
                 {MSt5, SizeReg}
         end,
     {MSt7, BSBinaryReg} = MMod:get_array_element(MSt6, MatchStateRegPtr, 1),
@@ -4491,15 +4492,36 @@ cond_raise_badarg_or_jump_to_fail_label(Cond, 0, MMod, MSt0) ->
 cond_raise_badarg_or_jump_to_fail_label(Cond, FailLabel, MMod, MSt0) when FailLabel > 0 ->
     cond_jump_to_label(Cond, FailLabel, MMod, MSt0).
 
+scale_size_by_unit(SizeReg, Unit, Fail, MMod, MSt0) ->
+    MSt1 = cond_jump_to_label({SizeReg, '<', 0}, Fail, MMod, MSt0),
+    {_MinSmall, MaxSmall} = small_integer_bounds(MMod),
+    % leave two bits of headroom so that adding the match offset cannot overflow
+    MaxSize = (1 bsl (MMod:word_size() * 8 - 2)) div max(Unit, 1),
+    MSt2 =
+        if
+            MaxSize >= MaxSmall ->
+                % the size is a small integer, so it can never exceed MaxSize
+                MSt1;
+            true ->
+                {MSt1a, MaxReg} = MMod:move_to_native_register(MSt1, MaxSize),
+                cond_jump_to_label({{free, MaxReg}, '<', SizeReg}, Fail, MMod, MSt1a)
+        end,
+    MMod:mul(MSt2, SizeReg, Unit).
+
 term_to_int(Term, _FailLabel, _MMod, MSt0) when is_integer(Term) ->
     {MSt0, Term bsr 4};
 term_to_int({literal, Val}, _FailLabel, _MMod, MSt0) when is_integer(Val) ->
     {MSt0, Val};
-% Optimized case: when we have type information showing this is an integer, skip the type check
-term_to_int({typed, Term, {t_integer, _Range}}, _FailLabel, MMod, MSt0) ->
-    {MSt1, Reg} = MMod:move_to_native_register(MSt0, Term),
-    {MSt2, IntReg} = MMod:shift_right(MSt1, {free, Reg}, 4),
-    {MSt2, IntReg};
+% Optimized case: when we have type information showing this is an integer small enough, skip the type check
+term_to_int({typed, Term, {t_integer, Range}}, FailLabel, MMod, MSt0) ->
+    case is_small_integer_range(Range, Range, MMod) of
+        true ->
+            {MSt1, Reg} = MMod:move_to_native_register(MSt0, Term),
+            {MSt2, IntReg} = MMod:shift_right_arith(MSt1, {free, Reg}, 4),
+            {MSt2, IntReg};
+        false ->
+            term_to_int(Term, FailLabel, MMod, MSt0)
+    end;
 term_to_int({typed, Term, _NonIntegerType}, FailLabel, MMod, MSt0) ->
     % Type information shows it's not an integer, fall back to generic path
     term_to_int(Term, FailLabel, MMod, MSt0);
@@ -4508,7 +4530,7 @@ term_to_int(Term, FailLabel, MMod, MSt0) ->
     MSt2 = cond_raise_badarg_or_jump_to_fail_label(
         {Reg, '&', ?TERM_IMMED_TAG_MASK, '!=', ?TERM_INTEGER_TAG}, FailLabel, MMod, MSt1
     ),
-    {MSt3, IntReg} = MMod:shift_right(MSt2, {free, Reg}, 4),
+    {MSt3, IntReg} = MMod:shift_right_arith(MSt2, {free, Reg}, 4),
     {MSt3, IntReg}.
 
 first_pass_float3(Primitive, Rest0, MMod, MSt0, State0) ->

--- a/src/libAtomVM/jit.c
+++ b/src/libAtomVM/jit.c
@@ -1479,10 +1479,10 @@ static term extract_bigint(Context *ctx, JITState *jit_state, const uint8_t *byt
 }
 
 static term jit_bitstring_extract_integer(
-    Context *ctx, JITState *jit_state, term *bin_ptr, size_t offset, int n, int bs_flags)
+    Context *ctx, JITState *jit_state, term *bin_ptr, size_t offset, size_t n, int bs_flags)
 {
     TRACE("jit_bitstring_extract_integer: bin_ptr=%p offset=%d n=%d bs_flags=%d\n",
-        (void *) bin_ptr, (int) offset, n, bs_flags);
+        (void *) bin_ptr, (int) offset, (int) n, bs_flags);
     if (n <= 64) {
         union maybe_unsigned_int64 value;
         bool status = bitstring_extract_integer(
@@ -1522,9 +1522,9 @@ static term jit_bitstring_extract_integer(
     }
 }
 
-static term jit_bitstring_extract_float(Context *ctx, JITState *jit_state, term *match_state_ptr, int n, int bs_flags, int live)
+static term jit_bitstring_extract_float(Context *ctx, JITState *jit_state, term *match_state_ptr, size_t n, int bs_flags, int live)
 {
-    TRACE("jit_bitstring_extract_float: match_state_ptr=%p n=%d bs_flags=%d live=%d\n", (void *) match_state_ptr, n, bs_flags, live);
+    TRACE("jit_bitstring_extract_float: match_state_ptr=%p n=%d bs_flags=%d live=%d\n", (void *) match_state_ptr, (int) n, bs_flags, live);
     avm_int_t offset = (avm_int_t) match_state_ptr[2];
     avm_float_t value;
     bool status;

--- a/src/libAtomVM/jit.h
+++ b/src/libAtomVM/jit.h
@@ -216,7 +216,7 @@ struct ModuleNativeInterface
     bool (*catch_end)(Context *ctx, JITState *jit_state);
     bool (*memory_ensure_free_with_roots)(Context *ctx, JITState *jit_state, int sz, int live, int flags);
     term (*term_alloc_bin_match_state)(Context *ctx, term src, int slots);
-    term (*bitstring_extract_integer)(Context *ctx, JITState *jit_state, term *bin_ptr, size_t offset, int n, int bs_flags);
+    term (*bitstring_extract_integer)(Context *ctx, JITState *jit_state, term *bin_ptr, size_t offset, size_t n, int bs_flags);
     size_t (*term_sub_binary_heap_size)(term *bin_ptr, size_t size);
     term (*term_maybe_create_sub_binary)(Context *ctx, term bin, size_t offset, size_t len);
     int (*term_find_map_pos)(Context *ctx, term map, term key);
@@ -234,7 +234,7 @@ struct ModuleNativeInterface
     void *(*malloc)(Context *ctx, JITState *jit_state, size_t sz);
     void (*free)(void *ptr);
     term (*put_map_assoc)(Context *ctx, JITState *jit_state, term src, size_t new_entries, size_t num_elements, term *kv);
-    term (*bitstring_extract_float)(Context *ctx, JITState *jit_state, term *match_state_ptr, int n, int bs_flags, int live);
+    term (*bitstring_extract_float)(Context *ctx, JITState *jit_state, term *match_state_ptr, size_t n, int bs_flags, int live);
     int (*module_get_fun_arity)(Module *fun_module, uint32_t fun_index);
     bool (*bitstring_match_module_str)(Context *ctx, JITState *jit_state, term bin, size_t offset, int str_id, size_t len);
     term (*bitstring_get_utf8)(term src);

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1240,6 +1240,40 @@ static bool sort_kv_pairs(struct kv_pair *kv, int size, GlobalContext *global)
 }
 #endif
 
+/**
+ * @brief Scale a dynamic segment size by its unit.
+ *
+ * @details Matching opcodes take a segment size from a register and scale it by
+ * the segment unit. The size can be negative or large enough for the product to
+ * overflow, so it cannot be multiplied blindly: the scaled size is compared
+ * against the remaining capacity and added to the match offset, and scaling
+ * first lets a negative size wrap to a small one that passes the capacity check,
+ * or move the match offset before the start of the binary.
+ *
+ * @param size the segment size, as a term (must be any integer)
+ * @param unit the segment unit
+ * @param max_value the largest acceptable scaled size
+ * @param scaled_size on success, the scaled size
+ * @returns \c true if the scaled size is representable and at most
+ * \c max_value, \c false if the match should fail
+ */
+static inline bool bs_scaled_size(term size, uint32_t unit, size_t max_value, size_t *scaled_size)
+{
+    if (!term_is_integer(size)) {
+        // a size that doesn't fit in a small integer cannot fit in max_value
+        return false;
+    }
+    avm_int_t size_val = term_to_int(size);
+    if (size_val < 0) {
+        return false;
+    }
+    if (unit != 0 && (size_t) size_val > max_value / unit) {
+        return false;
+    }
+    *scaled_size = (size_t) size_val * unit;
+    return true;
+}
+
 static term maybe_alloc_boxed_integer_fragment(Context *ctx, avm_int64_t value)
 {
 #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
@@ -4254,17 +4288,17 @@ schedule_in:
                 DECODE_LITERAL(flags_value, pc)
 
                 VERIFY_IS_MATCH_STATE(src, "bs_skip_bits2", 0);
-                VERIFY_IS_INTEGER(size, "bs_skip_bits2", 0);
+                VERIFY_IS_ANY_INTEGER(size, "bs_skip_bits2", 0);
                 // Ignore flags value as skipping bits is the same whatever the endianness
-                avm_int_t size_val = term_to_int(size);
+                TRACE("bs_skip_bits2/5, fail=%u src=%p unit=%u flags=%x\n", (unsigned) fail, (void *) src, (unsigned) unit, (int) flags_value);
 
-                TRACE("bs_skip_bits2/5, fail=%u src=%p size=0x%lx unit=%u flags=%x\n", (unsigned) fail, (void *) src, (unsigned long) size_val, (unsigned) unit, (int) flags_value);
-
-                size_t increment = size_val * unit;
                 avm_int_t bs_offset = term_get_match_state_offset(src);
                 term bs_bin = term_get_match_state_binary(src);
-                if ((bs_offset + increment) > term_binary_size(bs_bin) * 8) {
-                    TRACE("bs_skip_bits2: Insufficient capacity to skip bits: %lu, inc: %zu\n", (unsigned long) bs_offset, increment);
+                size_t bs_capacity = term_binary_size(bs_bin) * 8;
+                size_t increment;
+                if ((size_t) bs_offset > bs_capacity
+                    || !bs_scaled_size(size, unit, bs_capacity - bs_offset, &increment)) {
+                    TRACE("bs_skip_bits2: Insufficient capacity to skip bits: %lu\n", (unsigned long) bs_offset);
                     JUMP_TO_ADDRESS(mod->labels[fail]);
                 } else {
                     term_set_match_state_offset(src, bs_offset + increment);
@@ -4336,16 +4370,22 @@ schedule_in:
                 DECODE_LITERAL(flags_value, pc)
 
                 VERIFY_IS_MATCH_STATE(src, "bs_get_integer", 0);
-                VERIFY_IS_INTEGER(size, "bs_get_integer", 0);
+                VERIFY_IS_ANY_INTEGER(size, "bs_get_integer", 0);
 
-                avm_int_t size_val = term_to_int(size);
+                TRACE("bs_get_integer2/7, fail=%u src=%p live=%u unit=%u flags=%x\n", (unsigned) fail, (void *) src, (unsigned) live, (unsigned) unit, (int) flags_value);
 
-                TRACE("bs_get_integer2/7, fail=%u src=%p live=%u size=%u unit=%u flags=%x\n", (unsigned) fail, (void *) src, (unsigned) size_val, (unsigned) live, (unsigned) unit, (int) flags_value);
-
-                avm_int_t increment = size_val * unit;
                 union maybe_unsigned_int64 value;
                 term bs_bin = term_get_match_state_binary(src);
                 avm_int_t bs_offset = term_get_match_state_offset(src);
+                size_t bs_capacity = term_binary_size(bs_bin) * 8;
+                size_t increment_bits;
+                if ((size_t) bs_offset > bs_capacity
+                    || !bs_scaled_size(size, unit, bs_capacity - bs_offset, &increment_bits)) {
+                    TRACE("bs_get_integer2: size is negative or exceeds the remaining capacity\n");
+                    JUMP_TO_ADDRESS(mod->labels[fail]);
+                }
+                // bounded by the remaining capacity, so it fits in an avm_int_t
+                avm_int_t increment = (avm_int_t) increment_bits;
                 term t;
                 if (increment <= 64) {
                     bool status = bitstring_extract_integer(bs_bin, bs_offset, increment, flags_value, &value);
@@ -4408,16 +4448,23 @@ schedule_in:
                 DECODE_LITERAL(flags_value, pc);
 
                 VERIFY_IS_MATCH_STATE(src, "bs_get_float", 0);
-                VERIFY_IS_INTEGER(size, "bs_get_float", 0);
+                VERIFY_IS_ANY_INTEGER(size, "bs_get_float", 0);
 
-                avm_int_t size_val = term_to_int(size);
+                TRACE("bs_get_float2/7, fail=%u src=%p unit=%u flags=%x\n", (unsigned) fail, (void *) src, (unsigned) unit, (int) flags_value);
 
-                TRACE("bs_get_float2/7, fail=%u src=%p size=%u unit=%u flags=%x\n", (unsigned) fail, (void *) src, (unsigned) size_val, (unsigned) unit, (int) flags_value);
-
-                avm_int_t increment = size_val * unit;
                 avm_float_t value;
                 term bs_bin = term_get_match_state_binary(src);
                 avm_int_t bs_offset = term_get_match_state_offset(src);
+                size_t bs_capacity = term_binary_size(bs_bin) * 8;
+                size_t increment_bits;
+                if ((size_t) bs_offset > bs_capacity
+                    || !bs_scaled_size(size, unit, bs_capacity - bs_offset, &increment_bits)) {
+                    TRACE("bs_get_float2: size is negative or exceeds the remaining capacity\n");
+                    JUMP_TO_ADDRESS(mod->labels[fail]);
+                }
+                // both bounded by the remaining capacity, so they fit in an avm_int_t
+                avm_int_t size_val = term_to_int(size);
+                avm_int_t increment = (avm_int_t) increment_bits;
                 bool status;
                 switch (size_val) {
                     case 16:
@@ -4478,11 +4525,21 @@ schedule_in:
                     TRACE("bs_get_binary2: Unsupported: unit must be 8.\n");
                     RAISE_ERROR(UNSUPPORTED_ATOM);
                 }
-                avm_int_t size_val = 0;
-                if (term_is_integer(size)) {
-                    size_val = term_to_int(size);
+                size_t bs_capacity = term_binary_size(bs_bin);
+                if ((size_t) bs_offset / 8 > bs_capacity) {
+                    TRACE("bs_get_binary2: match state offset is past the end of the binary\n");
+                    JUMP_TO_ADDRESS(mod->labels[fail]);
+                }
+                size_t remaining_bytes = bs_capacity - bs_offset / 8;
+                size_t size_val = 0;
+                if (term_is_any_integer(size)) {
+                    // A negative or oversized size fails the match, as on BEAM
+                    if (!bs_scaled_size(size, 1, remaining_bytes, &size_val)) {
+                        TRACE("bs_get_binary2: size is negative or exceeds the remaining capacity\n");
+                        JUMP_TO_ADDRESS(mod->labels[fail]);
+                    }
                 } else if (size == ALL_ATOM) {
-                    size_val = term_binary_size(bs_bin) - bs_offset / 8;
+                    size_val = remaining_bytes;
                 } else {
                     TRACE("bs_get_binary2: size is neither an integer nor the atom `all`\n");
                     RAISE_ERROR(BADARG_ATOM);
@@ -4498,8 +4555,8 @@ schedule_in:
 
                 TRACE("bs_get_binary2/7, fail=%u src=%p live=%u unit=%u\n", (unsigned) fail, (void *) bs_bin, (unsigned) live, (unsigned) unit);
 
-                if ((unsigned int) (bs_offset / unit + size_val) > term_binary_size(bs_bin)) {
-                    TRACE("bs_get_binary2: insufficient capacity -- bs_offset = %d, size_val = %d\n", (int) bs_offset, (int) size_val);
+                if (size_val > remaining_bytes) {
+                    TRACE("bs_get_binary2: insufficient capacity -- bs_offset = %d, size_val = %zu\n", (int) bs_offset, size_val);
                     JUMP_TO_ADDRESS(mod->labels[fail]);
                 } else {
                     term_set_match_state_offset(src, bs_offset + size_val * unit);

--- a/tests/erlang_tests/test_bs.erl
+++ b/tests/erlang_tests/test_bs.erl
@@ -104,6 +104,8 @@ start() ->
     ok = test_bs_skip_bits2_little(),
 
     ok = test_bs_variable_size_bitstring(),
+    ok = test_negative_dynamic_size(),
+    ok = test_oversized_dynamic_size(),
     ok = test_float(),
 
     0.
@@ -688,6 +690,67 @@ create_float_binary(Value, Size) ->
 check_x86_64_jt(<<>>) -> ok;
 check_x86_64_jt(<<16#e9, _Offset:32/little, Tail/binary>>) -> check_x86_64_jt(Tail);
 check_x86_64_jt(Bin) -> {unexpected, Bin}.
+
+test_negative_dynamic_size() ->
+    B = id(<<1>>),
+    nope = skip_unit64(id(-1), B),
+    nope = skip_unit64(id(-(1 bsl 58)), B),
+    nope = skip_unit64(id(-(1 bsl 58) - 1), B),
+    nope = skip_unit8(id(-1), B),
+    nope = skip_unit8(id(-(1 bsl 61)), B),
+    nope = int_unit64(id(-1), B),
+    nope = int_unit64(id(-(1 bsl 58)), B),
+    nope = float_unit64(id(-1), id(<<1, 2, 3, 4, 5, 6, 7, 8>>)),
+    nope = bin_unit8(id(-1), B),
+    nope = bin_unit8(id(-(1 bsl 61)), B),
+    % the same segments still match when the size is valid
+    <<>> = skip_unit8(id(1), B),
+    {<<1>>, <<>>} = bin_unit8(id(1), B),
+    ok.
+
+test_oversized_dynamic_size() ->
+    B = id(<<1>>),
+    nope = skip_unit64(id(1 bsl 26), B),
+    nope = skip_unit64(id(1 bsl 58), B),
+    nope = skip_unit8(id(1 bsl 26), B),
+    nope = int_unit64(id(1 bsl 26), B),
+    nope = int_unit64(id(1 bsl 58), B),
+    nope = float_unit64(id(1 bsl 26), id(<<1, 2, 3, 4, 5, 6, 7, 8>>)),
+    nope = bin_unit8(id(1 bsl 26), B),
+    nope = skip_unit64(id(1 bsl 61), B),
+    nope = int_unit64(id(1 bsl 61), B),
+    nope = bin_unit8(id(1 bsl 61), B),
+    ok.
+
+skip_unit64(N, B) ->
+    case B of
+        <<_:N/binary-unit:64, R/binary>> -> R;
+        _ -> nope
+    end.
+
+skip_unit8(N, B) ->
+    case B of
+        <<_:N/binary-unit:8, R/binary>> -> R;
+        _ -> nope
+    end.
+
+bin_unit8(N, B) ->
+    case B of
+        <<X:N/binary-unit:8, R/binary>> -> {X, R};
+        _ -> nope
+    end.
+
+int_unit64(N, B) ->
+    case B of
+        <<X:N/integer-unit:64, _/binary>> -> X;
+        _ -> nope
+    end.
+
+float_unit64(N, B) ->
+    case B of
+        <<X:N/float-unit:64, _/binary>> -> X;
+        _ -> nope
+    end.
 
 id(X) -> ?MODULE:ext_id(X).
 

--- a/tests/libs/jit/jit_tests.erl
+++ b/tests/libs/jit/jit_tests.erl
@@ -216,22 +216,32 @@ term_to_int_verify_is_match_state_typed_optimization_x86_64_test() ->
         jit_x86_64, ?CODE_CHUNK_1, ?ATU8_CHUNK_1, ?TYPE_CHUNK_1
     ),
 
-    % Check the reading of x[1] is immediatly followed by a shift right.
+    % The size is typed as an unbounded integer (possibly a bignum), so
+    % term_to_int does NOT blindly untag x[1]; that unsafe optimized form,
+    % emitted only for a small-integer range, would be:
     % 15c:	4c 8b 5f 38          	mov    0x38(%rdi),%r11
-    % 160:	49 c1 eb 04          	shr    $0x4,%r11
+    % 160:	49 c1 fb 04          	sar    $0x4,%r11
 
-    % As opposed to testing its type
+    % Instead it keeps the immediate-tag check and untags with an arithmetic
+    % shift (sar), so a negative size stays negative:
     % 15c:	4c 8b 5f 38          	mov    0x38(%rdi),%r11
     % 160:	4d 89 da             	mov    %r11,%r10
     % 163:	41 80 e2 0f          	and    $0xf,%r10b
     % 167:	41 80 fa 0f          	cmp    $0xf,%r10b
     % 16b:	74 05                	je     0x172
     % 16d:	e9 ab 00 00 00       	jmpq   0x21d
-    % 172:	49 c1 eb 04          	shr    $0x4,%r11
+    % 172:	49 c1 fb 04          	sar    $0x4,%r11
     ?assertMatch(
-        {_, 8},
-        binary:match(CompiledCode, <<16#4c, 16#8b, 16#5f, 16#38, 16#49, 16#c1, 16#eb, 16#04>>)
+        {_, _},
+        binary:match(
+            CompiledCode,
+            <<16#4c, 16#8b, 16#5f, 16#38, 16#4d, 16#89, 16#da, 16#41, 16#80, 16#e2, 16#0f, 16#41,
+                16#80, 16#fa, 16#0f, 16#74, 16#05>>
+        )
     ),
+    % the untag is an arithmetic shift (sar), not a logical one (shr)
+    ?assertMatch({_, _}, binary:match(CompiledCode, <<16#49, 16#c1, 16#fb, 16#04>>)),
+    ?assertEqual(nomatch, binary:match(CompiledCode, <<16#49, 16#c1, 16#eb, 16#04>>)),
 
     % Check call to bs_start_match3 is followed by a skip of verify_is_boxed
     % The register value cache eliminates the redundant load after the store,


### PR DESCRIPTION
A dynamic segment size comes from a register and can be negative. It was scaled by the segment unit before being validated, so the scaled value could wrap to a small size that passed the capacity check and matched, or move the match state offset before the start of the binary.

The JIT also untagged small integers with a logical shift, which turned any negative integer into a large positive one.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
