### PR TITLE
Use optimized version of `lists:delete/2`

### DIFF
--- a/libs/estdlib/src/lists.erl
+++ b/libs/estdlib/src/lists.erl
@@ -153,16 +153,12 @@ member(_, []) ->
 %% @end
 %%-----------------------------------------------------------------------------
 -spec delete(E :: term(), L :: list()) -> Result :: list().
-delete(E, L) ->
-    delete(E, L, []).
-
-%% @private
-delete(_, [], Accum) ->
-    ?MODULE:reverse(Accum);
-delete(E, [E | T], Accum) ->
-    ?MODULE:reverse(Accum) ++ T;
-delete(E, [H | T], Accum) ->
-    delete(E, T, [H | Accum]).
+delete(Item, [Item | Rest]) ->
+    Rest;
+delete(Item, [H | Rest]) ->
+    [H | delete(Item, Rest)];
+delete(_, []) ->
+    [].
 
 %%-----------------------------------------------------------------------------
 %% @param   L the list to reverse


### PR DESCRIPTION
Follow OTP's implementation of a stack-heavier version of `lists:delete/2` which is even faster with JIT than a NIF implementation

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
