### PR TITLE
Disable esp32s2 wifi sim tests

### DIFF
--- a/src/platforms/esp32/test/main/test_main.c
+++ b/src/platforms/esp32/test/main/test_main.c
@@ -674,7 +674,8 @@ TEST_CASE("test_wifi_example", "[test_run]")
 }
 #endif
 
-#if !CONFIG_IDF_TARGET_ESP32C61
+// We also avoid the remaining WiFi tests on ESP32-S2, they proved too flaky
+#if !CONFIG_IDF_TARGET_ESP32S2 && !CONFIG_IDF_TARGET_ESP32C61
 TEST_CASE("test_wifi_managed", "[test_run]")
 {
     term ret_value = avm_test_case("test_wifi_managed.beam");


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
